### PR TITLE
Add SESSION_PERSIST_PATH to oncall-agent configmap

### DIFF
--- a/base-apps/oncall-agent/configmap.yaml
+++ b/base-apps/oncall-agent/configmap.yaml
@@ -30,6 +30,7 @@ data:
   # API Configuration
   API_HOST: "0.0.0.0"
   API_PORT: "8000"
+  SESSION_PERSIST_PATH: "/app/data/incidents"
   SESSION_TTL_MINUTES: "30"
   MAX_SESSIONS_PER_USER: "5"
   RATE_LIMIT_AUTHENTICATED: "60"


### PR DESCRIPTION
## Summary
- Add `SESSION_PERSIST_PATH: "/app/data/incidents"` to the oncall-agent configmap

## Context
The live deployment already has all the infrastructure in place:
- **PVC**: `incident-memory-pvc` is bound (1Gi, RWO)
- **Volume mount**: `/app/data/incidents` is mounted in the container
- **ConfigMap**: Had 21 keys but was missing `SESSION_PERSIST_PATH`

This single key addition enables session persistence by pointing to the existing PVC-backed mount path.

## Changes
- `base-apps/oncall-agent/configmap.yaml` — added `SESSION_PERSIST_PATH` key

## Test Plan
- [ ] Verify ArgoCD syncs the updated configmap
- [ ] Confirm oncall-agent pod restarts with the new env var
- [ ] Validate session data persists across pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to include a new session persistence path setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->