### PR TITLE
feat: bump agent-ui to :latest tag

### DIFF
--- a/base-apps/agent-ui-backend/deployments.yaml
+++ b/base-apps/agent-ui-backend/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: backend
-          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-backend:v1.0.3
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-backend:latest
           imagePullPolicy: Always
           ports:
             - name: http

--- a/base-apps/agent-ui-frontend/deployments.yaml
+++ b/base-apps/agent-ui-frontend/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: frontend
-          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-frontend:v1.0.3
+          image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/agent-ui-frontend:latest
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
## Summary
Update agent-ui-frontend and agent-ui-backend image tag from `v1.0.3` to `latest` to pick up the token usage parsing fix (arigsela/agent-ui#1).

Pods will roll automatically once ArgoCD syncs (imagePullPolicy is Always).

🤖 Generated with [Claude Code](https://claude.ai/code)