### PR TITLE
Add lg-agents namespace for LangGraph orchestrator

### DIFF
--- a/base-apps/lg-agents.yaml
+++ b/base-apps/lg-agents.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lg-agents
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/lg-agents
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: lg-agents
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/lg-agents/external-secret.yaml
+++ b/base-apps/lg-agents/external-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: orchestrator-secrets
+  namespace: lg-agents
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: orchestrator-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: lg-agents
+        property: anthropic-api-key
+    - secretKey: api-keys
+      remoteRef:
+        key: lg-agents
+        property: api-keys
+    - secretKey: jwt-secret
+      remoteRef:
+        key: lg-agents
+        property: jwt-secret

--- a/base-apps/lg-agents/external-secret.yaml
+++ b/base-apps/lg-agents/external-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: orchestrator-secrets
   namespace: lg-agents
 spec:
-  refreshInterval: 1h
+  refreshInterval: 15s
   secretStoreRef:
     name: vault-backend
     kind: SecretStore

--- a/base-apps/lg-agents/namespace.yaml
+++ b/base-apps/lg-agents/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lg-agents
+  labels:
+    app: lg-agents
+    team: devops
+    framework: langgraph

--- a/base-apps/lg-agents/orchestrator-configmap.yaml
+++ b/base-apps/lg-agents/orchestrator-configmap.yaml
@@ -12,4 +12,4 @@ data:
   CHECKPOINT_DB_PATH: "/data/checkpoints.db"
   USERS_DB_PATH: "/data/users.db"
   SESSION_META_DB_PATH: "/data/session_meta.db"
-  CORS_ORIGINS: "*"
+  CORS_ORIGINS: "https://oncall-crewai.arigsela.com"

--- a/base-apps/lg-agents/orchestrator-configmap.yaml
+++ b/base-apps/lg-agents/orchestrator-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-config
+  namespace: lg-agents
+  labels:
+    app: lg-agents-orchestrator
+data:
+  PROJECT_NAME: "lg-agents-orchestrator"
+  ANTHROPIC_MODEL: "claude-sonnet-4-6"
+  LOG_LEVEL: "INFO"
+  CHECKPOINT_DB_PATH: "/data/checkpoints.db"
+  USERS_DB_PATH: "/data/users.db"
+  SESSION_META_DB_PATH: "/data/session_meta.db"
+  CORS_ORIGINS: "*"

--- a/base-apps/lg-agents/orchestrator-deployment.yaml
+++ b/base-apps/lg-agents/orchestrator-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 
       containers:
         - name: orchestrator
-          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/lg-agents-orchestrator:latest
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/lg-agents-orchestrator:1.0.0
           imagePullPolicy: Always
           ports:
             - name: http

--- a/base-apps/lg-agents/orchestrator-deployment.yaml
+++ b/base-apps/lg-agents/orchestrator-deployment.yaml
@@ -1,0 +1,118 @@
+# ServiceAccount (defined in rbac.yaml, referenced here)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lg-agents-orchestrator
+  namespace: lg-agents
+  labels:
+    app: lg-agents-orchestrator
+spec:
+  type: ClusterIP
+  selector:
+    app: lg-agents-orchestrator
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lg-agents-orchestrator
+  namespace: lg-agents
+  labels:
+    app: lg-agents-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lg-agents-orchestrator
+  template:
+    metadata:
+      labels:
+        app: lg-agents-orchestrator
+        version: v1
+    spec:
+      serviceAccountName: lg-agents-orchestrator
+      imagePullSecrets:
+        - name: ecr-registry
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+
+      containers:
+        - name: orchestrator
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/lg-agents-orchestrator:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+
+          envFrom:
+            - configMapRef:
+                name: orchestrator-config
+
+          env:
+            - name: HOME
+              value: /tmp
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: orchestrator-secrets
+                  key: anthropic-api-key
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: orchestrator-secrets
+                  key: api-keys
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: orchestrator-secrets
+                  key: jwt-secret
+
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          securityContext:
+            allowPrivilegeEscalation: false
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: orchestrator-data
+      terminationGracePeriodSeconds: 30

