### PR TITLE
feat(falco): add runtime security DaemonSet (phase 1 quiet baseline)

### DIFF
--- a/base-apps/falco.yaml
+++ b/base-apps/falco.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: falco
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://falcosecurity.github.io/charts
+    chart: falco
+    targetRevision: 8.0.2
+    helm:
+      releaseName: falco
+      values: |
+        # Runtime security DaemonSet - must run on every node for full coverage.
+        # No nodeSelector: pinning to infrastructure would create blind spots on
+        # application/worker nodes where most workloads actually run.
+        driver:
+          kind: auto
+        tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+        falco:
+          priority: warning
+          json_output: true
+          json_include_output_property: true
+          log_level: info
+          log_stderr: true
+          log_syslog: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 1024Mi
+        collectors:
+          kubernetes:
+            enabled: false
+        falcosidekick:
+          enabled: false
+        customRules: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: falco
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Adds Falco (CNCF runtime-security agent) as `base-apps/falco.yaml`, following the repo's Helm-chart ArgoCD Application pattern (same shape as `cert-manager.yaml` / `kyverno.yaml`).

- **Chart**: `falco` `8.0.2` from `https://falcosecurity.github.io/charts`
- **Falco version**: `0.43.1`
- **Driver**: `auto` → selects modern eBPF on supported kernels (no kernel-module build)

### Phase 1 = quiet baseline

Intentionally minimal to avoid alert fatigue on day 1:

- `falco.priority: warning` — drops Info/Debug/Notice rules entirely
- Only **stable** rules loaded (chart default; incubating/sandbox skipped)
- `json_output: true` — parseable for Loki/Alloy later
- `falcosidekick.enabled: false` — no webhooks/Slack yet; alerts go to pod stdout
- `collectors.kubernetes.enabled: false` — skip k8s-metacollector to reduce event volume
- `customRules: {}` — placeholder, populated after ~1 week of baseline review

### Node placement decision

- **DaemonSet is NOT pinned** to `node.kubernetes.io/workload: infrastructure`. A runtime-security agent must run on every node — pinning would create blind spots on application/worker nodes where workloads actually execute.
- Tolerations for `node-role.kubernetes.io/control-plane` and `.../master` are set explicitly so Falco covers the full cluster.
- When falcosidekick is enabled in phase 2, that Deployment *will* be pinned to infrastructure nodes (matching ArgoCD/cert-manager/kyverno convention).

### Planned follow-ups (not in this PR)

1. **Phase 2** — enable falcosidekick, forward to existing Loki; pin sidekick to infra nodes
2. **Phase 3** — review top-firing rules in Grafana, add `customRules` overrides for known false-positives (ArgoCD/Alloy/kube-state patterns)
3. **Phase 4** — optionally enable k8s-metacollector for richer pod context once noise is tuned

### Notes on Coroot integration

falcosidekick has no native Coroot output (log sinks are Loki/ES/Grafana/etc., and OTEL support is metrics/traces only — no OTEL Logs exporter yet). Recommendation: route via Loki (already in-cluster), keep Coroot focused on APM.

## Test plan

- [ ] ArgoCD picks up `base-apps/falco.yaml` via master-app and creates the `falco` Application
- [ ] `falco` namespace is auto-created
- [ ] Falco DaemonSet lands on all nodes (control-plane + workers) and pods go Ready
- [ ] Driver auto-selection resolves to `modern_ebpf` (check pod logs for `Loaded event sources: syscall`)
- [ ] Trigger a benign known rule (e.g. `kubectl exec` into a test pod, run `cat /etc/shadow` → should fire `Read sensitive file untrusted` at Warning)
- [ ] Verify alert appears in pod stdout as JSON
- [ ] Review first 24h of alerts for noise candidates before planning phase 2
