### PR TITLE
feat: add MySQL database for asela-testmysql

### DIFF
--- a/base-apps/asela-testmysql/mysql-database.yaml
+++ b/base-apps/asela-testmysql/mysql-database.yaml
@@ -14,6 +14,14 @@ metadata:
     # These annotations are used by the kubernetes-ingestor to discover this resource
     backstage.io/kubernetes-id: asela-testmysql
     backstage.io/kubernetes-namespace: asela-testmysql
+    # Terasky kubernetes-ingestor annotations for catalog discovery
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: resource
+    terasky.backstage.io/description: MySQL database for asela-testmysql application
+    terasky.backstage.io/lifecycle: development
+    terasky.backstage.io/owner: group:default/platform-team
+    terasky.backstage.io/system: system:default/examples
+    terasky.backstage.io/tags: database,mysql,crossplane,infrastructure
 spec:
   compositionRef:
     name: xmysqldatabase.platform.io


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **asela-testmysql** in the **asela-testmysql** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: development
- **Database Name**: asela-testmysqldb
- **Username**: asela-testmysqluser
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
