### PR TITLE
fix: add LANGFLOW_SECRET_KEY and runtime /app/flows volume

### DIFF
--- a/base-apps/langflow-ide.yaml
+++ b/base-apps/langflow-ide.yaml
@@ -82,6 +82,11 @@ spec:
                   secretKeyRef:
                     name: langflow-api-secrets
                     key: anthropic-api-key
+              - name: LANGFLOW_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: langflow-api-secrets
+                    key: langflow-secret-key
           frontend:
             enabled: true
             resources:

--- a/base-apps/langflow-ide/external-secret.yaml
+++ b/base-apps/langflow-ide/external-secret.yaml
@@ -47,3 +47,7 @@ spec:
       remoteRef:
         key: langflow
         property: anthropic-api-key
+    - secretKey: langflow-secret-key
+      remoteRef:
+        key: langflow
+        property: langflow-secret-key

--- a/base-apps/langflow-runtime.yaml
+++ b/base-apps/langflow-runtime.yaml
@@ -54,12 +54,16 @@ spec:
             mountPath: /tmp
           - name: langflow-cache
             mountPath: /home/user/.langflow
+          - name: langflow-flows
+            mountPath: /app/flows
         volumes:
           - name: tmp
             emptyDir: {}
           - name: langflow-cache
             emptyDir:
               sizeLimit: 1Gi
+          - name: langflow-flows
+            emptyDir: {}
         nodeSelector:
           node.kubernetes.io/workload: application
   destination:


### PR DESCRIPTION
Two issues fixed:

1. IDE: API key decryption fails after pod restart because LANGFLOW_SECRET_KEY was not set. Add it as env var from Vault secret, and add the property to the ExternalSecret.

2. Runtime: CrashLoopBackOff with "mkdir: cannot create directory '/app/flows': Read-only file system". Add emptyDir volume mount at /app/flows to satisfy readOnlyRootFilesystem constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured secure secret key management for enhanced application security
  * Added persistent storage support for flow data retention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->