### PR TITLE
fix: set HOME=/tmp for crewai non-root containers

### DIFF
--- a/base-apps/oncall-crewai/github-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/github-agent-deployment.yaml
@@ -43,6 +43,8 @@ spec:
             name: github-agent-config
 
         env:
+        - name: HOME
+          value: /tmp
         - name: ANTHROPIC_API_KEY
           valueFrom:
             secretKeyRef:

--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -43,6 +43,8 @@ spec:
             name: k8s-agent-config
 
         env:
+        - name: HOME
+          value: /tmp
         - name: ANTHROPIC_API_KEY
           valueFrom:
             secretKeyRef:

--- a/base-apps/oncall-crewai/orchestrator-deployment.yaml
+++ b/base-apps/oncall-crewai/orchestrator-deployment.yaml
@@ -43,6 +43,8 @@ spec:
             name: orchestrator-config
 
         env:
+        - name: HOME
+          value: /tmp
         - name: ANTHROPIC_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary
- Fix `PermissionError: '/.local'` crash on all three crewai agent pods
- CrewAI's ChromaDB initialization tries to create `~/.local/share/app` at import time
- With `securityContext.runAsUser: 1000`, HOME defaults to `/` which is read-only

## Changes
- Added `HOME=/tmp` env var to all three agent containers:
  - `k8s-agent-deployment.yaml`
  - `github-agent-deployment.yaml`
  - `orchestrator-deployment.yaml`

This allows crewai to write its data directory at `/tmp/.local/share/app` instead.

## Test Plan
- [ ] Verify all three agent pods start without PermissionError
- [ ] Verify /health endpoints respond

🤖 Generated with [Claude Code](https://claude.ai/code)