### PR TITLE
feat: add dnd-agent K8s manifests

### DIFF
--- a/base-apps/oncall-crewai/dnd-agent/dnd-character-agent/configmap.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/dnd-character-agent/configmap.yaml
@@ -1,0 +1,23 @@
+# ==============================================================================
+# Sub-Agent ConfigMap (Dungeons and Dragons Character creation/knowledge specialist)
+# ==============================================================================
+# Non-sensitive configuration for the sub-agent container.
+# These values are injected as environment variables via 'envFrom'.
+# ==============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnd-character-agent-config
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-dnd-character-agent
+data:
+  # Logging level: DEBUG, INFO, WARNING, ERROR
+  AGENT_LOG_LEVEL: "INFO"
+  # Bind to all interfaces (required inside a container)
+  AGENT_HOST: "0.0.0.0"
+  # Must match the containerPort in deployment.yaml
+  AGENT_PORT: "8080"
+  # URL advertised in the A2A agent card (/.well-known/agent.json)
+  # This must be reachable by the orchestrator — using K8s internal DNS
+  AGENT_URL: "http://dnd-agent-dnd-character-agent.oncall-crewai.svc:8080"

--- a/base-apps/oncall-crewai/dnd-agent/dnd-character-agent/deployment.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/dnd-character-agent/deployment.yaml
@@ -1,0 +1,154 @@
+# ==============================================================================
+# Sub-Agent Deployment, ServiceAccount, and Service
+# ==============================================================================
+# The sub-agent (Dungeons and Dragons Character creation/knowledge specialist) is an independent AI agent
+# that handles domain-specific queries. It receives tasks from the orchestrator
+# via the A2A (Agent-to-Agent) protocol and returns structured results.
+#
+# Architecture:
+#   Orchestrator --A2A--> Service (port 8080) -> Deployment
+#
+# The sub-agent is NOT exposed to the internet — only reachable within
+# the cluster via its ClusterIP Service.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnd-agent-dnd-character-agent
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-dnd-character-agent
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dnd-agent-dnd-character-agent
+  template:
+    metadata:
+      labels:
+        app: dnd-agent-dnd-character-agent
+        version: v1
+    spec:
+      # Dedicated ServiceAccount for this sub-agent
+      serviceAccountName: dnd-agent-dnd-character-agent
+      # Disable automatic SA token mount — this pod doesn't need K8s API access
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ecr-registry
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+        - name: agent
+          # ECR image — built by deploy-to-ecr.sh, pinned to scaffolded version
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/dnd-agent-dnd-character-agent:1.0.0
+          imagePullPolicy: Always
+
+          # Container-level security hardening
+          securityContext:
+            allowPrivilegeEscalation: false
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          # Non-sensitive config from ConfigMap
+          envFrom:
+            - configMapRef:
+                name: dnd-character-agent-config
+
+          # Sensitive values from Vault via ExternalSecrets
+          env:
+            - name: HOME
+              value: /tmp
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dnd-character-agent-secrets
+                  key: anthropic-api-key
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: dnd-character-agent-secrets
+                  key: api-keys
+
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+      terminationGracePeriodSeconds: 30
+
+---
+# ------------------------------------------------------------------------------
+# ServiceAccount
+# ------------------------------------------------------------------------------
+# The sub-agent doesn't need K8s API access. The SA exists for:
+# 1. Vault authentication (SecretStore references it)
+# 2. Security isolation (pods shouldn't share the default SA)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dnd-agent-dnd-character-agent
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-dnd-character-agent
+    component: rbac
+automountServiceAccountToken: false
+
+---
+# ------------------------------------------------------------------------------
+# Service
+# ------------------------------------------------------------------------------
+# ClusterIP Service for internal A2A communication.
+# The orchestrator connects to this service using the DNS name:
+#   http://dnd-agent-dnd-character-agent.oncall-crewai.svc:8080
+apiVersion: v1
+kind: Service
+metadata:
+  name: dnd-agent-dnd-character-agent
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-dnd-character-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: dnd-agent-dnd-character-agent
+  ports:
+    - name: http
+      # Sub-agent service listens on the configured port directly
+      # (unlike the orchestrator which maps 80 -> containerPort)
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/base-apps/oncall-crewai/dnd-agent/external-secret.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/external-secret.yaml
@@ -1,0 +1,92 @@
+# ==============================================================================
+# ExternalSecrets for dnd-agent
+# ==============================================================================
+# ExternalSecret resources tell the External Secrets Operator (ESO) which
+# specific keys to pull from Vault and how to name the resulting K8s Secret.
+#
+# Flow: Vault secret -> ESO reads it -> creates K8s Secret -> pods reference it
+#
+# The Vault path for this project is: k8s-secrets/data/dnd-agent
+# Required keys in Vault:
+#   - anthropic-api-key  : API key for Anthropic Claude (CrewAI LLM calls)
+#   - api-keys           : Comma-separated API keys for inter-service A2A auth
+#
+# Vault setup is automated by the Backstage scaffolder's vault:setup action.
+# After deployment, replace the placeholder secrets with real values:
+#   vault kv put k8s-secrets/dnd-agent \
+#     anthropic-api-key="sk-ant-..." \
+#     api-keys="key1,key2"
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Orchestrator Secrets
+# ------------------------------------------------------------------------------
+# The orchestrator needs the Anthropic API key (for routing LLM calls) and
+# API keys (for authenticating requests from the ingress/frontend).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dnd-agent-orchestrator-secrets
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+    component: external-secret
+spec:
+  # How often ESO checks Vault for updated secret values
+  refreshInterval: 15s
+  secretStoreRef:
+    # References the SecretStore defined in secret-store.yaml
+    name: dnd-agent-vault
+    kind: SecretStore
+  target:
+    # The K8s Secret name that deployments reference via secretKeyRef
+    name: dnd-agent-orchestrator-secrets
+    # 'Owner' means ESO owns this Secret — it will be deleted if the
+    # ExternalSecret is deleted (clean lifecycle management)
+    creationPolicy: Owner
+  data:
+    # Anthropic API key for CrewAI LLM calls
+    - secretKey: anthropic-api-key
+      remoteRef:
+        # The Vault KV path (under the 'k8s-secrets' mount)
+        key: dnd-agent
+        # The specific key within the Vault secret
+        property: anthropic-api-key
+    # API keys for authenticating incoming requests
+    - secretKey: api-keys
+      remoteRef:
+        key: dnd-agent
+        property: api-keys
+
+---
+# ------------------------------------------------------------------------------
+# Sub-Agent Secrets (Dungeons and Dragons Character creation/knowledge specialist)
+# ------------------------------------------------------------------------------
+# The sub-agent needs the same core secrets as the orchestrator:
+# - anthropic-api-key for its own CrewAI agent LLM calls
+# - api-keys for A2A protocol authentication (orchestrator -> sub-agent)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dnd-character-agent-secrets
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-dnd-character-agent
+    component: external-secret
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: dnd-agent-vault
+    kind: SecretStore
+  target:
+    name: dnd-character-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: dnd-agent
+        property: anthropic-api-key
+    - secretKey: api-keys
+      remoteRef:
+        key: dnd-agent
+        property: api-keys

