### PR TITLE
Fix oncall-agent 504: add ingress timeout annotations

### DIFF
--- a/base-apps/oncall-agent/oncall-agent-external-ingress.yaml
+++ b/base-apps/oncall-agent/oncall-agent-external-ingress.yaml
@@ -7,6 +7,15 @@ metadata:
   namespace: oncall-agent
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "120"
+    nginx.ingress.kubernetes.io/limit-rps: "30"
+    nginx.ingress.kubernetes.io/limit-connections: "10"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
   labels:
     app: oncall-agent-api
 spec:


### PR DESCRIPTION
## Summary
- Adds nginx timeout and hardening annotations to oncall-agent ingress
- Fixes `504 Gateway Time-out` on AI agent queries that take 30-40s+

## Changes
| Annotation | Value | Reason |
|-----------|-------|--------|
| `proxy-read-timeout` | `120` | Agent queries involve multiple LLM round-trips |
| `proxy-send-timeout` | `120` | Match read timeout |
| `proxy-connect-timeout` | `30` | Standard backend connect |
| `ssl-redirect` | `true` | Force HTTPS |
| `force-ssl-redirect` | `true` | Force HTTPS |
| `backend-protocol` | `HTTP` | Backend serves HTTP |
| `limit-rps` | `30` | Rate limiting |
| `limit-connections` | `10` | Connection limiting |
| `proxy-body-size` | `10m` | Request body limit |

## Test plan
- [ ] Verify AI agent queries complete without 504 errors
- [ ] Confirm TLS still works at `oncall.arigsela.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for the oncall-agent service with SSL enforcement and improved reliability through optimized timeout configurations, rate limiting, and connection management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->