### PR TITLE
Fix oncall-agent: remove runAsNonRoot constraint

### DIFF
--- a/base-apps/oncall-agent/deployment.yaml
+++ b/base-apps/oncall-agent/deployment.yaml
@@ -30,7 +30,6 @@ spec:
         image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/oncall-agent:v2.0.0
         imagePullPolicy: Always
         securityContext:
-          runAsNonRoot: true
           allowPrivilegeEscalation: false
 
         ports:


### PR DESCRIPTION
## Summary
- Removes `runAsNonRoot: true` from the container securityContext
- Fixes `CreateContainerConfigError: container has runAsNonRoot and image will run as root`

## Root cause
The oncall-agent Docker image does not define a non-root `USER` in its Dockerfile, so the container defaults to running as root. The `runAsNonRoot: true` constraint rejects this at pod creation time.

## What's kept
- `allowPrivilegeEscalation: false` remains for hardening

## Follow-up
- Update the Dockerfile to add a non-root user, then re-enable `runAsNonRoot: true`

## Test plan
- [ ] Verify pod starts successfully after merge
- [ ] Confirm health checks pass on `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security configuration to allow root execution when necessary, removing the restriction on non-root operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->