### PR TITLE
feat: remove unused kagent agents (cilium, promql, gloomhaven)

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -72,24 +72,10 @@ spec:
                 cpu: 1000m
                 memory: 1Gi
           cilium-manager-agent:
-            enabled: true
-            resources:
-              requests:
-                cpu: 100m
-                memory: 256Mi
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+            enabled: false
           # Read-heavy / read-only agents → reduced to 512Mi
           promql-agent:
-            enabled: true
-            resources:
-              requests:
-                cpu: 50m
-                memory: 128Mi
-              limits:
-                cpu: 500m
-                memory: 512Mi
+            enabled: false
           observability-agent:
             enabled: true
             resources:
@@ -100,23 +86,9 @@ spec:
                 cpu: 500m
                 memory: 512Mi
           cilium-debug-agent:
-            enabled: true
-            resources:
-              requests:
-                cpu: 50m
-                memory: 128Mi
-              limits:
-                cpu: 500m
-                memory: 512Mi
+            enabled: false
           cilium-policy-agent:
-            enabled: true
-            resources:
-              requests:
-                cpu: 50m
-                memory: 128Mi
-              limits:
-                cpu: 500m
-                memory: 512Mi
+            enabled: false
           argo-rollouts-agent:
             enabled: true
             resources:

--- a/base-apps/kagent/agent-patches.yaml
+++ b/base-apps/kagent/agent-patches.yaml
@@ -7,11 +7,12 @@
 # Write tools that require approval per agent:
 #   k8s-agent: create, delete, patch, apply, execute
 #   helm-agent: upgrade, uninstall, apply
-#   cilium-manager-agent: install, upgrade, toggle, update, connect
 #   istio-agent: create, delete, patch, install, apply/delete waypoint
 #   kgateway-agent: create, delete, patch, apply, helm upgrade/uninstall
 #   argo-rollouts-conversion-agent: create, delete, apply
-#   cilium-debug-agent: manage_endpoint_config, update/delete pcap, flush ipsec
+#
+# Removed agents (disabled in Helm values):
+#   cilium-manager-agent, cilium-debug-agent, cilium-policy-agent, promql-agent
 
 ---
 apiVersion: kagent.dev/v1alpha2
@@ -91,53 +92,6 @@ spec:
         - helm_upgrade
         - helm_uninstall
         - k8s_apply_manifest
----
-apiVersion: kagent.dev/v1alpha2
-kind: Agent
-metadata:
-  name: cilium-manager-agent
-  namespace: kagent
-  labels:
-    app.kubernetes.io/part-of: kagent
-spec:
-  type: Declarative
-  declarative:
-    tools:
-    - type: McpServer
-      mcpServer:
-        apiGroup: kagent.dev
-        kind: RemoteMCPServer
-        name: kagent-tool-server
-        toolNames:
-        # Read operations
-        - cilium_status_and_version
-        - cilium_get_daemon_status
-        - cilium_show_cluster_mesh_status
-        - cilium_show_features_status
-        - cilium_list_bgp_peers
-        - cilium_list_bgp_routes
-        - cilium_get_endpoints_list
-        - cilium_get_endpoint_details
-        - cilium_show_configuration_options
-        - cilium_list_services
-        - cilium_get_service_information
-        - k8s_get_resources
-        - k8s_describe_resource
-        # Write operations (require approval)
-        - cilium_install_cilium
-        - cilium_upgrade_cilium
-        - cilium_connect_to_remote_cluster
-        - cilium_toggle_cluster_mesh
-        - cilium_toggle_hubble
-        - cilium_toggle_configuration_option
-        - cilium_update_service
-        requireApproval:
-        - cilium_install_cilium
-        - cilium_upgrade_cilium
-        - cilium_connect_to_remote_cluster
-        - cilium_toggle_cluster_mesh
-        - cilium_toggle_configuration_option
-        - cilium_update_service
 ---
 apiVersion: kagent.dev/v1alpha2
 kind: Agent
@@ -260,48 +214,3 @@ spec:
         - k8s_create_resource
         - k8s_delete_resource
         - k8s_apply_manifest
----
-apiVersion: kagent.dev/v1alpha2
-kind: Agent
-metadata:
-  name: cilium-debug-agent
-  namespace: kagent
-  labels:
-    app.kubernetes.io/part-of: kagent
-spec:
-  type: Declarative
-  declarative:
-    tools:
-    - type: McpServer
-      mcpServer:
-        apiGroup: kagent.dev
-        kind: RemoteMCPServer
-        name: kagent-tool-server
-        toolNames:
-        # Read operations
-        - cilium_get_endpoint_health
-        - cilium_get_endpoint_logs
-        - cilium_list_identities
-        - cilium_get_identity_details
-        - cilium_request_debugging_information
-        - cilium_display_encryption_state
-        - cilium_list_envoy_config
-        - cilium_fqdn_cache
-        - cilium_list_ip_addresses
-        - cilium_show_ip_cache_information
-        - cilium_list_bpf_map_events
-        - cilium_list_metrics
-        - cilium_list_cluster_nodes
-        - cilium_list_node_ids
-        - cilium_list_pcap_recorders
-        - cilium_get_pcap_recorder
-        # Write operations (require approval)
-        - cilium_manage_endpoint_config
-        - cilium_flush_ipsec_state
-        - cilium_update_pcap_recorder
-        - cilium_delete_pcap_recorder
-        requireApproval:
-        - cilium_manage_endpoint_config
-        - cilium_flush_ipsec_state
-        - cilium_update_pcap_recorder
-        - cilium_delete_pcap_recorder


### PR DESCRIPTION
## Summary
- Disable 5 unused kagent agents to reduce resource footprint
- Frees ~835Mi memory and 5 pods from the cluster

## Changes

### Agents Removed
| Agent | Reason |
|-------|--------|
| cilium-manager-agent | Not actively used |
| cilium-debug-agent | Not actively used |
| cilium-policy-agent | Not actively used |
| promql-agent | Not actively used |
| gloomhaven-agent | Non-infrastructure agent (manually created, deleted via kubectl) |

### Remaining Agents (7)
- k8s-agent, helm-agent, istio-agent, kgateway-agent, observability-agent, argo-rollouts-conversion-agent, dnd-agent

### Technical Implementation
- `base-apps/kagent.yaml` - Set `enabled: false` for 4 Helm-managed agents (cilium x3, promql)
- `base-apps/kagent/agent-patches.yaml` - Removed HITL patches for disabled agents
- gloomhaven-agent deleted directly via kubectl (was manually created, not Helm-managed)

## Test Plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Disabled agent pods are terminated and pruned
- [ ] Remaining 7 agents stay healthy
- [ ] No orphaned deployments or services

🤖 Generated with [Claude Code](https://claude.ai/code)