### PR TITLE
Fix namespace issues in test MySQL application

### DIFF
--- a/base-apps/test-mysql-app/claim.yaml
+++ b/base-apps/test-mysql-app/claim.yaml
@@ -7,7 +7,7 @@ spec:
   parameters:
     databaseName: testapp_db
     username: testapp_user
-    userNamespace: test-app-backend
+    userNamespace: test-app
     databaseNamespace: test-app
     privileges:
       - "SELECT"

--- a/base-apps/vault/secret_stores.yaml
+++ b/base-apps/vault/secret_stores.yaml
@@ -77,19 +77,3 @@ spec:
         tokenSecretRef:
           name: vault-token
           key: token
----
-apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
-metadata:
-  name: vault-backend
-  namespace: test-app-backend
-spec:
-  provider:
-    vault:
-      server: "http://vault.vault.svc.cluster.local:8200"
-      path: "secret"
-      version: "v2"
-      auth:
-        tokenSecretRef:
-          name: vault-token
-          key: token


### PR DESCRIPTION
## Summary
This PR fixes the namespace configuration errors in the test MySQL application that was causing ArgoCD sync failures.

## Issues Fixed
1. **"namespace not found"** - The claim was trying to create resources in `test-app-backend` namespace which doesn't exist
2. **"SecretStore not found"** - The external secret couldn't find the vault-backend SecretStore

## Changes
- Changed `userNamespace` from `test-app-backend` to `test-app` in the claim
- Removed the unnecessary `test-app-backend` SecretStore from vault configuration
- All resources now use a single `test-app` namespace for simplicity

## Testing
After merging this PR:
1. Ensure the vault-token secret exists in test-app namespace
2. Create the Vault secret:
   ```bash
   vault kv put test-app-database DB_PASSWORD="your-password-here"
   ```
3. Verify all resources are created in test-app namespace

🤖 Generated with [Claude Code](https://claude.ai/code)