### PR TITLE
Fix backstage RBAC: add limitranges and resourcequotas

### DIFF
--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -18,6 +18,8 @@ rules:
       - services
       - configmaps
       - namespaces
+      - limitranges
+      - resourcequotas
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources:


### PR DESCRIPTION
## Summary
- Adds `limitranges` and `resourcequotas` to the `backstage-read-only` ClusterRole
- The Backstage Kubernetes plugin queries these resources by default, causing repeated 403 Forbidden warnings in pod logs
- Read-only permissions only (get, list, watch)

## Test plan
- [ ] Verify ArgoCD syncs the updated ClusterRole
- [ ] Check backstage pod logs for 403 errors on limitranges/resourcequotas — should be gone
- [ ] Confirm Kubernetes tab in Backstage UI loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster access controls to enable read-only access to resource limit and quota information for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->