### PR TITLE
fix: point ecr-test app targetRevision to main

### DIFF
--- a/base-apps/ecr-test.yaml
+++ b/base-apps/ecr-test.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/arigsela/kubernetes
-    targetRevision: ecr-kyverno-test
+    targetRevision: main
     path: base-apps/ecr-test
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
The ecr-kyverno-test branch was deleted after merge.