### PR TITLE
HOTFIX: Remove deprecated dialTimeout causing Traefik v2.11.10 CrashL…

### DIFF
--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -93,7 +93,6 @@ spec:
       # Corrected serversTransport flags (timeouts, pooling, TLS verification)
       - "--serversTransport.insecureSkipVerify=true"      # For internal services
       - "--serversTransport.maxIdleConnsPerHost=100"      # Increase connection pool
-      - "--serversTransport.dialTimeout=30s"              # Increase dial timeout
       - "--serversTransport.responseHeaderTimeout=10s"    # Response header timeout
       # Temporary debug and access logging for 503 troubleshooting
       - "--log.level=DEBUG"


### PR DESCRIPTION
…oopBackOff

Critical issue preventing Traefik deployment completion:
- New Traefik pods failing: 'failed to decode configuration from flags: field not found, node: dialTimeout'
- Parameter --serversTransport.dialTimeout deprecated in Traefik v2.11.10
- Preventing new deployment rollout, keeping 503 errors partially unresolved

Fix: Remove deprecated dialTimeout parameter
Result: Allows new Traefik pods to start successfully and complete deployment

This completes the 503 error resolution by enabling the updated Traefik configuration to fully deploy.

🤖 Generated with [Claude Code](https://claude.ai/code)