### PR TITLE
Deploy cluster-scanner CronJob

### DIFF
--- a/base-apps/cluster-scanner.yaml
+++ b/base-apps/cluster-scanner.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-scanner
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/cluster-scanner
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cluster-scanner
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/cluster-scanner/configmap.yaml
+++ b/base-apps/cluster-scanner/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-scanner-config
+  namespace: cluster-scanner
+  labels:
+    app: cluster-scanner
+data:
+  ONCALL_API_URL: "http://oncall-agent-api.oncall-agent.svc.cluster.local:80"
+  SLACK_CHANNEL: "#oncall-alerts"
+  ANTHROPIC_MODEL: "claude-haiku-4-5-20251001"

--- a/base-apps/cluster-scanner/cronjob.yaml
+++ b/base-apps/cluster-scanner/cronjob.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cluster-scanner
+  namespace: cluster-scanner
+  labels:
+    app: cluster-scanner
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 1800
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: cluster-scanner
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cluster-scanner
+              image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/cluster-scanner:v1.0.0
+              resources:
+                requests:
+                  cpu: 256m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+              envFrom:
+                - configMapRef:
+                    name: cluster-scanner-config
+              env:
+                - name: ANTHROPIC_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-scanner-secrets
+                      key: anthropic-api-key
+                - name: ONCALL_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-scanner-secrets
+                      key: oncall-api-key
+                - name: SLACK_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cluster-scanner-secrets
+                      key: slack-bot-token
+              volumeMounts:
+                - name: ralph-data
+                  mountPath: /app/.ralph
+          volumes:
+            - name: ralph-data
+              persistentVolumeClaim:
+                claimName: cluster-scanner-ralph-data

--- a/base-apps/cluster-scanner/external-secret.yaml
+++ b/base-apps/cluster-scanner/external-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cluster-scanner-secrets
+  namespace: cluster-scanner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: cluster-scanner-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: cluster-scanner
+        property: anthropic-api-key
+    - secretKey: oncall-api-key
+      remoteRef:
+        key: cluster-scanner
+        property: oncall-api-key
+    - secretKey: slack-bot-token
+      remoteRef:
+        key: cluster-scanner
+        property: slack-bot-token

--- a/base-apps/cluster-scanner/pvc.yaml
+++ b/base-apps/cluster-scanner/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cluster-scanner-ralph-data
+  namespace: cluster-scanner
+  labels:
+    app: cluster-scanner
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi

--- a/base-apps/cluster-scanner/secret-store.yaml
+++ b/base-apps/cluster-scanner/secret-store.yaml
@@ -1,0 +1,19 @@
+# SecretStore for Cluster Scanner (k3s homelab)
+# Connects to Vault using Kubernetes authentication
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: cluster-scanner
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "cluster-scanner"
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
## Summary
- Add ArgoCD Application manifest for cluster-scanner
- Deploy daily CronJob (midnight UTC) that scans the cluster using Claude and reports to Slack via oncall-agent
- Vault-backed secrets for Anthropic API key, OnCall API key, and Slack bot token
- Image pinned to `v1.0.0`, PVC for persistent Ralph data

## Changes from initial draft
- Created missing `cluster-scanner.yaml` ArgoCD Application
- Removed redundant `namespace.yaml` (using `CreateNamespace=true` instead)
- Cleaned up `external-secret.yaml` to match repo conventions
- Changed CronJob schedule from every 30 minutes to daily at midnight
- Pinned image tag from `latest` to `v1.0.0`

## Prerequisites
- Vault role `cluster-scanner` with secrets at `k8s-secrets/cluster-scanner`
- ECR image `cluster-scanner:v1.0.0` pushed

## Test plan
- [ ] ArgoCD shows cluster-scanner app as Synced/Healthy
- [ ] `kubectl get cronjob -n cluster-scanner` shows the job with correct schedule
- [ ] ExternalSecret syncs successfully from Vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced cluster-scanner service for continuous cluster monitoring and health assessments with automated daily scans.
  * Configured alerting integration with Slack and on-call systems for anomaly notifications.
  * Added persistent storage for scan data and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->