### PR TITLE
Exclude Grafana storage from Velero PVC backup

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -57,6 +57,10 @@ spec:
     metadata:
       labels:
         app: grafana
+      annotations:
+        # Exclude Grafana storage from Velero backup - SQLite journal files cause backup failures
+        # Dashboards are provisioned from ConfigMaps, so no data loss
+        backup.velero.io/backup-volumes-excludes: storage
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application


### PR DESCRIPTION
SQLite journal files (grafana.db-journal) cause backup failures due to race conditions - the file appears/disappears during writes.

Grafana dashboards are provisioned from ConfigMaps, so excluding the PVC doesn't result in data loss. Only user-created dashboards would need to be recreated after restore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana deployment configuration to optimize backup procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->