### PR TITLE
feat: add chores-knowledge-agent K8s manifests

### DIFF
--- a/base-apps/chores-knowledge-agent.yaml
+++ b/base-apps/chores-knowledge-agent.yaml
@@ -1,0 +1,42 @@
+# ==============================================================================
+# ArgoCD Application for chores-knowledge-agent
+# ==============================================================================
+# This manifest tells ArgoCD to watch a directory in the kubernetes repo
+# and auto-deploy all manifests found there into the project's namespace.
+#
+# ArgoCD discovers this file and starts syncing the manifests from:
+#   base-apps/chores-knowledge-agent/
+# ==============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # The Application resource always lives in the argo-cd namespace
+  name: chores-knowledge-agent
+  namespace: argo-cd
+spec:
+  # 'default' AppProject — no restrictions on clusters/namespaces
+  project: default
+
+  source:
+    # The Git repo where K8s manifests are stored (GitOps repo)
+    repoURL: https://github.com/arigsela/kubernetes
+    # Track the main branch for automatic deployments
+    targetRevision: main
+    # ArgoCD reads all YAML files from this directory
+    path: base-apps/chores-knowledge-agent
+
+  destination:
+    # Deploy to the local cluster (in-cluster)
+    server: https://kubernetes.default.svc
+    # Target namespace for all resources
+    namespace: chores-knowledge-agent
+
+  syncPolicy:
+    automated:
+      # prune: delete resources from the cluster when they're removed from Git
+      prune: true
+      # selfHeal: revert manual changes made outside of Git
+      selfHeal: true
+    syncOptions:
+      # Create the namespace automatically if it doesn't exist yet
+      - CreateNamespace=true

--- a/base-apps/chores-knowledge-agent/external-secret.yaml
+++ b/base-apps/chores-knowledge-agent/external-secret.yaml
@@ -1,0 +1,91 @@
+# ==============================================================================
+# ExternalSecrets for chores-knowledge-agent
+# ==============================================================================
+# ExternalSecret resources tell the External Secrets Operator (ESO) which
+# specific keys to pull from Vault and how to name the resulting K8s Secret.
+#
+# Flow: Vault secret -> ESO reads it -> creates K8s Secret -> pods reference it
+#
+# The Vault path for this project is: k8s-secrets/data/chores-knowledge-agent
+# Required keys in Vault:
+#   - anthropic-api-key  : API key for Anthropic Claude (CrewAI LLM calls)
+#   - api-keys           : Comma-separated API keys for inter-service A2A auth
+#
+# PREREQUISITE: Create the Vault secrets:
+#   vault kv put k8s-secrets/chores-knowledge-agent \
+#     anthropic-api-key="sk-ant-..." \
+#     api-keys="key1,key2"
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Orchestrator Secrets
+# ------------------------------------------------------------------------------
+# The orchestrator needs the Anthropic API key (for routing LLM calls) and
+# API keys (for authenticating requests from the ingress/frontend).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: orchestrator-secrets
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+    component: external-secret
+spec:
+  # How often ESO checks Vault for updated secret values
+  refreshInterval: 1h
+  secretStoreRef:
+    # References the SecretStore defined in secret-store.yaml
+    name: vault-backend
+    kind: SecretStore
+  target:
+    # The K8s Secret name that deployments reference via secretKeyRef
+    name: orchestrator-secrets
+    # 'Owner' means ESO owns this Secret — it will be deleted if the
+    # ExternalSecret is deleted (clean lifecycle management)
+    creationPolicy: Owner
+  data:
+    # Anthropic API key for CrewAI LLM calls
+    - secretKey: anthropic-api-key
+      remoteRef:
+        # The Vault KV path (under the 'k8s-secrets' mount)
+        key: chores-knowledge-agent
+        # The specific key within the Vault secret
+        property: anthropic-api-key
+    # API keys for authenticating incoming requests
+    - secretKey: api-keys
+      remoteRef:
+        key: chores-knowledge-agent
+        property: api-keys
+
+---
+# ------------------------------------------------------------------------------
+# Sub-Agent Secrets (Chores Tracker Knowledge Specialist)
+# ------------------------------------------------------------------------------
+# The sub-agent needs the same core secrets as the orchestrator:
+# - anthropic-api-key for its own CrewAI agent LLM calls
+# - api-keys for A2A protocol authentication (orchestrator -> sub-agent)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: knowledge-agent-secrets
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-knowledge-agent
+    component: external-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: knowledge-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: chores-knowledge-agent
+        property: anthropic-api-key
+    - secretKey: api-keys
+      remoteRef:
+        key: chores-knowledge-agent
+        property: api-keys

