### PR TITLE
fix: remove /api/v1 suffix from frontend API_URL

### DIFF
--- a/base-apps/weather-kitchen-frontend/deployments.yaml
+++ b/base-apps/weather-kitchen-frontend/deployments.yaml
@@ -30,7 +30,7 @@ spec:
         - name: NODE_ENV
           value: "production"
         - name: API_URL
-          value: "https://weather-kitchen.arigsela.com/api/v1"
+          value: "https://weather-kitchen.arigsela.com"
         resources:
           requests:
             memory: "128Mi"


### PR DESCRIPTION
## Summary
- Fixes double path prefix causing `POST /api/v1/api/v1/families` (404)
- The frontend `publicClient` already includes `api/v1/` in each request path, so `API_URL` should be the base domain only

## Change
`API_URL`: `https://weather-kitchen.arigsela.com/api/v1` → `https://weather-kitchen.arigsela.com`

## Test plan
- [ ] Verify signup (`POST /api/v1/families`) returns 201 or 403 (beta code)
- [ ] Verify login (`POST /api/v1/auth/login`) works correctly

---
*Generated with [Claude Code](https://claude.com/claude-code)*