### PR TITLE
Add Coroot Community Edition for observability

### DIFF
--- a/base-apps/coroot.yaml
+++ b/base-apps/coroot.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coroot
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/coroot
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coroot
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/coroot/coroot-ce.yaml
+++ b/base-apps/coroot/coroot-ce.yaml
@@ -1,0 +1,82 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coroot-ce
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://coroot.github.io/helm-charts
+    chart: coroot-ce
+    targetRevision: 0.14.4
+    helm:
+      values: |
+        # Coroot Community Edition configuration
+
+        # ClickHouse configuration for data storage
+        clickhouse:
+          shards: 1
+          replicas: 1
+          persistence:
+            enabled: true
+            size: 20Gi
+            storageClass: local-path
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+
+        # Coroot server configuration
+        coroot:
+          service:
+            type: ClusterIP
+            port: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+        # Node agent configuration (eBPF-based monitoring)
+        node-agent:
+          enabled: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+        # Cluster agent for Kubernetes metadata
+        cluster-agent:
+          enabled: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+        # Prometheus configuration
+        # Using existing Prometheus in the cluster
+        prometheus:
+          enabled: false
+
+        externalPrometheus:
+          url: http://prometheus.logging.svc.cluster.local:9090
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coroot
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/coroot/coroot-operator.yaml
+++ b/base-apps/coroot/coroot-operator.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coroot-operator
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://coroot.github.io/helm-charts
+    chart: coroot-operator
+    targetRevision: 0.2.7
+    helm:
+      values: |
+        # Operator configuration
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coroot
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/coroot/ingress.yaml
+++ b/base-apps/coroot/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coroot
+  namespace: coroot
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - coroot.arigsela.com
+      secretName: coroot-tls
+  rules:
+    - host: coroot.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: coroot-coroot-ce
+                port:
+                  number: 8080

--- a/base-apps/coroot/ingress.yaml
+++ b/base-apps/coroot/ingress.yaml
@@ -4,10 +4,16 @@ metadata:
   name: coroot
   namespace: coroot
   annotations:
+    # TLS/SSL Configuration
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+
+    # IP Whitelist - Only allow home IP
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32"
+
+    # Timeouts (longer for dashboard loading)
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:

--- a/base-apps/coroot/namespace-config.yaml
+++ b/base-apps/coroot/namespace-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coroot
+  labels:
+    # Required for eBPF node agent to run with privileged access
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
- Deploy Coroot Community Edition to complement existing Prometheus/Loki/Grafana stack
- Add AI-powered root cause analysis, distributed tracing, and continuous profiling
- Configure eBPF-based node agent for system-level metrics collection

## Components Deployed
| Component | Purpose |
|-----------|---------|
| Coroot Operator | Manages Coroot deployments |
| Coroot CE | Main observability platform |
| ClickHouse | Data storage backend |
| Node Agent | eBPF-based system metrics |
| Cluster Agent | Kubernetes metadata |

## Configuration
- **Storage**: ClickHouse with 20Gi persistent volume
- **Prometheus**: Uses existing instance at `prometheus.logging.svc.cluster.local:9090`
- **Ingress**: Exposed at `coroot.arigsela.com`
- **Namespace**: Configured with privileged pod security for eBPF

## Test plan
- [ ] Verify ArgoCD syncs all applications successfully
- [ ] Confirm Coroot Operator is running
- [ ] Confirm Coroot CE and ClickHouse pods are healthy
- [ ] Verify node agent is collecting eBPF metrics
- [ ] Access Coroot UI at https://coroot.arigsela.com
- [ ] Confirm Prometheus integration is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed Coroot Community Edition monitoring platform for comprehensive infrastructure observability and performance tracking
  * Enabled eBPF-based node agent for lightweight system-level performance monitoring across the cluster
  * Configured secure external dashboard access with TLS encryption and network-based access controls
  * Integrated ClickHouse backend database for efficient metrics storage, aggregation, and historical analysis

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->