### PR TITLE
Increase Coroot cluster-agent memory limit to 512Mi

### DIFF
--- a/base-apps/coroot/coroot-instance.yaml
+++ b/base-apps/coroot/coroot-instance.yaml
@@ -60,8 +60,8 @@ spec:
   clusterAgent:
     resources:
       requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 200m
+        cpu: 100m
         memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi


### PR DESCRIPTION
## Summary
- Fix OOMKilled issues on Coroot cluster-agent
- Increase memory limit from 128Mi to 512Mi

## Problem
The cluster-agent is being OOMKilled (exit code 137) with the 128Mi memory limit.

## Changes
| Setting | Before | After |
|---------|--------|-------|
| CPU request | 50m | 100m |
| Memory request | 64Mi | 128Mi |
| CPU limit | 200m | 500m |
| Memory limit | 128Mi | **512Mi** |

## Test plan
- [ ] Verify cluster-agent pod stabilizes after deployment
- [ ] Confirm no more OOMKilled events
- [ ] Check cluster-agent is Running (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)