### PR TITLE
Fix kagent database type configuration

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -39,7 +39,7 @@ spec:
             name: kagent-secrets
             key: anthropic-api-key
         database:
-          type: postgresql
+          type: postgres
           connectionSecretRef:
             name: kagent-secrets
             key: db-connection-string


### PR DESCRIPTION
## Summary
- Fix kagent controller startup failure by changing database type from `postgresql` to `postgres`
- kagent expects the Go postgres driver convention (`postgres`) not the full name (`postgresql`)

## Test plan
- [ ] ArgoCD syncs the updated kagent app
- [ ] kagent controller pod starts without `invalid database type` error
- [ ] `kubectl logs -n kagent` shows successful database connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration in Helm release settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->