### PR TITLE
feat: add dungeons-dragons-agent K8s manifests

### DIFF
--- a/base-apps/oncall-crewai/dungeons-dragons-agent/external-secret.yaml
+++ b/base-apps/oncall-crewai/dungeons-dragons-agent/external-secret.yaml
@@ -57,11 +57,6 @@ spec:
       remoteRef:
         key: dungeons-dragons-agent
         property: api-keys
-    # JWT signing secret for user authentication
-    - secretKey: jwt-secret
-      remoteRef:
-        key: dungeons-dragons-agent
-        property: jwt-secret
 
 ---
 # ------------------------------------------------------------------------------

--- a/base-apps/oncall-crewai/dungeons-dragons-agent/orchestrator/deployment.yaml
+++ b/base-apps/oncall-crewai/dungeons-dragons-agent/orchestrator/deployment.yaml
@@ -87,11 +87,6 @@ spec:
                 secretKeyRef:
                   name: dungeons-dragons-agent-orchestrator-secrets
                   key: api-keys
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: dungeons-dragons-agent-orchestrator-secrets
-                  key: jwt-secret
 
           # Mount persistent storage for session data / CrewAI memory
           volumeMounts:


### PR DESCRIPTION
## K8s Manifests for dungeons-dragons-agent

Deployment manifests for the dungeons-dragons-agent agent, placed inside
`base-apps/oncall-crewai/dungeons-dragons-agent/` so they're managed by the
existing **oncall-crewai** ArgoCD Application. No separate ArgoCD app is created.

Scaffolded by the Backstage CrewAI template.

### Vault (automated by scaffolder)
- Policy, K8s auth role, and placeholder secrets were created automatically
- **Post-merge**: replace placeholder secrets with real values at `k8s-secrets/data/dungeons-dragons-agent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed JWT secret configuration references from deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->