### PR TITLE
feat: automate ECR pull secret distribution with Kyverno

### DIFF
--- a/base-apps/ecr-auth/cronjobs.yaml
+++ b/base-apps/ecr-auth/cronjobs.yaml
@@ -42,23 +42,15 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Namespaces to synchronize secrets to
-
-              for NAMESPACE in chores-tracker chores-tracker-frontend oncall-agent oncall-crewai cluster-scanner agent-ui-backend agent-ui-frontend backstage lg-agents weather-kitchen weather-kitchen-frontend; do
-                # Check if namespace exists
-                if ! kubectl get namespace $NAMESPACE > /dev/null 2>&1; then
-                  echo "Namespace $NAMESPACE doesn't exist. Please create it first."
-                  continue
-                fi
-
-                # Create or update secret in the namespace
-                echo "Syncing ECR credentials in namespace $NAMESPACE"
-                aws ecr get-login-password --region $AWS_REGION | kubectl delete secret --ignore-not-found=true docker-registry ecr-registry -n $NAMESPACE
-                aws ecr get-login-password --region $AWS_REGION | kubectl create secret docker-registry ecr-registry \
-                  --docker-server=852893458518.dkr.ecr.$AWS_REGION.amazonaws.com \
-                  --docker-username=AWS \
-                  --docker-password=$(aws ecr get-login-password --region $AWS_REGION) \
-                  -n $NAMESPACE
-              done
+              # Create/update ECR pull secret in kube-system as the single source of truth.
+              # Kyverno policy sync-ecr-secret clones this to all application namespaces.
+              TOKEN=$(aws ecr get-login-password --region $AWS_REGION)
+              echo "Syncing ECR credentials in kube-system (source for Kyverno sync)"
+              kubectl create secret docker-registry ecr-registry \
+                --docker-server=852893458518.dkr.ecr.$AWS_REGION.amazonaws.com \
+                --docker-username=AWS \
+                --docker-password=$TOKEN \
+                -n kube-system \
+                --dry-run=client -o yaml | kubectl apply -f -
           restartPolicy: OnFailure
 

--- a/base-apps/kyverno-policies/inject-ecr-pull-secret.yaml
+++ b/base-apps/kyverno-policies/inject-ecr-pull-secret.yaml
@@ -1,0 +1,41 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-ecr-pull-secret
+  annotations:
+    policies.kyverno.io/title: Inject ECR Pull Secret
+    policies.kyverno.io/category: Image Pull
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Automatically injects imagePullSecrets for the ECR registry into
+      any Pod that references an ECR image. Removes the need to manually
+      add imagePullSecrets to deployment manifests.
+spec:
+  rules:
+    - name: add-ecr-pull-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+      preconditions:
+        any:
+          - key: "{{ request.object.spec.containers[?contains(image, '.dkr.ecr.')] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+          - key: "{{ request.object.spec.initContainers[?contains(image, '.dkr.ecr.')] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+      mutate:
+        patchStrategicMerge:
+          spec:
+            imagePullSecrets:
+              - name: ecr-registry

--- a/base-apps/kyverno-policies/sync-ecr-secret.yaml
+++ b/base-apps/kyverno-policies/sync-ecr-secret.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: sync-ecr-secret
+  annotations:
+    policies.kyverno.io/title: Sync ECR Registry Secret
+    policies.kyverno.io/category: Image Pull
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Clones the ecr-registry pull secret from kube-system to all
+      application namespaces. Uses synchronize to keep secrets updated
+      when the source is refreshed by the ECR credentials CronJob.
+spec:
+  rules:
+    - name: clone-ecr-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - default
+                - kyverno
+      generate:
+        synchronize: true
+        apiVersion: v1
+        kind: Secret
+        name: ecr-registry
+        namespace: "{{request.object.metadata.name}}"
+        clone:
+          namespace: kube-system
+          name: ecr-registry


### PR DESCRIPTION
## Summary

- Add Kyverno `sync-ecr-secret` ClusterPolicy that clones the `ecr-registry` secret from `kube-system` to all application namespaces with `synchronize: true` for automatic propagation when the source refreshes
- Add Kyverno `inject-ecr-pull-secret` ClusterPolicy that mutates any Pod referencing an ECR image (`.dkr.ecr.`) to automatically inject `imagePullSecrets`, eliminating manual spec configuration
- Simplify ECR CronJob to only maintain the source secret in `kube-system` using `kubectl apply` (instead of delete+create) to avoid sync gaps during token refresh

### What this eliminates
Previously, deploying a new app with ECR images required two manual steps:
1. Adding the namespace to the hardcoded list in `ecr-auth/cronjobs.yaml`
2. Adding `imagePullSecrets: [{name: ecr-registry}]` to the pod spec

Both steps are now fully automated by Kyverno.

### How it works
```
CronJob (hourly) → creates/updates ecr-registry in kube-system
                          ↓
Kyverno sync-ecr-secret → clones to all app namespaces (synchronize: true)
                          ↓
Kyverno inject-ecr-pull-secret → mutates pods with ECR images to add imagePullSecrets
```

## Test plan
- [ ] Verify ECR CronJob runs successfully and creates the source secret in `kube-system`
- [ ] Verify Kyverno syncs the `ecr-registry` secret to existing application namespaces
- [ ] Verify pods with ECR images get `imagePullSecrets` injected automatically
- [ ] Verify creating a new namespace triggers automatic secret cloning
- [ ] Verify non-ECR pods (e.g., `whoami`) are NOT mutated
- [ ] Verify system namespaces (`kube-system`, `kyverno`) are excluded from both policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)