### PR TITLE
fix: restore directory.recurse on oncall-crewai ArgoCD app

### DIFF
--- a/base-apps/oncall-crewai.yaml
+++ b/base-apps/oncall-crewai.yaml
@@ -9,6 +9,8 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/oncall-crewai
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: oncall-crewai


### PR DESCRIPTION
## Summary
- Restores `directory.recurse: true` on the oncall-crewai ArgoCD Application
- This was accidentally removed in PR #111 when the old dnd-agent was deleted
- Without it, ArgoCD cannot discover manifests in subdirectories like `dungeons-dragons-agent/`

## Changes
- `oncall-crewai.yaml` - Re-added `directory.recurse: true` to the source config

## Test Plan
- [ ] Verify ArgoCD syncs and discovers the dungeons-dragons-agent manifests
- [ ] Verify new agent pods start spinning up in the oncall-crewai namespace

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application configuration to support recursive directory traversal during deployment, improving flexibility in managing nested configuration structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->