### PR TITLE
Add oncall-agent ArgoCD Application

### DIFF
--- a/base-apps/oncall-agent.yaml
+++ b/base-apps/oncall-agent.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oncall-agent
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/oncall-agent
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: oncall-agent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Deploy oncall-agent API with:
- Deployment with 2 replicas for HA
- IAM resources via Crossplane for NAT Gateway monitoring
- External Secrets for Vault integration
- Service account with cluster roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Oncall-agent application deployment configuration has been added with automated synchronization and self-healing enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->