### PR TITLE
fix: correct argo-workflows S3 accessKeyId secret key (attribute.id → username)

### DIFF
--- a/base-apps/argo-workflows.yaml
+++ b/base-apps/argo-workflows.yaml
@@ -37,7 +37,7 @@ spec:
             keyFormat: "{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}"
             accessKeySecret:
               name: argo-workflows-s3-creds
-              key: attribute.id
+              key: username
             secretKeySecret:
               name: argo-workflows-s3-creds
               key: attribute.secret


### PR DESCRIPTION
## Summary
Follow-up to #183. I assumed the Upbound `provider-aws-iam` `AccessKey` connection secret would include `attribute.id` — it doesn't. The access key ID is actually written under `username`.

Verified via `kubectl get secret argo-workflows-s3-creds -o yaml`:
```
data:
  username: <base64 of AKIA...>          ← access key ID
  password: <base64 of secret>
  attribute.secret: <base64 of secret>
  attribute.ses_smtp_password_v4: <unused>
```

Without this, the workflow-controller can't read the access key ID → artifact uploads would fail.

## Test plan
- [ ] After sync, workflow-controller-configmap shows `key: username` for `accessKeySecret`
- [ ] Submit `artifact-example` — all 3 steps succeed
- [ ] Objects land in `s3://asela-argo-workflows-artifacts/argo-workflows/<workflow-name>/<pod-name>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)