### PR TITLE
Fix XRD validation patterns to match MySQL naming rules

### DIFF
--- a/base-apps/crossplane-mysql/composition-xrd.yaml
+++ b/base-apps/crossplane-mysql/composition-xrd.yaml
@@ -33,11 +33,13 @@ spec:
                   databaseName:
                     type: string
                     description: "Name of the MySQL database"
-                    pattern: "^[a-zA-Z][a-zA-Z0-9_]{0,63}$"
+                    pattern: "^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,62}$"
+                    maxLength: 63
                   username:
                     type: string
                     description: "Name of the MySQL user"
-                    pattern: "^[a-zA-Z][a-zA-Z0-9_-]{0,31}$"
+                    pattern: "^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,30}$"
+                    maxLength: 31
                   userNamespace:
                     type: string
                     description: "Namespace where the user resource will be created"


### PR DESCRIPTION
## Summary
This PR fixes the XRD validation patterns that were causing the error:
`MySQLDatabase.platform.io "test-app-db" is invalid: spec.parameters.databaseName: Invalid value: "testapp-db"`

## Root Cause
The validation pattern was too restrictive compared to MySQL's actual naming rules:
- Required names to start with a letter (MySQL allows digits)
- Didn't allow hyphens (MySQL allows them)
- Character count was off by 1

## Changes
- Updated database name pattern from `^[a-zA-Z][a-zA-Z0-9_]{0,63}$` to `^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,62}$`
- Updated username pattern from `^[a-zA-Z][a-zA-Z0-9_-]{0,31}$` to `^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,30}$`
- Added explicit `maxLength` validation
- Now matches MySQL 5.7+ actual identifier rules

## Testing
After merging, the test app claim should validate successfully with names containing hyphens or starting with numbers.

🤖 Generated with [Claude Code](https://claude.ai/code)