### PR TITLE
feat: add kagent v0.8.6 ArgoCD Application with external PostgreSQL

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kagent
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    chart: kagent
+    repoURL: ghcr.io/kagent-dev/kagent/helm
+    targetRevision: 0.8.6
+    helm:
+      valuesObject:
+        # Database: use existing PostgreSQL with pgvector
+        database:
+          postgres:
+            bundled:
+              enabled: false
+            urlFile: /etc/kagent/secrets/db-url
+            vectorEnabled: true
+
+        # Mount the database URL secret as a file
+        controller:
+          volumes:
+            - name: db-secret
+              secret:
+                secretName: kagent-db-credentials
+                items:
+                  - key: db-url
+                    path: db-url
+          volumeMounts:
+            - name: db-secret
+              mountPath: /etc/kagent/secrets
+              readOnly: true
+
+        # OpenTelemetry tracing (disabled for now, enabled in Phase 3)
+        otel:
+          tracing:
+            enabled: false
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kagent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/kagent/external-secrets.yaml
+++ b/base-apps/kagent/external-secrets.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-db-credentials
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: kagent-db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: db-url
+      remoteRef:
+        key: kagent
+        property: db-url
+    - secretKey: db-user
+      remoteRef:
+        key: kagent
+        property: db-user
+    - secretKey: db-password
+      remoteRef:
+        key: kagent
+        property: db-password
+    - secretKey: db-name
+      remoteRef:
+        key: kagent
+        property: db-name

--- a/base-apps/kagent/secret-store.yaml
+++ b/base-apps/kagent/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: kagent
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "kagent"
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
Add ArgoCD Application managing kagent via Helm chart OCI registry (ghcr.io/kagent-dev/kagent/helm) at version 0.8.6.

Key configuration:
- External PostgreSQL with pgvector (bundled postgres disabled)
- Database URL loaded from Vault via ExternalSecret/urlFile
- SecretStore and ExternalSecret for kagent namespace credentials
- ServerSideApply enabled for CRD management
- OTEL tracing pre-configured but disabled (Phase 3)