### PR TITLE
feat: add argo-workflows-config app for ingress

### DIFF
--- a/base-apps/argo-workflows-config.yaml
+++ b/base-apps/argo-workflows-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows-config
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/argo-workflows
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-workflows
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- Adds path-based ArgoCD Application `argo-workflows-config` pointing at `base-apps/argo-workflows/`
- Unblocks the nginx ingress (and future Phase 2 SecretStore) that was shipped in PR #177 but never synced — the Helm app only deploys the chart, not local manifests
- Mirrors the existing `argo-rollouts-config` pattern

## Test plan
- [ ] `argo-workflows-config` app appears in ArgoCD as Synced/Healthy
- [ ] Ingress `argo-workflows-server-ingress` exists in `argo-workflows` namespace
- [ ] UI loads over HTTPS at `argo-workflows.arigsela.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)