### PR TITLE
Enable directory.recurse for oncall-crewai ArgoCD App

### DIFF
--- a/base-apps/oncall-crewai.yaml
+++ b/base-apps/oncall-crewai.yaml
@@ -9,6 +9,11 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/oncall-crewai
+    # Enable recursive directory scanning so ArgoCD picks up manifests
+    # in subdirectories (e.g. dnd-agent/, future scaffolded agents).
+    # Without this, only top-level YAML files are processed.
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: oncall-crewai


### PR DESCRIPTION
## Summary
- Adds `directory.recurse: true` to the `oncall-crewai` ArgoCD Application spec
- Without this, ArgoCD only processes YAML files in the top-level `base-apps/oncall-crewai/` directory and **silently ignores subdirectories**
- Scaffolded agents (e.g. `dnd-agent/`) place their manifests in subdirectories, so they were never deployed

## Root Cause
The Backstage scaffolder template creates K8s manifests in a subdirectory structure:
```
base-apps/oncall-crewai/
├── dnd-agent/                  ← NEW (ignored without recurse)
│   ├── orchestrator/
│   ├── dnd-character-agent/
│   ├── external-secret.yaml
│   ├── secret-store.yaml
│   └── ingress.yaml
├── orchestrator-deployment.yaml  ← existing (processed)
├── k8s-agent-deployment.yaml     ← existing (processed)
└── ...
```

ArgoCD's Directory source type defaults to **non-recursive** — it only reads files at the specified path level, not in subdirectories.

## Test plan
- [ ] Merge PR and sync ArgoCD
- [ ] Verify `dnd-agent-orchestrator` and `dnd-agent-dnd-character-agent` Deployments appear in `oncall-crewai` namespace
- [ ] Verify existing resources (orchestrator, k8s-agent, github-agent, frontend) remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)