### PR TITLE
Update oncall-agent API from v2.0.1 to v2.0.2

### DIFF
--- a/base-apps/oncall-agent/deployment.yaml
+++ b/base-apps/oncall-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: oncall-agent
   labels:
     app: oncall-agent-api
-    version: v2.0.1
+    version: v2.0.2
 spec:
   replicas: 1  # Single replica for homelab resource conservation
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: oncall-agent-api
-        version: v2.0.1
+        version: v2.0.2
     spec:
       serviceAccountName: oncall-agent
       nodeSelector:
@@ -27,7 +27,7 @@ spec:
 
       containers:
       - name: api
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/oncall-agent:v2.0.1
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/oncall-agent:v2.0.2
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oncall-agent service deployment to version v2.0.2 with refreshed container artifacts. This maintenance release contains no functional changes to service behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->