### PR TITLE
[oncall-agent] chores-tracker-backend: rollback-version-to-v3.0.0

### DIFF
--- a/base-apps/chores-tracker-backend/deployments.yaml
+++ b/base-apps/chores-tracker-backend/deployments.yaml
@@ -22,7 +22,7 @@ spec:
         node.kubernetes.io/workload: application
       containers:
       - name: chores-tracker-backend
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:7.0.2
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:3.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
## Automated Remediation PR

**Service**: chores-tracker-backend
**Action**: rollback-version-to-v3.0.0
**Reason**: Manual version rollback requested by operator. This will trigger an Argo Rollouts canary deployment with gradual traffic shifting (20% → 50% → 80% → 100%) over ~15-20 minutes with automatic rollback on failure.

### Incident Context
User requested deployment version change from 7.0.2 to 3.0.0 for chores-tracker-backend service

### Files Changed
- `base-apps/chores-tracker-backend/deployments.yaml` (update)

### Important
- This PR was created by the oncall-agent
- Review carefully before merging
- **DO NOT auto-merge** — requires human approval
- ArgoCD will sync changes after merge

---
*Created by oncall-agent-api*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the chores-tracker-backend container image to a new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->