### PR TITLE
fix: correct ingress service name to match actual Helm-created service

### DIFF
--- a/base-apps/langflow-ide/nginx-ingress.yaml
+++ b/base-apps/langflow-ide/nginx-ingress.yaml
@@ -26,6 +26,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: langflow-ide-langflow-service-frontend
+            name: langflow-service
             port:
               number: 8080


### PR DESCRIPTION
The Langflow IDE Helm chart creates the frontend service as 'langflow-service' (not 'langflow-ide-langflow-service-frontend'). Updated ingress backend to match, fixing the 503 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service routing configuration to improve system infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->