### PR TITLE
Configure kagent to use Anthropic as default LLM provider

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -32,12 +32,13 @@ spec:
           tolerations:
           - key: node-role.kubernetes.io/control-plane
             effect: NoSchedule
-        llm:
-          provider: anthropic
-          model: claude-sonnet-4-20250514
-          apiKeySecretRef:
-            name: kagent-secrets
-            key: anthropic-api-key
+        providers:
+          default: anthropic
+          anthropic:
+            provider: Anthropic
+            model: claude-sonnet-4-20250514
+            apiKeySecretRef: kagent-anthropic
+            apiKeySecretKey: ANTHROPIC_API_KEY
         demo:
           enabled: true
   destination:

--- a/base-apps/kagent/external-secrets.yaml
+++ b/base-apps/kagent/external-secrets.yaml
@@ -9,10 +9,10 @@ spec:
     name: vault-backend
     kind: SecretStore
   target:
-    name: kagent-secrets
+    name: kagent-anthropic
     creationPolicy: Owner
   data:
-    - secretKey: anthropic-api-key
+    - secretKey: ANTHROPIC_API_KEY
       remoteRef:
         key: kagent/anthropic
         property: api-key


### PR DESCRIPTION
Replace incorrect llm values with the correct providers.default path so the Helm chart generates a ModelConfig CRD pointing to Anthropic instead of the default OpenAI. Update ExternalSecret to match the expected secret name (kagent-anthropic) and key (ANTHROPIC_API_KEY).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured Kagent application configuration to implement a new provider-based architecture for large language model management.
  * Default provider is now explicitly configured as Anthropic with Claude Sonnet 4 as the selected model.
  * Reorganized API credential secret references and key mappings for improved configuration organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->