### PR TITLE
fix: add ArgoCD Application for kagent Vault secrets

### DIFF
--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kagent-secrets
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/kagent
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kagent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
The kagent Helm chart Application doesn't deploy the SecretStore and ExternalSecret from base-apps/kagent/ since it uses a Helm source. Add a separate ArgoCD Application (kagent-secrets) that deploys these manifests via Git source, synced before the main kagent app (sync-wave: -1).

This resolves the controller failure:
  MountVolume.SetUp failed: secret "kagent-db-credentials" not found