### PR TITLE
Deploy consolidated oncall-crewai agents

### DIFF
--- a/base-apps/oncall-crewai.yaml
+++ b/base-apps/oncall-crewai.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oncall-crewai
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/oncall-crewai
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: oncall-crewai
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/oncall-crewai/external-secret.yaml
+++ b/base-apps/oncall-crewai/external-secret.yaml
@@ -1,0 +1,84 @@
+# ExternalSecrets for OnCall CrewAI agents (k3s homelab)
+# Syncs secrets from Vault to Kubernetes
+# Vault path: k8s-secrets/oncall-crewai
+
+# K8s Agent secrets
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: k8s-agent-secrets
+  namespace: oncall-crewai
+  labels:
+    app: k8s-agent-a2a
+    component: external-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: k8s-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: oncall-crewai
+        property: anthropic-api-key
+
+---
+# GitHub Agent secrets
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-agent-secrets
+  namespace: oncall-crewai
+  labels:
+    app: github-agent-a2a
+    component: external-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: github-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: oncall-crewai
+        property: anthropic-api-key
+
+    - secretKey: github-token
+      remoteRef:
+        key: oncall-crewai
+        property: github-token
+
+---
+# Orchestrator secrets
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: orchestrator-secrets
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+    component: external-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: orchestrator-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: oncall-crewai
+        property: anthropic-api-key
+
+    - secretKey: api-keys
+      remoteRef:
+        key: oncall-crewai
+        property: api-keys

--- a/base-apps/oncall-crewai/github-agent-configmap.yaml
+++ b/base-apps/oncall-crewai/github-agent-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: github-agent-config
+  namespace: oncall-crewai
+  labels:
+    app: github-agent-a2a
+data:
+  AGENT_LOG_LEVEL: "INFO"
+  GITHUB_AGENT_HOST: "0.0.0.0"
+  GITHUB_AGENT_PORT: "8080"
+  GITHUB_ORG: "arigsela"
+  GITOPS_REPO: "arigsela/kubernetes"
+  GITOPS_BASE_PATH: "base-apps/"
+  GITOPS_BASE_BRANCH: "main"
+  DOCS_REPO: "arigsela/claude-agents"

--- a/base-apps/oncall-crewai/github-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/github-agent-deployment.yaml
@@ -1,0 +1,112 @@
+# Deployment for GitHub/GitOps A2A Agent
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-agent-a2a
+  namespace: oncall-crewai
+  labels:
+    app: github-agent-a2a
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-agent-a2a
+  template:
+    metadata:
+      labels:
+        app: github-agent-a2a
+        version: v1
+    spec:
+      serviceAccountName: github-gitops-agent
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+      - name: agent
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/crewai-github-agent:latest
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        envFrom:
+        - configMapRef:
+            name: github-agent-config
+
+        env:
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: github-agent-secrets
+              key: anthropic-api-key
+
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-agent-secrets
+              key: github-token
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      terminationGracePeriodSeconds: 30
+
+---
+# ServiceAccount for GitHub agent (no ClusterRole -- no K8s access)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-gitops-agent
+  namespace: oncall-crewai
+  labels:
+    app: github-agent-a2a
+    component: rbac
+
+---
+# Service for GitHub/GitOps Agent
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-agent-a2a
+  namespace: oncall-crewai
+  labels:
+    app: github-agent-a2a
+spec:
+  type: ClusterIP
+  selector:
+    app: github-agent-a2a
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP

--- a/base-apps/oncall-crewai/k8s-agent-configmap.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-agent-config
+  namespace: oncall-crewai
+  labels:
+    app: k8s-agent-a2a
+data:
+  AGENT_LOG_LEVEL: "INFO"
+  K8S_AGENT_HOST: "0.0.0.0"
+  K8S_AGENT_PORT: "8080"

--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -1,0 +1,95 @@
+# Deployment for K8s Diagnostics A2A Agent
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-agent-a2a
+  namespace: oncall-crewai
+  labels:
+    app: k8s-agent-a2a
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-agent-a2a
+  template:
+    metadata:
+      labels:
+        app: k8s-agent-a2a
+        version: v1
+    spec:
+      serviceAccountName: k8s-diagnostics-agent
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+      - name: agent
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/crewai-k8s-agent:latest
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        envFrom:
+        - configMapRef:
+            name: k8s-agent-config
+
+        env:
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: k8s-agent-secrets
+              key: anthropic-api-key
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      terminationGracePeriodSeconds: 30
+
+---
+# Service for K8s Diagnostics Agent
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-agent-a2a
+  namespace: oncall-crewai
+  labels:
+    app: k8s-agent-a2a
+spec:
+  type: ClusterIP
+  selector:
+    app: k8s-agent-a2a
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP

--- a/base-apps/oncall-crewai/namespace.yaml
+++ b/base-apps/oncall-crewai/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oncall-crewai
+  labels:
+    app: oncall-crewai
+    team: devops

--- a/base-apps/oncall-crewai/orchestrator-configmap.yaml
+++ b/base-apps/oncall-crewai/orchestrator-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-config
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+data:
+  AGENT_LOG_LEVEL: "INFO"
+  ORCHESTRATOR_HOST: "0.0.0.0"
+  ORCHESTRATOR_PORT: "8000"
+  CORS_ORIGINS: "*"
+  # Internal service DNS names for A2A agent discovery
+  K8S_AGENT_URL: "http://k8s-agent-a2a.oncall-crewai.svc:8080"
+  GITHUB_AGENT_URL: "http://github-agent-a2a.oncall-crewai.svc:8080"

