### PR TITLE
fix: remove nginx-conf-d emptyDir mount from frontend deployment

### DIFF
--- a/base-apps/weather-kitchen-frontend/deployments.yaml
+++ b/base-apps/weather-kitchen-frontend/deployments.yaml
@@ -71,16 +71,12 @@ spec:
           mountPath: /var/cache/nginx
         - name: nginx-run
           mountPath: /var/run
-        - name: nginx-conf-d
-          mountPath: /etc/nginx/conf.d
       volumes:
       - name: tmp
         emptyDir: {}
       - name: nginx-cache
         emptyDir: {}
       - name: nginx-run
-        emptyDir: {}
-      - name: nginx-conf-d
         emptyDir: {}
       imagePullSecrets:
       - name: ecr-registry


### PR DESCRIPTION
## Summary
- Removed `nginx-conf-d` emptyDir volume and mount from the weather-kitchen-frontend deployment
- The emptyDir was overwriting `/etc/nginx/conf.d/default.conf` from the Dockerfile, causing nginx to start with no server block

## Changes
### Technical Implementation
- Removed volumeMount for `nginx-conf-d` at `/etc/nginx/conf.d`
- Removed corresponding `nginx-conf-d` emptyDir volume definition
- Root cause: the volume mount pattern was copied from chores-tracker frontend which needs a writable conf.d, but weather-kitchen-frontend's Dockerfile bakes in its own `default.conf`

## Test Plan
- [ ] Verify ArgoCD syncs the updated deployment
- [ ] Confirm nginx starts with the correct `default.conf` and listens on port 3000
- [ ] Verify health checks pass on `/health`

🤖 Generated with [Claude Code](https://claude.ai/code)