### PR TITLE
Add Backstage developer portal deployment

### DIFF
--- a/base-apps/backstage.yaml
+++ b/base-apps/backstage.yaml
@@ -1,18 +1,3 @@
-# ==============================================================================
-# ArgoCD Application: Backstage Developer Portal
-# ==============================================================================
-#
-# This manifest tells ArgoCD to watch the base-apps/backstage/ directory
-# in the kubernetes repo and automatically sync its contents to the cluster.
-#
-# HOW IT WORKS:
-# 1. ArgoCD's Master App auto-discovers this file in base-apps/
-# 2. ArgoCD creates an Application that watches base-apps/backstage/
-# 3. Any YAML changes in that directory are auto-applied to the cluster
-# 4. Prune: removes resources deleted from Git. SelfHeal: reverts manual changes.
-# 5. CreateNamespace: creates the backstage namespace if it doesn't exist yet
-# ==============================================================================
-
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/base-apps/backstage.yaml
+++ b/base-apps/backstage.yaml
@@ -1,0 +1,35 @@
+# ==============================================================================
+# ArgoCD Application: Backstage Developer Portal
+# ==============================================================================
+#
+# This manifest tells ArgoCD to watch the base-apps/backstage/ directory
+# in the kubernetes repo and automatically sync its contents to the cluster.
+#
+# HOW IT WORKS:
+# 1. ArgoCD's Master App auto-discovers this file in base-apps/
+# 2. ArgoCD creates an Application that watches base-apps/backstage/
+# 3. Any YAML changes in that directory are auto-applied to the cluster
+# 4. Prune: removes resources deleted from Git. SelfHeal: reverts manual changes.
+# 5. CreateNamespace: creates the backstage namespace if it doesn't exist yet
+# ==============================================================================
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backstage
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/backstage
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: backstage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/backstage/configmaps.yaml
+++ b/base-apps/backstage/configmaps.yaml
@@ -1,22 +1,3 @@
-# ==============================================================================
-# Backstage ConfigMap — Non-Sensitive Configuration
-# ==============================================================================
-#
-# Stores environment variables that are NOT secrets. These are injected into
-# the Backstage pod via envFrom.configMapRef in the Deployment.
-#
-# WHY A CONFIGMAP (NOT A SECRET):
-# These values are not sensitive — they're just infrastructure addresses.
-# Putting them in a ConfigMap makes them easy to view and debug without
-# needing Vault access. Sensitive values (passwords, tokens) go in the
-# ExternalSecret → backstage-secrets Secret instead.
-#
-# POSTGRES_HOST uses cross-namespace DNS:
-# <service-name>.<namespace>.svc.cluster.local
-# This lets the Backstage pod in the 'backstage' namespace reach the
-# PostgreSQL service running in the 'postgresql' namespace.
-# ==============================================================================
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/base-apps/backstage/configmaps.yaml
+++ b/base-apps/backstage/configmaps.yaml
@@ -1,0 +1,27 @@
+# ==============================================================================
+# Backstage ConfigMap — Non-Sensitive Configuration
+# ==============================================================================
+#
+# Stores environment variables that are NOT secrets. These are injected into
+# the Backstage pod via envFrom.configMapRef in the Deployment.
+#
+# WHY A CONFIGMAP (NOT A SECRET):
+# These values are not sensitive — they're just infrastructure addresses.
+# Putting them in a ConfigMap makes them easy to view and debug without
+# needing Vault access. Sensitive values (passwords, tokens) go in the
+# ExternalSecret → backstage-secrets Secret instead.
+#
+# POSTGRES_HOST uses cross-namespace DNS:
+# <service-name>.<namespace>.svc.cluster.local
+# This lets the Backstage pod in the 'backstage' namespace reach the
+# PostgreSQL service running in the 'postgresql' namespace.
+# ==============================================================================
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-config
+  namespace: backstage
+data:
+  POSTGRES_HOST: "postgresql.postgresql.svc.cluster.local"
+  POSTGRES_PORT: "5432"

--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -51,8 +51,8 @@ spec:
 
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:latest
-        imagePullPolicy: IfNotPresent
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.0
+        imagePullPolicy: Always
         ports:
         - containerPort: 7007
 

