### PR TITLE
fix: correct Kyverno Helm chart webhook config format

### DIFF
--- a/base-apps/kyverno.yaml
+++ b/base-apps/kyverno.yaml
@@ -14,6 +14,9 @@ spec:
       values: |
         admissionController:
           replicas: 1
+          container:
+            extraArgs:
+              forceFailurePolicyIgnore: "true"
           nodeSelector:
             node.kubernetes.io/workload: infrastructure
           tolerations:
@@ -45,7 +48,6 @@ spec:
             effect: NoSchedule
         config:
           webhooks:
-          - failurePolicy: Ignore
             namespaceSelector:
               matchExpressions:
               - key: kubernetes.io/metadata.name


### PR DESCRIPTION
## Summary
- Fix Kyverno ArgoCD Application failing to sync due to incorrect Helm values format for `config.webhooks`
- The chart expects `config.webhooks` as a map, not a list — removed the `-` list syntax
- Moved `failurePolicy: Ignore` to `admissionController.container.extraArgs.forceFailurePolicyIgnore` (correct Helm values path)

## Changes
### Bug Fix
- `config.webhooks` was incorrectly formatted as a YAML list (`- failurePolicy: Ignore`) — chart expects a map with `namespaceSelector` directly
- `failurePolicy` is not a valid key under `config.webhooks` — moved to `admissionController.container.extraArgs.forceFailurePolicyIgnore: "true"`

### Error Fixed
```
cannot overwrite table with non table for kyverno.config.webhooks
error calling include: template: kyverno/templates/config/_helpers.tpl:74:51:
can't evaluate field namespaceSelector in type []interface {}
```

## Test Plan
- [ ] ArgoCD syncs `kyverno` Application successfully (no more template error)
- [ ] Kyverno pods start in `kyverno` namespace
- [ ] Webhooks registered with failurePolicy Ignore

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kyverno admission controller webhook failure policy configuration. Changes to failure handling parameters improve the reliability and behavior of the admission control system when processing webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->