### PR TITLE
feat: add MySQL database for asela-test2

### DIFF
--- a/base-apps/asela-test2.yaml
+++ b/base-apps/asela-test2.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: asela-test2
+  namespace: argo-cd
+  labels:
+    app.kubernetes.io/name: asela-test2
+    app.kubernetes.io/instance: asela-test2-argocd
+    app.kubernetes.io/component: gitops
+    app.kubernetes.io/part-of: asela-test2
+    environment: staging
+    backstage.io/kubernetes-id: asela-test2
+  annotations:
+    backstage.io/kubernetes-id: asela-test2
+    backstage.io/kubernetes-namespace: asela-test2
+    argocd.argoproj.io/sync-wave: '100'
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/asela-test2
+    directory:
+      exclude: 'catalog-info.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: asela-test2
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  revisionHistoryLimit: 10

--- a/base-apps/asela-test2/catalog-info.yaml
+++ b/base-apps/asela-test2/catalog-info.yaml
@@ -1,0 +1,64 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: asela-test2-mysql-db
+  description: testing the database creation
+  annotations:
+    backstage.io/kubernetes-id: asela-test2
+    backstage.io/kubernetes-namespace: asela-test2
+  links:
+    # Vault Secret Management
+    - url: https://vault.arigsela.com/ui/vault/secrets/secret/show/asela-test2/DB_PASSWORD
+      title: Database Password (Vault)
+      icon: key
+      type: admin
+
+    # Monitoring & Observability
+    - url: https://grafana.arigsela.com/d/mysql-overview/mysql-database-overview?var-database=asela-test2db&var-namespace=asela-test2
+      title: Grafana Dashboard
+      icon: dashboard
+      type: monitoring
+
+    - url: https://prometheus.example.com/graph?g0.expr=mysql_up%7Bdatabase%3D%22asela-test2db%22%7D&g0.tab=0
+      title: Prometheus Metrics
+      icon: dashboard
+      type: monitoring
+
+    # Database Administration
+    - url: https://phpmyadmin.arigsela.com/index.php?db=asela-test2db&server=asela-test2-mysql
+      title: phpMyAdmin
+      icon: database
+      type: admin
+
+    # Kubernetes Resources
+    - url: https://k8s-dashboard.example.com/#!/overview?namespace=asela-test2
+      title: Kubernetes Dashboard
+      icon: dashboard
+      type: infrastructure
+
+    - url: https://argocd.example.com/applications/asela-test2/asela-test2
+      title: ArgoCD Application
+      icon: docs
+      type: deployment
+
+    # Documentation & Support
+    - url: https://wiki.example.com/display/PLATFORM/MySQL+Database+asela-test2
+      title: Runbook
+      icon: docs
+      type: documentation
+
+    - url: https://slack.com/app_redirect?channel=C1234567890
+      title: Support Channel (#platform-support)
+      icon: chat
+      type: support
+
+    # Cost & Billing
+    - url: https://cloud.example.com/billing/project/asela-test2?filter=mysql
+      title: Cost Analysis
+      icon: report
+      type: cost
+spec:
+  type: database
+  owner: group:default/platform-team
+  system: system:default/examples
+  lifecycle: staging

--- a/base-apps/asela-test2/external_secrets.yaml
+++ b/base-apps/asela-test2/external_secrets.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: asela-test2-secret
+  namespace: asela-test2
+  labels:
+    app.kubernetes.io/name: asela-test2
+    app.kubernetes.io/instance: asela-test2-mysql
+    app.kubernetes.io/component: database-secret
+    app.kubernetes.io/part-of: asela-test2
+    environment: staging
+    backstage.io/kubernetes-id: asela-test2
+  annotations:
+    backstage.io/kubernetes-id: asela-test2
+    backstage.io/kubernetes-namespace: asela-test2
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: secret-store
+    kind: SecretStore
+  target:
+    name: asela-test2-secret
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: asela-test2
+        property: DB_PASSWORD

--- a/base-apps/asela-test2/mysql-database.yaml
+++ b/base-apps/asela-test2/mysql-database.yaml
@@ -1,0 +1,67 @@
+apiVersion: platform.io/v1alpha1
+kind: MySQLDatabase
+metadata:
+  name: asela-test2
+  namespace: asela-test2
+  labels:
+    app.kubernetes.io/name: asela-test2
+    app.kubernetes.io/instance: asela-test2-mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: asela-test2
+    environment: staging
+    backstage.io/kubernetes-id: asela-test2
+  annotations:
+    # These annotations are used by the kubernetes-ingestor to discover this resource
+    backstage.io/kubernetes-id: asela-test2
+    backstage.io/kubernetes-namespace: asela-test2
+    # Terasky kubernetes-ingestor annotations for catalog discovery
+    terasky.backstage.io/add-to-catalog: 'true'
+    terasky.backstage.io/component-type: resource
+    terasky.backstage.io/description: testing the database creation
+    terasky.backstage.io/lifecycle: staging
+    terasky.backstage.io/owner: platform-team
+    terasky.backstage.io/system: examples
+    terasky.backstage.io/tags: database,mysql,crossplane,infrastructure
+
+    # External resource links
+    backstage.io/view-url: https://k8s-dashboard.example.com/#!/overview?namespace=asela-test2&kind=MySQLDatabase&name=asela-test2
+    backstage.io/edit-url: https://github.com/arigsela/kubernetes/edit/main/base-apps/asela-test2/mysql-database.yaml
+
+    # Monitoring annotations
+    grafana/dashboard-url: https://grafana.example.com/d/mysql-overview/mysql-database?var-database=asela-test2db
+    grafana/alert-label-selector: 'database=asela-test2db'
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9104'
+    prometheus.io/path: '/metrics'
+
+    # Vault integration
+    vault.io/secret-path: secret/data/asela-test2
+    vault.io/role: asela-test2-db-reader
+
+    # Cost tracking
+    cost-center.io/team: platform-team
+    cost-center.io/product: examples
+    cost-center.io/environment: staging
+    finops.io/cost-allocation: database-services
+spec:
+  compositionRef:
+    name: xmysqldatabase.platform.io
+  parameters:
+    # Database configuration
+    databaseName: asela-test2db
+    databaseNamespace: asela-test2
+
+    # User configuration
+    username: asela-test2user
+    userNamespace: asela-test2
+    privileges: ["SELECT","INSERT","UPDATE","DELETE"]
+
+    # Password secret reference
+    passwordSecretRef:
+      name: asela-test2-secret
+      namespace: asela-test2
+      key: DB_PASSWORD
+
+  # Connection secret output
+  writeConnectionSecretToRef:
+    name: asela-test2-connection

--- a/base-apps/asela-test2/secret_stores.yaml
+++ b/base-apps/asela-test2/secret_stores.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: secret-store
+  namespace: asela-test2
+  labels:
+    app.kubernetes.io/name: asela-test2
+    app.kubernetes.io/instance: asela-test2-vault
+    app.kubernetes.io/component: secret-store
+    app.kubernetes.io/part-of: asela-test2
+    environment: staging
+    backstage.io/kubernetes-id: asela-test2
+  annotations:
+    backstage.io/kubernetes-id: asela-test2
+    backstage.io/kubernetes-namespace: asela-test2
+spec:
+  provider:
+    vault:
+      server: 'http://vault.vault.svc.cluster.local:8200'
+      path: 'secret'
+      version: 'v2'
+      auth:
+        tokenSecretRef:
+          name: 'vault-token'
+          key: 'token'


### PR DESCRIPTION
## Summary
This PR adds a MySQL database configuration for **asela-test2** in the **asela-test2** namespace.

## Changes
- 🗄️ MySQL database claim using Crossplane
- 🔐 External Secrets configuration for Vault integration
- 🚀 ArgoCD Application for GitOps deployment
- 📋 Backstage catalog registration

## Configuration Details
- **Environment**: staging
- **Database Name**: asela-test2db
- **Username**: asela-test2user
- **Privileges**: SELECT, INSERT, UPDATE, DELETE

Created via Backstage Software Template
