### PR TITLE
Set imagePullPolicy to Always for cluster-scanner

### DIFF
--- a/base-apps/cluster-scanner/cronjob.yaml
+++ b/base-apps/cluster-scanner/cronjob.yaml
@@ -25,6 +25,7 @@ spec:
           containers:
             - name: cluster-scanner
               image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/cluster-scanner:v1.0.0
+              imagePullPolicy: Always
               resources:
                 requests:
                   cpu: 256m


### PR DESCRIPTION
## Summary
- Add `imagePullPolicy: Always` to the cluster-scanner CronJob container spec
- Ensures the node always pulls the latest image on each job run

## Test plan
- [ ] ArgoCD syncs the change
- [ ] `kubectl get cronjob cluster-scanner -n cluster-scanner -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy}'` returns `Always`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cluster scanner deployment configuration to always fetch the latest image from the registry, ensuring consistent execution with the most current version and latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->