### PR TITLE
feat: deploy Ollama for kagent pgvector memory embeddings

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -7,12 +7,13 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   project: default
-  # Ignore diffs on Agent CRD tools field - managed separately via agent-patches
+  # Ignore diffs on Agent CRD tools and memory fields - managed separately via agent-patches
   ignoreDifferences:
     - group: kagent.dev
       kind: Agent
       jsonPointers:
         - /spec/declarative/tools
+        - /spec/declarative/memory
   source:
     chart: kagent
     repoURL: ghcr.io/kagent-dev/kagent/helm

--- a/base-apps/kagent/agent-patches.yaml
+++ b/base-apps/kagent/agent-patches.yaml
@@ -13,6 +13,8 @@
 #
 # Removed agents (disabled in Helm values):
 #   cilium-manager-agent, cilium-debug-agent, cilium-policy-agent, promql-agent
+#
+# Memory: All agents use Ollama nomic-embed-text for pgvector memory embeddings
 
 ---
 apiVersion: kagent.dev/v1alpha2
@@ -25,6 +27,8 @@ metadata:
 spec:
   type: Declarative
   declarative:
+    memory:
+      modelConfig: embedding-model-config
     tools:
     - type: McpServer
       mcpServer:
@@ -70,6 +74,8 @@ metadata:
 spec:
   type: Declarative
   declarative:
+    memory:
+      modelConfig: embedding-model-config
     tools:
     - type: McpServer
       mcpServer:
@@ -103,6 +109,8 @@ metadata:
 spec:
   type: Declarative
   declarative:
+    memory:
+      modelConfig: embedding-model-config
     tools:
     - type: McpServer
       mcpServer:
@@ -151,6 +159,8 @@ metadata:
 spec:
   type: Declarative
   declarative:
+    memory:
+      modelConfig: embedding-model-config
     tools:
     - type: McpServer
       mcpServer:
@@ -194,6 +204,8 @@ metadata:
 spec:
   type: Declarative
   declarative:
+    memory:
+      modelConfig: embedding-model-config
     tools:
     - type: McpServer
       mcpServer:
@@ -214,3 +226,27 @@ spec:
         - k8s_create_resource
         - k8s_delete_resource
         - k8s_apply_manifest
+---
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: observability-agent
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+spec:
+  type: Declarative
+  declarative:
+    memory:
+      modelConfig: embedding-model-config
+---
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: dnd-agent
+  namespace: kagent
+spec:
+  type: Declarative
+  declarative:
+    memory:
+      modelConfig: embedding-model-config

--- a/base-apps/kagent/embedding-model-config.yaml
+++ b/base-apps/kagent/embedding-model-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: kagent.dev/v1alpha2
+kind: ModelConfig
+metadata:
+  name: embedding-model-config
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+spec:
+  provider: Ollama
+  model: nomic-embed-text
+  ollama:
+    host: http://ollama.ollama.svc.cluster.local:11434

--- a/base-apps/ollama.yaml
+++ b/base-apps/ollama.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ollama
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/ollama
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ollama
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/ollama/deployments.yaml
+++ b/base-apps/ollama/deployments.yaml
@@ -21,7 +21,7 @@ spec:
         node.kubernetes.io/workload: application
       initContainers:
         - name: pull-model
-          image: ollama/ollama:0.7.0
+          image: ollama/ollama:0.20.5
           command:
             - sh
             - -c
@@ -47,7 +47,7 @@ spec:
               memory: 1Gi
       containers:
         - name: ollama
-          image: ollama/ollama:0.7.0
+          image: ollama/ollama:0.20.5
           ports:
             - containerPort: 11434
               name: http

--- a/base-apps/ollama/deployments.yaml
+++ b/base-apps/ollama/deployments.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: ollama
+  labels:
+    app: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      initContainers:
+        - name: pull-model
+          image: ollama/ollama:0.7.0
+          command:
+            - sh
+            - -c
+            - |
+              # Start ollama server in background, pull the model, then stop
+              ollama serve &
+              SERVER_PID=$!
+              sleep 5
+              echo "Pulling nomic-embed-text model..."
+              ollama pull nomic-embed-text
+              echo "Model pull complete"
+              kill $SERVER_PID
+              wait $SERVER_PID 2>/dev/null || true
+          volumeMounts:
+            - name: ollama-storage
+              mountPath: /root/.ollama
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 1Gi
+      containers:
+        - name: ollama
+          image: ollama/ollama:0.7.0
+          ports:
+            - containerPort: 11434
+              name: http
+          volumeMounts:
+            - name: ollama-storage
+              mountPath: /root/.ollama
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 11434
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 11434
+            initialDelaySeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: ollama-storage
+          persistentVolumeClaim:
+            claimName: ollama-pvc

--- a/base-apps/ollama/pvc.yaml
+++ b/base-apps/ollama/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-pvc
+  namespace: ollama
+  labels:
+    app: ollama
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/base-apps/ollama/services.yaml
+++ b/base-apps/ollama/services.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ollama
+  labels:
+    app: ollama
+spec:
+  selector:
+    app: ollama
+  ports:
+    - port: 11434
+      targetPort: 11434
+      name: http
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- Deploy Ollama as an in-cluster embedding model for kagent agent memory
- Uses `nomic-embed-text` (~274MB) for free, private, local vector embeddings
- Enables pgvector long-term memory storage that was configured in Phase 1 but missing an embedding provider

## Changes

### New Files
- `base-apps/ollama.yaml` - ArgoCD Application for Ollama
- `base-apps/ollama/deployments.yaml` - Ollama deployment with init container to pull nomic-embed-text
- `base-apps/ollama/services.yaml` - ClusterIP service at port 11434
- `base-apps/ollama/pvc.yaml` - 2Gi PVC for model storage
- `base-apps/kagent/embedding-model-config.yaml` - ModelConfig CRD (Ollama provider, nomic-embed-text model)

### Modified Files
- `base-apps/kagent/agent-patches.yaml` - Added `memory.modelConfig: embedding-model-config` to all 7 agents + observability-agent + dnd-agent
- `base-apps/kagent.yaml` - Added `/spec/declarative/memory` to `ignoreDifferences`

### Architecture
```
Agent conversation → kagent controller → Ollama (nomic-embed-text) → vector embedding → PostgreSQL (pgvector)
```

Each agent's `memory.modelConfig` points to the `embedding-model-config` ModelConfig, which uses the Ollama provider at `http://ollama.ollama.svc.cluster.local:11434`.

## Test Plan
- [ ] Ollama pod starts and init container pulls nomic-embed-text model
- [ ] `curl http://ollama.ollama.svc.cluster.local:11434/api/tags` shows model
- [ ] embedding-model-config ModelConfig is Accepted
- [ ] Send agent conversation, verify `SELECT count(*) FROM memory WHERE embedding IS NOT NULL` > 0
- [ ] No OOMKills on Ollama pod (1Gi limit for CPU-only inference)

## Related
- Phase 3.5 of `docs/plans/kagent-upgrade-implementation-plan.md`
- Phase 1 set up pgvector extension and memory table
- This PR provides the missing embedding model

🤖 Generated with [Claude Code](https://claude.ai/code)