--- a/base-apps/lg-agents/orchestrator-deployment.yaml
+++ b/base-apps/lg-agents/orchestrator-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 
       containers:
         - name: orchestrator
-          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/lg-agents-orchestrator:1.0.0
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/lg-agents-orchestrator:v1.0.0
           imagePullPolicy: Always
           ports:
             - name: http

--- a/base-apps/lg-agents/orchestrator-pvc.yaml
+++ b/base-apps/lg-agents/orchestrator-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: orchestrator-data
+  namespace: lg-agents
+  labels:
+    app: lg-agents-orchestrator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/base-apps/lg-agents/rbac.yaml
+++ b/base-apps/lg-agents/rbac.yaml
@@ -1,0 +1,47 @@
+# ServiceAccount for the orchestrator pod
+# Used for Vault K8s auth and K8s API access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lg-agents-orchestrator
+  namespace: lg-agents
+  labels:
+    app: lg-agents-orchestrator
+    component: rbac
+
+---
+# ClusterRole: read-only K8s access for the K8s agent tools
+# The LangGraph orchestrator contains a K8s specialist agent that needs
+# to list pods, read logs, describe deployments, etc.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lg-agents-k8s-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status", "events", "services", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Bind the ClusterRole to the orchestrator ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lg-agents-k8s-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lg-agents-k8s-reader
+subjects:
+  - kind: ServiceAccount
+    name: lg-agents-orchestrator
+    namespace: lg-agents

--- a/base-apps/lg-agents/secret-store.yaml
+++ b/base-apps/lg-agents/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: lg-agents
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "lg-agents"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/lg-agents/secret-store.yaml
+++ b/base-apps/lg-agents/secret-store.yaml
@@ -14,4 +14,4 @@ spec:
           mountPath: "kubernetes"
           role: "lg-agents"
           serviceAccountRef:
-            name: "default"
+            name: "lg-agents-orchestrator"


### PR DESCRIPTION
## Summary
- New `lg-agents` namespace for a LangGraph-based multi-agent orchestrator (separate from CrewAI)
- Orchestrator uses LangGraph StateGraph with supervisor routing to K8s specialist and Chores Tracker specialist agents
- Native session persistence via LangGraph checkpointer (SQLite)

## Manifests
- **`lg-agents.yaml`** — ArgoCD Application (auto-sync, self-heal, prune, recurse)
- **`namespace.yaml`** — `lg-agents` namespace
- **`rbac.yaml`** — ServiceAccount + ClusterRole (`lg-agents-k8s-reader`) with read-only K8s access for the K8s agent tools + ClusterRoleBinding
- **`secret-store.yaml`** — Vault SecretStore (role: `lg-agents`)
- **`external-secret.yaml`** — Syncs `anthropic-api-key`, `api-keys`, `jwt-secret` from `k8s-secrets/lg-agents`
- **`orchestrator-deployment.yaml`** — Deployment + Service (port 80 → 8000)
- **`orchestrator-configmap.yaml`** — Non-sensitive config (model, DB paths, CORS)
- **`orchestrator-pvc.yaml`** — 1Gi for SQLite databases

## Vault prerequisites (already provisioned)
- Policy: `lg-agents-read` ✅
- K8s auth role: `lg-agents` (bound to `default` SA in `lg-agents` namespace) ✅
- Secrets seeded at `k8s-secrets/lg-agents` ✅

## Pre-merge checklist
- [ ] ECR image `lg-agents-orchestrator:latest` pushed
- [ ] ECR CronJob updated to sync `ecr-registry` secret to `lg-agents` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LG Agents orchestrator with automated ArgoCD deployment and self-heal.
  * Created lg-agents namespace and persistent storage for orchestrator data.
  * Added runtime configuration via a ConfigMap and environment-driven settings.
  * Enabled Vault-backed external secrets and RBAC/service account for secure secret access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->