### PR TITLE
fix: Update nginx-ingress ArgoCD app to point to main branch

### DIFF
--- a/base-apps/nginx-ingress.yaml
+++ b/base-apps/nginx-ingress.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/arigsela/kubernetes
-    targetRevision: nginx-ingress-migration-clean
+    targetRevision: main
     path: base-apps/nginx-ingress
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
🔧 Fix ArgoCD nginx-ingress application branch reference

**Problem**: nginx-ingress app showing error in ArgoCD:
  'Failed to load target state: failed to generate manifest for source 1 of 1:
   rpc error: code = Unknown desc = unable to resolve 'nginx-ingress-migration-clean'
   to a commit SHA'

**Root Cause**: App still references deleted migration branch

**Solution**: Change targetRevision from 'nginx-ingress-migration-clean' to 'main'

**Expected Result**:
- ArgoCD nginx-ingress app sync succeeds
- No more branch resolution errors
- NGINX Ingress Controller updates work properly

🤖 Generated with [Claude Code](https://claude.ai/code)