### PR TITLE
Add Tavily API key for oncall-agent web search

### DIFF
--- a/base-apps/oncall-agent/deployment.yaml
+++ b/base-apps/oncall-agent/deployment.yaml
@@ -84,6 +84,14 @@ spec:
               name: oncall-agent-secrets
               key: slack-signing-secret
 
+        # Tavily API key for web search (desk assistant)
+        - name: TAVILY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: oncall-agent-secrets
+              key: tavily-api-key
+              optional: true
+
         # Note: API_HOST, API_PORT, SESSION_TTL_MINUTES, MAX_SESSIONS_PER_USER,
         # RATE_LIMIT_*, CORS_ORIGINS are loaded from oncall-agent-config ConfigMap
         # AGENT_LOG_LEVEL, GITHUB_ORG, AWS_REGION also from ConfigMap

--- a/base-apps/oncall-agent/external-secret.yaml
+++ b/base-apps/oncall-agent/external-secret.yaml
@@ -53,3 +53,9 @@ spec:
       remoteRef:
         key: oncall-agent
         property: slack-signing-secret
+
+    # Tavily API key for web search (Quake Copilot desk assistant)
+    - secretKey: tavily-api-key
+      remoteRef:
+        key: oncall-agent
+        property: tavily-api-key


### PR DESCRIPTION
Add tavily-api-key to ExternalSecret and TAVILY_API_KEY env var to deployment for Quake Copilot desk assistant web search capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured Tavily API integration for the on-call agent service through environment variable and external secret management, enabling secure API credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->