--- a/base-apps/chores-knowledge-agent/ingress.yaml
+++ b/base-apps/chores-knowledge-agent/ingress.yaml
@@ -1,0 +1,76 @@
+# ==============================================================================
+# Ingress for chores-knowledge-agent
+# ==============================================================================
+# Exposes the orchestrator to the internet via Nginx Ingress Controller.
+# Only the orchestrator is exposed — sub-agents are internal-only.
+#
+# Features:
+#   - TLS via cert-manager (Let's Encrypt production certificates)
+#   - IP whitelist for security (only your IPs can reach it)
+#   - Extended timeouts for AI agent queries (300s — LLM calls take time)
+#   - Rate limiting to prevent abuse
+#
+# This file is only generated when a domain is provided.
+# If no domain is configured, the orchestrator is only reachable within
+# the cluster (via port-forward or internal service DNS).
+#
+# DNS: Create an A record or CNAME pointing chores-agent.arigsela.com
+#      to your cluster's ingress controller external IP.
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chores-knowledge-agent-orchestrator
+  namespace: chores-knowledge-agent
+  annotations:
+    # ---- TLS/SSL Configuration ----
+    # Use the Let's Encrypt production issuer for real TLS certificates
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Force all HTTP traffic to redirect to HTTPS
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # ---- Backend Protocol ----
+    # The orchestrator serves plain HTTP (TLS terminates at the ingress)
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+
+    # ---- Rate Limiting ----
+    # 50 requests per second per IP — generous for API usage
+    nginx.ingress.kubernetes.io/limit-rps: "50"
+    # Max 20 concurrent connections per IP
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+
+    # ---- IP Whitelist ----
+    # SECURITY: Only allow traffic from known IPs
+    # Update these to your own IP addresses
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+
+    # ---- Timeouts ----
+    # AI agent queries can take 30-120+ seconds (LLM inference + tool calls)
+    # Set generous timeouts to avoid premature 504 Gateway Timeout errors
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+
+  labels:
+    app: chores-knowledge-agent-orchestrator
+spec:
+  # Use the nginx ingress class (installed cluster-wide)
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - chores-agent.arigsela.com
+    # cert-manager creates this Secret automatically with the TLS cert
+    secretName: chores-knowledge-agent-tls
+  rules:
+  - host: chores-agent.arigsela.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            # Route to the orchestrator's ClusterIP Service
+            name: chores-knowledge-agent-orchestrator
+            port:
+              number: 80

--- a/base-apps/chores-knowledge-agent/knowledge-agent/configmap.yaml
+++ b/base-apps/chores-knowledge-agent/knowledge-agent/configmap.yaml
@@ -1,0 +1,23 @@
+# ==============================================================================
+# Sub-Agent ConfigMap (Chores Tracker Knowledge Specialist)
+# ==============================================================================
+# Non-sensitive configuration for the sub-agent container.
+# These values are injected as environment variables via 'envFrom'.
+# ==============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knowledge-agent-config
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-knowledge-agent
+data:
+  # Logging level: DEBUG, INFO, WARNING, ERROR
+  AGENT_LOG_LEVEL: "INFO"
+  # Bind to all interfaces (required inside a container)
+  AGENT_HOST: "0.0.0.0"
+  # Must match the containerPort in deployment.yaml
+  AGENT_PORT: "8080"
+  # URL advertised in the A2A agent card (/.well-known/agent.json)
+  # This must be reachable by the orchestrator — using K8s internal DNS
+  AGENT_URL: "http://chores-knowledge-agent-knowledge-agent.chores-knowledge-agent.svc:8080"

