### PR TITLE
fix: correct Sonnet 4.6 model ID

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -47,7 +47,7 @@ spec:
           default: anthropic
           anthropic:
             provider: Anthropic
-            model: claude-sonnet-4-6-20250514
+            model: claude-sonnet-4-6
             apiKeySecretRef: kagent-anthropic
             apiKeySecretKey: ANTHROPIC_API_KEY
 


### PR DESCRIPTION
## Summary
- Fix model ID from `claude-sonnet-4-6-20250514` to `claude-sonnet-4-6`
- The date suffix version doesn't exist in the Anthropic API, causing 404 errors and "(no response)" in the UI

## Root Cause
Anthropic API returns `404: model not found` for `claude-sonnet-4-6-20250514`. The correct ID is `claude-sonnet-4-6` without a date suffix. Verified via `GET /v1/models`.

🤖 Generated with [Claude Code](https://claude.ai/code)