### PR TITLE
fix: argo-workflows ingress backend-protocol HTTP (504 fix)

### DIFF
--- a/base-apps/argo-workflows-config.yaml
+++ b/base-apps/argo-workflows-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows-config
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/argo-workflows
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-workflows
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/base-apps/argo-workflows/nginx-ingress.yaml
+++ b/base-apps/argo-workflows/nginx-ingress.yaml
@@ -8,8 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
-    # Argo Workflows server serves HTTPS by default on 2746
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # Helm chart sets --secure=false, so server listens on plain HTTP on 2746
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
 
     # Rate Limiting
     nginx.ingress.kubernetes.io/limit-rps: "100"


### PR DESCRIPTION
## Summary
- Fixes 504 Gateway Timeout at `argo-workflows.arigsela.com`
- Helm chart deploys `argo-server` with `--secure=false` (plain HTTP on 2746), but the ingress had `backend-protocol: HTTPS` — nginx was trying to TLS-handshake against an HTTP server
- Switches the annotation to `HTTP`

Verified via `kubectl get deploy argo-workflows-server -o yaml` — the container args include `--secure=false` and the readiness probe uses `scheme: HTTP`.

## Test plan
- [ ] After sync, `curl -I https://argo-workflows.arigsela.com` returns 200 (not 504)
- [ ] UI loads in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)