### PR TITLE
Fix oncall-agent Vault 403: use default SA for auth

### DIFF
--- a/base-apps/oncall-agent/secret-store.yaml
+++ b/base-apps/oncall-agent/secret-store.yaml
@@ -16,4 +16,4 @@ spec:
           mountPath: "kubernetes"
           role: "oncall-agent"
           serviceAccountRef:
-            name: "oncall-agent"
+            name: "default"


### PR DESCRIPTION
## Summary
- Reverts `serviceAccountRef` in SecretStore from `oncall-agent` back to `default`
- Fixes `403 permission denied` when ExternalSecret syncs from Vault

## Root cause
The External Secrets Operator needs token projection permissions on the referenced SA to authenticate with Vault. The `default` SA has these permissions out of the box, which is why all other apps in the repo use it. The `oncall-agent` SA does not.

## Test plan
- [ ] Verify ExternalSecret status shows `SecretSynced` after merge
- [ ] Confirm `oncall-agent-secrets` Kubernetes secret is created in the namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)