### PR TITLE
fix: add atlantis-config ArgoCD Application for supporting manifests

### DIFF
--- a/base-apps/atlantis-config.yaml
+++ b/base-apps/atlantis-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: atlantis-config
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/atlantis
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: atlantis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Root Cause

`base-apps/atlantis/` (containing SecretStore, ExternalSecrets, Ingress, NetworkPolicy) was never being deployed — there was no ArgoCD Application pointing to that path. This caused:

```
Error: secret "atlantis-env" not found
```

The `atlantis-env` and `atlantis-vcs` K8s secrets are created by ExternalSecrets syncing from Vault, but those ExternalSecret resources were never applied to the cluster.

## Fix

Add `base-apps/atlantis-config.yaml` — an ArgoCD Application that deploys everything in `base-apps/atlantis/`. Follows the same pattern as `base-apps/cert-manager-config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated deployment configuration for Atlantis with continuous synchronization enabled. The setup includes automatic pruning and self-healing capabilities to maintain the desired state in the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->