### PR TITLE
feat: bump agent-ui-backend to v1.0.3

### DIFF
--- a/base-apps/agent-ui-backend/deployments.yaml
+++ b/base-apps/agent-ui-backend/deployments.yaml
@@ -26,7 +26,7 @@ spec:
       - name: ecr-registry
       containers:
         - name: backend
-          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-backend:v1.0.2
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-backend:v1.0.3
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
## Summary
- Bumps `agent-ui-backend` image from v1.0.2 to v1.0.3

## Test plan
- [ ] Verify ArgoCD syncs the Rollout update
- [ ] Confirm canary pod starts with v1.0.3 image
- [ ] Promote through canary steps (20% → 50% → 80% → 100%)
- [ ] Validate Istio VirtualService traffic splitting during rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Backend service updated to version 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->