### PR TITLE
fix: Force Cloudflare tunnel to use HTTP2 protocol instead of QUIC

### DIFF
--- a/base-apps/cloudflare-tunnel/configmaps.yaml
+++ b/base-apps/cloudflare-tunnel/configmaps.yaml
@@ -9,6 +9,7 @@ data:
     credentials-file: /etc/cloudflared/creds/token
     metrics: 0.0.0.0:2000
     no-autoupdate: true
+    protocol: http2
     ingress:
       - hostname: "*.arigsela.com"
         service: http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80


### PR DESCRIPTION
- Added 'protocol: http2' to cloudflared configuration
- Resolves 503 errors caused by UDP/QUIC timeout issues
- HTTP2 uses TCP which is more reliable than UDP for this network
- Based on research of known Cloudflare tunnel issues with UDP blocking

Expected outcome: Eliminate intermittent 503 errors (1-2% → 0%)

🤖 Generated with [Claude Code](https://claude.ai/code)