### PR TITLE
fix: add GitHub webhook IPs to Atlantis ingress whitelist

### DIFF
--- a/base-apps/atlantis/nginx-ingress.yaml
+++ b/base-apps/atlantis/nginx-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    # Your IPs + GitHub webhook delivery IPs (from https://api.github.com/meta hooks)
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,192.30.252.0/22,185.199.108.0/22,140.82.112.0/20,143.55.64.0/20,2a0a:a440::/29,2606:50c0::/32"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Root Cause

GitHub webhook deliveries were returning `403 Forbidden` because the nginx ingress `whitelist-source-range` only allowed the user's own IPs. GitHub's webhook infrastructure IPs were blocked.

## Fix

Add GitHub's webhook delivery CIDR ranges (from `https://api.github.com/meta` → `hooks`) to the whitelist alongside the existing personal IPs:

```
192.30.252.0/22
185.199.108.0/22
140.82.112.0/20
143.55.64.0/20
2a0a:a440::/29
2606:50c0::/32
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the network access whitelist to enable GitHub webhook deliveries. The configuration has been updated to include additional IP address ranges and regions from GitHub's global infrastructure, supporting both IPv4 and IPv6 addresses. This ensures webhooks are reliably delivered to the application from all of GitHub's delivery network locations worldwide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->