### PR TITLE
Fix certificate resolver configuration - trigger helm reload

### DIFF
--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -68,7 +68,7 @@ spec:
           storage: /data/acme.json
           dnsChallenge:
             provider: cloudflare
-            delayBeforeCheck: 90
+            delayBeforeCheck: 120
             resolvers:
               - "1.1.1.1:53"
               - "8.8.8.8:53"


### PR DESCRIPTION
- Increase delayBeforeCheck to 120s to trigger config reload
- Root cause: HelmChartConfig certificatesResolvers section not being applied
- This should resolve 503 errors caused by missing certificate resolver

🤖 Generated with [Claude Code](https://claude.ai/code)