### PR TITLE
Add init container to fix Ralph data volume permissions

### DIFF
--- a/base-apps/cluster-scanner/cronjob.yaml
+++ b/base-apps/cluster-scanner/cronjob.yaml
@@ -19,9 +19,18 @@ spec:
           labels:
             app: cluster-scanner
         spec:
+          securityContext:
+            fsGroup: 1001
           restartPolicy: Never
           imagePullSecrets:
             - name: ecr-registry
+          initContainers:
+            - name: fix-permissions
+              image: busybox
+              command: ["sh", "-c", "chown -R 1001:1001 /app/.ralph"]
+              volumeMounts:
+                - name: ralph-data
+                  mountPath: /app/.ralph
           containers:
             - name: cluster-scanner
               image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/cluster-scanner:v1.0.0


### PR DESCRIPTION
Add securityContext with fsGroup 1001 and a busybox init container that chowns the /app/.ralph PVC mount to uid/gid 1001 before the main container starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file permission issues in the cluster-scanner deployment by configuring proper access controls and ownership for application data directories before container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->