--- a/base-apps/oncall-crewai/dnd-agent/ingress.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/ingress.yaml
@@ -1,0 +1,76 @@
+# ==============================================================================
+# Ingress for dnd-agent
+# ==============================================================================
+# Exposes the orchestrator to the internet via Nginx Ingress Controller.
+# Only the orchestrator is exposed — sub-agents are internal-only.
+#
+# Features:
+#   - TLS via cert-manager (Let's Encrypt production certificates)
+#   - IP whitelist for security (only your IPs can reach it)
+#   - Extended timeouts for AI agent queries (300s — LLM calls take time)
+#   - Rate limiting to prevent abuse
+#
+# This file is only generated when a domain is provided.
+# If no domain is configured, the orchestrator is only reachable within
+# the cluster (via port-forward or internal service DNS).
+#
+# DNS: Create an A record or CNAME pointing 
+#      to your cluster's ingress controller external IP.
+# ==============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dnd-agent-orchestrator
+  namespace: oncall-crewai
+  annotations:
+    # ---- TLS/SSL Configuration ----
+    # Use the Let's Encrypt production issuer for real TLS certificates
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Force all HTTP traffic to redirect to HTTPS
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # ---- Backend Protocol ----
+    # The orchestrator serves plain HTTP (TLS terminates at the ingress)
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+
+    # ---- Rate Limiting ----
+    # 50 requests per second per IP — generous for API usage
+    nginx.ingress.kubernetes.io/limit-rps: "50"
+    # Max 20 concurrent connections per IP
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+
+    # ---- IP Whitelist ----
+    # SECURITY: Only allow traffic from known IPs
+    # Update these to your own IP addresses
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+
+    # ---- Timeouts ----
+    # AI agent queries can take 30-120+ seconds (LLM inference + tool calls)
+    # Set generous timeouts to avoid premature 504 Gateway Timeout errors
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+
+  labels:
+    app: dnd-agent-orchestrator
+spec:
+  # Use the nginx ingress class (installed cluster-wide)
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - 
+      # cert-manager creates this Secret automatically with the TLS cert
+      secretName: dnd-agent-tls
+  rules:
+    - host: 
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Route to the orchestrator's ClusterIP Service
+                name: dnd-agent-orchestrator
+                port:
+                  number: 80

