### PR TITLE
feat: add weather-kitchen namespace to ECR credentials sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents weather-kitchen; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Added `weather-kitchen` namespace to the ECR credentials sync CronJob
- Enables weather-kitchen-backend and weather-kitchen-frontend pods to pull images from ECR

## Changes
### Key Features
- Added `weather-kitchen` to the namespace loop in `base-apps/ecr-auth/cronjobs.yaml`
- Both frontend and backend share the same namespace, so only one entry needed

### Technical Implementation
- Updated the `for NAMESPACE in ...` loop in the ECR credentials sync CronJob to include `weather-kitchen`
- The CronJob will now create/refresh `ecr-registry` docker-registry secret in the `weather-kitchen` namespace hourly

## Test Plan
- [ ] Verify ArgoCD syncs the updated CronJob
- [ ] Trigger the CronJob manually or wait for the next hourly run
- [ ] Confirm `ecr-registry` secret is created in the `weather-kitchen` namespace
- [ ] Verify weather-kitchen pods can pull images from ECR

## Related
- Follows the existing ECR auth pattern used by chores-tracker, backstage, and other namespaces
- Supports the new weather-kitchen application deployment

🤖 Generated with [Claude Code](https://claude.ai/code)