### PR TITLE
fix: correct atlantis-vcs secret key names for Helm chart

### DIFF
--- a/base-apps/atlantis/external-secrets.yaml
+++ b/base-apps/atlantis/external-secrets.yaml
@@ -15,11 +15,11 @@ spec:
     name: atlantis-vcs
     creationPolicy: Owner
   data:
-    - secretKey: token
+    - secretKey: github_token
       remoteRef:
         key: atlantis/github
         property: token
-    - secretKey: webhook
+    - secretKey: github_webhook_secret
       remoteRef:
         key: atlantis/webhook
         property: secret


### PR DESCRIPTION
## Root Cause

```
Error: couldn't find key github_token in Secret atlantis/atlantis-vcs
```

The Atlantis Helm chart expects keys named `github_token` and `github_webhook_secret` in the `vcsSecretName` secret. Our ExternalSecret was creating keys named `token` and `webhook`.

## Fix

Rename the ExternalSecret target keys to match what the chart schema requires:
- `token` → `github_token`
- `webhook` → `github_webhook_secret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)