--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/configmap.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/configmap.yaml
@@ -1,0 +1,35 @@
+# ==============================================================================
+# Orchestrator ConfigMap
+# ==============================================================================
+# Non-sensitive configuration for the orchestrator container.
+# These values are injected as environment variables via 'envFrom'.
+#
+# ConfigMaps are the right place for:
+#   - Service URLs (internal DNS names)
+#   - Ports and host bindings
+#   - Log levels and feature flags
+#   - CORS configuration
+#
+# Secrets (API keys, tokens) go in ExternalSecrets, NOT here.
+# ==============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-config
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+data:
+  # Logging level: DEBUG, INFO, WARNING, ERROR
+  AGENT_LOG_LEVEL: "INFO"
+  # Bind to all interfaces (required inside a container)
+  ORCHESTRATOR_HOST: "0.0.0.0"
+  # Must match the containerPort in deployment.yaml
+  ORCHESTRATOR_PORT: "8000"
+  # CORS: allow all origins by default. For production, restrict to your
+  # specific domain (e.g. "https://") to prevent
+  # unauthorized cross-origin requests.
+  CORS_ORIGINS: "*"
+  # Internal service DNS name for the sub-agent
+  # Format: http://<service-name>.<namespace>.svc:<port>
+  SUB_AGENT_URL: "http://dnd-agent-dnd-character-agent.oncall-crewai.svc:8080"

--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/deployment.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/deployment.yaml
@@ -1,0 +1,174 @@
+# ==============================================================================
+# Orchestrator Deployment, ServiceAccount, and Service
+# ==============================================================================
+# The orchestrator is the entry point for all queries. It receives requests,
+# classifies them using keyword matching, and routes to the appropriate
+# sub-agent via the A2A (Agent-to-Agent) protocol.
+#
+# Architecture:
+#   Ingress -> Service (port 80) -> Deployment (port 8000)
+#                                       |
+#                                       +--> A2A call to sub-agent Service
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnd-agent-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+    version: v1
+spec:
+  # Single replica — sufficient for homelab; scale up for production
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dnd-agent-orchestrator
+  template:
+    metadata:
+      labels:
+        app: dnd-agent-orchestrator
+        version: v1
+    spec:
+      # Use a dedicated ServiceAccount (not default) for security isolation
+      serviceAccountName: dnd-agent-orchestrator
+      # Disable automatic SA token mount — this pod doesn't need K8s API access
+      automountServiceAccountToken: false
+      # Pull ECR images using the ecr-registry imagePullSecret
+      # (created by the ECR CronJob that refreshes Docker credentials)
+      imagePullSecrets:
+        - name: ecr-registry
+      # Schedule on application-designated nodes (avoids system workloads)
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      # Run as non-root user (UID/GID 1000) for security
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+        - name: orchestrator
+          # ECR image — tag updated by CI/CD pipeline or deploy-to-ecr.sh
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/dnd-agent-orchestrator:1.0.0
+          # Always pull to ensure we get the latest image
+          imagePullPolicy: Always
+
+          # Container-level security hardening
+          securityContext:
+            allowPrivilegeEscalation: false
+
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+
+          # Load non-sensitive config from ConfigMap (log level, URLs, ports)
+          envFrom:
+            - configMapRef:
+                name: orchestrator-config
+
+          # Sensitive values injected from Vault via ExternalSecrets
+          env:
+            # HOME must be writable for CrewAI's internal file operations
+            - name: HOME
+              value: /tmp
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dnd-agent-orchestrator-secrets
+                  key: anthropic-api-key
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: dnd-agent-orchestrator-secrets
+                  key: api-keys
+
+          # Mount persistent storage for session data / CrewAI memory
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+          # Resource requests/limits matching oncall-crewai pattern
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+          # Liveness probe: is the process alive and responding?
+          # If this fails 3 times, K8s restarts the pod
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+
+          # Readiness probe: is the pod ready to receive traffic?
+          # If this fails, the pod is removed from the Service's endpoint list
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: orchestrator-data
+
+      # Allow 30 seconds for graceful shutdown (finish in-flight requests)
+      terminationGracePeriodSeconds: 30
+
+---
+# ------------------------------------------------------------------------------
+# ServiceAccount
+# ------------------------------------------------------------------------------
+# The orchestrator doesn't need direct K8s API access, so no ClusterRole
+# is bound. The SA exists for Vault auth (SecretStore references it).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dnd-agent-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+    component: rbac
+automountServiceAccountToken: false
+
+---
+# ------------------------------------------------------------------------------
+# Service
+# ------------------------------------------------------------------------------
+# ClusterIP Service exposes the orchestrator within the cluster.
+# The Ingress routes external traffic to this Service on port 80.
+apiVersion: v1
+kind: Service
+metadata:
+  name: dnd-agent-orchestrator
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+spec:
+  type: ClusterIP
+  selector:
+    app: dnd-agent-orchestrator
+  ports:
+    - name: http
+      # Service listens on port 80 (standard HTTP)
+      port: 80
+      # Routes to the container's port
+      targetPort: 8000
+      protocol: TCP

