### PR TITLE
fix: resolve terraform plan errors — kms:ListAliases and helm provider

### DIFF
--- a/terraform/roots/asela-cluster/atlantis-iam.tf
+++ b/terraform/roots/asela-cluster/atlantis-iam.tf
@@ -192,8 +192,6 @@ resource "aws_iam_policy" "atlantis" {
           "kms:DisableKey",
           "kms:GetKeyPolicy",
           "kms:GetKeyRotationStatus",
-          "kms:ListKeys",
-          "kms:ListAliases",
           "kms:ListResourceTags",
           "kms:PutKeyPolicy",
           "kms:UpdateKeyDescription",
@@ -205,6 +203,16 @@ resource "aws_iam_policy" "atlantis" {
         Resource = [
           "arn:aws:kms:us-east-2:${data.aws_caller_identity.current.account_id}:key/*"
         ]
+      },
+      # kms:ListAliases and kms:ListKeys require * resource (AWS limitation)
+      {
+        Sid    = "KMSListActions"
+        Effect = "Allow"
+        Action = [
+          "kms:ListAliases",
+          "kms:ListKeys"
+        ]
+        Resource = ["*"]
       },
       {
         Sid    = "KMSAliasManagement"

--- a/terraform/roots/asela-cluster/providers.tf
+++ b/terraform/roots/asela-cluster/providers.tf
@@ -36,6 +36,9 @@ provider "kubernetes" {
 
 provider "helm" {
   kubernetes {
-    config_path = "~/.kube/config"
+    host                   = var.host
+    client_certificate     = base64decode(var.client_certificate)
+    client_key             = base64decode(var.client_key)
+    cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
   }
 }


### PR DESCRIPTION
## Summary

Two issues found from the first successful `terraform plan` run via Atlantis:

- Move `kms:ListAliases` + `kms:ListKeys` to a new `KMSListActions` statement with `Resource: ["*"]` — AWS requires wildcard for list operations (same pattern already used for `RDSDescribeActions`, `EC2DescribeActions`, `IAMDescribeActions`)
- Fix helm provider to use explicit credentials (`var.host`, `var.client_certificate`, etc.) instead of `config_path = "~/.kube/config"` which doesn't exist in the Atlantis container

## Errors resolved

```
Error: reading KMS Alias (alias/vault-auto-unseal): AccessDeniedException:
  User atlantis-terraform is not authorized to perform: kms:ListAliases on resource: *

Error: Kubernetes cluster unreachable:
  stat /home/atlantis/.kube/config: no such file or directory
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster infrastructure configuration to enhance deployment tooling connectivity and reliability
  * Refined access control permissions for cluster management operations to align security standards across components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->