### PR TITLE
Increase crewai-frontend resource limits

### DIFF
--- a/base-apps/oncall-crewai/frontend-deployment.yaml
+++ b/base-apps/oncall-crewai/frontend-deployment.yaml
@@ -52,11 +52,11 @@ spec:
 
         resources:
           requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
             memory: "256Mi"
-            cpu: "250m"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
 
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary\n- Increase frontend memory limit from 256Mi to 512Mi\n- Increase frontend CPU limit from 250m to 500m\n- Increase requests proportionally (128Mi→256Mi, 100m→200m)\n\n## Problem\nFrontend pod throwing `ERR_INSUFFICIENT_RESOURCES` and `ERR_HTTP2_SERVER_REFUSED_STREAM` errors. Next.js + CopilotKit runtime needs more memory than initially allocated.\n\n## Test plan\n- [ ] ArgoCD syncs updated deployment\n- [ ] Pod restarts with new resource limits\n- [ ] `oncall-crewai.arigsela.com` loads without client-side errors\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)