### PR TITLE
EMERGENCY: Fix Traefik helm chart v27+ compatibility causing 48% 503 …

### DIFF
--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -11,8 +11,11 @@ spec:
         port: 8000
         exposedPort: 80
         protocol: TCP
-        # HTTP to HTTPS redirect
-        redirectTo: websecure
+        expose:
+          default: true
+        # HTTP to HTTPS redirect (chart >=27 expects object with port)
+        redirectTo:
+          port: websecure
         forwardedHeaders:
           trustedIPs:
             - 10.0.0.0/8
@@ -32,6 +35,8 @@ spec:
         port: 8443
         exposedPort: 443
         protocol: TCP
+        expose:
+          default: true
         tls:
           enabled: true
         forwardedHeaders:


### PR DESCRIPTION
…errors

Critical service outage fix for chores.arigsela.com

Root Cause:
- Traefik helm chart v27.0.2 incompatible with current configuration
- Helm upgrades failing: 'can't index item of type bool' template error
- Traefik stuck with old config, causing massive service degradation

The Fix:
- Add explicit expose.default: true to web and websecure ports
- Update redirectTo to object format: {port: websecure}
- Chart v27+ expects expose as object {default: true}, not boolean true

Impact:
- Current: 48% error rate (48/100 requests failing)
- API endpoint: 28/50 requests failed (56%)
- Health endpoint: 12/30 requests failed (40%)

This enables helm upgrades to succeed and restores service availability.

🤖 Generated with [Claude Code](https://claude.ai/code)