### PR TITLE
fix: increase k8s-agent-a2a liveness probe tolerance to prevent restarts

### DIFF
--- a/base-apps/oncall-crewai/k8s-agent-deployment.yaml
+++ b/base-apps/oncall-crewai/k8s-agent-deployment.yaml
@@ -71,8 +71,8 @@ spec:
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 30
-          timeoutSeconds: 10
-          failureThreshold: 3
+          timeoutSeconds: 30
+          failureThreshold: 5
 
         readinessProbe:
           httpGet:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes health check configuration for the oncall-crewai agent deployment with adjusted timeout duration and failure tolerance settings to optimize pod lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->