### PR TITLE
Add GitOps config and enable debug logging for oncall-agent

### DIFF
--- a/base-apps/oncall-agent/configmap.yaml
+++ b/base-apps/oncall-agent/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: oncall-agent
 data:
   # Agent configuration
-  AGENT_LOG_LEVEL: "INFO"
+  AGENT_LOG_LEVEL: "DEBUG"
   AGENT_MAX_THINKING_TOKENS: "12000"
   INCIDENT_MEMORY_PATH: "/app/data/incidents"
 
@@ -14,6 +14,11 @@ data:
 
   # GitHub configuration
   GITHUB_ORG: "arigsela"
+
+  # GitOps PR Creation
+  GITOPS_REPO: "arigsela/kubernetes"
+  GITOPS_BASE_PATH: "base-apps/"
+  GITOPS_BASE_BRANCH: "main"
 
   # AWS configuration (ECR image checks, Secrets Manager verification)
   AWS_REGION: "us-east-2"
@@ -31,7 +36,7 @@ data:
   RATE_LIMIT_UNAUTHENTICATED: "10"
   CORS_ORIGINS: "*"
 
-  # Slack integration
+  # Slack Integration
   SLACK_ENABLED: "true"
   SLACK_ALERT_CHANNEL: "#oncall-alerts"
   SLACK_ALERT_MIN_SEVERITY: "high"


### PR DESCRIPTION
## Summary
- Add GitOps PR creation environment variables (`GITOPS_REPO`, `GITOPS_BASE_PATH`, `GITOPS_BASE_BRANCH`) to enable oncall-agent to create PRs against this repository
- Change `AGENT_LOG_LEVEL` from `INFO` to `DEBUG` for troubleshooting
- Retains `INCIDENT_MEMORY_PATH` from the previous fix

## Test plan
- [ ] ArgoCD syncs the configmap update
- [ ] Pod restarts and picks up new env vars
- [ ] `kubectl exec -n oncall-agent deployment/oncall-agent-api -- env | grep GITOPS` shows the new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated agent logging level to DEBUG
  * Added GitOps configuration options for repository, base path, and branch
  
* **Style**
  * Minor formatting adjustment to configuration comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->