### PR TITLE
fix: rename github_webhook_secret to github_secret in atlantis-vcs

### DIFF
--- a/base-apps/atlantis/external-secrets.yaml
+++ b/base-apps/atlantis/external-secrets.yaml
@@ -19,7 +19,7 @@ spec:
       remoteRef:
         key: atlantis/github
         property: token
-    - secretKey: github_webhook_secret
+    - secretKey: github_secret
       remoteRef:
         key: atlantis/webhook
         property: secret


### PR DESCRIPTION
## Root Cause

```
Error: couldn't find key github_secret in Secret atlantis/atlantis-vcs
```

The Atlantis Helm chart expects the webhook secret key to be named `github_secret`, not `github_webhook_secret`.

## Fix

`github_webhook_secret` → `github_secret` in the `atlantis-vcs` ExternalSecret target keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub webhook secret configuration mapping for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->