--- a/base-apps/oncall-crewai/orchestrator-deployment.yaml
+++ b/base-apps/oncall-crewai/orchestrator-deployment.yaml
@@ -1,0 +1,112 @@
+# Deployment for OnCall CrewAI Orchestrator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crewai-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crewai-orchestrator
+  template:
+    metadata:
+      labels:
+        app: crewai-orchestrator
+        version: v1
+    spec:
+      serviceAccountName: crewai-orchestrator
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+      - name: orchestrator
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/crewai-orchestrator:latest
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+
+        envFrom:
+        - configMapRef:
+            name: orchestrator-config
+
+        env:
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: anthropic-api-key
+
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: api-keys
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      terminationGracePeriodSeconds: 30
+
+---
+# ServiceAccount for orchestrator (no ClusterRole -- no direct K8s access)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crewai-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+    component: rbac
+
+---
+# Service for OnCall Orchestrator
+apiVersion: v1
+kind: Service
+metadata:
+  name: crewai-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+spec:
+  type: ClusterIP
+  selector:
+    app: crewai-orchestrator
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8000
+    protocol: TCP

--- a/base-apps/oncall-crewai/rbac.yaml
+++ b/base-apps/oncall-crewai/rbac.yaml
@@ -1,0 +1,60 @@
+# ServiceAccount for K8s Diagnostics Agent
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-diagnostics-agent
+  namespace: oncall-crewai
+  labels:
+    app: k8s-agent-a2a
+    component: rbac
+
+---
+# ClusterRole - Read-only access to K8s resources for diagnostics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crewai-k8s-agent-reader
+  labels:
+    app: k8s-agent-a2a
+rules:
+  # Pod monitoring
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status"]
+    verbs: ["get", "list", "watch"]
+
+  # Event monitoring
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+
+  # Deployment monitoring
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+
+  # Namespace information
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+
+  # Service information
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+
+---
+# ClusterRoleBinding - Bind read-only role to K8s agent service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crewai-k8s-agent-reader-binding
+  labels:
+    app: k8s-agent-a2a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crewai-k8s-agent-reader
+subjects:
+  - kind: ServiceAccount
+    name: k8s-diagnostics-agent
+    namespace: oncall-crewai

--- a/base-apps/oncall-crewai/secret-store.yaml
+++ b/base-apps/oncall-crewai/secret-store.yaml
@@ -1,0 +1,19 @@
+# SecretStore for OnCall CrewAI (k3s homelab)
+# Connects to Vault using Kubernetes authentication
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: oncall-crewai
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "oncall-crewai"
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
## Summary
- Consolidate three CrewAI agent deployments (k8s, github, orchestrator) into a single `oncall-crewai` ArgoCD application
- Deduplicate shared resources (namespace, secret-store, external-secrets) that were previously triplicated across directories
- Align with repo best practices: added securityContext, nodeSelector, and removed conflicting plain secret.yaml files

## Changes
### Key Features
- **Single ArgoCD Application**: `oncall-crewai.yaml` manages all three agents from one directory
- **Deduplicated resources**: namespace, SecretStore, and ExternalSecrets defined once instead of 3x
- **Security hardening**: Added `securityContext` (runAsUser/runAsGroup/fsGroup: 1000) to all deployments
- **Node scheduling**: Added `nodeSelector: node.kubernetes.io/workload: application` matching n8n pattern
- **Removed plain secrets**: Eliminated `secret.yaml` files that conflicted with ExternalSecret `creationPolicy: Owner`

### Technical Implementation
- Created `base-apps/oncall-crewai/` consolidated directory with 11 manifest files
- Vault policy, Kubernetes auth role, and secrets created for `oncall-crewai` path
- Reused existing Anthropic API key and GitHub token from `oncall-agent` Vault path
- Generated fresh API key for orchestrator authentication

### Files
| File | Purpose |
|---|---|
| `oncall-crewai.yaml` | ArgoCD Application |
| `namespace.yaml` | Shared namespace |
| `secret-store.yaml` | Vault SecretStore (single) |
| `external-secret.yaml` | All 3 agents' ExternalSecrets (single) |
| `rbac.yaml` | K8s agent ServiceAccount + ClusterRole |
| `k8s-agent-deployment.yaml` | K8s diagnostics agent + Service |
| `k8s-agent-configmap.yaml` | K8s agent config |
| `github-agent-deployment.yaml` | GitHub agent + ServiceAccount + Service |
| `github-agent-configmap.yaml` | GitHub agent config |
| `orchestrator-deployment.yaml` | Orchestrator + ServiceAccount + Service |
| `orchestrator-configmap.yaml` | Orchestrator config |

## Deployment Notes
- Vault policy `oncall-crewai` and K8s auth role already created
- Secrets stored at `k8s-secrets/oncall-crewai` in Vault
- ArgoCD will auto-sync once merged to main

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed new OnCall CrewAI automation system with orchestration capabilities
  * Added Kubernetes cluster diagnostics and monitoring agent
  * Integrated GitHub and GitOps automation agent for repository operations
  * Configured secure credential management with Vault integration for enhanced security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->