### PR TITLE
fix: Remove configuration-snippet from frontend Ingress - CRITICAL

### DIFF
--- a/base-apps/chores-tracker-frontend/nginx-ingress.yaml
+++ b/base-apps/chores-tracker-frontend/nginx-ingress.yaml
@@ -11,9 +11,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
     # Lower priority than API - handle everything except /api
     nginx.ingress.kubernetes.io/priority: "50"
-    # Handle SPA routing by serving index.html for non-API routes
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      try_files $uri $uri/ /index.html;
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
🚨 CRITICAL FIX: ArgoCD sync failure resolved

**Problem**: Frontend application sync failing with error:
  admission webhook denied: configuration-snippet annotation cannot be used.
  Snippet directives are disabled by Ingress administrator

**Root Cause**: NGINX Ingress has configuration-snippet disabled for security

**Solution**: Remove configuration-snippet annotation from frontend Ingress
- Keep priority-based routing (API=100, Frontend=50)
- Let frontend service handle SPA routing internally
- Focus on getting basic routing working first

**Expected Result**: Frontend ArgoCD sync succeeds, site becomes accessible

This fixes the complete site failure we experienced after path configuration changes.

🤖 Generated with [Claude Code](https://claude.ai/code)