### PR TITLE
fix: resolve n8n workflow bugs and add secondary IP to ingress whitelists

### DIFF
--- a/base-apps/coroot/ingress.yaml
+++ b/base-apps/coroot/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
 
     # IP Whitelist - Only allow home IP
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32"
 
     # Timeouts (longer for dashboard loading)
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"

--- a/base-apps/n8n/nginx-ingress-admin.yaml
+++ b/base-apps/n8n/nginx-ingress-admin.yaml
@@ -19,7 +19,7 @@ metadata:
 
     # 🔒 IP WHITELIST - Admin UI Only
     # Only this IP can access the n8n admin interface
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32"
 
     # Timeouts
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"

--- a/n8n-workflows/claude-digest-generator.json
+++ b/n8n-workflows/claude-digest-generator.json
@@ -31,8 +31,8 @@
       "position": [240, 304],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       }
     },
@@ -159,10 +159,8 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "UPDATE feed_articles\nSET last_digest_date = CURRENT_DATE, is_processed = true\nWHERE url = ANY(string_to_array($1, '|||'));",
-        "options": {
-          "queryParameters": "={{ $('Format for Notion').first().json.urls.join('|||') }}"
-        }
+        "query": "={{ 'UPDATE feed_articles SET last_digest_date = CURRENT_DATE, is_processed = true WHERE url = ANY(ARRAY[' + $('Prepare for LLM').first().json.urls.map(u => \"'\" + u.replace(/'/g, \"''\") + \"'\").join(',') + ']);' }}",
+        "options": {}
       },
       "id": "mark-processed",
       "name": "Mark as Processed",
@@ -171,8 +169,8 @@
       "position": [1488, 224],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       }
     },

--- a/n8n-workflows/devops-digest-generator.json
+++ b/n8n-workflows/devops-digest-generator.json
@@ -1,5 +1,5 @@
 {
-  "name": "DevOps Digest Generator",
+  "name": "DevOps Daily Dispatch",
   "nodes": [
     {
       "parameters": {
@@ -12,11 +12,14 @@
           ]
         }
       },
-      "id": "schedule-trigger",
+      "id": "b6853ead-2ffe-4237-a891-01361bc883e3",
       "name": "Daily 8 AM",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
-      "position": [0, 304]
+      "position": [
+        -1040,
+        -16
+      ]
     },
     {
       "parameters": {
@@ -24,15 +27,18 @@
         "query": "SELECT\n    url, title, content_snippet, source_name, category, pub_date,\n    metadata->>'author' as author,\n    metadata->>'comments_count' as engagement\nFROM feed_articles\nWHERE 'devops' = ANY(topic)\n  AND pub_date >= NOW() - INTERVAL '24 hours'\n  AND (last_digest_date IS NULL OR last_digest_date < CURRENT_DATE)\nORDER BY pub_date DESC\nLIMIT 30;",
         "options": {}
       },
-      "id": "query-articles",
+      "id": "a466dce8-ea8d-4876-b3a4-dc1f290e8ba2",
       "name": "Query DevOps Articles",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [240, 304],
+      "position": [
+        -816,
+        -16
+      ],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       }
     },
@@ -60,21 +66,27 @@
         },
         "options": {}
       },
-      "id": "if-has-articles",
+      "id": "3d2b595f-b345-4619-af49-56c390472670",
       "name": "Has Articles?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [448, 304]
+      "position": [
+        -592,
+        -16
+      ]
     },
     {
       "parameters": {
         "jsCode": "// Combine all items into a single text for the LLM, grouped by category\nconst items = $input.all();\n\nif (!items || items.length === 0) {\n  return [{\n    json: {\n      posts: 'No new articles found for today.',\n      date: new Date().toISOString().split('T')[0],\n      itemCount: 0,\n      urls: []\n    }\n  }];\n}\n\n// Group by category\nconst byCategory = { official: [], blog: [], community: [] };\nitems.forEach(item => {\n  const cat = (item.json.category || 'blog').toLowerCase();\n  if (byCategory[cat]) byCategory[cat].push(item.json);\n  else byCategory.blog.push(item.json);\n});\n\nlet postsText = '';\n\nconst categoryNames = {\n  official: 'Official Sources',\n  blog: 'Blog Posts',\n  community: 'Community Discussions'\n};\n\nfor (const [category, posts] of Object.entries(byCategory)) {\n  if (posts.length === 0) continue;\n  postsText += `\\n## ${categoryNames[category]}\\n`;\n  posts.forEach((post) => {\n    postsText += `### ${post.title}\\n`;\n    postsText += `**Source:** ${post.source_name} | **Date:** ${post.pub_date}\\n`;\n    postsText += `**Link:** ${post.url}\\n`;\n    postsText += `**Preview:** ${post.content_snippet || 'No content'}\\n\\n`;\n  });\n}\n\n// Collect URLs for marking as processed later\nconst urls = items.map(item => item.json.url);\n\nreturn [{\n  json: {\n    posts: postsText,\n    date: new Date().toISOString().split('T')[0],\n    itemCount: items.length,\n    urls: urls\n  }\n}];"
       },
-      "id": "prepare-for-llm",
+      "id": "f7cc9ed3-77d7-4ad4-878e-a3bb2324764b",
       "name": "Prepare for LLM",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [656, 224]
+      "position": [
+        -368,
+        -112
+      ]
     },
     {
       "parameters": {
@@ -85,145 +97,245 @@
           "cachedResultName": "Claude Haiku 4.5"
         },
         "options": {
-          "maxTokensToSample": 4096
+          "maxTokensToSample": 8192
         }
       },
