### PR TITLE
feat: configure S3 artifact repository for Argo Workflows

### DIFF
--- a/base-apps/argo-workflows.yaml
+++ b/base-apps/argo-workflows.yaml
@@ -28,6 +28,19 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+        artifactRepository:
+          archiveLogs: true
+          s3:
+            endpoint: s3.amazonaws.com
+            bucket: asela-argo-workflows-artifacts
+            region: us-east-1
+            keyFormat: "{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}"
+            accessKeySecret:
+              name: argo-workflows-s3-creds
+              key: accessKey
+            secretKeySecret:
+              name: argo-workflows-s3-creds
+              key: secretKey
         server:
           enabled: true
           authModes:

--- a/base-apps/argo-workflows/external-secret.yaml
+++ b/base-apps/argo-workflows/external-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argo-workflows-s3-creds
+  namespace: argo-workflows
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    name: argo-workflows-s3-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: accessKey
+      remoteRef:
+        key: argo-workflows/s3
+        property: accessKey
+    - secretKey: secretKey
+      remoteRef:
+        key: argo-workflows/s3
+        property: secretKey

--- a/base-apps/argo-workflows/secret-store.yaml
+++ b/base-apps/argo-workflows/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: argo-workflows
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "argo-workflows"
+          serviceAccountRef:
+            name: "default"


### PR DESCRIPTION
## Summary
Wires up S3 artifact storage for Argo Workflows, unblocking `artifact-example` and any future workflow that uses `outputs.artifacts`.

**This bundles Phase 2 (Vault SecretStore) with the artifact-repo work since they share a purpose.**

### Changes
- **`base-apps/argo-workflows/secret-store.yaml`** — SecretStore pointing at Vault (role: `argo-workflows`)
- **`base-apps/argo-workflows/external-secret.yaml`** — ExternalSecret syncing `argo-workflows/s3` → K8s secret `argo-workflows-s3-creds`
- **`base-apps/argo-workflows.yaml`** — adds `artifactRepository` to Helm values (S3 bucket + secret refs)

### Out-of-band setup (already done)
- ✅ S3 bucket `asela-argo-workflows-artifacts` (us-east-1)
- ✅ IAM user `argo-workflows` with bucket-scoped policy (`s3:GetObject`, `PutObject`, `DeleteObject`, `ListBucket`)
- ✅ Creds written to Vault: `k8s-secrets/argo-workflows/s3` (keys: `accessKey`, `secretKey`)
- ✅ Vault policy `argo-workflows` (read on `k8s-secrets/data/argo-workflows/*`)
- ✅ Vault k8s auth role `argo-workflows` bound to SA `default` in namespace `argo-workflows`

## Test plan
- [ ] SecretStore `vault-backend` shows status `Valid` in `argo-workflows` namespace
- [ ] ExternalSecret `argo-workflows-s3-creds` shows `SecretSynced`
- [ ] K8s Secret `argo-workflows-s3-creds` exists with `accessKey` + `secretKey`
- [ ] workflow-controller-configmap has `artifactRepository` section with the bucket config
- [ ] Submit `artifact-example` — all 3 steps succeed, artifacts visible in S3 bucket
- [ ] S3 objects appear under `argo-workflows/<workflow-name>/<pod-name>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)