### PR TITLE
feat: add AWS + Vault credentials to Backstage pod

### DIFF
--- a/base-apps/backstage/configmaps.yaml
+++ b/base-apps/backstage/configmaps.yaml
@@ -6,3 +6,7 @@ metadata:
 data:
   POSTGRES_HOST: "postgresql.postgresql.svc.cluster.local"
   POSTGRES_PORT: "5432"
+  # AWS region for ECR scaffolder actions (aws:ecr:create, aws:ecr:build-push)
+  AWS_DEFAULT_REGION: "us-east-2"
+  # Vault address for the vault:setup scaffolder action (in-cluster Vault)
+  VAULT_ADDR: "http://vault.vault.svc.cluster.local:8200"

--- a/base-apps/backstage/external-secrets.yaml
+++ b/base-apps/backstage/external-secrets.yaml
@@ -40,3 +40,21 @@ spec:
       remoteRef:
         key: backstage
         property: k8s-service-account-token
+    # --- AWS (Scaffolder ECR Actions) ---
+    # Used by aws:ecr:create and aws:ecr:build-push scaffolder actions
+    # to create ECR repos and push Docker images during template execution.
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: backstage
+        property: aws-access-key-id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: backstage
+        property: aws-secret-access-key
+    # --- Vault (Scaffolder vault:setup Action) ---
+    # Used by the vault:setup scaffolder action to provision Vault resources
+    # (policy, K8s auth role, placeholder secrets) when scaffolding new projects.
+    - secretKey: VAULT_TOKEN
+      remoteRef:
+        key: backstage
+        property: vault-token


### PR DESCRIPTION
## Summary

- Add `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `VAULT_TOKEN` to the Backstage ExternalSecret (sourced from Vault at `k8s-secrets/data/backstage`)
- Add `AWS_DEFAULT_REGION` and `VAULT_ADDR` to the Backstage ConfigMap (non-sensitive values)

## Why

The CrewAI template scaffolder actions need these credentials when running in-cluster:
- **`aws:ecr:create`** — creates ECR repositories for new agent projects
- **`aws:ecr:build-push`** — builds Docker images and pushes to ECR
- **`vault:setup`** — provisions Vault policy, K8s auth role, and placeholder secrets

Locally these work because the shell has `~/.aws/credentials` and exported `VAULT_*` env vars, but the Backstage pod in the cluster has no AWS identity or Vault token.

## Vault secrets required

After merging, add these keys to `k8s-secrets/data/backstage` in Vault:

| Vault Property | Description |
|---|---|
| `aws-access-key-id` | AWS IAM access key with ECR permissions |
| `aws-secret-access-key` | AWS IAM secret key |
| `vault-token` | Vault token with permissions to manage policies, K8s auth roles, and KV secrets |

## Test plan

- [ ] Add the 3 new secrets to Vault at `k8s-secrets/data/backstage`
- [ ] Merge this PR and wait for ArgoCD sync
- [ ] Verify ExternalSecret syncs: `kubectl get externalsecret backstage-secrets -n backstage`
- [ ] Run the CrewAI template from Backstage UI — ECR + Vault steps should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scaffolder actions now support AWS ECR integration with region configuration for container registry operations
  * Scaffolder actions now support Vault integration with token-based authentication for secure credential management
  * Extended configuration support enables enhanced external service integrations within Backstage templates and workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->