-      "id": "anthropic-model",
+      "id": "bc84573d-147e-4d12-b553-d4c905624fce",
       "name": "Claude Haiku",
       "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
       "typeVersion": 1.3,
-      "position": [864, 400]
+      "position": [
+        -136,
+        112
+      ],
+      "credentials": {
+        "anthropicApi": {
+          "id": "xQWTf0PXZe20RDYY",
+          "name": "asela_anthropic"
+        }
+      }
     },
     {
       "parameters": {
         "promptType": "define",
-        "text": "=You are a DevOps and Infrastructure news analyst creating daily digests.\n\nYou have memory of your previous daily digest summaries. Use this memory to:\n- Focus on NEW content not covered in previous summaries\n- Avoid repeating information from previous digests\n- Reference trends or ongoing discussions if relevant\n\n## Today's Posts ({{ $json.itemCount }} articles from database):\n{{ $json.posts }}\n\n## Instructions:\nCreate a markdown-formatted daily digest with these sections:\n\n1. **Key Releases & Announcements** - New tool versions, major updates, product launches\n2. **Infrastructure Trends** - GitOps, IaC, platform engineering, cloud native patterns\n3. **Community Highlights** - Hot discussions, popular tips, interesting debates\n4. **Tools & Tutorials** - New tools, how-to guides, best practices\n5. **Security Updates** - CVEs, security best practices, compliance news\n\nFor each item, include the source name in parentheses.\nKeep summaries concise but informative. Focus on actionable insights.\nIf a section has no relevant NEW content, write \"No notable items today.\"\n\nFormat the output as clean markdown suitable for Notion.",
+        "text": "=You are \"DevOps Dave\" — a witty, slightly over-caffeinated DevOps engineer who hosts a daily morning news show called \"The Daily Dispatch\" for fellow engineers.\n\n## Your Personality\n- Talk like you're actually speaking to someone over coffee — conversational, natural, with real personality\n- Use humor freely: dad jokes, pop culture references, sarcastic asides, and funny analogies\n- Be genuinely informative — your audience is technical, so don't dumb things down\n- Show excitement about cool releases, healthy skepticism about hype, and empathy about pain points\n- Reference common DevOps struggles for relatability (\"We've all been there at 2 AM staring at CrashLoopBackOff...\")\n- Use smooth transitions between topics like a real broadcaster\n- Keep paragraphs short — this should read like spoken word, not documentation\n\n## Show Structure\n1. **Opening** — A funny greeting, the date, and a quick one-liner to set the mood\n2. **Top Stories** (2-3 items) — The biggest news with your commentary, opinions, and why it matters\n3. **The Deep Dive** — Pick ONE story and go deeper: practical takeaways, what it means for the industry, your hot take\n4. **Lightning Round** — Rapid-fire 1-2 sentence mentions of the remaining items\n5. **Dave's Sign-Off** — A memorable closing line, a \"DevOps tip of the day\", and a teaser for tomorrow\n\n## Rules\n- Target 800-1100 words (5-8 minutes reading time)\n- For each story, naturally mention the source name and include the URL as a markdown link\n- Use markdown formatting: headers, bold, italic, links\n- Write in a way that makes someone actually look forward to reading this every morning\n- If you have memory of previous broadcasts, make callbacks (\"Remember that Kubernetes CVE from Tuesday? Plot twist...\")\n\nYou have memory of your previous broadcasts. Use it to avoid repetition and reference ongoing storylines.\n\n## Today's Feed ({{ $json.itemCount }} articles):\n{{ $json.posts }}\n\nNow go live, Dave!",
         "options": {}
       },
-      "id": "ai-agent",
+      "id": "c60333fd-a214-4f86-a05d-2976ac820c9f",
       "name": "AI Agent",
       "type": "@n8n/n8n-nodes-langchain.agent",
       "typeVersion": 1.7,
-      "position": [864, 224]
+      "position": [
+        -144,
+        -112
+      ]
     },
     {
       "parameters": {
         "sessionIdType": "customKey",
-        "sessionKey": "devops-daily-digest",
+        "sessionKey": "devops-daily-dispatch",
         "contextWindowLength": 10
       },
-      "id": "simple-memory",
+      "id": "d91c42c1-9ac2-45bd-8457-0e6689ff4597",
       "name": "Simple Memory",
       "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
       "typeVersion": 1.3,
-      "position": [864, 480]
+      "position": [
+        -8,
+        112
+      ]
     },
     {
       "parameters": {
-        "language": "javaScript",
-        "mode": "runOnceForAllItems",
-        "jsCode": "const item = $input.first();\n// AI Agent outputs to 'output' field, chainLlm outputs to 'text'\nconst text = item.json.output || item.json.text || '';\nconst urls = $('Prepare for LLM').first().json.urls || [];\nconst maxLength = 1900;\nconst maxBlocks = 98;\n\nfunction parseRichText(text) {\n  const segments = [];\n  let remaining = text;\n  \n  while (remaining.length > 0) {\n    const boldMatch = remaining.match(/^\\*\\*(.+?)\\*\\*/);\n    const italicMatch = remaining.match(/^\\*(.+?)\\*/);\n    const codeMatch = remaining.match(/^`(.+?)`/);\n    const linkMatch = remaining.match(/^\\[(.+?)\\]\\((.+?)\\)/);\n    \n    if (boldMatch) {\n      segments.push({ type: 'text', text: { content: boldMatch[1] }, annotations: { bold: true } });\n      remaining = remaining.substring(boldMatch[0].length);\n    } else if (codeMatch) {\n      segments.push({ type: 'text', text: { content: codeMatch[1] }, annotations: { code: true } });\n      remaining = remaining.substring(codeMatch[0].length);\n    } else if (linkMatch) {\n      segments.push({ type: 'text', text: { content: linkMatch[1], link: { url: linkMatch[2] } } });\n      remaining = remaining.substring(linkMatch[0].length);\n    } else if (italicMatch && !remaining.startsWith('**')) {\n      segments.push({ type: 'text', text: { content: italicMatch[1] }, annotations: { italic: true } });\n      remaining = remaining.substring(italicMatch[0].length);\n    } else {\n      const nextSpecial = remaining.search(/\\*|`|\\[/);\n      const plainEnd = nextSpecial === -1 ? remaining.length : nextSpecial;\n      if (plainEnd > 0) {\n        segments.push({ type: 'text', text: { content: remaining.substring(0, plainEnd) } });\n        remaining = remaining.substring(plainEnd);\n      } else {\n        segments.push({ type: 'text', text: { content: remaining[0] } });\n        remaining = remaining.substring(1);\n      }\n    }\n  }\n  \n  return segments.length > 0 ? segments : [{ type: 'text', text: { content: text } }];\n}\n\nfunction splitRichText(segments) {\n  const result = [];\n  let current = [];\n  let currentLen = 0;\n  \n  for (const seg of segments) {\n    const content = seg.text.content;\n    if (currentLen + content.length <= maxLength) {\n      current.push(seg);\n      currentLen += content.length;\n    } else {\n      if (current.length > 0) result.push(current);\n      current = [seg];\n      currentLen = content.length;\n    }\n  }\n  if (current.length > 0) result.push(current);\n  return result;\n}\n\nconst lines = text.split('\\n');\nconst children = [];\n\nfor (const line of lines) {\n  if (children.length >= maxBlocks) break;\n  \n  const trimmed = line.trim();\n  if (!trimmed) continue;\n  \n  if (trimmed.startsWith('# ')) {\n    children.push({ object: 'block', type: 'heading_1', heading_1: { rich_text: parseRichText(trimmed.substring(2)) } });\n  } else if (trimmed.startsWith('## ')) {\n    children.push({ object: 'block', type: 'heading_2', heading_2: { rich_text: parseRichText(trimmed.substring(3)) } });\n  } else if (trimmed.startsWith('### ')) {\n    children.push({ object: 'block', type: 'heading_3', heading_3: { rich_text: parseRichText(trimmed.substring(4)) } });\n  } else if (trimmed === '---' || trimmed === '***' || trimmed === '___') {\n    children.push({ object: 'block', type: 'divider', divider: {} });\n  } else if (trimmed.startsWith('- ')) {\n    const richText = parseRichText(trimmed.substring(2));\n    const chunks = splitRichText(richText);\n    for (const chunk of chunks) {\n      if (children.length >= maxBlocks) break;\n      children.push({ object: 'block', type: 'bulleted_list_item', bulleted_list_item: { rich_text: chunk } });\n    }\n  } else if (/^\\d+\\.\\s/.test(trimmed)) {\n    const content = trimmed.replace(/^\\d+\\.\\s/, '');\n    children.push({ object: 'block', type: 'numbered_list_item', numbered_list_item: { rich_text: parseRichText(content) } });\n  } else {\n    const richText = parseRichText(trimmed);\n    const chunks = splitRichText(richText);\n    for (const chunk of chunks) {\n      if (children.length >= maxBlocks) break;\n      children.push({ object: 'block', type: 'paragraph', paragraph: { rich_text: chunk } });\n    }\n  }\n}\n\nreturn [{ json: { notionChildren: children, date: new Date().toISOString().split('T')[0], urls: urls } }];"
+        "jsCode": "const item = $input.first();\nconst text = item.json.output || item.json.text || '';\nconst date = $('Prepare for LLM').first().json.date;\nconst urls = $('Prepare for LLM').first().json.urls || [];\n\n// Strip markdown formatting for clean plain text that audioread can parse\nlet plainText = text\n  // Remove markdown headers but keep the text\n  .replace(/^#{1,3}\\s*/gm, '')\n  // Remove bold/italic markers\n  .replace(/\\*\\*(.+?)\\*\\*/g, '$1')\n  .replace(/\\*(.+?)\\*/g, '$1')\n  // Convert markdown links to just the text\n  .replace(/\\[(.+?)\\]\\((.+?)\\)/g, '$1')\n  // Clean up extra whitespace\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\n\nreturn [{ json: { plainText, date, urls, subject: 'The Daily Dispatch - ' + date } }];"
       },
-      "id": "format-for-notion",
-      "name": "Format for Notion",
+      "id": "62d0d20a-567e-45f3-9c71-f1571eac0675",
+      "name": "Format Email HTML",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1072, 224]
+      "position": [
+        208,
+        -112
+      ]
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "https://api.notion.com/v1/pages",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            { "name": "Notion-Version", "value": "2022-06-28" },
-            { "name": "Content-Type", "value": "application/json" }
-          ]
-        },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ parent: { page_id: '2d38e013c07f80c59d93c9aeb9e271b7' }, properties: { title: [{ text: { content: 'DevOps - ' + $json.date } }] }, children: $json.notionChildren }) }}",
-        "options": {}
+        "fromEmail": "arigsela@gmail.com",
+        "toEmail": "user-7b646405-60f8-4029-9ebd-3731b48d9a80@email.audioread.com",
+        "subject": "={{ $json.subject }}",
+        "emailFormat": "text",
+        "text": "={{ $json.plainText }}",
+        "options": {"appendAttribution": false}
       },
