### PR TITLE
docs: mark Phase 5 complete — GitHub webhook validated

### DIFF
--- a/base-apps/atlantis/nginx-ingress.yaml
+++ b/base-apps/atlantis/nginx-ingress.yaml
@@ -11,7 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    # Your IPs + GitHub webhook delivery IPs (from https://api.github.com/meta hooks)
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,192.30.252.0/22,185.199.108.0/22,140.82.112.0/20,143.55.64.0/20,2a0a:a440::/29,2606:50c0::/32"
 spec:
   ingressClassName: nginx
   tls:

--- a/docs/plans/atlantis-infracost-implementation-plan.md
+++ b/docs/plans/atlantis-infracost-implementation-plan.md
@@ -1,11 +1,12 @@
 # Atlantis + Infracost Implementation Plan
 
-**Status:** Phase 4 Complete (4/7 phases)
-**Last Updated:** 2026-03-29
+**Status:** Phase 5 Complete (5/7 phases)
+**Last Updated:** 2026-03-30
 **Phase 1 Completed:** 2026-03-29
 **Phase 2 Completed:** 2026-03-29
 **Phase 3 Completed:** 2026-03-29
 **Phase 4 Completed:** 2026-03-29
+**Phase 5 Completed:** 2026-03-30
 
 ## Overview
 


### PR DESCRIPTION
Atlantis is live and responding to GitHub webhooks. Ping event returns 200 with "Ignoring unsupported event" — expected behavior.

Up next: Phase 6 (CI/CD pipelines) and Phase 7 (end-to-end testing with a real terraform PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)