### PR TITLE
feat: add BETA_ACCESS_CODE to weather-kitchen-backend configmap

### DIFF
--- a/base-apps/weather-kitchen-backend/configmaps.yaml
+++ b/base-apps/weather-kitchen-backend/configmaps.yaml
@@ -7,4 +7,3 @@ data:
   ENVIRONMENT: "production"
   DEBUG: "False"
   BACKEND_CORS_ORIGINS: "https://weather-kitchen.arigsela.com"
-  BETA_ACCESS_CODE: "WK-BETA-2026-2479"

--- a/base-apps/weather-kitchen-backend/configmaps.yaml
+++ b/base-apps/weather-kitchen-backend/configmaps.yaml
@@ -7,3 +7,4 @@ data:
   ENVIRONMENT: "production"
   DEBUG: "False"
   BACKEND_CORS_ORIGINS: "https://weather-kitchen.arigsela.com"
+  BETA_ACCESS_CODE: "WK-BETA-2026-2479"

--- a/base-apps/weather-kitchen-backend/external_secrets.yaml
+++ b/base-apps/weather-kitchen-backend/external_secrets.yaml
@@ -20,3 +20,7 @@ spec:
       remoteRef:
         key: weather-kitchen-backend
         property: database-url
+    - secretKey: BETA_ACCESS_CODE
+      remoteRef:
+        key: weather-kitchen-backend
+        property: beta-access-code


### PR DESCRIPTION
## Summary
- Added `BETA_ACCESS_CODE` environment variable to the weather-kitchen-backend ConfigMap
- Supports the new beta gate feature that validates access codes on login and signup

## Changes
### Technical Implementation
- Added `BETA_ACCESS_CODE` to `base-apps/weather-kitchen-backend/configmaps.yaml`
- The backend reads this via the `BETA_ACCESS_CODE` env var to gate access
- Set to empty string `""` to disable the beta gate

## Test Plan
- [ ] Verify ArgoCD syncs the updated ConfigMap
- [ ] Confirm backend pods restart with the new env var
- [ ] Test login/signup with correct beta code succeeds
- [ ] Test login/signup with wrong beta code returns 403

🤖 Generated with [Claude Code](https://claude.ai/code)