### PR TITLE
[oncall-agent] chores-tracker-backend: increase-memory-limit

### DIFF
--- a/base-apps/chores-tracker-backend/deployments.yaml
+++ b/base-apps/chores-tracker-backend/deployments.yaml
@@ -54,10 +54,10 @@ spec:
           successThreshold: 1
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "200m"
           limits:
-            memory: "512Mi"
+            memory: "1Gi"
             cpu: "500m"
       imagePullSecrets:
       - name: ecr-registry


### PR DESCRIPTION
## Automated Remediation PR

**Service**: chores-tracker-backend
**Action**: increase-memory-limit
**Reason**: Increase memory allocation to prevent OOM kills. Current 512Mi limit is insufficient for FastAPI application under normal load. Doubling memory request to 512Mi and limit to 1Gi to provide adequate headroom for stable operation.

### Incident Context
OOMKilled errors on chores-tracker-backend pods. Pods exceeded 512Mi memory limit causing container termination and service instability. This is a recurring issue (3rd incident in 2 months).

### Files Changed
- `base-apps/chores-tracker-backend/deployments.yaml` (update)

### Important
- This PR was created by the oncall-agent
- Review carefully before merging
- **DO NOT auto-merge** — requires human approval
- ArgoCD will sync changes after merge

---
*Created by oncall-agent-api*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased container memory allocations to improve stability and performance of the chores tracker service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->