-      "id": "create-child-page",
-      "name": "Create Notion Child Page",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [1280, 224],
-      "notesInFlow": true,
-      "notes": "Requires 'Header Auth' credential with: Name=Authorization, Value=Bearer YOUR_NOTION_TOKEN"
+      "id": "4feb0f36-3120-4821-a647-af1e2a5899d2",
+      "name": "Send Digest Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        432,
+        -112
+      ],
+      "webhookId": "5f287adf-ac64-4334-b565-f64e0a905713",
+      "credentials": {
+        "smtp": {
+          "id": "DtjHnOSdz1h7Xpuw",
+          "name": "SMTP account"
+        }
+      }
     },
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "UPDATE feed_articles\nSET last_digest_date = CURRENT_DATE, is_processed = true\nWHERE url = ANY(string_to_array($1, '|||'));",
-        "options": {
-          "queryParameters": "={{ $('Format for Notion').first().json.urls.join('|||') }}"
-        }
+        "query": "={{ 'UPDATE feed_articles SET last_digest_date = CURRENT_DATE, is_processed = true WHERE url = ANY(ARRAY[' + $('Prepare for LLM').first().json.urls.map(u => \"'\" + u.replace(/'/g, \"''\") + \"'\").join(',') + ']);' }}",
+        "options": {}
       },
