### PR TITLE
Remove mysql namespace from ECR credential sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend mysql oncall-agent; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Remove `mysql` from the ECR credentials sync CronJob namespace list
- MySQL resources were removed in PR #23, so this namespace no longer needs ECR credentials

## Test plan
- [ ] Verify CronJob runs successfully without the mysql namespace: `kubectl create job --from=cronjob/ecr-credentials-sync ecr-test -n kube-system`
- [ ] Confirm ECR secrets still sync to remaining namespaces (chores-tracker, chores-tracker-frontend, oncall-agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cronjob configuration to refine namespace processing logic.
  * Improved error handling for missing namespace detection to prevent execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->