### PR TITLE
SECURITY: Remove vault-token.yaml with exposed credentials

### DIFF
--- a/base-apps/test-mysql-app/vault-token.yaml
+++ b/base-apps/test-mysql-app/vault-token.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vault-token
-  namespace: test-app
-data:
-  token: aHZzLlZxbldsblVEMjdBWjlvODhMSVpBT0pPdA==
-type: Opaque


### PR DESCRIPTION
## 🚨 SECURITY ISSUE 🚨

This PR removes `base-apps/test-mysql-app/vault-token.yaml` which contained a base64-encoded vault token that should never be stored in Git.

## What was exposed
- A vault token in base64 format: `aHZzLlZxbldsblVEMjdBWjlvODhMSVpBT0pPdA==`
- This token was accidentally committed to the repository

## Action Required
1. **MERGE THIS PR IMMEDIATELY** to remove the exposed token from the repository
2. **REVOKE THE VAULT TOKEN** as it has been exposed in Git history
3. **REGENERATE A NEW VAULT TOKEN** if still needed
4. **NEVER COMMIT SECRETS TO GIT** - use External Secrets Operator or similar

## Security Best Practices
- Use External Secrets Operator to fetch secrets from Vault
- Never commit secrets, tokens, or credentials to Git
- Use proper secret management tools for sensitive data

This is a critical security fix that needs immediate attention.