### PR TITLE
[oncall-agent] chores-tracker-backend: increase-memory-limit

### DIFF
--- a/base-apps/chores-tracker-backend/deployments.yaml
+++ b/base-apps/chores-tracker-backend/deployments.yaml
@@ -54,10 +54,10 @@ spec:
           successThreshold: 1
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "200m"
           limits:
-            memory: "512Mi"
+            memory: "1Gi"
             cpu: "500m"
       imagePullSecrets:
       - name: ecr-registry


### PR DESCRIPTION
## Automated Remediation PR

**Service**: chores-tracker-backend
**Action**: increase-memory-limit
**Reason**: Increase memory limits to prevent OOMKilled crashes. Current 512Mi limit is insufficient based on recent incident patterns. Doubling to 1Gi provides adequate headroom for the FastAPI backend service.

### Incident Context
User requested memory increase to 1Gi for chores-tracker-backend. This follows recurring OOMKilled incidents (Feb 8 and Feb 11) where the current 512Mi limit proved insufficient for normal operation.

### Files Changed
- `base-apps/chores-tracker-backend/deployments.yaml` (update)

### Important
- This PR was created by the oncall-agent
- Review carefully before merging
- **DO NOT auto-merge** — requires human approval
- ArgoCD will sync changes after merge

---
*Created by oncall-agent-api*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service resource allocation to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->