### PR TITLE
fix: change prometheus scrape path from /metrics to /health

### DIFF
--- a/base-apps/weather-kitchen-backend/deployments.yaml
+++ b/base-apps/weather-kitchen-backend/deployments.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"
-        prometheus.io/path: "/metrics"
+        prometheus.io/path: "/health"
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application


### PR DESCRIPTION
## Summary
- Updated Prometheus scrape annotation path from `/metrics` to `/health` on weather-kitchen-backend
- The backend does not expose a `/metrics` endpoint

## Changes
### Technical Implementation
- Changed `prometheus.io/path` annotation from `"/metrics"` to `"/health"` in `base-apps/weather-kitchen-backend/deployments.yaml`

## Test Plan
- [ ] Verify ArgoCD syncs the updated deployment
- [ ] Confirm Prometheus can scrape the `/health` endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)