### PR TITLE
Add lg-agents to ECR credentials sync CronJob

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Adds `lg-agents` namespace to the ECR credentials sync CronJob
- Required for the LangGraph orchestrator deployment to pull images from ECR

## Changes
- `base-apps/ecr-auth/cronjobs.yaml`: Added `lg-agents` to the namespace loop

## Context
This is a prerequisite for PR #119 (lg-agents namespace manifests). The ECR CronJob must sync the `ecr-registry` imagePullSecret to the `lg-agents` namespace before the orchestrator pod can start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)