### PR TITLE
fix: revert to Haiku 4.5 - Sonnet incompatible with ADK 1.25.0

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -47,7 +47,7 @@ spec:
           default: anthropic
           anthropic:
             provider: Anthropic
-            model: claude-sonnet-4-5-20250929
+            model: claude-haiku-4-5-20251001
             apiKeySecretRef: kagent-anthropic
             apiKeySecretKey: ANTHROPIC_API_KEY
 


### PR DESCRIPTION
## Summary
Revert model to `claude-haiku-4-5-20251001`. Both Sonnet 4.5 and 4.6 fail with `400: system: Input should be a valid list` through the google-adk pipeline in kagent v0.8.6.

Direct Anthropic SDK calls work fine - the issue is specifically in how google-adk v1.25.0 transforms the system prompt before sending. Upgrading to Sonnet requires kagent v0.9.0+ with a newer ADK.

🤖 Generated with [Claude Code](https://claude.ai/code)