### PR TITLE
feat: add MySQL database for mysqltest

### DIFF
--- a/argocd/mysqltest-mysqltest.yaml
+++ b/argocd/mysqltest-mysqltest.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mysqltest-mysqltest
+  namespace: openshift-gitops
+  labels:
+    app.kubernetes.io/name: mysqltest
+    app.kubernetes.io/instance: mysqltest-argocd
+    app.kubernetes.io/component: gitops
+    app.kubernetes.io/part-of: mysqltest
+    environment: development
+    backstage.io/kubernetes-id: mysqltest
+  annotations:
+    backstage.io/kubernetes-id: mysqltest
+    backstage.io/kubernetes-namespace: mysqltest
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/mysqltest-mysqltest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mysqltest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  revisionHistoryLimit: 10

--- a/base-apps/mysqltest-mysqltest/catalog-info.yaml
+++ b/base-apps/mysqltest-mysqltest/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: mysqltest-mysql-db
+  description: MySQL database for mysqltest
+  annotations:
+    backstage.io/kubernetes-id: mysqltest
+    backstage.io/kubernetes-namespace: mysqltest
+spec:
+  type: database
+  owner: group:default/platform-team
+  system: system:default/examples
+  lifecycle: development

--- a/base-apps/mysqltest-mysqltest/resources/external_secrets.yaml
+++ b/base-apps/mysqltest-mysqltest/resources/external_secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mysqltest-secret
+  namespace: mysqltest
+  labels:
+    app.kubernetes.io/name: mysqltest
+    app.kubernetes.io/instance: mysqltest-mysql
+    app.kubernetes.io/component: database-secret
+    app.kubernetes.io/part-of: mysqltest
+    environment: development
+    backstage.io/kubernetes-id: mysqltest
+  annotations:
+    backstage.io/kubernetes-id: mysqltest
+    backstage.io/kubernetes-namespace: mysqltest
+spec:
+  refreshInterval: 30s
+  secretStoreRef:
+    name: secret-store
+    kind: SecretStore
+  target:
+    name: mysqltest-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Database password from Vault
+        DB_PASSWORD: "{{ .password | toString }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: mysqltest/DB_PASSWORD

--- a/base-apps/mysqltest-mysqltest/resources/mysql-database.yaml
+++ b/base-apps/mysqltest-mysqltest/resources/mysql-database.yaml
@@ -1,0 +1,34 @@
+apiVersion: platform.io/v1alpha1
+kind: MySQLDatabase
+metadata:
+  name: mysqltest
+  namespace: mysqltest
+  labels:
+    app.kubernetes.io/name: mysqltest
+    app.kubernetes.io/instance: mysqltest-mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: mysqltest
+    environment: development
+    backstage.io/kubernetes-id: mysqltest
+  annotations:
+    # These annotations are used by the kubernetes-ingestor to discover this resource
+    backstage.io/kubernetes-id: mysqltest
+    backstage.io/kubernetes-namespace: mysqltest
+spec:
+  compositionRef:
+    name: xmysqldatabases.platform.io
+  parameters:
+    # Database configuration
+    databaseName: mysqltestdb
+    storageSize: 1Gi
+    
+    # User configuration
+    username: mysqltestuser
+    privileges: ["SELECT","INSERT","UPDATE","DELETE"]
+    
+    # Connection secret configuration
+    connectionSecretName: mysqltest-connection
+    connectionSecretNamespace: mysqltest
+    
+    # Resource class based on environment
+    resourceClass: development

--- a/base-apps/mysqltest-mysqltest/resources/secret_stores.yaml
+++ b/base-apps/mysqltest-mysqltest/resources/secret_stores.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: secret-store
+  namespace: mysqltest
+  labels:
+    app.kubernetes.io/name: mysqltest
+    app.kubernetes.io/instance: mysqltest-vault
+    app.kubernetes.io/component: secret-store
+    app.kubernetes.io/part-of: mysqltest
+    environment: development
+    backstage.io/kubernetes-id: mysqltest
+  annotations:
+    backstage.io/kubernetes-id: mysqltest
+    backstage.io/kubernetes-namespace: mysqltest
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "kv"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "external-secrets"
+          serviceAccountRef:
+            name: "external-secrets"


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **mysqltest** in the **mysqltest** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: mysqltestdb
- **Username**: mysqltestuser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
