### PR TITLE
feat: Optimize Traefik connection handling to eliminate remaining 503…

### DIFF
--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -88,6 +88,9 @@ spec:
     # Additional configuration for tunnel compatibility
     additionalArguments:
       - "--serverstransport.insecureskipverify=true"  # For internal services
+      - "--serverstransport.maxidleconnsperhost=100"  # Increase connection pool
+      - "--serverstransport.dialtimeout=30s"          # Increase dial timeout
+      - "--serverstransport.respondeheadertimeout=10s" # Response header timeout
       - "--log.level=INFO"
     
     # Global redirect middleware


### PR DESCRIPTION
… errors

- Increase maxidleconnsperhost from default (2) to 100 connections
- Increase dialtimeout from 30s to 30s (explicit setting)
- Add respondeheadertimeout of 10s for better error handling
- These settings address the remaining ~20% 503 errors from connection pool limits

Connection pool improvements should eliminate intermittent 503s during load by:
- Maintaining more persistent connections to backend services
- Providing better timeout handling for connection establishment
- Reducing connection churn between Traefik and backend pods

🤖 Generated with [Claude Code](https://claude.ai/code)