### PR TITLE
feat: add pgvector support and kagent database initialization

### DIFF
--- a/base-apps/postgresql/deployments.yaml
+++ b/base-apps/postgresql/deployments.yaml
@@ -22,7 +22,7 @@ spec:
         runAsGroup: 999
       containers:
       - name: postgresql
-        image: pgvector/pgvector:pg18
+        image: pgvector/pgvector:0.8.2-pg18
         env:
         - name: POSTGRES_DB
           valueFrom:

--- a/base-apps/postgresql/deployments.yaml
+++ b/base-apps/postgresql/deployments.yaml
@@ -22,7 +22,7 @@ spec:
         runAsGroup: 999
       containers:
       - name: postgresql
-        image: postgres:18.1
+        image: pgvector/pgvector:pg18
         env:
         - name: POSTGRES_DB
           valueFrom:

--- a/base-apps/postgresql/external-secrets-kagent.yaml
+++ b/base-apps/postgresql/external-secrets-kagent.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-db-credentials
+  namespace: postgresql
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: kagent-db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: kagent-user
+      remoteRef:
+        key: kagent
+        property: db-user
+    - secretKey: kagent-password
+      remoteRef:
+        key: kagent
+        property: db-password
+    - secretKey: kagent-database
+      remoteRef:
+        key: kagent
+        property: db-name

--- a/base-apps/postgresql/init-kagent-db.yaml
+++ b/base-apps/postgresql/init-kagent-db.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: postgresql
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 5
   template:
     metadata:
       labels:
@@ -13,40 +14,44 @@ spec:
       nodeSelector:
         node.kubernetes.io/workload: application
       restartPolicy: OnFailure
-      backoffLimit: 5
       containers:
       - name: init-kagent-db
-        image: pgvector/pgvector:pg18
+        image: pgvector/pgvector:0.8.2-pg18
         command:
         - /bin/sh
         - -c
         - |
           set -e
 
+          PG_HOST="postgresql.postgresql.svc.cluster.local"
+          PG_PORT="5432"
+
+          # Escape single quotes in password for safe SQL interpolation
+          ESCAPED_PASSWORD=$(echo "$KAGENT_PASSWORD" | sed "s/'/''/g")
+
           # Wait for PostgreSQL to be ready
-          until pg_isready -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER"; do
+          until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$POSTGRES_USER"; do
             echo "Waiting for PostgreSQL..."
             sleep 2
           done
 
           # Create kagent user and database
-          PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<EOSQL
-            DO \$\$
-            BEGIN
-              IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$KAGENT_USER') THEN
-                CREATE ROLE "$KAGENT_USER" WITH LOGIN PASSWORD '$KAGENT_PASSWORD';
-              ELSE
-                ALTER ROLE "$KAGENT_USER" WITH PASSWORD '$KAGENT_PASSWORD';
-              END IF;
-            END
-            \$\$;
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+            -v kagent_user="$KAGENT_USER" \
+            -v kagent_password="$ESCAPED_PASSWORD" \
+            -v kagent_db="$KAGENT_DB" <<'EOSQL'
+            SELECT format('CREATE ROLE %I WITH LOGIN PASSWORD %L', :'kagent_user', :'kagent_password')
+            WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = :'kagent_user')\gexec
 
-            SELECT 'CREATE DATABASE "$KAGENT_DB" OWNER "$KAGENT_USER"'
-            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$KAGENT_DB')\gexec
+            SELECT format('ALTER ROLE %I WITH PASSWORD %L', :'kagent_user', :'kagent_password')
+            WHERE EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = :'kagent_user')\gexec
+
+            SELECT format('CREATE DATABASE %I OWNER %I', :'kagent_db', :'kagent_user')
+            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'kagent_db')\gexec
           EOSQL
 
           # Enable pgvector extension in kagent database
-          PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER" -d "$KAGENT_DB" <<EOSQL
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" -U "$POSTGRES_USER" -d "$KAGENT_DB" <<'EOSQL'
             CREATE EXTENSION IF NOT EXISTS vector;
           EOSQL
 

--- a/base-apps/postgresql/init-kagent-db.yaml
+++ b/base-apps/postgresql/init-kagent-db.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-kagent-db
+  namespace: postgresql
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: init-kagent-db
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      restartPolicy: OnFailure
+      backoffLimit: 5
+      containers:
+      - name: init-kagent-db
+        image: pgvector/pgvector:pg18
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+
+          # Wait for PostgreSQL to be ready
+          until pg_isready -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER"; do
+            echo "Waiting for PostgreSQL..."
+            sleep 2
+          done
+
+          # Create kagent user and database
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<EOSQL
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$KAGENT_USER') THEN
+                CREATE ROLE "$KAGENT_USER" WITH LOGIN PASSWORD '$KAGENT_PASSWORD';
+              ELSE
+                ALTER ROLE "$KAGENT_USER" WITH PASSWORD '$KAGENT_PASSWORD';
+              END IF;
+            END
+            \$\$;
+
+            SELECT 'CREATE DATABASE "$KAGENT_DB" OWNER "$KAGENT_USER"'
+            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$KAGENT_DB')\gexec
+          EOSQL
+
+          # Enable pgvector extension in kagent database
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgresql.postgresql.svc.cluster.local -p 5432 -U "$POSTGRES_USER" -d "$KAGENT_DB" <<EOSQL
+            CREATE EXTENSION IF NOT EXISTS vector;
+          EOSQL
+
+          echo "kagent database initialized successfully with pgvector extension"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: n8n-user
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: n8n-password
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-credentials
+              key: database-name
+        - name: KAGENT_USER
+          valueFrom:
+            secretKeyRef:
+              name: kagent-db-credentials
+              key: kagent-user
+        - name: KAGENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: kagent-db-credentials
+              key: kagent-password
+        - name: KAGENT_DB
+          valueFrom:
+            secretKeyRef:
+              name: kagent-db-credentials
+              key: kagent-database
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"


### PR DESCRIPTION
Switch PostgreSQL image from postgres:18.1 to pgvector/pgvector:pg18 (drop-in replacement, no data loss) to enable vector extension support.

Add ExternalSecret to sync kagent database credentials from Vault and a one-time init Job that creates the kagent user, database, and enables the pgvector extension. This prepares PostgreSQL for the kagent v0.8.6 upgrade which requires PostgreSQL with pgvector for agent memory.