### PR TITLE
fix: use Sonnet 4.5 - ADK incompatible with Sonnet 4.6

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -47,7 +47,7 @@ spec:
           default: anthropic
           anthropic:
             provider: Anthropic
-            model: claude-sonnet-4-6
+            model: claude-sonnet-4-5-20250929
             apiKeySecretRef: kagent-anthropic
             apiKeySecretKey: ANTHROPIC_API_KEY
 


### PR DESCRIPTION
## Summary
- Switch from `claude-sonnet-4-6` to `claude-sonnet-4-5-20250929`
- google-adk v1.25.0 (bundled in kagent v0.8.6) sends the `system` prompt as a string, but Sonnet 4.6 requires it as a list of content blocks, causing `400: system: Input should be a valid list`

## Why not just upgrade the ADK?
The ADK is bundled inside the kagent container image. Upgrading requires a new kagent release (v0.9.0 when stable). Sonnet 4.5 is the best compatible option - better quality than Haiku and higher rate limits.

🤖 Generated with [Claude Code](https://claude.ai/code)