### PR TITLE
Add session persistence storage for crewai orchestrator

### DIFF
--- a/base-apps/oncall-crewai/orchestrator-configmap.yaml
+++ b/base-apps/oncall-crewai/orchestrator-configmap.yaml
@@ -13,3 +13,5 @@ data:
   # Internal service DNS names for A2A agent discovery
   K8S_AGENT_URL: "http://k8s-agent-a2a.oncall-crewai.svc:8080"
   GITHUB_AGENT_URL: "http://github-agent-a2a.oncall-crewai.svc:8080"
+  SESSION_DB_PATH: "/data/sessions.db"
+  SESSION_TTL_HOURS: "24"

--- a/base-apps/oncall-crewai/orchestrator-deployment.yaml
+++ b/base-apps/oncall-crewai/orchestrator-deployment.yaml
@@ -57,6 +57,10 @@ spec:
               name: orchestrator-secrets
               key: api-keys
 
+        volumeMounts:
+        - name: data
+          mountPath: /data
+
         resources:
           requests:
             memory: "256Mi"
@@ -82,6 +86,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: orchestrator-data
 
       terminationGracePeriodSeconds: 30
 

--- a/base-apps/oncall-crewai/orchestrator-pvc.yaml
+++ b/base-apps/oncall-crewai/orchestrator-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orchestrator-data
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary

- **New PVC** (`orchestrator-pvc.yaml`): 1Gi ReadWriteOnce volume for SQLite session database
- **Updated Deployment** (`orchestrator-deployment.yaml`): Added `volumeMounts` at `/data` and `volumes` referencing the PVC
- **Updated ConfigMap** (`orchestrator-configmap.yaml`): Added `SESSION_DB_PATH=/data/sessions.db` and `SESSION_TTL_HOURS=24`

This enables the orchestrator to persist CopilotKit chat sessions across pod restarts using a SQLite database on persistent storage.

## Test plan

- [ ] PVC is created and bound in `oncall-crewai` namespace
- [ ] Orchestrator pod starts with `/data` volume mounted
- [ ] Sessions persist across pod restarts
- [ ] ConfigMap env vars (`SESSION_DB_PATH`, `SESSION_TTL_HOURS`) are available in the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent storage support for session data with configurable retention settings.
  * Session data now persists across container restarts, with a 24-hour default time-to-live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->