### PR TITLE
feat: Crossplane-managed S3 artifact infra for Argo Workflows

### DIFF
--- a/base-apps/argo-workflows-aws-infrastructure.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows-aws-infrastructure
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/argo-workflows-aws-infrastructure
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-workflows
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/base-apps/argo-workflows-aws-infrastructure/access-key.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure/access-key.yaml
@@ -1,0 +1,23 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: argo-workflows-s3-key
+  labels:
+    app: argo-workflows
+    component: access-key
+    managed-by: crossplane
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        app: argo-workflows
+        component: iam-user
+  # Connection secret keys written by Upbound provider-aws-iam:
+  #   attribute.id     -> the AWS access key ID
+  #   attribute.secret -> the AWS secret access key
+  #   username         -> the IAM username
+  writeConnectionSecretToRef:
+    name: argo-workflows-s3-creds
+    namespace: argo-workflows
+  providerConfigRef:
+    name: default

--- a/base-apps/argo-workflows-aws-infrastructure/iam-policy-attachment.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure/iam-policy-attachment.yaml
@@ -1,0 +1,18 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: argo-workflows-s3-user-policy
+  labels:
+    app: argo-workflows
+    component: iam-policy-attachment
+    managed-by: crossplane
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        app: argo-workflows
+        component: iam-policy
+    userRef:
+      name: argo-workflows-s3-user
+  providerConfigRef:
+    name: default

--- a/base-apps/argo-workflows-aws-infrastructure/iam-policy.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure/iam-policy.yaml
@@ -1,0 +1,39 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: argo-workflows-s3-access
+  labels:
+    app: argo-workflows
+    component: iam-policy
+    managed-by: crossplane
+spec:
+  forProvider:
+    description: "Allows Argo Workflows to read/write artifacts and logs to the artifacts S3 bucket"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "ArgoWorkflowsS3Access",
+            "Effect": "Allow",
+            "Action": [
+              "s3:ListBucket",
+              "s3:PutObject",
+              "s3:GetObject",
+              "s3:DeleteObject"
+            ],
+            "Resource": [
+              "arn:aws:s3:::asela-argo-workflows-artifacts",
+              "arn:aws:s3:::asela-argo-workflows-artifacts/*"
+            ]
+          }
+        ]
+      }
+    tags:
+      Name: "Argo Workflows S3 Access Policy"
+      Purpose: "Argo-Workflows-S3-Access"
+      ManagedBy: "Crossplane"
+      Environment: "homelab"
+      Project: "argo-workflows"
+  providerConfigRef:
+    name: default

--- a/base-apps/argo-workflows-aws-infrastructure/iam-user.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure/iam-user.yaml
@@ -1,0 +1,19 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: argo-workflows-s3-user
+  labels:
+    app: argo-workflows
+    component: iam-user
+    managed-by: crossplane
+spec:
+  forProvider:
+    path: /serviceaccounts/
+    tags:
+      Name: "Argo Workflows S3 Service Account"
+      Purpose: "Argo-Workflows-S3-Access"
+      ManagedBy: "Crossplane"
+      Environment: "homelab"
+      Project: "argo-workflows"
+  providerConfigRef:
+    name: default

--- a/base-apps/argo-workflows-aws-infrastructure/s3-bucket.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure/s3-bucket.yaml
@@ -1,0 +1,19 @@
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: asela-argo-workflows-artifacts
+  labels:
+    app: argo-workflows
+    component: storage
+    managed-by: crossplane
+spec:
+  forProvider:
+    region: us-east-1
+    tags:
+      Name: "Argo Workflows Artifacts"
+      Environment: "homelab"
+      ManagedBy: "Crossplane"
+      Purpose: "Argo Workflows artifact + log storage"
+      Project: "argo-workflows"
+  providerConfigRef:
+    name: default

--- a/base-apps/argo-workflows.yaml
+++ b/base-apps/argo-workflows.yaml
@@ -28,6 +28,19 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+        artifactRepository:
+          archiveLogs: true
+          s3:
+            endpoint: s3.amazonaws.com
+            bucket: asela-argo-workflows-artifacts
+            region: us-east-1
+            keyFormat: "{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}"
+            accessKeySecret:
+              name: argo-workflows-s3-creds
+              key: attribute.id
+            secretKeySecret:
+              name: argo-workflows-s3-creds
+              key: attribute.secret
         server:
           enabled: true
           authModes:


### PR DESCRIPTION
## Summary
Replaces PR #182 (manual AWS + Vault) with a fully GitOps-managed approach via Crossplane. Mirrors the existing `loki-aws-infrastructure` pattern.

### New ArgoCD app: `argo-workflows-aws-infrastructure`
Crossplane provisions all AWS resources declaratively:

| Resource | Purpose |
|---|---|
| `Bucket` | `asela-argo-workflows-artifacts` (us-east-1) |
| `User` | `argo-workflows-s3-user` under `/serviceaccounts/` |
| `Policy` | `argo-workflows-s3-access` (bucket-scoped `GetObject`/`PutObject`/`DeleteObject`/`ListBucket`) |
| `UserPolicyAttachment` | Links policy → user |
| `AccessKey` | Generates the key, writes connection secret `argo-workflows-s3-creds` into `argo-workflows` namespace |

### Helm values update
`artifactRepository` added to `base-apps/argo-workflows.yaml` pointing at the bucket. Keys reference the connection-secret fields Crossplane writes: `attribute.id` (access key ID) and `attribute.secret` (secret access key).

### Cleanup done out-of-band
- ✅ Manual AWS resources deleted (bucket/user/policy/key)
- ✅ Vault entry at `k8s-secrets/argo-workflows/s3` deleted
- ✅ Exposed Vault token revoked
- ✅ PR #182 closed

## Key rotation
```bash
kubectl delete accesskey.iam.aws.upbound.io argo-workflows-s3-key
# Crossplane recreates key + updates secret, ExternalSecret pattern not needed
```

## Test plan
- [ ] `argo-workflows-aws-infrastructure` app shows Synced/Healthy
- [ ] Bucket visible in AWS console
- [ ] Secret `argo-workflows-s3-creds` exists in `argo-workflows` namespace with `attribute.id` + `attribute.secret` keys
- [ ] workflow-controller-configmap has `artifactRepository` section
- [ ] Submit `artifact-example` — all 3 steps succeed
- [ ] S3 objects appear under `argo-workflows/<workflow-name>/<pod-name>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)