### PR TITLE
feat: add MySQL database for testmysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
-terraform/roots/asela-cluster/.terraform.lock.hcl
-terraform/roots/asela-cluster/terraform.tfvars
-terraform/roots/asela-cluster/.terraform/terraform.tfstate
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/gavinbunney/kubectl/1.16.0/linux_amd64/LICENSE
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/gavinbunney/kubectl/1.16.0/linux_amd64/README.md
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/gavinbunney/kubectl/1.16.0/linux_amd64/terraform-provider-kubectl_v1.16.0
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/aws/5.78.0/linux_amd64/LICENSE.txt
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/aws/5.78.0/linux_amd64/terraform-provider-aws_v5.78.0_x5
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/helm/2.16.1/linux_amd64/LICENSE.txt
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/helm/2.16.1/linux_amd64/terraform-provider-helm_v2.16.1_x5
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/kubernetes/2.34.0/linux_amd64/LICENSE.txt
-terraform/roots/asela-cluster/.terraform/providers/registry.terraform.io/hashicorp/kubernetes/2.34.0/linux_amd64/terraform-provider-kubernetes_v2.34.0_x5
+# Local testing files
+.DS_Store
+*.tmp
+*.log
+
+# Generated files during testing
+test-output/
+rendered/
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Temporary files
+*~
+.#*

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# This file ensures the skeleton directory is tracked by git

--- a/argocd/testmysql-testmysql.yaml
+++ b/argocd/testmysql-testmysql.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: testmysql-testmysql
+  namespace: openshift-gitops
+  labels:
+    app.kubernetes.io/name: testmysql
+    app.kubernetes.io/instance: testmysql-argocd
+    app.kubernetes.io/component: gitops
+    app.kubernetes.io/part-of: testmysql
+    environment: development
+    backstage.io/kubernetes-id: testmysql
+  annotations:
+    backstage.io/kubernetes-id: testmysql
+    backstage.io/kubernetes-namespace: testmysql
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/testmysql-testmysql
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: testmysql
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  revisionHistoryLimit: 10

--- a/base-apps/testmysql-testmysql/catalog-info.yaml
+++ b/base-apps/testmysql-testmysql/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: testmysql-mysql-db
+  description: MySQL database for testmysql
+  annotations:
+    backstage.io/kubernetes-id: testmysql
+    backstage.io/kubernetes-namespace: testmysql
+spec:
+  type: database
+  owner: group:default/platform-team
+  system: system:default/examples
+  lifecycle: development

--- a/base-apps/testmysql-testmysql/resources/external_secrets.yaml
+++ b/base-apps/testmysql-testmysql/resources/external_secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: testmysql-secret
+  namespace: testmysql
+  labels:
+    app.kubernetes.io/name: testmysql
+    app.kubernetes.io/instance: testmysql-mysql
+    app.kubernetes.io/component: database-secret
+    app.kubernetes.io/part-of: testmysql
+    environment: development
+    backstage.io/kubernetes-id: testmysql
+  annotations:
+    backstage.io/kubernetes-id: testmysql
+    backstage.io/kubernetes-namespace: testmysql
+spec:
+  refreshInterval: 30s
+  secretStoreRef:
+    name: secret-store
+    kind: SecretStore
+  target:
+    name: testmysql-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Database password from Vault
+        DB_PASSWORD: "{{ .password | toString }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: testmysql/DB_PASSWORD

--- a/base-apps/testmysql-testmysql/resources/mysql-database.yaml
+++ b/base-apps/testmysql-testmysql/resources/mysql-database.yaml
@@ -1,0 +1,38 @@
+apiVersion: platform.io/v1alpha1
+kind: MySQLDatabase
+metadata:
+  name: testmysql
+  namespace: testmysql
+  labels:
+    app.kubernetes.io/name: testmysql
+    app.kubernetes.io/instance: testmysql-mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: testmysql
+    environment: development
+    backstage.io/kubernetes-id: testmysql
+  annotations:
+    # These annotations are used by the kubernetes-ingestor to discover this resource
+    backstage.io/kubernetes-id: testmysql
+    backstage.io/kubernetes-namespace: testmysql
+spec:
+  compositionRef:
+    name: xmysqldatabases.platform.io
+  parameters:
+    # Database configuration
+    databaseName: testmysqldb
+    storageSize: 1Gi
+    
+    # User configuration
+    username: testmysqluser
+    privileges:
+      - {{ privilege }}
+      - {{ privilege }}
+      - {{ privilege }}
+      - {{ privilege }}
+    
+    # Connection secret configuration
+    connectionSecretName: testmysql-connection
+    connectionSecretNamespace: testmysql
+    
+    # Resource class based on environment
+    resourceClass: development

--- a/base-apps/testmysql-testmysql/resources/secret_stores.yaml
+++ b/base-apps/testmysql-testmysql/resources/secret_stores.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: secret-store
+  namespace: testmysql
+  labels:
+    app.kubernetes.io/name: testmysql
+    app.kubernetes.io/instance: testmysql-vault
+    app.kubernetes.io/component: secret-store
+    app.kubernetes.io/part-of: testmysql
+    environment: development
+    backstage.io/kubernetes-id: testmysql
+  annotations:
+    backstage.io/kubernetes-id: testmysql
+    backstage.io/kubernetes-namespace: testmysql
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "kv"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "external-secrets"
+          serviceAccountRef:
+            name: "external-secrets"


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **testmysql** in the **testmysql** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: testmysqldb
- **Username**: testmysqluser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
