### PR TITLE
fix: remove broken observability-agent from orchestrator

### DIFF
--- a/base-apps/kagent/build-orchestrator.yaml
+++ b/base-apps/kagent/build-orchestrator.yaml
@@ -26,7 +26,6 @@ spec:
       - **helm-agent**: Helm chart operations - install, upgrade, rollback, list releases
       - **istio-agent**: Istio service mesh configuration, traffic management, waypoints
       - **kgateway-agent**: Kubernetes Gateway API management (Envoy-based kgateway)
-      - **observability-agent**: Prometheus metrics, Grafana dashboards, monitoring setup
       - **argo-rollouts-conversion-agent**: Convert Deployments to Argo Rollouts for progressive delivery
 
       ## Rules
@@ -49,9 +48,6 @@ spec:
       - type: Agent
         agent:
           name: kgateway-agent
-      - type: Agent
-        agent:
-          name: observability-agent
       - type: Agent
         agent:
           name: argo-rollouts-conversion-agent


### PR DESCRIPTION
## Summary
- Remove observability-agent from build-orchestrator's sub-agent tools
- The observability-agent has a transitive dependency on promql-agent (disabled), which causes the kagent controller to fail reconciliation for the entire orchestrator

## Root Cause
The kagent controller validates all transitive agent references. Since observability-agent → promql-agent (deleted), adding observability-agent to the orchestrator causes a cascading reconciliation failure, resulting in the red dot in the UI.

## Test Plan
- [ ] Orchestrator shows green dot in kagent UI after merge
- [ ] Orchestrator successfully delegates to remaining 5 sub-agents

🤖 Generated with [Claude Code](https://claude.ai/code)