--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/pvc.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/pvc.yaml
@@ -1,0 +1,29 @@
+# ==============================================================================
+# Orchestrator PersistentVolumeClaim
+# ==============================================================================
+# Provides persistent storage for the orchestrator across pod restarts.
+# Used for:
+#   - CrewAI memory/knowledge embeddings cache
+#   - Session data (if session persistence is enabled)
+#   - Any file-based state the orchestrator needs to persist
+#
+# The k3s default StorageClass (local-path) provisions storage on the
+# node where the pod runs. For multi-node clusters, consider a network-
+# attached storage class (e.g., Longhorn, EFS).
+# ==============================================================================
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orchestrator-data
+  namespace: oncall-crewai
+  labels:
+    app: dnd-agent-orchestrator
+spec:
+  # ReadWriteOnce: only one pod can mount this volume at a time
+  # Safe for single-replica deployments
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 1Gi is generous for session DBs and embedding caches
+      storage: 1Gi

--- a/base-apps/oncall-crewai/dnd-agent/secret-store.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/secret-store.yaml
@@ -1,0 +1,39 @@
+# ==============================================================================
+# SecretStore for dnd-agent
+# ==============================================================================
+# Connects the External Secrets Operator to HashiCorp Vault.
+# This tells ESO *how* to authenticate with Vault and *where* to find secrets.
+#
+# How it works:
+# 1. The pod's ServiceAccount token is sent to Vault's Kubernetes auth backend
+# 2. Vault verifies the token against the K8s API server
+# 3. If the SA matches the configured Vault role, Vault issues a Vault token
+# 4. ESO uses that Vault token to read secrets from the configured path
+#
+# Vault setup is automated by the Backstage scaffolder's vault:setup action.
+# The scaffolder creates the Vault policy, K8s auth role, and placeholder secrets
+# automatically during project creation — no manual Vault commands needed.
+# ==============================================================================
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: dnd-agent-vault
+  namespace: oncall-crewai
+spec:
+  provider:
+    vault:
+      # Vault's ClusterIP service address (internal to the cluster)
+      server: "http://vault.vault.svc.cluster.local:8200"
+      # The KV v2 secrets engine mount path
+      path: "k8s-secrets"
+      # KV secrets engine version (v2 supports versioning)
+      version: "v2"
+      auth:
+        kubernetes:
+          # The Vault auth method mount path
+          mountPath: "kubernetes"
+          # The Vault role that this namespace's ServiceAccount is bound to
+          role: "dnd-agent"
+          # Use the default ServiceAccount in this namespace for auth
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
## K8s Manifests for dnd-agent

Deployment manifests for the dnd-agent agent, placed inside
`base-apps/oncall-crewai/dnd-agent/` so they're managed by the
existing **oncall-crewai** ArgoCD Application. No separate ArgoCD app is created.

Scaffolded by the Backstage CrewAI template.

### Vault (automated by scaffolder)
- Policy, K8s auth role, and placeholder secrets were created automatically
- **Post-merge**: replace placeholder secrets with real values at `k8s-secrets/data/dnd-agent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DND Agent service now available with secure HTTPS endpoint for public access
  * Automatic health monitoring ensures service availability and recovery
  * Persistent data storage for agent state and operations

* **Chores**
  * Deployed multi-component infrastructure (orchestrator and character agent) with encrypted secrets management, resource quotas, and Vault integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->