-      "id": "mark-processed",
+      "id": "879fe629-c932-4307-a490-35e9a67ab0d2",
       "name": "Mark as Processed",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [1488, 224],
+      "position": [
+        736,
+        -112
+      ],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       }
     },
     {
       "parameters": {},
-      "id": "no-articles",
+      "id": "cdc539bb-bbc9-4cfa-82a5-5b339a2565e6",
       "name": "No New Articles",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [656, 384]
+      "position": [
+        -368,
+        80
+      ]
     }
   ],
+  "pinData": {},
   "connections": {
     "Daily 8 AM": {
-      "main": [[{ "node": "Query DevOps Articles", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Query DevOps Articles",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Query DevOps Articles": {
-      "main": [[{ "node": "Has Articles?", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Has Articles?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Has Articles?": {
       "main": [
-        [{ "node": "Prepare for LLM", "type": "main", "index": 0 }],
-        [{ "node": "No New Articles", "type": "main", "index": 0 }]
+        [
+          {
+            "node": "Prepare for LLM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No New Articles",
+            "type": "main",
+            "index": 0
+          }
+        ]
       ]
     },
     "Prepare for LLM": {
-      "main": [[{ "node": "AI Agent", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Claude Haiku": {
-      "ai_languageModel": [[{ "node": "AI Agent", "type": "ai_languageModel", "index": 0 }]]
+      "ai_languageModel": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Simple Memory": {
-      "ai_memory": [[{ "node": "AI Agent", "type": "ai_memory", "index": 0 }]]
+      "ai_memory": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "ai_memory",
+            "index": 0
+          }
+        ]
+      ]
     },
     "AI Agent": {
-      "main": [[{ "node": "Format for Notion", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Format Email HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
-    "Format for Notion": {
-      "main": [[{ "node": "Create Notion Child Page", "type": "main", "index": 0 }]]
+    "Format Email HTML": {
+      "main": [
+        [
+          {
+            "node": "Send Digest Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
-    "Create Notion Child Page": {
-      "main": [[{ "node": "Mark as Processed", "type": "main", "index": 0 }]]
+    "Send Digest Email": {
+      "main": [
+        [
+          {
+            "node": "Mark as Processed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
+  "active": false,
   "settings": {
     "executionOrder": "v1",
-    "timezone": "America/New_York",
-    "saveDataErrorExecution": "all",
-    "saveDataSuccessExecution": "all"
+    "binaryMode": "separate",
+    "availableInMCP": false
   },
+  "versionId": "0d546723-9c53-4613-bcdc-cb31fa28c542",
   "meta": {
-    "notes": "DevOps digest generator. Queries PostgreSQL for devops-tagged articles from the last 24 hours, generates a digest using AI Agent with memory, creates a Notion page, and marks articles as processed."
-  }
+    "templateCredsSetupCompleted": true,
+    "instanceId": "1ac1edd945dd6547c06503f16d68924976acb661550d12289650d4bae82f1e28"
+  },
+  "id": "Ye8YOBg_y9ajCody55Kii",
+  "tags": []
 }

--- a/n8n-workflows/feed-data-ingestion.json
+++ b/n8n-workflows/feed-data-ingestion.json
@@ -12,22 +12,22 @@
           ]
         }
       },
-      "id": "schedule-trigger",
+      "id": "1e1b0f48-9a88-4312-b3e7-680c6909f527",
       "name": "Every 4 Hours",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.3,
-      "position": [0, 560]
+      "position": [-448, 544]
     },
     {
       "parameters": {
         "url": "https://www.reddit.com/r/ClaudeAI/.rss",
         "options": {}
       },
-      "id": "rss-claudeai",
+      "id": "397df817-5817-4ee8-a6aa-13cc2c08d665",
       "name": "RSS r/ClaudeAI",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 0],
+      "position": [-160, -16],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -38,11 +38,11 @@
         "url": "https://www.reddit.com/r/anthropic/.rss",
         "options": {}
       },
-      "id": "rss-anthropic",
+      "id": "5bce421b-188c-4acb-8578-4805396d9139",
       "name": "RSS r/anthropic",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 112],
+      "position": [-160, 96],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -53,11 +53,11 @@
         "url": "https://hnrss.org/newest?q=claude",
         "options": {}
       },
-      "id": "rss-hn-claude",
+      "id": "50a23bf8-9c18-4fc5-956f-67456fe121da",
       "name": "RSS HN Claude",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 224],
+      "position": [-160, 208],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -68,11 +68,11 @@
         "url": "https://hnrss.org/newest?q=anthropic",
         "options": {}
       },
-      "id": "rss-hn-anthropic",
+      "id": "f07fe1ec-68b5-4d34-876c-f742595a7a60",
       "name": "RSS HN Anthropic",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 336],
+      "position": [-160, 320],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -83,11 +83,11 @@
         "url": "https://devops.com/feed/",
         "options": {}
       },
-      "id": "rss-devops-com",
+      "id": "ecdef641-ff09-44cf-bb17-1651a67e8c58",
       "name": "RSS DevOps.com",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 448],
+      "position": [-160, 432],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -98,11 +98,11 @@
         "url": "https://theagileadmin.com/feed/",
         "options": {}
       },
-      "id": "rss-agile-admin",
+      "id": "ca22cf80-480d-4073-96c3-f9bff26ee417",
       "name": "RSS Agile Admin",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 560],
+      "position": [-160, 544],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -113,11 +113,11 @@
         "url": "https://feed.infoq.com/Devops/articles/",
         "options": {}
       },
-      "id": "rss-infoq",
+      "id": "b4643128-2684-4e91-91a0-7fc08713687d",
       "name": "RSS InfoQ DevOps",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 672],
+      "position": [-160, 656],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -128,11 +128,11 @@
         "url": "https://www.hashicorp.com/blog/feed.xml",
         "options": {}
       },
-      "id": "rss-hashicorp",
+      "id": "7d9c1479-c295-4640-b2e7-5ab39ef449b3",
       "name": "RSS HashiCorp",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 784],
+      "position": [-160, 768],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -143,11 +143,11 @@
         "url": "https://www.cncf.io/blog/feed/",
         "options": {}
       },
-      "id": "rss-cncf",
+      "id": "825ab90c-8e42-4b96-aaa0-61094c1806e3",
       "name": "RSS CNCF",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 896],
