### PR TITLE
fix: add RBAC for Kyverno secret generation

### DIFF
--- a/base-apps/kyverno-policies/kyverno-generate-secrets-rbac.yaml
+++ b/base-apps/kyverno-policies/kyverno-generate-secrets-rbac.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:generate-secrets
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary

- Adds an aggregated ClusterRole granting Kyverno's admission and background controllers permissions to manage Secrets across namespaces
- Fixes `admission webhook "validate-policy.kyverno.svc" denied the request` error from PR #150's `sync-ecr-secret` policy
- Uses Kyverno's built-in label-based aggregation (`rbac.kyverno.io/aggregate-to-*`) so permissions are automatically merged into existing Kyverno roles

### Root cause
The `sync-ecr-secret` ClusterPolicy uses `generate` with `clone` to copy Secrets across namespaces. Kyverno validates at admission time that the controller has the necessary RBAC permissions for the target resource. The default Kyverno Helm install does not include Secret permissions since generate policies are opt-in.

## Test plan
- [ ] Verify the `sync-ecr-secret` ClusterPolicy syncs without SyncError in ArgoCD
- [ ] Verify `ecr-registry` secret gets cloned to application namespaces
- [ ] Verify Kyverno admission controller ClusterRole now includes Secret permissions via aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)