### PR TITLE
fix: remove hardcoded AWS profile from Terraform providers

### DIFF
--- a/terraform/roots/asela-cluster/atlantis-iam.tf
+++ b/terraform/roots/asela-cluster/atlantis-iam.tf
@@ -31,6 +31,7 @@ resource "aws_iam_user" "atlantis" {
     ManagedBy   = "Terraform"
     Service     = "Platform-Engineering"
     Environment = "Prod"
+    Team        = "Platform"
     Description = "IAM user for Atlantis to run terraform plan/apply via PR workflow"
   }
 }
@@ -50,6 +51,7 @@ resource "aws_iam_policy" "atlantis" {
     ManagedBy   = "Terraform"
     Service     = "Platform-Engineering"
     Environment = "Prod"
+    Team        = "Platform"
   }
 
   policy = jsonencode({

--- a/terraform/roots/asela-cluster/providers.tf
+++ b/terraform/roots/asela-cluster/providers.tf
@@ -4,7 +4,6 @@ terraform {
     bucket  = "asela-terraform-states"
     key     = "asela-cluster"
     region  = "us-east-2"
-    profile = "default"
     encrypt = true
   }
 
@@ -24,8 +23,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-east-2"
-  profile = "default"
+  region = "us-east-2"
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
## Summary

- Remove `profile = "default"` from S3 backend config
- Remove `profile = "default"` from AWS provider config

## Why

Atlantis injects AWS credentials as env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`). The hardcoded `profile = "default"` forces Terraform to look for `~/.aws/config` which doesn't exist in the Atlantis container — causing `terraform init` to fail with:

```
Error: failed to get shared config profile, default
```

Removing `profile` lets the AWS SDK use the standard env var credential chain automatically.

## Local development

Set `AWS_PROFILE=default` in your shell, or use `aws-vault exec default -- terraform plan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure resource tags for organizational tracking
  * Simplified AWS provider and backend configuration by removing redundant default profile settings while maintaining existing region configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->