+      "position": [-160, 880],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -158,11 +158,11 @@
         "url": "https://kubernetes.io/feed.xml",
         "options": {}
       },
-      "id": "rss-kubernetes",
+      "id": "ad9a8eac-b876-41a9-8309-c0e1498f9ccc",
       "name": "RSS Kubernetes",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 1008],
+      "position": [-160, 992],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -173,11 +173,11 @@
         "url": "https://hnrss.org/newest?q=kubernetes+OR+devops+OR+terraform",
         "options": {}
       },
-      "id": "rss-hn-devops",
+      "id": "fab826aa-5c37-447e-9cf2-12783294be82",
       "name": "RSS HN DevOps",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 1120],
+      "position": [-160, 1104],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -188,11 +188,11 @@
         "url": "https://www.reddit.com/r/devops/.rss",
         "options": {}
       },
-      "id": "rss-reddit-devops",
+      "id": "a522432f-888f-4dcc-898b-f16f77377732",
       "name": "RSS r/devops",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 1232],
+      "position": [-160, 1216],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
@@ -203,86 +203,75 @@
         "url": "https://www.reddit.com/r/kubernetes/.rss",
         "options": {}
       },
-      "id": "rss-reddit-k8s",
+      "id": "56f7708b-4056-461e-a990-44d2d9b8cc72",
       "name": "RSS r/kubernetes",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1.2,
