### PR TITLE
Fix oncall-agent incident memory path to use PVC

### DIFF
--- a/base-apps/oncall-agent/configmap.yaml
+++ b/base-apps/oncall-agent/configmap.yaml
@@ -7,6 +7,7 @@ data:
   # Agent configuration
   AGENT_LOG_LEVEL: "INFO"
   AGENT_MAX_THINKING_TOKENS: "12000"
+  INCIDENT_MEMORY_PATH: "/app/data/incidents"
 
   # Kubernetes configuration (k3s homelab - no context needed for in-cluster)
   # K8S_CONTEXT not set - uses in-cluster auth via ServiceAccount


### PR DESCRIPTION
## Summary
- Add `INCIDENT_MEMORY_PATH=/app/data/incidents` to oncall-agent configmap
- The PVC mounts at `/app/data/incidents` but the code defaults to `/app/data/incident_memory/`
- Without this env var, `incidents.db` writes to the ephemeral container filesystem and is lost on pod restart

## Test plan
- [ ] ArgoCD syncs and pod restarts with new configmap
- [ ] `kubectl exec -n oncall-agent deployment/oncall-agent-api -- ls -la /app/data/incidents/` shows `incidents.db`
- [ ] `/app/data/incident_memory/` is no longer used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oncall-agent configuration with a new data path parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->