--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -1,0 +1,114 @@
+# ==============================================================================
+# Backstage Deployment
+# ==============================================================================
+#
+# Runs the Backstage backend as a standard Kubernetes Deployment (not a Rollout,
+# since Backstage is an internal tool where canary deployments aren't needed).
+#
+# KEY DESIGN DECISIONS:
+# - Single replica: Backstage is stateless (state lives in PostgreSQL), but a
+#   single replica is sufficient for an internal developer portal.
+# - envFrom: Pulls ALL keys from the ConfigMap and Secret as env vars.
+#   This keeps the manifest clean — adding a new env var only requires
+#   updating the ConfigMap/Secret, not this Deployment.
+# - imagePullSecrets: The ecr-registry secret is synced by the ECR CronJob
+#   every hour. Without it, K8s can't pull images from our private ECR.
+# - Security: Runs as non-root user (UID 1000), no privilege escalation.
+#   The Backstage Dockerfile already creates a node user with UID 1000.
+# ==============================================================================
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backstage
+  namespace: backstage
+  labels:
+    app: backstage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backstage
+  template:
+    metadata:
+      labels:
+        app: backstage
+    spec:
+      # Schedule on application nodes (not infrastructure/control-plane nodes).
+      nodeSelector:
+        node.kubernetes.io/workload: application
+
+      # Security context at the pod level:
+      # - runAsUser/runAsGroup 1000: matches the 'node' user in the Dockerfile
+      # - fsGroup 1000: ensures mounted volumes are writable by the node user
+      # - runAsNonRoot: prevents the container from running as root even if
+      #   the image's USER directive is somehow bypassed
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+
+      containers:
+      - name: backstage
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 7007
+
+        # Load all environment variables from:
+        # 1. backstage-config ConfigMap (non-sensitive: POSTGRES_HOST, POSTGRES_PORT)
+        # 2. backstage-secrets Secret (sensitive: passwords, tokens, OAuth creds)
+        #    Created by External Secrets Operator from Vault
+        envFrom:
+        - configMapRef:
+            name: backstage-config
+        - secretRef:
+            name: backstage-secrets
+
+        # Container-level security: prevent privilege escalation attacks.
+        securityContext:
+          allowPrivilegeEscalation: false
+
+        # LIVENESS PROBE: "Is the process alive?"
+        # If this fails 3 times, Kubernetes kills and restarts the pod.
+        # initialDelaySeconds is 60s because Backstage loads many plugins
+        # at startup (catalog, auth, kubernetes, techdocs, etc.).
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 7007
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        # READINESS PROBE: "Is it ready to serve traffic?"
+        # Until this passes, the Service won't route traffic to this pod.
+        # Lower initialDelay than liveness — we want to start routing
+        # as soon as the server is listening, even if some plugins are
+        # still initializing in the background.
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 7007
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        # RESOURCE LIMITS:
+        # requests: guaranteed minimum (used for scheduling decisions)
+        # limits: hard ceiling (pod gets OOM-killed or CPU-throttled beyond this)
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+
+      # ECR pull secret — synced hourly by the ecr-credentials-sync CronJob.
+      # Without this, the kubelet can't authenticate to pull from our private ECR.
+      imagePullSecrets:
+      - name: ecr-registry

--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -1,22 +1,3 @@
-# ==============================================================================
-# Backstage Deployment
-# ==============================================================================
-#
-# Runs the Backstage backend as a standard Kubernetes Deployment (not a Rollout,
-# since Backstage is an internal tool where canary deployments aren't needed).
-#
-# KEY DESIGN DECISIONS:
-# - Single replica: Backstage is stateless (state lives in PostgreSQL), but a
-#   single replica is sufficient for an internal developer portal.
-# - envFrom: Pulls ALL keys from the ConfigMap and Secret as env vars.
-#   This keeps the manifest clean — adding a new env var only requires
-#   updating the ConfigMap/Secret, not this Deployment.
-# - imagePullSecrets: The ecr-registry secret is synced by the ECR CronJob
-#   every hour. Without it, K8s can't pull images from our private ECR.
-# - Security: Runs as non-root user (UID 1000), no privilege escalation.
-#   The Backstage Dockerfile already creates a node user with UID 1000.
-# ==============================================================================
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,46 +15,26 @@ spec:
       labels:
         app: backstage
     spec:
-      # Schedule on application nodes (not infrastructure/control-plane nodes).
       nodeSelector:
         node.kubernetes.io/workload: application
