### PR TITLE
feat: add MySQL database for asela-testmysql

### DIFF
--- a/base-apps/asela-testmysql/external_secrets.yaml
+++ b/base-apps/asela-testmysql/external_secrets.yaml
@@ -14,19 +14,14 @@ metadata:
     backstage.io/kubernetes-id: asela-testmysql
     backstage.io/kubernetes-namespace: asela-testmysql
 spec:
-  refreshInterval: 30s
+  refreshInterval: 1h
   secretStoreRef:
     name: secret-store
     kind: SecretStore
   target:
     name: asela-testmysql-secret
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        # Database password from Vault
-        DB_PASSWORD: "{{ .password | toString }}"
   data:
-    - secretKey: password
+    - secretKey: DB_PASSWORD
       remoteRef:
-        key: asela-testmysql/DB_PASSWORD
+        key: asela-testmysql
+        property: DB_PASSWORD


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **asela-testmysql** in the **asela-testmysql** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: asela-testmysqldb
- **Username**: asela-testmysqluser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
