### PR TITLE
fix: add argo-workflow SA for WorkflowTemplates (403 on workflowtaskresults)

### DIFF
--- a/base-apps/argo-workflow-tasks/artifact-example.yaml
+++ b/base-apps/argo-workflow-tasks/artifact-example.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argo-workflows
 spec:
   entrypoint: main
+  serviceAccountName: argo-workflow
   templates:
     - name: main
       steps:

--- a/base-apps/argo-workflow-tasks/cluster-health-check.yaml
+++ b/base-apps/argo-workflow-tasks/cluster-health-check.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argo-workflows
 spec:
   entrypoint: main
+  serviceAccountName: argo-workflow
   # NOTE: requires Phase 4 RBAC (ClusterRole with get/list on nodes & pods)
   # to read cluster-wide. Uses the default ServiceAccount until then.
   templates:

--- a/base-apps/argo-workflow-tasks/hello-world-dag.yaml
+++ b/base-apps/argo-workflow-tasks/hello-world-dag.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argo-workflows
 spec:
   entrypoint: main
+  serviceAccountName: argo-workflow
   arguments:
     parameters:
       - name: message

--- a/base-apps/argo-workflow-tasks/serviceaccount.yaml
+++ b/base-apps/argo-workflow-tasks/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflow
+  namespace: argo-workflows
+# Referenced by the Helm chart's argo-workflows-workflow RoleBinding
+# (which grants create on workflowtaskresults). The chart binds the SA
+# but does not create it, so we define it here.


### PR DESCRIPTION
## Summary
Fixes `workflowtaskresults.argoproj.io is forbidden` error when submitting any WorkflowTemplate.

**Root cause:** The Helm chart creates a RoleBinding `argo-workflows-workflow` that grants workflow-executor perms to ServiceAccount `argo-workflow`, but the chart doesn't create the SA itself. Our workflows were running under `default` SA, which has no perms → executor fails with 403.

**Fix:**
- Add the missing `argo-workflow` ServiceAccount
- Set `serviceAccountName: argo-workflow` on all three WorkflowTemplates

## Test plan
- [ ] Resubmit `hello-world-dag` — all 4 DAG nodes succeed
- [ ] Resubmit `artifact-example` — all 3 steps succeed
- [ ] Resubmit `cluster-health-check` — nodes/pods tasks succeed (cluster-wide reads still need Phase 4 RBAC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)