### PR TITLE
fix: use correct Helm values path for Anthropic provider config

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -35,12 +35,14 @@ spec:
               mountPath: /etc/kagent/secrets
               readOnly: true
 
-        # Model config: use existing Anthropic API key secret
-        modelConfig:
-          provider: Anthropic
-          model: claude-haiku-4-5-20251001
-          apiKeySecret: kagent-anthropic
-          apiKeySecretKey: ANTHROPIC_API_KEY
+        # LLM provider: use Anthropic with existing secret
+        providers:
+          default: anthropic
+          anthropic:
+            provider: Anthropic
+            model: claude-haiku-4-5-20251001
+            apiKeySecretRef: kagent-anthropic
+            apiKeySecretKey: ANTHROPIC_API_KEY
 
         # OpenTelemetry tracing (disabled for now, enabled in Phase 3)
         otel:


### PR DESCRIPTION
The chart uses providers.default/providers.anthropic, not modelConfig. Switch default provider to anthropic with claude-haiku-4-5-20251001 and reference the existing kagent-anthropic secret via apiKeySecretRef.