### PR TITLE
feat: add weather-kitchen-frontend namespace to ECR credentials sync

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -44,7 +44,7 @@ spec:
             - |
               # Namespaces to synchronize secrets to
 
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents weather-kitchen; do
+              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents weather-kitchen weather-kitchen-frontend; do
                 # Check if namespace exists
                 if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
                   echo "Namespace $NAMESPACE doesn't exist. Please create it first."


### PR DESCRIPTION
## Summary
- Added `weather-kitchen-frontend` namespace to the ECR credentials sync CronJob
- The frontend deploys to a separate namespace from the backend, so it needs its own `ecr-registry` secret

## Changes
### Technical Implementation
- Updated the `for NAMESPACE in ...` loop in `base-apps/ecr-auth/cronjobs.yaml` to include `weather-kitchen-frontend`
- The CronJob will now create/refresh `ecr-registry` docker-registry secret in both `weather-kitchen` and `weather-kitchen-frontend` namespaces

### Context
- Backend ArgoCD app deploys to namespace `weather-kitchen`
- Frontend ArgoCD app deploys to namespace `weather-kitchen-frontend`
- Both pull images from ECR and reference `imagePullSecrets: ecr-registry`

## Test Plan
- [ ] Verify ArgoCD syncs the updated CronJob
- [ ] Confirm `ecr-registry` secret is created in the `weather-kitchen-frontend` namespace
- [ ] Verify weather-kitchen-frontend pods can pull images from ECR

## Related
- Follows up on PR #143 which added `weather-kitchen` namespace

🤖 Generated with [Claude Code](https://claude.ai/code)