### PR TITLE
Fix ArgoCD sync issues with Crossplane-generated resources

### DIFF
--- a/base-apps/test-mysql-app.yaml
+++ b/base-apps/test-mysql-app.yaml
@@ -20,3 +20,12 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    # Ignore Crossplane-generated composite resources
+    - group: platform.io
+      kind: XMySQLDatabase
+      jsonPointers:
+        - /metadata
+        - /spec
+        - /status


### PR DESCRIPTION
## Summary
This PR fixes the ArgoCD "OutOfSync" warning for Crossplane Composite Resources (XRs).

## Problem
When you create a MySQLDatabase claim, Crossplane automatically creates an XMySQLDatabase composite resource with a generated name (e.g., `test-app-db-fmpgk`). ArgoCD sees this resource exists in the cluster but not in Git, marks it as OutOfSync, and wants to delete it.

## Solution
Configure ArgoCD to ignore Crossplane-generated resources by adding:
- `ignoreDifferences` for XMySQLDatabase resources
- `RespectIgnoreDifferences=true` sync option

This prevents ArgoCD from trying to prune resources that Crossplane manages.

## Testing
After merging, the XMySQLDatabase resource should show as "Synced" instead of "OutOfSync" in ArgoCD.

🤖 Generated with [Claude Code](https://claude.ai/code)