### PR TITLE
fix: Adjust probe timings for MySQL startup and migrations

### DIFF
--- a/base-apps/chores-tracker/deployments.yaml
+++ b/base-apps/chores-tracker/deployments.yaml
@@ -28,16 +28,18 @@ spec:
           httpGet:
             path: /health
             port: 8000
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+          initialDelaySeconds: 360
+          periodSeconds: 30
+          timeoutSeconds: 10
           failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /health
             port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 5
+          initialDelaySeconds: 300
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
- Increase liveness probe initialDelaySeconds: 60s → 360s (6 minutes)
- Increase readiness probe initialDelaySeconds: 30s → 300s (5 minutes)
- Adjust probe periods and timeouts for database-dependent startup
- This accounts for MySQL connection wait and Alembic migration execution

The backend needs time for:
1. MySQL database connection (mysql.mysql.svc.cluster.local:3306)
2. Alembic migration execution
3. Application initialization

🤖 Generated with [Claude Code](https://claude.ai/code)