### PR TITLE
feat: Phase 6 — Terraform validate and Infracost GHA workflows

### DIFF
--- a/.github/workflows/infracost.yaml
+++ b/.github/workflows/infracost.yaml
@@ -1,0 +1,53 @@
+name: Infracost
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "terraform/**"
+
+jobs:
+  infracost:
+    name: Cost Estimation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v3
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+
+      - name: Generate baseline (base branch)
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          infracost breakdown \
+            --path=terraform/roots/asela-cluster \
+            --terraform-init-flags="-backend=false" \
+            --format=json \
+            --out-file=/tmp/infracost-base.json
+
+      - name: Generate diff (PR branch)
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          infracost diff \
+            --path=terraform/roots/asela-cluster \
+            --terraform-init-flags="-backend=false" \
+            --compare-to=/tmp/infracost-base.json \
+            --format=json \
+            --out-file=/tmp/infracost.json
+
+      - name: Post PR comment
+        run: |
+          infracost comment github \
+            --path=/tmp/infracost.json \
+            --repo=$GITHUB_REPOSITORY \
+            --pull-request=${{ github.event.pull_request.number }} \
+            --behavior=update \
+            --github-token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-validate.yaml
+++ b/.github/workflows/terraform-validate.yaml
@@ -1,0 +1,68 @@
+name: Terraform Validate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "terraform/**"
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+
+jobs:
+  terraform-fmt:
+    name: Terraform Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.2"
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive terraform/
+
+  terraform-validate:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.2"
+
+      - name: Init (no backend)
+        working-directory: terraform/roots/asela-cluster
+        run: terraform init -backend=false
+
+      - name: Validate
+        working-directory: terraform/roots/asela-cluster
+        run: terraform validate
+
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: terraform-linters/setup-tflint@v4
+
+      - name: Run TFLint
+        working-directory: terraform/roots/asela-cluster
+        run: tflint --format compact
+
+  tfsec:
+    name: tfsec Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          working_directory: terraform/
+          soft_fail: true
+          format: lovely

--- a/docs/plans/atlantis-infracost-implementation-plan.md
+++ b/docs/plans/atlantis-infracost-implementation-plan.md
@@ -1,12 +1,13 @@
 # Atlantis + Infracost Implementation Plan
 
-**Status:** Phase 5 Complete (5/7 phases)
+**Status:** Phase 6 Complete (6/7 phases)
 **Last Updated:** 2026-03-30
 **Phase 1 Completed:** 2026-03-29
 **Phase 2 Completed:** 2026-03-29
 **Phase 3 Completed:** 2026-03-29
 **Phase 4 Completed:** 2026-03-29
 **Phase 5 Completed:** 2026-03-30
+**Phase 6 Completed:** 2026-03-30
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows that run on PRs touching `terraform/**`:

### `.github/workflows/terraform-validate.yaml`
Four parallel jobs:
- **terraform-fmt** — `terraform fmt -check -recursive` (fails PR if formatting is off)
- **terraform-validate** — `terraform init -backend=false` + `terraform validate` on `asela-cluster` root
- **tflint** — Static analysis with TFLint
- **tfsec** — Security scan (soft-fail initially — reports findings without blocking PRs)

### `.github/workflows/infracost.yaml`
- Generates cost diff between base branch and PR branch
- Posts/updates a cost estimate comment directly on the PR
- **No AWS credentials needed** — uses `--terraform-init-flags="-backend=false"` for static HCL parsing

## Pre-requisite

Add `INFRACOST_API_KEY` as a GitHub Actions repository secret:
**Settings → Secrets and variables → Actions → New repository secret**

(Same API key stored in Vault at `k8s-secrets/atlantis/infracost`)

## What's next (Phase 7)

Open a test PR with a Terraform change to validate the full end-to-end flow:
- Atlantis posts `terraform plan` as a PR comment
- Infracost GHA posts cost estimate
- All validation checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)