### PR TITLE
Update oncall-agent API to v2.0.1

### DIFF
--- a/base-apps/oncall-agent/deployment.yaml
+++ b/base-apps/oncall-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: oncall-agent
   labels:
     app: oncall-agent-api
-    version: v2.0.0
+    version: v2.0.1
 spec:
   replicas: 1  # Single replica for homelab resource conservation
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: oncall-agent-api
-        version: v2.0.0
+        version: v2.0.1
     spec:
       serviceAccountName: oncall-agent
       nodeSelector:
@@ -27,7 +27,7 @@ spec:
 
       containers:
       - name: api
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/oncall-agent:v2.0.0
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/oncall-agent:v2.0.1
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Update oncall-agent image tag from `v2.0.0` to `v2.0.1`
- Update version labels on deployment and pod template to match

## Test plan
- [ ] ArgoCD syncs and rolls out new pod
- [ ] `kubectl get pods -n oncall-agent` shows new pod running
- [ ] `/health` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Service updated to version v2.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->