-
-      # Security context at the pod level:
-      # - runAsUser/runAsGroup 1000: matches the 'node' user in the Dockerfile
-      # - fsGroup 1000: ensures mounted volumes are writable by the node user
-      # - runAsNonRoot: prevents the container from running as root even if
-      #   the image's USER directive is somehow bypassed
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         runAsNonRoot: true
-
       containers:
       - name: backstage
         image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 7007
-
-        # Load all environment variables from:
-        # 1. backstage-config ConfigMap (non-sensitive: POSTGRES_HOST, POSTGRES_PORT)
-        # 2. backstage-secrets Secret (sensitive: passwords, tokens, OAuth creds)
-        #    Created by External Secrets Operator from Vault
         envFrom:
         - configMapRef:
             name: backstage-config
         - secretRef:
             name: backstage-secrets
-
-        # Container-level security: prevent privilege escalation attacks.
         securityContext:
           allowPrivilegeEscalation: false
-
-        # LIVENESS PROBE: "Is the process alive?"
-        # If this fails 3 times, Kubernetes kills and restarts the pod.
-        # initialDelaySeconds is 60s because Backstage loads many plugins
-        # at startup (catalog, auth, kubernetes, techdocs, etc.).
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -82,12 +43,6 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3
-
-        # READINESS PROBE: "Is it ready to serve traffic?"
-        # Until this passes, the Service won't route traffic to this pod.
-        # Lower initialDelay than liveness — we want to start routing
-        # as soon as the server is listening, even if some plugins are
-        # still initializing in the background.
         readinessProbe:
           httpGet:
             path: /healthcheck
@@ -96,10 +51,6 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
-
-        # RESOURCE LIMITS:
-        # requests: guaranteed minimum (used for scheduling decisions)
-        # limits: hard ceiling (pod gets OOM-killed or CPU-throttled beyond this)
         resources:
           requests:
             memory: "256Mi"
@@ -107,8 +58,5 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
-
-      # ECR pull secret — synced hourly by the ecr-credentials-sync CronJob.
-      # Without this, the kubelet can't authenticate to pull from our private ECR.
       imagePullSecrets:
       - name: ecr-registry

--- a/base-apps/backstage/external-secrets.yaml
+++ b/base-apps/backstage/external-secrets.yaml
@@ -1,0 +1,78 @@
+# ==============================================================================
+# Backstage ExternalSecret — Vault → Kubernetes Secret
+# ==============================================================================
+#
+# Maps secrets stored in HashiCorp Vault to a Kubernetes Secret that the
+# Backstage Deployment can consume via envFrom.secretRef.
+#
+# HOW IT WORKS:
+# 1. ESO reads this ExternalSecret every refreshInterval (1 hour)
+# 2. ESO connects to Vault using the vault-backend SecretStore
+# 3. ESO reads individual properties from the Vault path: k8s-secrets/data/backstage
+# 4. ESO creates/updates the 'backstage-secrets' Kubernetes Secret
+# 5. The Backstage Deployment loads all keys from this Secret as env vars
+#
+# SECRET MAPPING:
+# Left side (secretKey) = env var name in the Backstage container
+# Right side (property) = key name in the Vault KV store
+#
+# TO ADD A NEW SECRET:
+# 1. Store it in Vault: vault kv patch k8s-secrets/backstage new-key=value
+# 2. Add a mapping below with secretKey (env var) and property (Vault key)
+# 3. Reference ${ENV_VAR_NAME} in app-config.production.yaml
+# ==============================================================================
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: backstage-secrets
+  namespace: backstage
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: backstage-secrets
+    creationPolicy: Owner
+  data:
+    # PostgreSQL credentials for the Backstage database
+    - secretKey: POSTGRES_USER
+      remoteRef:
+        key: backstage
+        property: postgres-user
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: backstage
+        property: postgres-password
+
+    # GitHub Personal Access Token — used by:
+    # - integrations.github (catalog reads YAML from repos)
+    # - catalog.providers.github (auto-discovers repos with catalog-info.yaml)
+    # - scaffolder (creates repos from templates)
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        key: backstage
+        property: github-token
+
+    # GitHub OAuth App credentials — used by auth.providers.github
+    # for user sign-in via the GitHub OAuth flow
+    - secretKey: AUTH_GITHUB_CLIENT_ID
+      remoteRef:
+        key: backstage
+        property: github-oauth-client-id
+    - secretKey: AUTH_GITHUB_CLIENT_SECRET
+      remoteRef:
+        key: backstage
+        property: github-oauth-client-secret
+
+    # Kubernetes plugin credentials — used by the kubernetes backend plugin
+    # to query pod/deployment status and show it on entity pages
+    - secretKey: K8S_CLUSTER_URL
+      remoteRef:
+        key: backstage
+        property: k8s-cluster-url
+    - secretKey: K8S_SERVICE_ACCOUNT_TOKEN
+      remoteRef:
+        key: backstage
+        property: k8s-service-account-token