--- a/base-apps/chores-knowledge-agent/knowledge-agent/deployment.yaml
+++ b/base-apps/chores-knowledge-agent/knowledge-agent/deployment.yaml
@@ -1,0 +1,147 @@
+# ==============================================================================
+# Sub-Agent Deployment, ServiceAccount, and Service
+# ==============================================================================
+# The sub-agent (Chores Tracker Knowledge Specialist) is an independent AI agent
+# that handles domain-specific queries. It receives tasks from the orchestrator
+# via the A2A (Agent-to-Agent) protocol and returns structured results.
+#
+# Architecture:
+#   Orchestrator --A2A--> Service (port 8080) -> Deployment
+#
+# The sub-agent is NOT exposed to the internet — only reachable within
+# the cluster via its ClusterIP Service.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chores-knowledge-agent-knowledge-agent
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-knowledge-agent
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chores-knowledge-agent-knowledge-agent
+  template:
+    metadata:
+      labels:
+        app: chores-knowledge-agent-knowledge-agent
+        version: v1
+    spec:
+      # Dedicated ServiceAccount for this sub-agent
+      serviceAccountName: chores-knowledge-agent-knowledge-agent
+      imagePullSecrets:
+      - name: ecr-registry
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+      - name: agent
+        # ECR image — built by deploy-to-ecr.sh
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-knowledge-agent-knowledge-agent:latest
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        # Non-sensitive config from ConfigMap
+        envFrom:
+        - configMapRef:
+            name: knowledge-agent-config
+
+        # Sensitive values from Vault via ExternalSecrets
+        env:
+        - name: HOME
+          value: /tmp
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: knowledge-agent-secrets
+              key: anthropic-api-key
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: knowledge-agent-secrets
+              key: api-keys
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      terminationGracePeriodSeconds: 30
+
+---
+# ------------------------------------------------------------------------------
+# ServiceAccount
+# ------------------------------------------------------------------------------
+# The sub-agent doesn't need K8s API access. The SA exists for:
+# 1. Vault authentication (SecretStore references it)
+# 2. Security isolation (pods shouldn't share the default SA)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chores-knowledge-agent-knowledge-agent
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-knowledge-agent
+    component: rbac
+
+---
+# ------------------------------------------------------------------------------
+# Service
+# ------------------------------------------------------------------------------
+# ClusterIP Service for internal A2A communication.
+# The orchestrator connects to this service using the DNS name:
+#   http://chores-knowledge-agent-knowledge-agent.chores-knowledge-agent.svc:8080
+apiVersion: v1
+kind: Service
+metadata:
+  name: chores-knowledge-agent-knowledge-agent
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-knowledge-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: chores-knowledge-agent-knowledge-agent
+  ports:
+  - name: http
+    # Sub-agent service listens on the configured port directly
+    # (unlike the orchestrator which maps 80 -> containerPort)
+    port: 8080
+    targetPort: 8080
+    protocol: TCP

--- a/base-apps/chores-knowledge-agent/namespace.yaml
+++ b/base-apps/chores-knowledge-agent/namespace.yaml
@@ -1,0 +1,16 @@
+# ==============================================================================
+# Namespace for chores-knowledge-agent
+# ==============================================================================
+# Creates a dedicated Kubernetes namespace for this agent project.
+# ArgoCD's CreateNamespace=true sync option also creates the namespace,
+# but having an explicit manifest lets us attach labels for identification.
+# ==============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chores-knowledge-agent
+  labels:
+    # The 'app' label ties all resources in this namespace to the project
+    app: chores-knowledge-agent
+    # The 'team' label identifies which team owns this namespace
+    team: devops

