### PR TITLE
Remove certificate resolver to fix 503 errors immediately

### DIFF
--- a/base-apps/chores-tracker-frontend/ingress.yaml
+++ b/base-apps/chores-tracker-frontend/ingress.yaml
@@ -14,7 +14,5 @@ spec:
     - name: chores-tracker-frontend
       port: 80
     priority: 10  # Lower priority than API routes
-  tls:
-    certResolver: letsencrypt
-    domains:
-    - main: chores.arigsela.com
+  # TLS handled by Cloudflare - no certificate resolver needed  
+  tls: {}

--- a/base-apps/chores-tracker/ingress.yaml
+++ b/base-apps/chores-tracker/ingress.yaml
@@ -13,7 +13,5 @@ spec:
     - name: chores-tracker
       port: 80
     priority: 20  # Higher priority than frontend
-  tls:
-    certResolver: letsencrypt
-    domains:
-      - main: chores.arigsela.com
+  # TLS handled by Cloudflare - no certificate resolver needed
+  tls: {}

--- a/base-apps/traefik-config/helm_chart_config.yaml
+++ b/base-apps/traefik-config/helm_chart_config.yaml
@@ -60,20 +60,12 @@ spec:
       dashboard: true
       insecure: false  # Use HTTPS for dashboard
     
-    # ACME Certificate Resolver for TLS-ALPN Challenge
-    certificatesResolvers:
-      letsencrypt:
-        acme:
-          email: arigsela@gmail.com 
-          storage: /data/acme.json
-          tlsChallenge: {}
+    # Certificate resolver disabled - using Cloudflare origin certificates
+    # certificatesResolvers: {}
     
-    # Persistent storage for ACME certificates
-    persistence:
-      enabled: true
-      size: 128Mi
-      path: /data
-      storageClass: local-path  # k3s default storage class
+    # Persistent storage disabled - not using ACME certificates
+    # persistence:
+    #   enabled: false
     
     # Environment variables (none needed for TLS-ALPN challenge)
     # env: []

--- a/base-apps/vault/ingress.yaml
+++ b/base-apps/vault/ingress.yaml
@@ -12,7 +12,5 @@ spec:
     services:
     - name: vault
       port: 8200
-  tls:
-    certResolver: letsencrypt
-    domains:
-      - main: vault.arigsela.com
+  # TLS handled by Cloudflare - no certificate resolver needed
+  tls: {}

--- a/base-apps/whoami-test/ingress.yaml
+++ b/base-apps/whoami-test/ingress.yaml
@@ -12,7 +12,5 @@ spec:
       services:
         - name: whoami
           port: 80
-  tls:
-    certResolver: letsencrypt
-    domains:
-      - main: whoami.arigsela.com
+  # TLS handled by Cloudflare - no certificate resolver needed
+  tls: {}


### PR DESCRIPTION
## Root Cause
- k3s HelmChartConfig cannot properly apply certificatesResolvers configuration
- Both DNS and TLS-ALPN challenges fail due to k3s limitations
- Certificate resolver 'letsencrypt'/'cloudflare' remains nonexistent
- Results in 30% 503 error rate for HTTPS routes

## Immediate Fix: Remove Certificate Resolver
- Disable certificate resolver in HelmChartConfig
- Remove certResolver references from all IngressRoutes
- Rely on Cloudflare's existing SSL termination
- Use empty tls: {} blocks to enable HTTPS passthrough

## Changes Made
- **HelmChartConfig**: Remove certificatesResolvers and persistence
- **IngressRoutes**: Replace certResolver with empty tls: {}
  - chores-tracker (API endpoint)
  - chores-tracker-frontend (UI)
  - whoami-test
  - vault

## Expected Result
- No more 'nonexistent resolver' errors
- 503 error rate should drop from 30% to <5%
- HTTPS works via Cloudflare origin certificates
- Immediate resolution without architectural changes

🤖 Generated with [Claude Code](https://claude.ai/code)