### PR TITLE
Fix A2A agent card URLs for oncall-crewai agents

### DIFF
--- a/base-apps/oncall-crewai/github-agent-configmap.yaml
+++ b/base-apps/oncall-crewai/github-agent-configmap.yaml
@@ -9,6 +9,8 @@ data:
   AGENT_LOG_LEVEL: "INFO"
   GITHUB_AGENT_HOST: "0.0.0.0"
   GITHUB_AGENT_PORT: "8080"
+  # URL advertised in the A2A agent card — must be reachable by the orchestrator
+  GITHUB_AGENT_URL: "http://github-agent-a2a.oncall-crewai.svc:8080"
   GITHUB_ORG: "arigsela"
   GITOPS_REPO: "arigsela/kubernetes"
   GITOPS_BASE_PATH: "base-apps/"

--- a/base-apps/oncall-crewai/k8s-agent-configmap.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-configmap.yaml
@@ -9,3 +9,5 @@ data:
   AGENT_LOG_LEVEL: "INFO"
   K8S_AGENT_HOST: "0.0.0.0"
   K8S_AGENT_PORT: "8080"
+  # URL advertised in the A2A agent card — must be reachable by the orchestrator
+  K8S_AGENT_URL: "http://k8s-agent-a2a.oncall-crewai.svc:8080"


### PR DESCRIPTION
## Summary
- Add `K8S_AGENT_URL` to k8s-agent configmap so the A2A agent card advertises `http://k8s-agent-a2a.oncall-crewai.svc:8080` instead of `http://0.0.0.0:8080`
- Add `GITHUB_AGENT_URL` to github-agent configmap for the same reason

## Problem
The orchestrator's CrewAI A2A client fetches the agent card from each agent, then uses the `url` field in the card for subsequent JSON-RPC calls. Without these env vars, the agents default to advertising `http://0.0.0.0:8080` which is unreachable from the orchestrator pod, resulting in `HTTP 503: All connection attempts failed`.

## Test plan
- [ ] ArgoCD syncs the configmap changes
- [ ] Agent pods restart and pick up the new env vars
- [ ] Verify agent cards now advertise the correct service DNS URLs
- [ ] Test orchestrator `/query` endpoint routes to agents successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added configuration entries for GitHub and Kubernetes agent service URLs to enable service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->