--- a/base-apps/chores-knowledge-agent/orchestrator/configmap.yaml
+++ b/base-apps/chores-knowledge-agent/orchestrator/configmap.yaml
@@ -1,0 +1,33 @@
+# ==============================================================================
+# Orchestrator ConfigMap
+# ==============================================================================
+# Non-sensitive configuration for the orchestrator container.
+# These values are injected as environment variables via 'envFrom'.
+#
+# ConfigMaps are the right place for:
+#   - Service URLs (internal DNS names)
+#   - Ports and host bindings
+#   - Log levels and feature flags
+#   - CORS configuration
+#
+# Secrets (API keys, tokens) go in ExternalSecrets, NOT here.
+# ==============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-config
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+data:
+  # Logging level: DEBUG, INFO, WARNING, ERROR
+  AGENT_LOG_LEVEL: "INFO"
+  # Bind to all interfaces (required inside a container)
+  ORCHESTRATOR_HOST: "0.0.0.0"
+  # Must match the containerPort in deployment.yaml
+  ORCHESTRATOR_PORT: "8000"
+  # CORS: allow all origins for development; restrict in production
+  CORS_ORIGINS: "*"
+  # Internal service DNS name for the sub-agent
+  # Format: http://<service-name>.<namespace>.svc:<port>
+  SUB_AGENT_URL: "http://chores-knowledge-agent-knowledge-agent.chores-knowledge-agent.svc:8080"

--- a/base-apps/chores-knowledge-agent/orchestrator/deployment.yaml
+++ b/base-apps/chores-knowledge-agent/orchestrator/deployment.yaml
@@ -1,0 +1,167 @@
+# ==============================================================================
+# Orchestrator Deployment, ServiceAccount, and Service
+# ==============================================================================
+# The orchestrator is the entry point for all queries. It receives requests,
+# classifies them using keyword matching, and routes to the appropriate
+# sub-agent via the A2A (Agent-to-Agent) protocol.
+#
+# Architecture:
+#   Ingress -> Service (port 80) -> Deployment (port 8000)
+#                                       |
+#                                       +--> A2A call to sub-agent Service
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chores-knowledge-agent-orchestrator
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+    version: v1
+spec:
+  # Single replica — sufficient for homelab; scale up for production
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chores-knowledge-agent-orchestrator
+  template:
+    metadata:
+      labels:
+        app: chores-knowledge-agent-orchestrator
+        version: v1
+    spec:
+      # Use a dedicated ServiceAccount (not default) for security isolation
+      serviceAccountName: chores-knowledge-agent-orchestrator
+      # Pull ECR images using the ecr-registry imagePullSecret
+      # (created by the ECR CronJob that refreshes Docker credentials)
+      imagePullSecrets:
+      - name: ecr-registry
+      # Schedule on application-designated nodes (avoids system workloads)
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      # Run as non-root user (UID/GID 1000) for security
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+      - name: orchestrator
+        # ECR image — tag updated by CI/CD pipeline or deploy-to-ecr.sh
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-knowledge-agent-orchestrator:latest
+        # Always pull to ensure we get the latest image (useful with :latest tag)
+        imagePullPolicy: Always
+
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+
+        # Load non-sensitive config from ConfigMap (log level, URLs, ports)
+        envFrom:
+        - configMapRef:
+            name: orchestrator-config
+
+        # Sensitive values injected from Vault via ExternalSecrets
+        env:
+        # HOME must be writable for CrewAI's internal file operations
+        - name: HOME
+          value: /tmp
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: anthropic-api-key
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: orchestrator-secrets
+              key: api-keys
+
+        # Mount persistent storage for session data / CrewAI memory
+        volumeMounts:
+        - name: data
+          mountPath: /data
+
+        # Resource requests/limits matching oncall-crewai pattern
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        # Liveness probe: is the process alive and responding?
+        # If this fails 3 times, K8s restarts the pod
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        # Readiness probe: is the pod ready to receive traffic?
+        # If this fails, the pod is removed from the Service's endpoint list
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: orchestrator-data
+
+      # Allow 30 seconds for graceful shutdown (finish in-flight requests)
+      terminationGracePeriodSeconds: 30
+
+---
+# ------------------------------------------------------------------------------
+# ServiceAccount
+# ------------------------------------------------------------------------------
+# The orchestrator doesn't need direct K8s API access, so no ClusterRole
+# is bound. The SA exists for Vault auth (SecretStore references it).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chores-knowledge-agent-orchestrator
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+    component: rbac
+
+---
+# ------------------------------------------------------------------------------
+# Service
+# ------------------------------------------------------------------------------
+# ClusterIP Service exposes the orchestrator within the cluster.
+# The Ingress routes external traffic to this Service on port 80.
+apiVersion: v1
+kind: Service
+metadata:
+  name: chores-knowledge-agent-orchestrator
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+spec:
+  type: ClusterIP
+  selector:
+    app: chores-knowledge-agent-orchestrator
+  ports:
+  - name: http
+    # Service listens on port 80 (standard HTTP)
+    port: 80
+    # Routes to the container's port
+    targetPort: 8000
+    protocol: TCP

