### PR TITLE
Add ECR image pull secret to cluster-scanner CronJob

### DIFF
--- a/base-apps/cluster-scanner/cronjob.yaml
+++ b/base-apps/cluster-scanner/cronjob.yaml
@@ -20,6 +20,8 @@ spec:
             app: cluster-scanner
         spec:
           restartPolicy: Never
+          imagePullSecrets:
+            - name: ecr-registry
           containers:
             - name: cluster-scanner
               image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/cluster-scanner:v1.0.0


### PR DESCRIPTION
## Summary
- Add `imagePullSecrets: ecr-registry` to cluster-scanner CronJob pod spec
- Fixes image pull failure for ECR-hosted `cluster-scanner:v1.0.0` image

## Note
After merging, trigger the ECR credentials sync to create the `ecr-registry` secret in the `cluster-scanner` namespace:
```bash
kubectl create job --from=cronjob/ecr-credentials-sync ecr-sync-cluster-scanner -n kube-system
```

## Test plan
- [ ] `kubectl get secret ecr-registry -n cluster-scanner` exists after ECR sync runs
- [ ] CronJob pod can pull the image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)