### PR TITLE
Add cluster-scanner to ECR credentials sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent cluster-scanner; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Adds `cluster-scanner` namespace to the ECR credentials sync CronJob so it receives the `ecr-registry` pull secret needed to pull images from ECR

## Test plan
- [ ] Verify ArgoCD syncs the updated CronJob
- [ ] Trigger the CronJob manually or wait for the next hourly run
- [ ] Confirm the `ecr-registry` secret is created in the `cluster-scanner` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)