### PR TITLE
Update chores-tracker image to v2.0.0

### DIFF
--- a/base-apps/chores-tracker/deployments.yaml
+++ b/base-apps/chores-tracker/deployments.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: chores-tracker
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:v0.9.9
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:v2.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Updates the chores-tracker deployment to use image version v2.0.0 from ECR.

🤖 Generated with [Claude Code](https://claude.ai/code)