### PR TITLE
Increase Coroot node-agent memory limit to 1Gi

### DIFF
--- a/base-apps/coroot/coroot-instance.yaml
+++ b/base-apps/coroot/coroot-instance.yaml
@@ -42,10 +42,10 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 200Mi
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
     tolerations:
       - operator: Exists
     ebpfTracer:


### PR DESCRIPTION
## Summary
- Fix OOMKilled issues on Coroot node-agents
- Increase memory limit from 512Mi to 1Gi

## Problem
The eBPF tracer and profiler in the node-agent require more memory than 512Mi, causing pods to be OOMKilled and enter CrashLoopBackOff on some nodes.

## Changes
| Setting | Before | After |
|---------|--------|-------|
| Memory request | 200Mi | 256Mi |
| Memory limit | 512Mi | 1Gi |

## Test plan
- [ ] Verify node-agent pods stabilize after deployment
- [ ] Confirm no more OOMKilled events
- [ ] Check all 3 node-agents are Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory resource allocation for the node agent component to optimize resource usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->