--- a/base-apps/chores-knowledge-agent/orchestrator/pvc.yaml
+++ b/base-apps/chores-knowledge-agent/orchestrator/pvc.yaml
@@ -1,0 +1,29 @@
+# ==============================================================================
+# Orchestrator PersistentVolumeClaim
+# ==============================================================================
+# Provides persistent storage for the orchestrator across pod restarts.
+# Used for:
+#   - CrewAI memory/knowledge embeddings cache
+#   - Session data (if session persistence is enabled)
+#   - Any file-based state the orchestrator needs to persist
+#
+# The k3s default StorageClass (local-path) provisions storage on the
+# node where the pod runs. For multi-node clusters, consider a network-
+# attached storage class (e.g., Longhorn, EFS).
+# ==============================================================================
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orchestrator-data
+  namespace: chores-knowledge-agent
+  labels:
+    app: chores-knowledge-agent-orchestrator
+spec:
+  # ReadWriteOnce: only one pod can mount this volume at a time
+  # Safe for single-replica deployments
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 1Gi is generous for session DBs and embedding caches
+      storage: 1Gi

--- a/base-apps/chores-knowledge-agent/secret-store.yaml
+++ b/base-apps/chores-knowledge-agent/secret-store.yaml
@@ -1,0 +1,42 @@
+# ==============================================================================
+# SecretStore for chores-knowledge-agent
+# ==============================================================================
+# Connects the External Secrets Operator to HashiCorp Vault.
+# This tells ESO *how* to authenticate with Vault and *where* to find secrets.
+#
+# How it works:
+# 1. The pod's ServiceAccount token is sent to Vault's Kubernetes auth backend
+# 2. Vault verifies the token against the K8s API server
+# 3. If the SA matches the configured Vault role, Vault issues a Vault token
+# 4. ESO uses that Vault token to read secrets from the configured path
+#
+# PREREQUISITE: Create a Vault role for this project:
+#   vault write auth/kubernetes/role/chores-knowledge-agent \
+#     bound_service_account_names=default \
+#     bound_service_account_namespaces=chores-knowledge-agent \
+#     policies=k8s-secrets-read \
+#     ttl=1h
+# ==============================================================================
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: chores-knowledge-agent
+spec:
+  provider:
+    vault:
+      # Vault's ClusterIP service address (internal to the cluster)
+      server: "http://vault.vault.svc.cluster.local:8200"
+      # The KV v2 secrets engine mount path
+      path: "k8s-secrets"
+      # KV secrets engine version (v2 supports versioning)
+      version: "v2"
+      auth:
+        kubernetes:
+          # The Vault auth method mount path
+          mountPath: "kubernetes"
+          # The Vault role that this namespace's ServiceAccount is bound to
+          role: "chores-knowledge-agent"
+          # Use the default ServiceAccount in this namespace for auth
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
## K8s Manifests for chores-knowledge-agent

ArgoCD Application + deployment manifests for the chores-knowledge-agent agent.

Scaffolded by the Backstage CrewAI template.

### Post-merge steps
- Add `chores-knowledge-agent` namespace to ECR auth CronJob (`base-apps/ecr-auth/cronjobs.yaml`)
- Create Vault role `chores-knowledge-agent` with K8s auth
- Add secrets at `k8s-secrets/data/chores-knowledge-agent`: `anthropic-api-key`, `api-keys`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment of a new chores-knowledge-agent service accessible at chores-agent.arigsela.com with TLS encryption and rate limiting (50 requests per second, 20 concurrent connections).

* **Chores**
  * Added infrastructure configuration including namespace setup, secret management integration, and internal service routing for the new workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->