### PR TITLE
feat(chores-tracker-backend): enable OTel tracing to Coroot + bump to 7.1.0

### DIFF
--- a/base-apps/chores-tracker-backend/configmaps.yaml
+++ b/base-apps/chores-tracker-backend/configmaps.yaml
@@ -7,3 +7,19 @@ data:
   ENVIRONMENT: "production"
   DEBUG: "False"
   BACKEND_CORS_ORIGINS: "https://chores.arigsela.com"
+
+  # OpenTelemetry tracing → Coroot (Phase 3 of OTel rollout)
+  # Endpoint confirmed via Phase 1 discovery: Coroot exposes only gRPC on 4317.
+  # The SDK is a no-op until OTEL_TRACES_EXPORTER=otlp + endpoint are set,
+  # which is why older pod versions (pre-7.1.0) are unaffected by this ConfigMap.
+  OTEL_SERVICE_NAME: "chores-tracker-backend"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=chores-tracker,deployment.environment=production"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://coroot-coroot.coroot.svc.cluster.local:4317"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+  OTEL_EXPORTER_OTLP_INSECURE: "true"
+  OTEL_TRACES_EXPORTER: "otlp"
+  OTEL_METRICS_EXPORTER: "none"
+  OTEL_LOGS_EXPORTER: "none"
+  OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
+  OTEL_TRACES_SAMPLER_ARG: "0.1"
+  OTEL_PYTHON_LOG_CORRELATION: "true"

--- a/base-apps/chores-tracker-backend/deployments.yaml
+++ b/base-apps/chores-tracker-backend/deployments.yaml
@@ -22,7 +22,7 @@ spec:
         node.kubernetes.io/workload: application
       containers:
       - name: chores-tracker-backend
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:7.0.2
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:7.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000


### PR DESCRIPTION
## Summary
Phase 3 of the chores-tracker-backend OpenTelemetry rollout. Wires up the in-cluster Coroot instance as the OTLP traces backend and bumps the container image to `7.1.0` (the first tag containing the OTel SDK + auto-instrumentations).

Companion to [chores-tracker#62](https://github.com/arigsela/chores-tracker/pull/62) which added the app-side instrumentation. Merge this after that PR ships and `chores-tracker:7.1.0` is pushed to ECR.

## Changes
| File | Change |
|---|---|
| `base-apps/chores-tracker-backend/configmaps.yaml` | Adds 11 OTEL_* env vars (service name, endpoint, protocol, sampler, exporters) |
| `base-apps/chores-tracker-backend/deployments.yaml` | Image tag `7.0.2` → `7.1.0` |

## Why This Is Safe to Merge Without the 7.1.0 Image Yet
The existing Rollout uses `imagePullPolicy: IfNotPresent` + Argo Rollouts canary steps (20% → 50% → 80% → 100% with 5-min pauses). If `chores-tracker:7.1.0` doesn't exist in ECR when this PR merges, the first canary pod fails `ImagePullBackOff`, readiness never passes, and the rollout **halts at 20% with the stable ReplicaSet still serving**. No user-visible impact. Recovery: push the image, the existing canary pod resolves and the rollout proceeds.

Still — recommended order: build/push `chores-tracker:7.1.0` via the backend `Release and Deploy` workflow first, then merge this PR.

## OTel Configuration
```yaml
OTEL_SERVICE_NAME: "chores-tracker-backend"
OTEL_EXPORTER_OTLP_ENDPOINT: "http://coroot-coroot.coroot.svc.cluster.local:4317"
OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
OTEL_EXPORTER_OTLP_INSECURE: "true"      # cluster-internal plaintext
OTEL_TRACES_EXPORTER: "otlp"
OTEL_METRICS_EXPORTER: "none"            # Prometheus keeps metrics
OTEL_LOGS_EXPORTER: "none"               # Loki keeps logs
OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
OTEL_TRACES_SAMPLER_ARG: "0.1"           # 10% of root spans
OTEL_PYTHON_LOG_CORRELATION: "true"
```

Endpoint was verified via live cluster inspection in Phase 1:
- `coroot-coroot` service in `coroot` ns exposes port 4317 (named `grpc`)
- Port 4318 (HTTP/protobuf) is **not** exposed — gRPC is the only option
- `tracesTTL: 7d`, ClickHouse PVC = 20Gi — enough headroom at 10% sampling

## Pre-Merge Checklist
- [ ] `chores-tracker:7.1.0` exists in ECR (check via `Release and Deploy` workflow on chores-tracker repo)
- [ ] chores-tracker PR #62 merged (app-side instrumentation present in the image)
- [ ] Coroot instance still healthy: `kubectl get pods -n coroot`

## Post-Merge Validation (Phase 4)
```bash
# Watch rollout
kubectl argo rollouts get rollout chores-tracker-backend -n chores-tracker -w

# Confirm OTel SDK loaded cleanly — look for no exporter errors
kubectl logs -n chores-tracker -l app=chores-tracker-backend | grep -iE "otel|opentelemetry"

# Verify /metrics still scraping (Prometheus path unaffected)
kubectl exec -n chores-tracker deploy/chores-tracker-backend -- curl -s localhost:8000/metrics | head -5

# Check Coroot UI → chores-tracker-backend service → Traces tab
# (should see FastAPI HTTP spans with SQL child spans from SQLAlchemy/asyncpg)
```

## Rollback
Revert this PR or cherry-pick either change independently:
- Revert image bump only → keeps ConfigMap but reverts to 7.0.2 (no-op since 7.0.2 doesn't read OTEL_* vars)
- Revert ConfigMap only → 7.1.0 SDK stays silent (no endpoint configured)

No data migrations, no stateful changes, no external dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)