### PR TITLE
feat: add MySQL database for asela-testmysql

### DIFF
--- a/base-apps/asela-testmysql.yaml
+++ b/base-apps/asela-testmysql.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: asela-testmysql
+  namespace: openshift-gitops
+  labels:
+    app.kubernetes.io/name: asela-testmysql
+    app.kubernetes.io/instance: asela-testmysql-argocd
+    app.kubernetes.io/component: gitops
+    app.kubernetes.io/part-of: asela-testmysql
+    environment: development
+    backstage.io/kubernetes-id: asela-testmysql
+  annotations:
+    backstage.io/kubernetes-id: asela-testmysql
+    backstage.io/kubernetes-namespace: asela-testmysql
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/asela-testmysql
+    directory:
+      exclude: 'catalog-info.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: asela-testmysql
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  revisionHistoryLimit: 10

--- a/base-apps/asela-testmysql/catalog-info.yaml
+++ b/base-apps/asela-testmysql/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: asela-testmysql-mysql-db
+  description: MySQL database for asela-testmysql
+  annotations:
+    backstage.io/kubernetes-id: asela-testmysql
+    backstage.io/kubernetes-namespace: asela-testmysql
+spec:
+  type: database
+  owner: group:default/platform-team
+  system: system:default/examples
+  lifecycle: development

--- a/base-apps/asela-testmysql/resources/external_secrets.yaml
+++ b/base-apps/asela-testmysql/resources/external_secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: asela-testmysql-secret
+  namespace: asela-testmysql
+  labels:
+    app.kubernetes.io/name: asela-testmysql
+    app.kubernetes.io/instance: asela-testmysql-mysql
+    app.kubernetes.io/component: database-secret
+    app.kubernetes.io/part-of: asela-testmysql
+    environment: development
+    backstage.io/kubernetes-id: asela-testmysql
+  annotations:
+    backstage.io/kubernetes-id: asela-testmysql
+    backstage.io/kubernetes-namespace: asela-testmysql
+spec:
+  refreshInterval: 30s
+  secretStoreRef:
+    name: secret-store
+    kind: SecretStore
+  target:
+    name: asela-testmysql-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Database password from Vault
+        DB_PASSWORD: "{{ .password | toString }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: asela-testmysql/DB_PASSWORD

--- a/base-apps/asela-testmysql/resources/mysql-database.yaml
+++ b/base-apps/asela-testmysql/resources/mysql-database.yaml
@@ -1,0 +1,34 @@
+apiVersion: platform.io/v1alpha1
+kind: MySQLDatabase
+metadata:
+  name: asela-testmysql
+  namespace: asela-testmysql
+  labels:
+    app.kubernetes.io/name: asela-testmysql
+    app.kubernetes.io/instance: asela-testmysql-mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: asela-testmysql
+    environment: development
+    backstage.io/kubernetes-id: asela-testmysql
+  annotations:
+    # These annotations are used by the kubernetes-ingestor to discover this resource
+    backstage.io/kubernetes-id: asela-testmysql
+    backstage.io/kubernetes-namespace: asela-testmysql
+spec:
+  compositionRef:
+    name: xmysqldatabases.platform.io
+  parameters:
+    # Database configuration
+    databaseName: asela-testmysqldb
+    storageSize: 1Gi
+    
+    # User configuration
+    username: asela-testmysqluser
+    privileges: ["SELECT","INSERT","UPDATE","DELETE"]
+    
+    # Connection secret configuration
+    connectionSecretName: asela-testmysql-connection
+    connectionSecretNamespace: asela-testmysql
+    
+    # Resource class based on environment
+    resourceClass: development

--- a/base-apps/asela-testmysql/resources/secret_stores.yaml
+++ b/base-apps/asela-testmysql/resources/secret_stores.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: secret-store
+  namespace: asela-testmysql
+  labels:
+    app.kubernetes.io/name: asela-testmysql
+    app.kubernetes.io/instance: asela-testmysql-vault
+    app.kubernetes.io/component: secret-store
+    app.kubernetes.io/part-of: asela-testmysql
+    environment: development
+    backstage.io/kubernetes-id: asela-testmysql
+  annotations:
+    backstage.io/kubernetes-id: asela-testmysql
+    backstage.io/kubernetes-namespace: asela-testmysql
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "kv"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "external-secrets"
+          serviceAccountRef:
+            name: "external-secrets"


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **asela-testmysql** in the **asela-testmysql** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: asela-testmysqldb
- **Username**: asela-testmysqluser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
