### PR TITLE
fix: correct Atlantis Helm chart schema violations

### DIFF
--- a/base-apps/atlantis.yaml
+++ b/base-apps/atlantis.yaml
@@ -26,7 +26,18 @@ spec:
 
         # AWS creds + Infracost API key injected as env vars from atlantis-env K8s secret
         environmentSecrets:
-          - name: atlantis-env
+          - name: AWS_ACCESS_KEY_ID
+            secretKeyRef:
+              name: atlantis-env
+              key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            secretKeyRef:
+              name: atlantis-env
+              key: AWS_SECRET_ACCESS_KEY
+          - name: INFRACOST_API_KEY
+            secretKeyRef:
+              name: atlantis-env
+              key: INFRACOST_API_KEY
 
         atlantisUrl: https://atlantis.arigsela.com
 
@@ -62,10 +73,12 @@ spec:
             effect: NoSchedule
 
         # Persist Atlantis working directory across restarts
-        persistence:
+        volumeClaim:
           enabled: true
-          storageClass: local-path
-          size: 5Gi
+          dataStorage: 5Gi
+          storageClassName: local-path
+          accessModes:
+            - ReadWriteOnce
 
         readinessProbe:
           periodSeconds: 10


### PR DESCRIPTION
## Summary

Fixes two Helm schema violations seen in ArgoCD after merging #125:

```
Failed to load target state: values don't meet the specifications of the schema(s):
- (root): Additional property persistence is not allowed
- environmentSecrets.0: secretKeyRef is required
```

**Changes:**
- `persistence` → `volumeClaim` with correct sub-keys (`dataStorage`, `storageClassName`, `accessModes`) — this is the correct key in Atlantis chart v6
- `environmentSecrets` — each entry now has an explicit `secretKeyRef` with `name` and `key` fields as required by the chart schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated credential injection to use separate environment variables from the Atlantis secret for AWS and Infracost credentials
  * Modified persistent storage configuration schema with revised parameters and explicit access mode settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->