### PR TITLE
fix: Configure NGINX Ingress path routing for proper API and frontend…

### DIFF
--- a/base-apps/chores-tracker-frontend/nginx-ingress.yaml
+++ b/base-apps/chores-tracker-frontend/nginx-ingress.yaml
@@ -9,7 +9,11 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
-    nginx.ingress.kubernetes.io/priority: "10"
+    # Lower priority than API - handle everything except /api
+    nginx.ingress.kubernetes.io/priority: "50"
+    # Handle SPA routing by serving index.html for non-API routes
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      try_files $uri $uri/ /index.html;
 spec:
   ingressClassName: nginx
   rules:

--- a/base-apps/chores-tracker/nginx-ingress.yaml
+++ b/base-apps/chores-tracker/nginx-ingress.yaml
@@ -9,14 +9,18 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+    # Rewrite /api requests to / for the backend
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # Higher priority than frontend for /api paths
+    nginx.ingress.kubernetes.io/priority: "100"
 spec:
   ingressClassName: nginx
   rules:
   - host: chores.arigsela.com
     http:
       paths:
-      - path: /api
-        pathType: Prefix
+      - path: /api(/|$)(.*)
+        pathType: ImplementationSpecific
         backend:
           service:
             name: chores-tracker


### PR DESCRIPTION
… access

🔧 NGINX Ingress Path Configuration Fixes

### Problem:
- API backend expects requests on root path (/) but received /api/* paths → 404
- Frontend working but path priorities conflicting
- Users getting 404 instead of working application

### Solutions:

#### API Backend (chores-tracker):
- Add path rewriting: /api/xyz → /xyz for backend
- Use regex path: /api(/|$)(.*) with rewrite-target: /$2
- Higher priority (100) to ensure API routes match first
- Maintain timeout configurations for Cloudflare compatibility

#### Frontend (chores-tracker-frontend):
- Lower priority (50) to handle non-API routes
- Add SPA routing support: try_files $uri $uri/ /index.html
- Maintain timeout configurations
- Handle all paths except /api/*

### Expected Results:
- https://chores.arigsela.com/ → Frontend React app (200)
- https://chores.arigsela.com/api → API root info (200)
- https://chores.arigsela.com/api/* → API endpoints (200)
- No more 404 errors for legitimate requests

### Technical Details:
- API path rewrite: /api/health → /health → backend root + path
- Frontend SPA routing for client-side navigation
- Priority-based routing to prevent conflicts

🎯 Complete migration: Traefik→NGINX + proper application routing

🤖 Generated with [Claude Code](https://claude.ai/code)