-      "position": [280, 1344],
+      "position": [-160, 1328],
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 5000,
       "onError": "continueRegularOutput"
     },
     {
-      "parameters": {
-        "numberInputs": 10
-      },
-      "id": "merge-group-1",
+      "parameters": { "numberInputs": 10 },
+      "id": "cf2d2ca3-8011-4130-b782-88820ba2efb4",
       "name": "Merge Group 1",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3.2,
-      "position": [560, 336]
+      "position": [128, 320]
     },
     {
-      "parameters": {
-        "numberInputs": 3
-      },
-      "id": "merge-group-2",
+      "parameters": { "numberInputs": 3 },
+      "id": "df4c0be5-cb78-423b-9f94-15223bde3f8b",
       "name": "Merge Group 2",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3.2,
-      "position": [560, 1176]
+      "position": [128, 1168]
     },
     {
-      "parameters": {
-        "numberInputs": 2
-      },
-      "id": "merge-all",
+      "parameters": {},
+      "id": "3d75bb7d-2729-40e7-b77f-22e1c5d547dd",
       "name": "Merge All Feeds",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3.2,
-      "position": [768, 560]
+      "position": [336, 544]
     },
     {
       "parameters": {
         "jsCode": "// Normalize all feeds to consistent schema with topic tagging\nconst items = $input.all();\nconst now = new Date();\nconst sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);\n\nfunction getTopicTags(link, title) {\n  const tags = [];\n  const lowerTitle = (title || '').toLowerCase();\n  const lowerLink = (link || '').toLowerCase();\n\n  // Claude/Anthropic topics\n  if (lowerLink.includes('claudeai') || lowerLink.includes('r/anthropic') ||\n      lowerTitle.includes('claude') || lowerTitle.includes('anthropic') ||\n      lowerLink.includes('q=claude') || lowerLink.includes('q=anthropic')) {\n    tags.push('claude');\n  }\n\n  // DevOps topics\n  if (lowerLink.includes('devops') || lowerLink.includes('kubernetes') ||\n      lowerLink.includes('terraform') || lowerLink.includes('hashicorp') ||\n      lowerLink.includes('cncf') || lowerLink.includes('argoproj') ||\n      lowerTitle.includes('devops') || lowerTitle.includes('kubernetes') ||\n      lowerTitle.includes('gitops') || lowerTitle.includes('terraform') ||\n      lowerTitle.includes('argocd') || lowerTitle.includes('helm')) {\n    tags.push('devops');\n  }\n\n  // General AI topics\n  if (lowerTitle.includes('openai') || lowerTitle.includes('gpt') ||\n      lowerTitle.includes('llm') || lowerTitle.includes('machine learning') ||\n      lowerTitle.includes('ai agent')) {\n    tags.push('ai-general');\n  }\n\n  return tags.length > 0 ? tags : ['uncategorized'];\n}\n\nfunction getSourceCategory(link) {\n  if (link.includes('reddit.com') || link.includes('news.ycombinator.com')) {\n    return 'community';\n  }\n  if (link.includes('anthropic.com') || link.includes('hashicorp.com') ||\n      link.includes('kubernetes.io') || link.includes('cncf.io') ||\n      link.includes('argoproj.io')) {\n    return 'official';\n  }\n  return 'blog';\n}\n\nfunction getSourceName(link) {\n  const mapping = {\n    'reddit.com/r/ClaudeAI': 'r/ClaudeAI',\n    'reddit.com/r/anthropic': 'r/anthropic',\n    'reddit.com/r/devops': 'r/devops',\n    'reddit.com/r/kubernetes': 'r/kubernetes',\n    'news.ycombinator.com': 'Hacker News',\n    'anthropic.com': 'Anthropic Blog',\n    'devops.com': 'DevOps.com',\n    'theagileadmin.com': 'Agile Admin',\n    'infoq.com': 'InfoQ',\n    'hashicorp.com': 'HashiCorp',\n    'kubernetes.io': 'Kubernetes',\n    'cncf.io': 'CNCF',\n    'argoproj.io': 'ArgoCD Blog'\n  };\n\n  for (const [pattern, name] of Object.entries(mapping)) {\n    if (link.includes(pattern)) return name;\n  }\n  return 'Unknown';\n}\n\n// Deduplicate by URL within this batch\nconst seen = new Set();\n\nconst normalized = items\n  .map(item => {\n    const json = item.json;\n    const link = json.link || json.guid || '';\n    const title = json.title || 'No title';\n    const pubDate = new Date(json.pubDate || json.isoDate || json.date || now);\n\n    return {\n      url: link,\n      title: title,\n      content: json.content || json.description || '',\n      content_snippet: (json.contentSnippet || json.content || json.description || '').substring(0, 500),\n      source_name: getSourceName(link),\n      source_url: json.feedUrl || '',\n      topic: getTopicTags(link, title),\n      category: getSourceCategory(link),\n      pub_date: pubDate.toISOString(),\n      metadata: JSON.stringify({\n        author: json.creator || json.author || null,\n        comments_count: json.comments || null,\n        original_guid: json.guid || null\n      })\n    };\n  })\n  // Filter out items without URLs\n  .filter(item => item.url)\n  // Filter to last 7 days\n  .filter(item => new Date(item.pub_date) >= sevenDaysAgo)\n  // Deduplicate within batch\n  .filter(item => {\n    if (seen.has(item.url)) return false;\n    seen.add(item.url);\n    return true;\n  });\n\nreturn normalized.map(item => ({ json: item }));"
       },
-      "id": "normalize-feeds",
+      "id": "520c056e-c720-4156-ad74-1fa4dbc7fca2",
       "name": "Normalize & Tag Topics",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [976, 560]
+      "position": [544, 544]
     },
     {
-      "parameters": {
-        "batchSize": 1,
-        "options": {}
-      },
-      "id": "split-batches",
+      "parameters": { "options": {} },
+      "id": "9a7aa1e9-5895-4281-a72b-584adf02c9ac",
       "name": "Process One at a Time",
       "type": "n8n-nodes-base.splitInBatches",
       "typeVersion": 3,
-      "position": [1184, 560]
+      "position": [752, 544]
     },
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT id FROM feed_articles WHERE url_hash = md5($1) LIMIT 1;",
-        "options": {
-          "queryParameters": "={{ [$json.url] }}"
-        }
+        "query": "={{ 'SELECT COUNT(*) as cnt FROM feed_articles WHERE url_hash = md5(\\'' + $json.url.replace(/\\'/g, \"''\") + '\\') LIMIT 1;' }}",
+        "options": {}
       },
