### PR TITLE
feat(n8n): enable MCP server and fix 503 errors

### DIFF
--- a/base-apps/n8n.yaml
+++ b/base-apps/n8n.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/arigsela/kubernetes
-    targetRevision: main
+    targetRevision: feature/n8n-mcp-server-setup
     path: base-apps/n8n
   destination:
     server: https://kubernetes.default.svc

--- a/base-apps/n8n.yaml
+++ b/base-apps/n8n.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/arigsela/kubernetes
-    targetRevision: feature/n8n-mcp-server-setup
+    targetRevision: main
     path: base-apps/n8n
   destination:
     server: https://kubernetes.default.svc

--- a/base-apps/n8n/nginx-ingress-admin.yaml
+++ b/base-apps/n8n/nginx-ingress-admin.yaml
@@ -15,7 +15,7 @@ metadata:
     # Rate Limiting (prevent brute force attacks on admin UI)
     # Increased from 10 to 100 to allow n8n's many JS assets to load on initial page load
     nginx.ingress.kubernetes.io/limit-rps: "100"
-    nginx.ingress.kubernetes.io/limit-connections: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "50"
 
     # 🔒 IP WHITELIST - Admin UI Only
     # Only this IP can access the n8n admin interface

--- a/base-apps/n8n/nginx-ingress-webhook.yaml
+++ b/base-apps/n8n/nginx-ingress-webhook.yaml
@@ -54,3 +54,11 @@ spec:
             name: n8n
             port:
               number: 5678
+      # MCP Server Path - Publicly Accessible (secured by Access Token auth)
+      - path: /mcp-server
+        pathType: Prefix
+        backend:
+          service:
+            name: n8n
+            port:
+              number: 5678


### PR DESCRIPTION
- Add /mcp-server path to webhook ingress for public MCP access
- Increase connection limit from 20 to 50 to fix 503 errors on page load
- Point n8n ArgoCD app to feature branch for testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/mcp-server` endpoint to expand service capabilities.

* **Chores**
  * Increased admin UI concurrent connection limit to improve performance under load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->