### PR TITLE
Fix dnd-agent ConfigMap and PVC name collisions

### DIFF
--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/configmap.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/configmap.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: orchestrator-config
+  name: dnd-agent-orchestrator-config
   namespace: oncall-crewai
   labels:
     app: dnd-agent-orchestrator

--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/deployment.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/deployment.yaml
@@ -70,7 +70,7 @@ spec:
           # Load non-sensitive config from ConfigMap (log level, URLs, ports)
           envFrom:
             - configMapRef:
-                name: orchestrator-config
+                name: dnd-agent-orchestrator-config
 
           # Sensitive values injected from Vault via ExternalSecrets
           env:
@@ -127,7 +127,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: orchestrator-data
+            claimName: dnd-agent-orchestrator-data
 
       # Allow 30 seconds for graceful shutdown (finish in-flight requests)
       terminationGracePeriodSeconds: 30

--- a/base-apps/oncall-crewai/dnd-agent/orchestrator/pvc.yaml
+++ b/base-apps/oncall-crewai/dnd-agent/orchestrator/pvc.yaml
@@ -14,7 +14,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: orchestrator-data
+  name: dnd-agent-orchestrator-data
   namespace: oncall-crewai
   labels:
     app: dnd-agent-orchestrator


### PR DESCRIPTION
## Summary
- Prefixes dnd-agent orchestrator ConfigMap from `orchestrator-config` → `dnd-agent-orchestrator-config`
- Prefixes dnd-agent orchestrator PVC from `orchestrator-data` → `dnd-agent-orchestrator-data`
- Updates Deployment `configMapRef` and `claimName` references to match

## Root Cause
The scaffolder template used generic resource names (`orchestrator-config`, `orchestrator-data`) that collide with the existing oncall-crewai orchestrator resources when `directory.recurse: true` is enabled.

ArgoCD reported:
```
RepeatedResourceWarning: Resource /ConfigMap/oncall-crewai/orchestrator-config appeared 2 times
RepeatedResourceWarning: Resource /PersistentVolumeClaim/oncall-crewai/orchestrator-data appeared 2 times
```

## Test plan
- [ ] Merge and sync ArgoCD
- [ ] Verify warnings disappear
- [ ] Verify dnd-agent-orchestrator pod references the correct ConfigMap and PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes resource identifiers with standardized naming conventions for improved configuration management and resource organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->