### PR TITLE
Add oncall-crewai to ECR credential sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent cluster-scanner agent-ui-backend agent-ui-frontend; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."

--- a/base-apps/oncall-crewai/github-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/github-agent-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         version: v1
     spec:
       serviceAccountName: github-gitops-agent
+      imagePullSecrets:
+      - name: ecr-registry
       nodeSelector:
         node.kubernetes.io/workload: application
       securityContext:

--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         version: v1
     spec:
       serviceAccountName: k8s-diagnostics-agent
+      imagePullSecrets:
+      - name: ecr-registry
       nodeSelector:
         node.kubernetes.io/workload: application
       securityContext:

--- a/base-apps/oncall-crewai/orchestrator-deployment.yaml
+++ b/base-apps/oncall-crewai/orchestrator-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         version: v1
     spec:
       serviceAccountName: crewai-orchestrator
+      imagePullSecrets:
+      - name: ecr-registry
       nodeSelector:
         node.kubernetes.io/workload: application
       securityContext:


### PR DESCRIPTION
## Summary
- Add `oncall-crewai` namespace to ECR credentials sync CronJob so agents can pull images from ECR
- Add `imagePullSecrets: ecr-registry` to all three agent deployments matching the `oncall-agent` pattern

## Changes
### ECR Auth
- Added `oncall-crewai` to the namespace list in `base-apps/ecr-auth/cronjobs.yaml`

### Agent Deployments
- Added `imagePullSecrets` referencing `ecr-registry` to:
  - `k8s-agent-deployment.yaml`
  - `github-agent-deployment.yaml`
  - `orchestrator-deployment.yaml`

## Test Plan
- [ ] Verify ECR CronJob runs successfully and syncs credentials to `oncall-crewai` namespace
- [ ] Verify all three agent pods can pull images from ECR

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment security by configuring private container registry authentication for orchestrator, GitHub agent, and Kubernetes agent services
  * Improved automated task processing with refined namespace management and enhanced error handling for consistent execution across all monitored namespaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->