### PR TITLE
Add Slack integration to oncall-agent

### DIFF
--- a/base-apps/oncall-agent/configmap.yaml
+++ b/base-apps/oncall-agent/configmap.yaml
@@ -30,6 +30,11 @@ data:
   RATE_LIMIT_UNAUTHENTICATED: "10"
   CORS_ORIGINS: "*"
 
+  # Slack integration
+  SLACK_ENABLED: "true"
+  SLACK_ALERT_CHANNEL: "#oncall-alerts"
+  SLACK_ALERT_MIN_SEVERITY: "high"
+
   # Zeus Integration - disabled for k3s homelab
   # ZEUS_NAMESPACE: "preprod"
   # ZEUS_SERVICE: "zeus-service"

--- a/base-apps/oncall-agent/deployment.yaml
+++ b/base-apps/oncall-agent/deployment.yaml
@@ -71,6 +71,19 @@ spec:
               name: oncall-agent-secrets
               key: api-keys
 
+        # Slack secrets
+        - name: SLACK_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: oncall-agent-secrets
+              key: slack-bot-token
+
+        - name: SLACK_SIGNING_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oncall-agent-secrets
+              key: slack-signing-secret
+
         # Note: API_HOST, API_PORT, SESSION_TTL_MINUTES, MAX_SESSIONS_PER_USER,
         # RATE_LIMIT_*, CORS_ORIGINS are loaded from oncall-agent-config ConfigMap
         # AGENT_LOG_LEVEL, GITHUB_ORG, AWS_REGION also from ConfigMap

--- a/base-apps/oncall-agent/external-secret.yaml
+++ b/base-apps/oncall-agent/external-secret.yaml
@@ -41,3 +41,15 @@ spec:
       remoteRef:
         key: oncall-agent
         property: api-keys
+
+    # Slack bot token (xoxb-...)
+    - secretKey: slack-bot-token
+      remoteRef:
+        key: oncall-agent
+        property: slack-bot-token
+
+    # Slack signing secret for HMAC verification
+    - secretKey: slack-signing-secret
+      remoteRef:
+        key: oncall-agent
+        property: slack-signing-secret


### PR DESCRIPTION
## Summary
- Add Slack config variables (`SLACK_ENABLED`, `SLACK_ALERT_CHANNEL`, `SLACK_ALERT_MIN_SEVERITY`) to the ConfigMap
- Add `slack-bot-token` and `slack-signing-secret` ExternalSecret refs to sync from Vault
- Add `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` env vars to the deployment

## Pre-requisites before merging
- [ ] Write `slack-bot-token` and `slack-signing-secret` to Vault under `k8s-secrets/oncall-agent`
- [ ] Rebuild and push the oncall-agent container image with Slack SDK and new code
- [ ] Create `#oncall-alerts` channel in Slack (or update `SLACK_ALERT_CHANNEL`)
- [ ] Complete Slack app setup (slash command, OAuth scopes, install to workspace)

## Test plan
- [ ] Verify ExternalSecret syncs successfully: `kubectl get es -n oncall-agent`
- [ ] Confirm `/slack/health` returns all fields as `true`/`configured`
- [ ] Test `/oncall` slash command in Slack
- [ ] Test proactive alert posting to `#oncall-alerts`

See `docs/plans/slack-integration-plan.md` for full setup instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack integration enabled for oncall alerts with configurable alert channels
  * Customizable alert severity filtering for Slack notifications (minimum severity threshold settable)
  * Secure credential handling for Slack bot authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->