### PR TITLE
[oncall-agent] n8n: update-image-tag-to-1.80.1

### DIFF
--- a/base-apps/n8n/deployments.yaml
+++ b/base-apps/n8n/deployments.yaml
@@ -22,7 +22,7 @@ spec:
         runAsGroup: 1000
       containers:
       - name: n8n
-        image: n8nio/n8n:latest
+        image: n8nio/n8n:1.80.1
         env:
         # Database Configuration
         - name: DB_TYPE


### PR DESCRIPTION
## Automated Remediation PR

**Service**: n8n
**Action**: update-image-tag-to-1.80.1
**Reason**: Pin n8n to specific version 1.80.1 instead of 'latest' tag to ensure controlled updates and version stability

### Incident Context
User requested update from n8n:latest to n8n:1.80.1 for better version control and predictability

### Files Changed
- `base-apps/n8n/deployments.yaml` (update)

### Important
- This PR was created by the oncall-agent
- Review carefully before merging
- **DO NOT auto-merge** — requires human approval
- ArgoCD will sync changes after merge

---
*Created by oncall-agent-api*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated n8n container image to version 1.80.1, pinned from the latest tag for improved deployment stability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->