--- a/base-apps/backstage/external-secrets.yaml
+++ b/base-apps/backstage/external-secrets.yaml
@@ -1,27 +1,3 @@
-# ==============================================================================
-# Backstage ExternalSecret — Vault → Kubernetes Secret
-# ==============================================================================
-#
-# Maps secrets stored in HashiCorp Vault to a Kubernetes Secret that the
-# Backstage Deployment can consume via envFrom.secretRef.
-#
-# HOW IT WORKS:
-# 1. ESO reads this ExternalSecret every refreshInterval (1 hour)
-# 2. ESO connects to Vault using the vault-backend SecretStore
-# 3. ESO reads individual properties from the Vault path: k8s-secrets/data/backstage
-# 4. ESO creates/updates the 'backstage-secrets' Kubernetes Secret
-# 5. The Backstage Deployment loads all keys from this Secret as env vars
-#
-# SECRET MAPPING:
-# Left side (secretKey) = env var name in the Backstage container
-# Right side (property) = key name in the Vault KV store
-#
-# TO ADD A NEW SECRET:
-# 1. Store it in Vault: vault kv patch k8s-secrets/backstage new-key=value
-# 2. Add a mapping below with secretKey (env var) and property (Vault key)
-# 3. Reference ${ENV_VAR_NAME} in app-config.production.yaml
-# ==============================================================================
-
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -36,7 +12,6 @@ spec:
     name: backstage-secrets
     creationPolicy: Owner
   data:
-    # PostgreSQL credentials for the Backstage database
     - secretKey: POSTGRES_USER
       remoteRef:
         key: backstage
@@ -45,18 +20,10 @@ spec:
       remoteRef:
         key: backstage
         property: postgres-password
-
-    # GitHub Personal Access Token — used by:
-    # - integrations.github (catalog reads YAML from repos)
-    # - catalog.providers.github (auto-discovers repos with catalog-info.yaml)
-    # - scaffolder (creates repos from templates)
     - secretKey: GITHUB_TOKEN
       remoteRef:
         key: backstage
         property: github-token
-
-    # GitHub OAuth App credentials — used by auth.providers.github
-    # for user sign-in via the GitHub OAuth flow
     - secretKey: AUTH_GITHUB_CLIENT_ID
       remoteRef:
         key: backstage
@@ -65,9 +32,6 @@ spec:
       remoteRef:
         key: backstage
         property: github-oauth-client-secret
-
-    # Kubernetes plugin credentials — used by the kubernetes backend plugin
-    # to query pod/deployment status and show it on entity pages
     - secretKey: K8S_CLUSTER_URL
       remoteRef:
         key: backstage

--- a/base-apps/backstage/nginx-ingress.yaml
+++ b/base-apps/backstage/nginx-ingress.yaml
@@ -1,0 +1,54 @@
+# ==============================================================================
+# Backstage NGINX Ingress with TLS
+# ==============================================================================
+#
+# Routes external HTTPS traffic from backstage.arigsela.com to the Backstage
+# ClusterIP Service. TLS is handled by cert-manager (Let's Encrypt).
+#
+# HOW TLS WORKS:
+# 1. cert-manager sees the cluster-issuer annotation and the tls section
+# 2. It requests a certificate from Let's Encrypt for backstage.arigsela.com
+# 3. The certificate is stored in the backstage-tls Secret
+# 4. NGINX Ingress Controller terminates TLS using that certificate
+# 5. Traffic from NGINX → Backstage pod is plain HTTP (within the cluster)
+#
+# TIMEOUT CONFIGURATION:
+# Backstage can be slow on first request (cold catalog load, plugin init).
+# The 60s timeouts prevent 504 errors during these initial loads.
+# ==============================================================================
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backstage-nginx
+  namespace: backstage
+  annotations:
+    # Tell cert-manager to issue a certificate using the letsencrypt-prod ClusterIssuer
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Force all HTTP traffic to HTTPS (301 redirect)
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # Backend speaks plain HTTP (TLS terminates at the ingress controller)
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    # Generous timeouts for Backstage — initial catalog load and TechDocs
+    # generation can take time on first request
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - backstage.arigsela.com
+    secretName: backstage-tls
+  rules:
+  - host: backstage.arigsela.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: backstage
+            port:
+              number: 80

