### PR TITLE
fix: set imagePullPolicy to Always for weather-kitchen apps

### DIFF
--- a/base-apps/weather-kitchen-backend/deployments.yaml
+++ b/base-apps/weather-kitchen-backend/deployments.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: weather-kitchen-backend
         image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-backend:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8000
         envFrom:

--- a/base-apps/weather-kitchen-frontend/deployments.yaml
+++ b/base-apps/weather-kitchen-frontend/deployments.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
       - name: frontend
         image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-frontend:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 3000
           name: http


### PR DESCRIPTION
## Summary
- Set `imagePullPolicy: Always` on both weather-kitchen-backend and weather-kitchen-frontend deployments
- Required when using the `:latest` tag to ensure pods always pull fresh images from ECR

## Changes
### Technical Implementation
- **Backend**: Changed `imagePullPolicy` from `IfNotPresent` to `Always`
- **Frontend**: Added `imagePullPolicy: Always` (was not set, defaulting to K8s default behavior)

## Test Plan
- [ ] Verify ArgoCD syncs the updated deployments
- [ ] Confirm pods pull the latest image on next rollout
- [ ] Verify both frontend and backend pods start successfully

🤖 Generated with [Claude Code](https://claude.ai/code)