### PR TITLE
test: add ecr-test app to validate Kyverno ECR automation

### DIFF
--- a/base-apps/ecr-test.yaml
+++ b/base-apps/ecr-test.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ecr-test
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: ecr-kyverno-test
+    path: base-apps/ecr-test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ecr-test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/ecr-test/deployment.yaml
+++ b/base-apps/ecr-test/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ecr-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ecr-test
+  template:
+    metadata:
+      labels:
+        app: ecr-test
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      containers:
+      - name: ecr-test
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:5.3.0
+        command: ["sleep", "infinity"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "50m"


### PR DESCRIPTION
Minimal deployment using an ECR image with no imagePullSecrets. Validates: namespace creation → Kyverno secret clone → Kyverno imagePullSecrets injection → successful ECR image pull.

Remove after validation.