--- a/base-apps/backstage/nginx-ingress.yaml
+++ b/base-apps/backstage/nginx-ingress.yaml
@@ -1,40 +1,17 @@
-# ==============================================================================
-# Backstage NGINX Ingress with TLS
-# ==============================================================================
-#
-# Routes external HTTPS traffic from backstage.arigsela.com to the Backstage
-# ClusterIP Service. TLS is handled by cert-manager (Let's Encrypt).
-#
-# HOW TLS WORKS:
-# 1. cert-manager sees the cluster-issuer annotation and the tls section
-# 2. It requests a certificate from Let's Encrypt for backstage.arigsela.com
-# 3. The certificate is stored in the backstage-tls Secret
-# 4. NGINX Ingress Controller terminates TLS using that certificate
-# 5. Traffic from NGINX → Backstage pod is plain HTTP (within the cluster)
-#
-# TIMEOUT CONFIGURATION:
-# Backstage can be slow on first request (cold catalog load, plugin init).
-# The 60s timeouts prevent 504 errors during these initial loads.
-# ==============================================================================
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: backstage-nginx
   namespace: backstage
   annotations:
-    # Tell cert-manager to issue a certificate using the letsencrypt-prod ClusterIssuer
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    # Force all HTTP traffic to HTTPS (301 redirect)
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    # Backend speaks plain HTTP (TLS terminates at the ingress controller)
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    # Generous timeouts for Backstage — initial catalog load and TechDocs
-    # generation can take time on first request
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
 spec:
   ingressClassName: nginx
   tls:

--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -1,33 +1,3 @@
-# ==============================================================================
-# Backstage RBAC — ServiceAccount + ClusterRole + ClusterRoleBinding
-# ==============================================================================
-#
-# Creates the Kubernetes RBAC resources needed for Backstage's Kubernetes plugin.
-# The plugin queries the K8s API to show pod status, logs, and deployments
-# directly on entity pages in the Backstage UI.
-#
-# WHY A ClusterRole (NOT Role):
-# Backstage needs to read resources across ALL namespaces — it shows the
-# Kubernetes tab for any entity with a kubernetes-id annotation, regardless
-# of which namespace the workload runs in. A Role is namespace-scoped,
-# so we need a ClusterRole for cross-namespace read access.
-#
-# SECURITY:
-# - Read-only access only (get, list, watch) — Backstage cannot modify resources
-# - No access to Secrets (prevents credential leakage through the UI)
-# - The ServiceAccount token is stored in Vault and injected as K8S_SERVICE_ACCOUNT_TOKEN
-#
-# GENERATING THE TOKEN:
-# After ArgoCD deploys these resources, generate a long-lived token:
-#   kubectl create token backstage -n backstage --duration=8760h
-# Then store it in Vault:
-#   vault kv patch k8s-secrets/backstage k8s-service-account-token=<token>
-# ==============================================================================
-
-# ServiceAccount for the Backstage Kubernetes plugin.
-# This SA is used to generate the token that Backstage uses to query the K8s API.
-# NOTE: This is NOT the SA the pod runs as — the pod uses 'default'.
-# This SA exists solely for the Kubernetes plugin's API access.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -36,8 +6,6 @@ metadata:
 
 ---
 
-# ClusterRole with read-only access to common workload resources.
-# These are the resources the Kubernetes plugin displays on entity pages.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -74,8 +42,6 @@ rules:
 
 ---
 
