### PR TITLE
Add CopilotKit frontend to oncall-crewai

### DIFF
--- a/base-apps/oncall-crewai/frontend-configmap.yaml
+++ b/base-apps/oncall-crewai/frontend-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: oncall-crewai
+  labels:
+    app: crewai-frontend
+data:
+  # Internal service DNS for the orchestrator
+  ORCHESTRATOR_URL: "http://crewai-orchestrator.oncall-crewai.svc:80"

--- a/base-apps/oncall-crewai/frontend-deployment.yaml
+++ b/base-apps/oncall-crewai/frontend-deployment.yaml
@@ -31,6 +31,8 @@ spec:
       - name: frontend
         image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/crewai-frontend:latest
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - name: http

--- a/base-apps/oncall-crewai/frontend-deployment.yaml
+++ b/base-apps/oncall-crewai/frontend-deployment.yaml
@@ -1,0 +1,96 @@
+# Deployment for OnCall CrewAI Frontend (CopilotKit Chat UI)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crewai-frontend
+  namespace: oncall-crewai
+  labels:
+    app: crewai-frontend
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crewai-frontend
+  template:
+    metadata:
+      labels:
+        app: crewai-frontend
+        version: v1
+    spec:
+      imagePullSecrets:
+      - name: ecr-registry
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        runAsGroup: 1001
+
+      containers:
+      - name: frontend
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/crewai-frontend:latest
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+
+        envFrom:
+        - configMapRef:
+            name: frontend-config
+
+        env:
+        - name: ORCHESTRATOR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: api-keys
+
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      terminationGracePeriodSeconds: 15
+
+---
+# Service for OnCall Frontend
+apiVersion: v1
+kind: Service
+metadata:
+  name: crewai-frontend
+  namespace: oncall-crewai
+  labels:
+    app: crewai-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: crewai-frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+    protocol: TCP

--- a/base-apps/oncall-crewai/frontend-ingress.yaml
+++ b/base-apps/oncall-crewai/frontend-ingress.yaml
@@ -28,10 +28,10 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - oncall.arigsela.com
-    secretName: oncall-frontend-tls
+    - oncall-crewai.arigsela.com
+    secretName: oncall-crewai-frontend-tls
   rules:
-  - host: oncall.arigsela.com
+  - host: oncall-crewai.arigsela.com
     http:
       paths:
       - path: /

--- a/base-apps/oncall-crewai/frontend-ingress.yaml
+++ b/base-apps/oncall-crewai/frontend-ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: crewai-frontend
+  namespace: oncall-crewai
+  annotations:
+    # TLS/SSL Configuration
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # Backend Protocol
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+
+    # Rate Limiting
+    nginx.ingress.kubernetes.io/limit-rps: "50"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+
+    # IP Whitelist — only reachable from your IP
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32"
+
+    # Timeouts (agent queries can take a while)
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - oncall.arigsela.com
+    secretName: oncall-frontend-tls
+  rules:
+  - host: oncall.arigsela.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: crewai-frontend
+            port:
+              number: 80


### PR DESCRIPTION
## Summary
- Adds `frontend-configmap.yaml` — ConfigMap with `ORCHESTRATOR_URL` pointing to the orchestrator's internal ClusterIP service
- Adds `frontend-deployment.yaml` — Deployment (1 replica, port 3000) + ClusterIP Service (port 80→3000) for the CopilotKit chat UI

## Details
The frontend is a Next.js app using CopilotKit that connects to the orchestrator's `/copilotkit` AG-UI SSE endpoint. It reuses the existing `orchestrator-secrets` for the API key (no new secrets needed).

**No changes to external-secret.yaml** — the frontend references the existing `orchestrator-secrets` secret (key: `api-keys`).

## New resources
| Resource | Name | Description |
|----------|------|-------------|
| ConfigMap | `frontend-config` | `ORCHESTRATOR_URL=http://crewai-orchestrator.oncall-crewai.svc:80` |
| Deployment | `crewai-frontend` | 1 replica, `crewai-frontend:latest` from ECR |
| Service | `crewai-frontend` | ClusterIP, port 80 → 3000 |

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] Pod starts and passes readiness probe
- [ ] `kubectl port-forward -n oncall-crewai svc/crewai-frontend 3000:80` → chat UI loads at localhost:3000
- [ ] Sending a query routes through orchestrator to agents and returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployed the CrewAI frontend and exposed it via internal service for cluster access.
  * Connected frontend to the orchestrator endpoint via configurable environment settings.
* **Chores**
  * Added resource limits/requests and container runtime/security settings for stability.
  * Enabled health checks (liveness/readiness) and graceful termination.
* **Security**
  * Configured secret-backed API key injection for orchestrator access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->