### PR TITLE
HOTFIX: Remove deprecated responseHeaderTimeout parameter

### DIFF
--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -93,7 +93,6 @@ spec:
       # Corrected serversTransport flags (timeouts, pooling, TLS verification)
       - "--serversTransport.insecureSkipVerify=true"      # For internal services
       - "--serversTransport.maxIdleConnsPerHost=100"      # Increase connection pool
-      - "--serversTransport.responseHeaderTimeout=10s"    # Response header timeout
       # Temporary debug and access logging for 503 troubleshooting
       - "--log.level=DEBUG"
       - "--accesslog=true"


### PR DESCRIPTION
Another deprecated Traefik parameter causing pod crashes:
- New error: 'field not found, node: responseHeaderTimeout'
- Parameter --serversTransport.responseHeaderTimeout deprecated in v2.11.10
- Preventing successful pod startup after dialTimeout fix

This removes the final deprecated parameter to allow Traefik deployment completion and debug logging activation.

🤖 Generated with [Claude Code](https://claude.ai/code)