### PR TITLE
fix: inject openclaw-env-secret into container via envFrom

### DIFF
--- a/base-apps/openclaw.yaml
+++ b/base-apps/openclaw.yaml
@@ -19,6 +19,11 @@ spec:
             pod:
               nodeSelector:
                 node.kubernetes.io/workload: application
+            containers:
+              main:
+                envFrom:
+                  - secretRef:
+                      name: openclaw-env-secret
 
         configMap:
           openclaw:
@@ -28,9 +33,7 @@ spec:
                   "gateway": {
                     "port": 18789,
                     "trustedProxies": ["10.42.0.0/16", "10.43.0.0/16"],
-                    "auth": {
-                      "token": "${OPENCLAW_GATEWAY_TOKEN}"
-                    },
+                    "auth": {},
                     "controlUi": {
                       "dangerouslyDisableDeviceAuth": false
                     }
@@ -74,8 +77,6 @@ spec:
                     "slack": {
                       "enabled": true,
                       "mode": "socket",
-                      "appToken": "${SLACK_APP_TOKEN}",
-                      "botToken": "${SLACK_BOT_TOKEN}",
                       "userTokenReadOnly": true,
                       "groupPolicy": "allowlist",
                       "channels": {}


### PR DESCRIPTION
The Helm chart does not perform shell variable substitution on the openclaw.json ConfigMap, so the literal strings \${OPENCLAW_GATEWAY_TOKEN}, \${SLACK_APP_TOKEN}, and \${SLACK_BOT_TOKEN} were written to the config file unchanged, causing the gateway to refuse to start.

Fix by:
- Adding envFrom to mount openclaw-env-secret into the main container, so OpenClaw reads OPENCLAW_GATEWAY_TOKEN, ANTHROPIC_API_KEY, SLACK_APP_TOKEN, and SLACK_BOT_TOKEN from the environment
- Removing the unresolvable \${...} placeholders from gateway.auth and the Slack channel config (env vars take precedence)