### PR TITLE
Add oncall-agent namespace to ECR credentials sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend mysql; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend mysql oncall-agent; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
Include oncall-agent in the list of namespaces that receive ECR registry credentials for pulling images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended ECR authentication secret synchronization to cover additional namespaces, improving consistency across deployment environments
  * Enhanced namespace validation error handling to gracefully skip invalid namespaces without interrupting the overall synchronization process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->