### PR TITLE
[oncall-agent] chores-tracker-backend: scale-replicas

### DIFF
--- a/base-apps/chores-tracker-backend/deployments.yaml
+++ b/base-apps/chores-tracker-backend/deployments.yaml
@@ -4,7 +4,7 @@ metadata:
   name: chores-tracker-backend
   namespace: chores-tracker
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: chores-tracker-backend


### PR DESCRIPTION
## Automated Remediation PR

**Service**: chores-tracker-backend
**Action**: scale-replicas
**Reason**: Scaling from 2 to 3 replicas to provide additional capacity and improve redundancy for the customer-facing backend service.

### Incident Context
User requested to increase replica count from 2 to 3 for additional capacity and redundancy of the P0 customer-facing chores-tracker-backend service.

### Files Changed
- `base-apps/chores-tracker-backend/deployments.yaml` (update)

### Important
- This PR was created by the oncall-agent
- Review carefully before merging
- **DO NOT auto-merge** — requires human approval
- ArgoCD will sync changes after merge

---
*Created by oncall-agent-api*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service deployment configuration to increase running instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->