### PR TITLE
Add API key auth to oncall-crewai A2A sub-agents

### DIFF
--- a/base-apps/oncall-crewai/external-secret.yaml
+++ b/base-apps/oncall-crewai/external-secret.yaml
@@ -25,6 +25,11 @@ spec:
         key: oncall-crewai
         property: anthropic-api-key
 
+    - secretKey: api-keys
+      remoteRef:
+        key: oncall-crewai
+        property: api-keys
+
 ---
 # GitHub Agent secrets
 apiVersion: external-secrets.io/v1beta1
@@ -53,6 +58,11 @@ spec:
       remoteRef:
         key: oncall-crewai
         property: github-token
+
+    - secretKey: api-keys
+      remoteRef:
+        key: oncall-crewai
+        property: api-keys
 
 ---
 # Orchestrator secrets

--- a/base-apps/oncall-crewai/github-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/github-agent-deployment.yaml
@@ -57,6 +57,12 @@ spec:
               name: github-agent-secrets
               key: github-token
 
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: github-agent-secrets
+              key: api-keys
+
         resources:
           requests:
             memory: "256Mi"

--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -51,6 +51,12 @@ spec:
               name: k8s-agent-secrets
               key: anthropic-api-key
 
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: k8s-agent-secrets
+              key: api-keys
+
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
## Summary
- Add `api-keys` to k8s-agent and github-agent ExternalSecrets (synced from same Vault path as orchestrator)
- Inject `API_KEYS` env var into both sub-agent Deployments
- Enables the auth middleware added to the agent Docker images to enforce API key authentication on A2A JSON-RPC endpoints

## Context
Security review identified that the k8s-agent and github-agent A2A servers exposed their `POST /` JSON-RPC endpoints with zero authentication. Any pod in the cluster could invoke the full tool set (including cross-namespace pod log reads and GitOps PR creation) without credentials. This PR adds the K8s-side config needed for the auth middleware in the new Docker images.

## Changes
| File | Change |
|------|--------|
| `external-secret.yaml` | Add `api-keys` property to k8s-agent and github-agent ExternalSecrets |
| `k8s-agent-deployment.yaml` | Add `API_KEYS` env var from `k8s-agent-secrets` |
| `github-agent-deployment.yaml` | Add `API_KEYS` env var from `github-agent-secrets` |

## Prerequisites
- `api-keys` must exist in Vault at `k8s-secrets/oncall-crewai` (already present — used by orchestrator)
- New Docker images with auth middleware must be pushed before merging (orchestrator, k8s-agent, github-agent)

## Test plan
- [ ] Verify ExternalSecrets sync `api-keys` to both sub-agent K8s Secrets
- [ ] Verify sub-agent pods start with `API_KEYS` env var set
- [ ] Verify unauthenticated `POST /` to sub-agents returns 401
- [ ] Verify orchestrator can still successfully delegate to sub-agents (passes API key via A2AClientConfig)
- [ ] Verify `/health` and `/.well-known/agent.json` remain accessible without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret management configuration to include API key mappings across multiple services.
  * Configured API key environment variables for deployment containers to enable proper credential injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->