### PR TITLE
feat: upgrade kagent LLM from Haiku 4.5 to Sonnet 4.6

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -47,7 +47,7 @@ spec:
           default: anthropic
           anthropic:
             provider: Anthropic
-            model: claude-haiku-4-5-20251001
+            model: claude-sonnet-4-6-20250514
             apiKeySecretRef: kagent-anthropic
             apiKeySecretKey: ANTHROPIC_API_KEY
 


### PR DESCRIPTION
## Summary
- Upgrade kagent default model from `claude-haiku-4-5-20251001` to `claude-sonnet-4-6-20250514`
- Fixes rate limit errors (429) when orchestrator delegates to multiple sub-agents concurrently

## Changes
- `base-apps/kagent.yaml` - Changed `model` field in providers.anthropic

## Why
The orchestrator delegates to 5 sub-agents which each call the Anthropic API. With Haiku's 50k input tokens/min limit, concurrent calls exceeded the rate limit causing "No Response" in the UI. Sonnet 4.6 provides higher rate limits and significantly better reasoning quality.

## Test Plan
- [ ] ModelConfig updates after ArgoCD sync
- [ ] Agent pods restart with new model
- [ ] Orchestrator multi-agent delegation completes without 429 errors
- [ ] Verify response quality improvement

🤖 Generated with [Claude Code](https://claude.ai/code)