### PR TITLE
fix(n8n): use postgresql vault secret for db password

### DIFF
--- a/base-apps/n8n/external-secrets.yaml
+++ b/base-apps/n8n/external-secrets.yaml
@@ -34,8 +34,8 @@ spec:
         property: db-user
     - secretKey: db-password
       remoteRef:
-        key: n8n
-        property: db-password
+        key: postgresql
+        property: n8n-password
     - secretKey: webhook-url
       remoteRef:
         key: n8n


### PR DESCRIPTION
Point n8n's db-password to the postgresql Vault secret instead of n8n's own secret. This ensures the password matches what CloudNativePG expects and fixes intermittent "password authentication failed" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database secret configuration to source credentials from an updated secret provider, improving secret management infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->