### PR TITLE
Fix MySQL claim composition assignment

### DIFF
--- a/base-apps/test-mysql-app/claim.yaml
+++ b/base-apps/test-mysql-app/claim.yaml
@@ -4,6 +4,8 @@ metadata:
   name: test-app-db
   namespace: test-app
 spec:
+  compositionRef:
+    name: xmysqldatabase.platform.io
   parameters:
     databaseName: testapp-db
     username: testapp-user


### PR DESCRIPTION
## Summary
The MySQL claim `test-app-db` was not being assigned to a composition despite the XRD having a `defaultCompositionRef`. This was causing the claim to be stuck in a "Waiting" state with the message "Claim is waiting for composite resource to become Ready".

## Changes
- Added explicit `compositionRef` to the MySQL claim in `base-apps/test-mysql-app/claim.yaml`
- Points to the `xmysqldatabase.platform.io` composition

## Impact
This should resolve the issue where the composite resource is created without a composition reference, allowing the MySQL database resources to be properly provisioned.

## Testing
Once merged, ArgoCD will automatically sync the changes and the claim should successfully provision the MySQL database resources.