### PR TITLE
Add JWT auth, session persistence, and relaxed probes for oncall-crewai

### DIFF
--- a/base-apps/oncall-crewai/external-secret.yaml
+++ b/base-apps/oncall-crewai/external-secret.yaml
@@ -25,6 +25,11 @@ spec:
         key: oncall-crewai
         property: anthropic-api-key
 
+    - secretKey: api-keys
+      remoteRef:
+        key: oncall-crewai
+        property: api-keys
+
 ---
 # GitHub Agent secrets
 apiVersion: external-secrets.io/v1beta1
@@ -54,6 +59,11 @@ spec:
         key: oncall-crewai
         property: github-token
 
+    - secretKey: api-keys
+      remoteRef:
+        key: oncall-crewai
+        property: api-keys
+
 ---
 # Orchestrator secrets
 apiVersion: external-secrets.io/v1beta1
@@ -82,3 +92,8 @@ spec:
       remoteRef:
         key: oncall-crewai
         property: api-keys
+
+    - secretKey: jwt-secret
+      remoteRef:
+        key: oncall-crewai
+        property: jwt-secret

--- a/base-apps/oncall-crewai/frontend-deployment.yaml
+++ b/base-apps/oncall-crewai/frontend-deployment.yaml
@@ -52,11 +52,11 @@ spec:
 
         resources:
           requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
             memory: "256Mi"
-            cpu: "250m"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
 
         livenessProbe:
           httpGet:

--- a/base-apps/oncall-crewai/github-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/github-agent-deployment.yaml
@@ -57,6 +57,12 @@ spec:
               name: github-agent-secrets
               key: github-token
 
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: github-agent-secrets
+              key: api-keys
+
         resources:
           requests:
             memory: "256Mi"
@@ -70,18 +76,18 @@ spec:
             path: /health
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 60
           timeoutSeconds: 10
-          failureThreshold: 3
+          failureThreshold: 5
 
         readinessProbe:
           httpGet:
             path: /health
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 5
 
       terminationGracePeriodSeconds: 30
 

--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -51,6 +51,12 @@ spec:
               name: k8s-agent-secrets
               key: anthropic-api-key
 
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: k8s-agent-secrets
+              key: api-keys
+
         resources:
           requests:
             memory: "256Mi"
@@ -64,18 +70,18 @@ spec:
             path: /health
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 60
           timeoutSeconds: 10
-          failureThreshold: 3
+          failureThreshold: 5
 
         readinessProbe:
           httpGet:
             path: /health
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 5
 
       terminationGracePeriodSeconds: 30
 

--- a/base-apps/oncall-crewai/orchestrator-configmap.yaml
+++ b/base-apps/oncall-crewai/orchestrator-configmap.yaml
@@ -13,3 +13,5 @@ data:
   # Internal service DNS names for A2A agent discovery
   K8S_AGENT_URL: "http://k8s-agent-a2a.oncall-crewai.svc:8080"
   GITHUB_AGENT_URL: "http://github-agent-a2a.oncall-crewai.svc:8080"
+  SESSION_DB_PATH: "/data/sessions.db"
+  SESSION_TTL_HOURS: "24"

--- a/base-apps/oncall-crewai/orchestrator-deployment.yaml
+++ b/base-apps/oncall-crewai/orchestrator-deployment.yaml
@@ -57,6 +57,16 @@ spec:
               name: orchestrator-secrets
               key: api-keys
 
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: jwt-secret
+
+        volumeMounts:
+        - name: data
+          mountPath: /data
+
         resources:
           requests:
             memory: "256Mi"
@@ -82,6 +92,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: orchestrator-data
 
       terminationGracePeriodSeconds: 30
 

--- a/base-apps/oncall-crewai/orchestrator-pvc.yaml
+++ b/base-apps/oncall-crewai/orchestrator-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orchestrator-data
+  namespace: oncall-crewai
+  labels:
+    app: crewai-orchestrator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary\n- Add `jwt-secret` to orchestrator ExternalSecret and deployment env var for user authentication\n- Add `api-keys` to k8s-agent and github-agent ExternalSecrets for A2A auth\n- Add PVC volume mount to orchestrator for session/user DB persistence\n- Add session config (`SESSION_DB_PATH`, `SESSION_TTL_HOURS`) to orchestrator configmap\n- Relax liveness/readiness probes on k8s-agent and github-agent (60s period, 5 failures) to prevent pod restarts during long-running CrewAI queries\n- Increase frontend resource limits\n\n## Test plan\n- [ ] Verify ArgoCD syncs all changes successfully\n- [ ] Verify orchestrator-secrets includes jwt-secret from Vault\n- [ ] Verify k8s-agent and github-agent pods no longer restart during queries\n- [ ] Verify orchestrator PVC is mounted at /data\n- [ ] Verify user login/session persistence works end-to-end\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend resource allocation (increased CPU to 200m, memory limit to 512Mi) for improved performance.
  * Integrated API key authentication for K8s and GitHub agents.
  * Added JWT secret support to the orchestrator.
  * Enabled session persistence with configurable TTL (24 hours) in orchestrator.
  * Enhanced health monitoring with adjusted check intervals and failure thresholds.
  * Provisioned persistent storage infrastructure for data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->