### PR TITLE
Deploy kagent AI agent framework to cluster

### DIFF
--- a/base-apps/kagent-crds.yaml
+++ b/base-apps/kagent-crds.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kagent-crds
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    chart: kagent-crds
+    repoURL: ghcr.io/kagent-dev/kagent/helm
+    targetRevision: 0.7.7
+    helm:
+      releaseName: kagent-crds
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kagent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kagent
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    chart: kagent
+    repoURL: ghcr.io/kagent-dev/kagent/helm
+    targetRevision: 0.7.7
+    helm:
+      releaseName: kagent
+      values: |
+        controller:
+          replicaCount: 1
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 512Mi
+          nodeSelector:
+            node.kubernetes.io/workload: infrastructure
+          tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+        app:
+          nodeSelector:
+            node.kubernetes.io/workload: infrastructure
+          tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+        llm:
+          provider: anthropic
+          model: claude-sonnet-4-20250514
+          apiKeySecretRef:
+            name: kagent-secrets
+            key: anthropic-api-key
+        database:
+          type: postgresql
+          connectionSecretRef:
+            name: kagent-secrets
+            key: db-connection-string
+        demo:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kagent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/kagent/external-secrets.yaml
+++ b/base-apps/kagent/external-secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-secrets
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: kagent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: kagent/anthropic
+        property: api-key
+    - secretKey: db-connection-string
+      remoteRef:
+        key: kagent
+        property: db-connection-string

--- a/base-apps/kagent/ingress.yaml
+++ b/base-apps/kagent/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kagent
+  namespace: kagent
+  annotations:
+    # TLS/SSL Configuration
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+
+    # IP Whitelist - Only allow home IP
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32"
+
+    # Timeouts (longer for dashboard loading)
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - kagent.arigsela.com
+      secretName: kagent-tls
+  rules:
+    - host: kagent.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kagent-app
+                port:
+                  number: 8080

--- a/base-apps/kagent/secret-store.yaml
+++ b/base-apps/kagent/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: kagent
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "kagent"
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
Add ArgoCD applications for kagent CRDs and main Helm chart (v0.7.7) with Anthropic LLM provider, PostgreSQL backend, demo profile, Vault secret management, and ingress for dashboard access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment infrastructure for kagent application, including Argo CD application manifests for kagent and kagent-crds Helm releases.
  * Added Kubernetes ingress configuration for secure HTTPS access with IP-based access control.
  * Added secret management integration with Vault for secure credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->