-# Bind the ClusterRole to the backstage ServiceAccount.
-# This grants the SA read-only access cluster-wide.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -1,0 +1,90 @@
+# ==============================================================================
+# Backstage RBAC — ServiceAccount + ClusterRole + ClusterRoleBinding
+# ==============================================================================
+#
+# Creates the Kubernetes RBAC resources needed for Backstage's Kubernetes plugin.
+# The plugin queries the K8s API to show pod status, logs, and deployments
+# directly on entity pages in the Backstage UI.
+#
+# WHY A ClusterRole (NOT Role):
+# Backstage needs to read resources across ALL namespaces — it shows the
+# Kubernetes tab for any entity with a kubernetes-id annotation, regardless
+# of which namespace the workload runs in. A Role is namespace-scoped,
+# so we need a ClusterRole for cross-namespace read access.
+#
+# SECURITY:
+# - Read-only access only (get, list, watch) — Backstage cannot modify resources
+# - No access to Secrets (prevents credential leakage through the UI)
+# - The ServiceAccount token is stored in Vault and injected as K8S_SERVICE_ACCOUNT_TOKEN
+#
+# GENERATING THE TOKEN:
+# After ArgoCD deploys these resources, generate a long-lived token:
+#   kubectl create token backstage -n backstage --duration=8760h
+# Then store it in Vault:
+#   vault kv patch k8s-secrets/backstage k8s-service-account-token=<token>
+# ==============================================================================
+
+# ServiceAccount for the Backstage Kubernetes plugin.
+# This SA is used to generate the token that Backstage uses to query the K8s API.
+# NOTE: This is NOT the SA the pod runs as — the pod uses 'default'.
+# This SA exists solely for the Kubernetes plugin's API access.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage
+  namespace: backstage
+
+---
+
+# ClusterRole with read-only access to common workload resources.
+# These are the resources the Kubernetes plugin displays on entity pages.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-read-only
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - namespaces
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+---
+
+# Bind the ClusterRole to the backstage ServiceAccount.
+# This grants the SA read-only access cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-read-only
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+roleRef:
+  kind: ClusterRole
+  name: backstage-read-only
+  apiGroup: rbac.authorization.k8s.io

--- a/base-apps/backstage/secret-store.yaml
+++ b/base-apps/backstage/secret-store.yaml
@@ -1,0 +1,39 @@
+# ==============================================================================
+# Backstage Vault SecretStore
+# ==============================================================================
+#
+# Tells the External Secrets Operator (ESO) how to connect to HashiCorp Vault.
+# ESO uses this SecretStore to fetch secrets and create Kubernetes Secrets.
+#
+# HOW IT WORKS:
+# 1. ESO reads ExternalSecret resources that reference this SecretStore
+# 2. ESO authenticates to Vault using Kubernetes ServiceAccount auth
+# 3. ESO reads secrets from the k8s-secrets KV v2 engine in Vault
+# 4. ESO creates/updates Kubernetes Secrets with the fetched values
+#
+# VAULT AUTH:
+# The Kubernetes auth method works by:
+# 1. ESO sends the 'default' ServiceAccount's JWT token to Vault
+# 2. Vault verifies the token with the K8s API server
+# 3. If the SA is in the 'backstage' namespace and matches the 'backstage' role,
+#    Vault returns a Vault token with the 'backstage' policy attached
+# 4. That policy grants read access to k8s-secrets/data/backstage
+# ==============================================================================
+
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: backstage
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "backstage"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/backstage/secret-store.yaml
+++ b/base-apps/backstage/secret-store.yaml
@@ -1,25 +1,3 @@
-# ==============================================================================
-# Backstage Vault SecretStore
-# ==============================================================================
-#
-# Tells the External Secrets Operator (ESO) how to connect to HashiCorp Vault.
-# ESO uses this SecretStore to fetch secrets and create Kubernetes Secrets.
-#
-# HOW IT WORKS:
-# 1. ESO reads ExternalSecret resources that reference this SecretStore
-# 2. ESO authenticates to Vault using Kubernetes ServiceAccount auth
-# 3. ESO reads secrets from the k8s-secrets KV v2 engine in Vault
-# 4. ESO creates/updates Kubernetes Secrets with the fetched values
-#
-# VAULT AUTH:
-# The Kubernetes auth method works by:
-# 1. ESO sends the 'default' ServiceAccount's JWT token to Vault
-# 2. Vault verifies the token with the K8s API server
-# 3. If the SA is in the 'backstage' namespace and matches the 'backstage' role,
-#    Vault returns a Vault token with the 'backstage' policy attached
-# 4. That policy grants read access to k8s-secrets/data/backstage
-# ==============================================================================
-
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:

--- a/base-apps/backstage/services.yaml
+++ b/base-apps/backstage/services.yaml
@@ -1,0 +1,28 @@
+# ==============================================================================
+# Backstage ClusterIP Service
+# ==============================================================================
+#
+# Exposes the Backstage backend within the cluster on port 80.
+#
+# WHY PORT 80 → 7007:
+# Following the cluster convention, services listen on port 80 externally
+# (so Ingress can target port 80) and forward to the container's actual port
+# (7007 for Backstage). This is consistent with chores-tracker-backend and
+# other services in this cluster.
+#
+# ClusterIP (default type) means this service is only reachable from within
+# the cluster — external access goes through the Ingress controller.
+# ==============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  selector:
+    app: backstage
+  ports:
+  - port: 80
+    targetPort: 7007
+  type: ClusterIP

--- a/base-apps/backstage/services.yaml
+++ b/base-apps/backstage/services.yaml
@@ -1,19 +1,3 @@
-# ==============================================================================
-# Backstage ClusterIP Service
-# ==============================================================================
-#
-# Exposes the Backstage backend within the cluster on port 80.
-#
-# WHY PORT 80 → 7007:
-# Following the cluster convention, services listen on port 80 externally
-# (so Ingress can target port 80) and forward to the container's actual port
-# (7007 for Backstage). This is consistent with chores-tracker-backend and
-# other services in this cluster.
-#
-# ClusterIP (default type) means this service is only reachable from within
-# the cluster — external access goes through the Ingress controller.
-# ==============================================================================
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Add ArgoCD Application + full K8s manifests for Backstage developer portal (Deployment, Service, NGINX Ingress with TLS, ConfigMap, Vault SecretStore, ExternalSecret, RBAC)
- Add `backstage` namespace to ECR credentials sync CronJob
- Backstage will be accessible at `https://backstage.arigsela.com`

## New Files
| File | Description |
|------|-------------|
| `base-apps/backstage.yaml` | ArgoCD Application (auto-sync, prune, selfHeal, CreateNamespace) |
| `base-apps/backstage/deployments.yaml` | Deployment: 1 replica, ECR image, health probes, security context (non-root) |
| `base-apps/backstage/services.yaml` | ClusterIP Service: port 80 → 7007 |
| `base-apps/backstage/nginx-ingress.yaml` | NGINX Ingress: TLS via cert-manager, 60s timeouts |
| `base-apps/backstage/configmaps.yaml` | Non-sensitive config (POSTGRES_HOST, POSTGRES_PORT) |
| `base-apps/backstage/secret-store.yaml` | Vault SecretStore (k8s-secrets engine, backstage role) |
| `base-apps/backstage/external-secrets.yaml` | ExternalSecret mapping 7 Vault keys → backstage-secrets K8s Secret |
| `base-apps/backstage/rbac.yaml` | ServiceAccount + ClusterRole (read-only) + ClusterRoleBinding |

## Modified Files
| File | Change |
|------|--------|
| `base-apps/ecr-auth/cronjobs.yaml` | Added `backstage` to namespace list |

## Manual Steps Required Before Merge
1. **Create ECR repository**: `aws ecr create-repository --repository-name backstage-portal --region us-east-2`
2. **Build & push first image**: `cd ~/git/backstage && ./scripts/build-and-push.sh --version 1.0.0`
3. **Create PostgreSQL database & user** in the existing postgresql namespace
4. **Configure Vault**: Create `backstage` policy, Kubernetes auth role, and store secrets
5. **Update GitHub OAuth callback URL** to `https://backstage.arigsela.com/api/auth/github/handler/frame`
6. **After deploy**: Generate SA token (`kubectl create token backstage -n backstage --duration=8760h`) and store in Vault

## Test Plan
- [ ] ArgoCD syncs after merge and creates backstage namespace
- [ ] ECR CronJob syncs ecr-registry secret to backstage namespace
- [ ] ExternalSecret resolves and creates backstage-secrets
- [ ] Pod starts, passes health checks
- [ ] `https://backstage.arigsela.com` loads Backstage UI
- [ ] GitHub OAuth sign-in works
- [ ] Catalog shows entities, Kubernetes tab shows resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backstage deployed and reachable via HTTPS at its hostname with TLS and enforced HTTP→HTTPS.
  * Automated ArgoCD deployment with automatic namespace creation, pruning and self-heal.
  * Secrets auto-synced from a central Vault into the cluster; non-sensitive config exposed via ConfigMap.
  * Secure, non-root backend deployment with probes, resource limits, and read-only cluster visibility for Kubernetes integration.

* **Chores**
  * Image credential sync job updated to include Backstage namespace and skip missing namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->