-      "id": "check-existing",
+      "id": "f1ddd0b1-0203-437b-b2cd-9cb3773abaa4",
       "name": "Check If Exists",
       "notesInFlow": true,
       "notes": "Uses $json.url from splitInBatches output",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [1392, 560],
+      "position": [960, 544],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       },
       "onError": "continueRegularOutput"
@@ -291,19 +280,19 @@
       "parameters": {
         "conditions": {
           "options": {
-            "caseSensitive": true,
+            "version": 2,
             "leftValue": "",
+            "caseSensitive": true,
             "typeValidation": "strict"
           },
           "conditions": [
             {
-              "id": "check-empty",
-              "leftValue": "={{ $json.id }}",
-              "rightValue": "",
+              "id": "check-count-zero",
+              "leftValue": "={{ $json.cnt }}",
+              "rightValue": "0",
               "operator": {
                 "type": "string",
-                "operation": "empty",
-                "singleValue": true
+                "operation": "equals"
               }
             }
           ],
@@ -311,52 +300,60 @@
         },
         "options": {}
       },
-      "id": "if-new",
+      "id": "ca83cef6-9696-4bca-ab8f-ce4ed58eef34",
       "name": "Is New Article?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [1600, 560]
+      "position": [1168, 544]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build INSERT SQL with properly escaped values\nconst data = $('Process One at a Time').item.json;\n\nfunction esc(val) {\n  if (val === null || val === undefined || val === '') return 'NULL';\n  return \"'\" + String(val).replace(/'/g, \"''\") + \"'\";\n}\n\nconst topicArray = \"'{\" + (data.topic || []).join(',') + \"}'\";\n\nconst sql = `INSERT INTO feed_articles (url, title, content, content_snippet, source_name, source_url, topic, category, pub_date, metadata)\nVALUES (${esc(data.url)}, ${esc(data.title)}, ${esc(data.content)}, ${esc(data.content_snippet)}, ${esc(data.source_name)}, ${esc(data.source_url)}, ${topicArray}::text[], ${esc(data.category)}, ${esc(data.pub_date)}::timestamptz, ${esc(data.metadata)}::jsonb)\nON CONFLICT (url) DO NOTHING\nRETURNING id;`;\n\nreturn [{ json: { insertQuery: sql } }];"
+      },
+      "id": "5098a279-fd05-49c3-a1b7-5bb3be8ab03a",
+      "name": "Build Insert SQL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1272, 464]
     },
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO feed_articles (url, title, content, content_snippet, source_name, source_url, topic, category, pub_date, metadata)\nVALUES ($1, $2, $3, $4, $5, $6, $7::text[], $8, $9::timestamptz, $10::jsonb)\nON CONFLICT (url) DO NOTHING\nRETURNING id;",
-        "options": {
-          "queryParameters": "={{ [$('Process One at a Time').item.json.url, $('Process One at a Time').item.json.title, $('Process One at a Time').item.json.content, $('Process One at a Time').item.json.content_snippet, $('Process One at a Time').item.json.source_name, $('Process One at a Time').item.json.source_url, '{' + $('Process One at a Time').item.json.topic.join(',') + '}', $('Process One at a Time').item.json.category, $('Process One at a Time').item.json.pub_date, $('Process One at a Time').item.json.metadata] }}"
-        }
+        "query": "={{ $json.insertQuery }}",
+        "options": {}
       },
