### PR TITLE
fix: add kagent-crds ArgoCD Application for CRD management

### DIFF
--- a/base-apps/kagent-crds.yaml
+++ b/base-apps/kagent-crds.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kagent-crds
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    chart: kagent-crds
+    repoURL: ghcr.io/kagent-dev/kagent/helm
+    targetRevision: 0.8.6
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kagent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - Replace=true
+      - ServerSideApply=true

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: kagent
   namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   project: default
   source:


### PR DESCRIPTION
The kagent Helm chart requires CRDs from a separate chart (kagent-crds). Without these v0.8.6 CRDs, ArgoCD fails with schema validation errors (e.g. promptTemplate field not declared).

- Add kagent-crds.yaml ArgoCD Application (sync-wave: -1)
- Add sync-wave: 0 to main kagent app to ensure ordering
- Use Replace=true to adopt existing CRDs lacking Helm labels