### PR TITLE
feat: add weather-kitchen backend and frontend k8s manifests

### DIFF
--- a/base-apps/weather-kitchen-backend.yaml
+++ b/base-apps/weather-kitchen-backend.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: weather-kitchen-backend
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/weather-kitchen-backend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: weather-kitchen
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/weather-kitchen-backend/configmaps.yaml
+++ b/base-apps/weather-kitchen-backend/configmaps.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: weather-kitchen-backend-config
+  namespace: weather-kitchen
+data:
+  ENVIRONMENT: "production"
+  DEBUG: "False"
+  BACKEND_CORS_ORIGINS: "https://weather-kitchen.arigsela.com"

--- a/base-apps/weather-kitchen-backend/deployments.yaml
+++ b/base-apps/weather-kitchen-backend/deployments.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-kitchen-backend
+  namespace: weather-kitchen
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: weather-kitchen-backend
+  template:
+    metadata:
+      labels:
+        app: weather-kitchen-backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      containers:
+      - name: weather-kitchen-backend
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-backend:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+        envFrom:
+        - configMapRef:
+            name: weather-kitchen-backend-config
+        - secretRef:
+            name: weather-kitchen-backend-secrets
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 90
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      imagePullSecrets:
+      - name: ecr-registry

--- a/base-apps/weather-kitchen-backend/external_secrets.yaml
+++ b/base-apps/weather-kitchen-backend/external_secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: weather-kitchen-backend-secrets
+  namespace: weather-kitchen
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: weather-kitchen-backend-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: JWT_SECRET_KEY
+      remoteRef:
+        key: weather-kitchen-backend
+        property: jwt-secret-key
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: weather-kitchen-backend
+        property: database-url

--- a/base-apps/weather-kitchen-backend/nginx-ingress.yaml
+++ b/base-apps/weather-kitchen-backend/nginx-ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: weather-kitchen-backend-nginx
+  namespace: weather-kitchen
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+    nginx.ingress.kubernetes.io/rewrite-target: /api/$1
+    nginx.ingress.kubernetes.io/priority: "100"
+    # IP Whitelist - restrict access to known IPs
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - weather-kitchen.arigsela.com
+    secretName: weather-kitchen-tls
+  rules:
+  - host: weather-kitchen.arigsela.com
+    http:
+      paths:
+      - path: /api/(?!docs|openapi\.json)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: weather-kitchen-backend
+            port:
+              number: 80

--- a/base-apps/weather-kitchen-backend/secret-store.yaml
+++ b/base-apps/weather-kitchen-backend/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: weather-kitchen
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "weather-kitchen"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/weather-kitchen-backend/services.yaml
+++ b/base-apps/weather-kitchen-backend/services.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather-kitchen-backend
+  namespace: weather-kitchen
+spec:
+  selector:
+    app: weather-kitchen-backend
+  ports:
+  - port: 80
+    targetPort: 8000
+  type: ClusterIP

--- a/base-apps/weather-kitchen-frontend.yaml
+++ b/base-apps/weather-kitchen-frontend.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: weather-kitchen-frontend
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/weather-kitchen-frontend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: weather-kitchen-frontend
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/weather-kitchen-frontend/deployments.yaml
+++ b/base-apps/weather-kitchen-frontend/deployments.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-kitchen-frontend
+  namespace: weather-kitchen-frontend
+  labels:
+    app: weather-kitchen-frontend
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: weather-kitchen-frontend
+  template:
+    metadata:
+      labels:
+        app: weather-kitchen-frontend
+        component: frontend
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      containers:
+      - name: frontend
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-frontend:latest
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: API_URL
+          value: "https://weather-kitchen.arigsela.com/api/v1"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1001
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: nginx-conf-d
+          mountPath: /etc/nginx/conf.d
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: nginx-conf-d
+        emptyDir: {}
+      imagePullSecrets:
+      - name: ecr-registry
+      securityContext:
+        fsGroup: 1001
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/base-apps/weather-kitchen-frontend/nginx-ingress.yaml
+++ b/base-apps/weather-kitchen-frontend/nginx-ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: weather-kitchen-frontend-nginx
+  namespace: weather-kitchen-frontend
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+    nginx.ingress.kubernetes.io/priority: "50"
+    # IP Whitelist - restrict access to known IPs
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - weather-kitchen.arigsela.com
+    secretName: weather-kitchen-tls
+  rules:
+  - host: weather-kitchen.arigsela.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: weather-kitchen-frontend
+            port:
+              number: 80

--- a/base-apps/weather-kitchen-frontend/services.yaml
+++ b/base-apps/weather-kitchen-frontend/services.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather-kitchen-frontend
+  namespace: weather-kitchen-frontend
+  labels:
+    app: weather-kitchen-frontend
+    component: frontend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 3000
+    protocol: TCP
+    name: http
+  selector:
+    app: weather-kitchen-frontend


### PR DESCRIPTION
## Summary
- Adds full Kubernetes deployment manifests for the **Weather Kitchen** application (backend + frontend)
- Follows existing patterns from chores-tracker (regular Deployment, no Argo Rollouts/Istio)
- IP whitelisted ingress matching the n8n admin pattern

## Manifests Created

### ArgoCD Applications
- `weather-kitchen-backend.yaml` — deploys to `weather-kitchen` namespace
- `weather-kitchen-frontend.yaml` — deploys to `weather-kitchen-frontend` namespace

### Backend (`weather-kitchen-backend/`)
| File | Purpose |
|------|---------|
| `deployments.yaml` | Deployment (2 replicas, 200m/256Mi → 500m/512Mi) |
| `services.yaml` | ClusterIP service (80 → 8000) |
| `nginx-ingress.yaml` | HTTPS ingress for `/api/(.*)` with IP whitelist, priority 100 |
| `configmaps.yaml` | ENVIRONMENT, DEBUG, BACKEND_CORS_ORIGINS |
| `secret-store.yaml` | Vault backend (role: weather-kitchen) |
| `external_secrets.yaml` | JWT_SECRET_KEY, DATABASE_URL from Vault |

### Frontend (`weather-kitchen-frontend/`)
| File | Purpose |
|------|---------|
| `deployments.yaml` | Deployment (2 replicas, nginx, security context, 100m/128Mi → 200m/256Mi) |
| `services.yaml` | ClusterIP service (80 → 3000) |
| `nginx-ingress.yaml` | HTTPS ingress for `/` with IP whitelist, priority 50 |

## Pre-deployment Requirements
- [ ] Create ECR repos: `weather-kitchen-backend`, `weather-kitchen-frontend`
- [ ] Update `ecr-credentials-sync` CronJob to include `weather-kitchen` and `weather-kitchen-frontend` namespaces
- [ ] Create Vault role `weather-kitchen` bound to the namespace service account
- [ ] Seed Vault secrets: `k8s-secrets/weather-kitchen-backend/jwt-secret-key` and `database-url`
- [ ] Add DNS record: `weather-kitchen.arigsela.com` → ingress controller

## Domain
`weather-kitchen.arigsela.com` — both frontend and backend share the domain, with backend at `/api/*` (priority 100) and frontend at `/` (priority 50).

---
*Generated with [Claude Code](https://claude.com/claude-code)*