### PR TITLE
Use default SQLite database for kagent

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -38,11 +38,6 @@ spec:
           apiKeySecretRef:
             name: kagent-secrets
             key: anthropic-api-key
-        database:
-          type: postgres
-          connectionSecretRef:
-            name: kagent-secrets
-            key: db-connection-string
         demo:
           enabled: true
   destination:

--- a/base-apps/kagent/external-secrets.yaml
+++ b/base-apps/kagent/external-secrets.yaml
@@ -16,7 +16,3 @@ spec:
       remoteRef:
         key: kagent/anthropic
         property: api-key
-    - secretKey: db-connection-string
-      remoteRef:
-        key: kagent
-        property: db-connection-string


### PR DESCRIPTION
## Summary
- Remove PostgreSQL database config from kagent Helm values — the chart doesn't bundle a PostgreSQL subchart, so the `postgres` type caused a connection failure to a non-existent service
- kagent defaults to an embedded SQLite backend which works out of the box
- Remove unused `db-connection-string` entry from ExternalSecret

## Test plan
- [ ] ArgoCD syncs the updated kagent app
- [ ] kagent controller starts without database connection errors
- [ ] `kubectl get agents -n kagent` shows demo agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)