### PR TITLE
feat: add MySQL database for asela-testmysql

### DIFF
--- a/base-apps/asela-testmysql/mysql-database.yaml
+++ b/base-apps/asela-testmysql/mysql-database.yaml
@@ -16,19 +16,23 @@ metadata:
     backstage.io/kubernetes-namespace: asela-testmysql
 spec:
   compositionRef:
-    name: xmysqldatabases.platform.io
+    name: xmysqldatabase.platform.io
   parameters:
     # Database configuration
     databaseName: asela-testmysqldb
-    storageSize: 1Gi
+    databaseNamespace: asela-testmysql
     
     # User configuration
     username: asela-testmysqluser
+    userNamespace: asela-testmysql
     privileges: ["SELECT","INSERT","UPDATE","DELETE"]
     
-    # Connection secret configuration
-    connectionSecretName: asela-testmysql-connection
-    connectionSecretNamespace: asela-testmysql
-    
-    # Resource class based on environment
-    resourceClass: development
+    # Password secret reference
+    passwordSecretRef:
+      name: asela-testmysql-secret
+      namespace: asela-testmysql
+      key: DB_PASSWORD
+  
+  # Connection secret output
+  writeConnectionSecretToRef:
+    name: asela-testmysql-connection


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **asela-testmysql** in the **asela-testmysql** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: asela-testmysqldb
- **Username**: asela-testmysqluser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