-      "id": "insert-article",
+      "id": "b731e268-b403-46de-909f-9f9fc4a03f16",
       "name": "Insert Article",
       "notesInFlow": true,
-      "notes": "References original data from splitInBatches node",
+      "notes": "Executes pre-built INSERT from Build Insert SQL node",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [1808, 480],
+      "position": [1480, 464],
       "credentials": {
         "postgres": {
-          "id": "POSTGRES_CREDENTIAL_ID",
-          "name": "Postgres - n8n"
+          "id": "GCohHH3qGUDCi7xo",
+          "name": "Postgres account"
         }
       },
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {},
-      "id": "no-op-skip",
+      "id": "1a248f2b-a8ee-43cf-971f-c9c13cdbfd53",
       "name": "Skip Existing",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [1808, 640]
+      "position": [1376, 624]
     },
     {
       "parameters": {
         "jsCode": "// Count results from the batch processing\nconst items = $input.all();\nconst inserted = items.filter(i => i.json.id).length;\n\nreturn [{\n  json: {\n    status: 'complete',\n    processed_at: new Date().toISOString(),\n    articles_checked: items.length,\n    new_articles_inserted: inserted\n  }\n}];"
       },
-      "id": "summary",
+      "id": "5db84d4e-e1b3-409f-a328-9fb9a007dc71",
       "name": "Summary",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2224, 560]
+      "position": [1792, 544]
     }
   ],
   "connections": {
@@ -400,9 +397,10 @@
     ]},
     "Check If Exists": { "main": [[{ "node": "Is New Article?", "type": "main", "index": 0 }]] },
     "Is New Article?": { "main": [
-      [{ "node": "Insert Article", "type": "main", "index": 0 }],
+      [{ "node": "Build Insert SQL", "type": "main", "index": 0 }],
       [{ "node": "Skip Existing", "type": "main", "index": 0 }]
     ]},
+    "Build Insert SQL": { "main": [[{ "node": "Insert Article", "type": "main", "index": 0 }]] },
     "Insert Article": { "main": [[{ "node": "Process One at a Time", "type": "main", "index": 0 }]] },
     "Skip Existing": { "main": [[{ "node": "Process One at a Time", "type": "main", "index": 0 }]] }
   },


### PR DESCRIPTION
## Summary
- **Feed Data Ingestion**: Fixed SplitInBatches loop breakage by changing `SELECT id` to `SELECT COUNT(*) as cnt` so Postgres always returns a row for downstream nodes to process
- **DevOps/Claude Digest Generators**: Replaced `$1` parameterized query with inline SQL expression in Mark as Processed node to fix "there is no parameter $1" error
- **DevOps Digest**: Switched email output from complex HTML to plain text for audioread text-to-speech compatibility
- **Ingress whitelists**: Added secondary IP `170.85.56.189/32` to n8n admin and coroot ingresses to match argo-rollouts

## Test plan
- [x] Feed Data Ingestion workflow tested — articles now insert correctly
- [x] DevOps Digest workflow tested — email sends successfully in plain text
- [ ] Verify n8n admin UI accessible from both whitelisted IPs
- [ ] Verify coroot dashboard accessible from both whitelisted IPs
- [ ] Verify Claude Digest Generator runs without Mark as Processed error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated IP address allowlist for infrastructure access

* **Refactor**
  * Restructured article ingestion pipeline with optimized data processing flow
  * Reorganized digest generation workflows with updated delivery mechanisms and credential management across integrated services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->