### PR TITLE
feat(n8n): add newsletter-digest send workflow + plan docs

### DIFF
--- a/docs/plans/newsletter-digest-cowork-skill-handoff.md
+++ b/docs/plans/newsletter-digest-cowork-skill-handoff.md
@@ -1,0 +1,262 @@
+# Handoff: Modify `newsletter-digest` Skill to Send via n8n Webhook
+
+**Audience:** Claude Code running in Cowork sandbox, with access to the `newsletter-digest` skill.
+**Prereqs on the n8n side:** complete and verified (workflow active, webhook authenticated, end-to-end email send tested from curl).
+**Scope of this doc:** exactly what edits to make to the skill file, and how to test them.
+
+---
+
+## 1. Background
+
+The `newsletter-digest` skill currently ends every run by creating a Gmail **draft** that the user must manually send. A self-hosted **n8n** instance now exposes a webhook that accepts a JSON payload and sends the digest as a real email, with no manual step.
+
+Your job: change **Phase 6** of the skill so that, when the webhook env vars are present, the skill POSTs to n8n and only falls back to Gmail draft on failure. When the env vars are absent, the skill must behave exactly as it does today (draft-only, backward-compatible).
+
+---
+
+## 2. Target file
+
+`<skill-root>/newsletter-digest/SKILL.md`
+
+Edits are confined to:
+
+- Phase 6 ("Deliver both ways") — rewrite.
+- A new short config section near the top of the skill listing the optional env vars.
+
+**Do NOT modify:** Phases 1–5 (time window, discovery, fetch, rank, build summary), Phase 7 (state update), the Error handling section, or the References list (except to note the template change, see §5 step 3).
+
+---
+
+## 3. Webhook contract (source of truth)
+
+### Endpoint
+
+```http
+POST https://n8n.arigsela.com/webhook/newsletter-digest
+```
+
+### Required headers
+
+```http
+Authorization: Bearer <N8N_WEBHOOK_TOKEN>
+Content-Type: application/json
+```
+
+### Request body (JSON)
+
+```json
+{
+  "subject": "Newsletter Digest — April 22, 2026",
+  "to": "arigsela@gmail.com",
+  "html_body": "<!doctype html><html>...</html>",
+  "markdown_body": "# Newsletter Digest — April 22, 2026\n\n...",
+  "meta": {
+    "run_id": "2026-04-22T13:04:11Z",
+    "source_count": 5,
+    "sources": ["tldr.tech", "newsletter.platformengineer.io"],
+    "top_pick_urls": ["https://...", "https://..."]
+  }
+}
+```
+
+Field notes:
+
+- `subject`, `to`, `html_body` are **required** — n8n returns 400 if any is empty.
+- `to` should stay hard-coded to `"arigsela@gmail.com"`.
+- `markdown_body` and `meta` are informational (useful for future archival and n8n-side alerting).
+
+### Success response (200)
+
+```json
+{
+  "status": "sent",
+  "message_id": "<uuid@gmail.com>",
+  "sent_at": "2026-04-22T13:04:14.986-04:00"
+}
+```
+
+### Failure responses
+
+- `400 {"error": "missing required fields"}` — payload was incomplete.
+- `403 Authorization data is wrong!` — token missing or wrong (note: n8n returns a bare text body here, not JSON — handle gracefully).
+- `5xx` — SMTP send failed or n8n itself crashed. An n8n-side error workflow will alert separately.
+
+On any non-2xx (or curl transport error), fall back to `Gmail:create_draft` — never lose the digest.
+
+---
+
+## 4. Config surface to document in SKILL.md
+
+Add near the top of the skill, right after the frontmatter / opening paragraph:
+
+```markdown
+## Configuration
+
+This skill optionally delivers digests as sent emails via an n8n webhook. When the env vars below are present at run time, the skill POSTs the digest to n8n for automated send. When either is absent, the skill falls back to creating a Gmail draft (original behavior, backward-compatible).
+
+| Env var              | Description                                     |
+| -------------------- | ----------------------------------------------- |
+| `N8N_WEBHOOK_URL`    | Full webhook URL, including path                |
+| `N8N_WEBHOOK_TOKEN`  | Bearer token for the `Authorization` header    |
+
+Both are expected to be set in the session env by the user — the skill never reads them from disk.
+```
+
+---
+
+## 5. New Phase 6 behavior
+
+Replace the existing Phase 6 block (currently the "Deliver both ways" section) with the following logic. Keep the section header style consistent with other phase headers in the file.
+
+### Step 1 — Inline render (unchanged)
+
+Render the complete Markdown summary inline in the chat response. This stays the primary deliverable.
+
+### Step 2 — Check env vars
+
+If `N8N_WEBHOOK_URL` **or** `N8N_WEBHOOK_TOKEN` is unset or empty, skip the webhook entirely and go to Step 6 (Gmail draft). Log a single line: `n8n not configured — saving Gmail draft instead`.
+
+### Step 3 — Build HTML body
+
+Wrap the Markdown summary in a minimal, Gmail-friendly HTML shell. **Do not depend on `references/html_template.md`** — that file is not guaranteed to exist in the sandbox. Inline the conversion:
+
+- Outer wrapper: `<!doctype html><html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 680px; margin: 0 auto; padding: 16px; line-height: 1.5;"> ... </body></html>`
+- Convert `#` / `##` / `###` headings, `**bold**`, `[text](url)` links, and paragraphs.
+- Use a small Python one-liner, `pandoc` if available, or a similar tool — whichever works cleanly. Do not introduce a new dependency.
+- The HTML content must match the inline Markdown summary semantically.
+
+### Step 4 — POST to n8n
+
+Compose the payload per §3 of this document and POST it with `curl`:
+
+```bash
+curl -sS --fail-with-body --max-time 30 \
+  -X POST "$N8N_WEBHOOK_URL" \
+  -H "Authorization: Bearer $N8N_WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @payload.json \
+  -w '\n__HTTP_CODE__%{http_code}\n'
+```
+
+Capture both the response body and `%{http_code}` (the `__HTTP_CODE__<n>` sentinel at the end makes parsing trivial).
+
+**Logging rule:** log `http_code` and `message_id` (on success) to stdout. **Never log the bearer token or the full `Authorization` header.**
+
+### Step 5 — Branch on HTTP code
+
+- **2xx:** parse the JSON response, extract `message_id`, and confirm inline with:
+  `Digest emailed via n8n — message_id: <id>.`
+  Then proceed to Phase 7 (state update).
+
+- **Any non-2xx, curl non-zero exit, or timeout:** go to Step 6 (fallback draft).
+
+### Step 6 — Fallback to Gmail draft
+
+Create a Gmail draft with the same subject and the HTML body from Step 3, using the existing `Gmail:create_draft` MCP tool. Subject format stays `Newsletter Digest — <Month DD, YYYY>`. Recipient stays `arigsela@gmail.com`.
+
+Surface a warning inline:
+
+- If env vars were unset (Step 2): `Digest saved to Gmail draft — review and send when ready.`
+- If n8n call failed: `n8n delivery failed (<http_status>/<short_reason>). Saved as Gmail draft instead — review and send manually.`
+
+Then proceed to Phase 7.
+
+### A note about the "never send directly" rule
+
+The existing SKILL.md text says: *"Never send the email directly — drafting only. The safety rules require explicit per-send confirmation for email."* This constraint is **relaxed** under the n8n pattern — the user has authorized automated send via the n8n workflow because the send decision now lives in n8n (where it can be audited, disabled, or rate-limited independently of the skill). Remove that sentence from the new Phase 6.
+
+---
+
+## 6. Error handling section updates
+
+Locate the existing `## Error handling` section. Add one new bullet; keep the rest.
+
+```markdown
+- **n8n webhook returns non-2xx or is unreachable**: fall back to `Gmail:create_draft` as Phase 6 Step 6 describes, and surface the failure reason inline.
+```
+
+---
+
+## 7. Test plan — run these after making the edits
+
+Run each scenario end-to-end. All four must behave as specified.
+
+### 7.1 Happy path
+
+**Given:** `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_TOKEN` are set and valid.
+**When:** you run the skill against a Gmail window containing newsletters.
+**Then:**
+
+- curl returns HTTP 200 with a non-empty `message_id`.
+- Skill prints `Digest emailed via n8n — message_id: <id>.`
+- An email arrives in `arigsela@gmail.com` within ~10 seconds.
+- No Gmail draft is created.
+
+### 7.2 n8n unreachable
+
+**Given:** `N8N_WEBHOOK_URL="https://n8n.arigsela.com/webhook/does-not-exist"` (or any bogus host/path); `N8N_WEBHOOK_TOKEN` is anything.
+**When:** you run the skill.
+**Then:**
+
+- curl returns non-2xx (404 for bad path; nonzero exit for DNS failure).
+- Skill creates a Gmail draft with the correct subject and HTML body.
+- Skill prints `n8n delivery failed (<status>/<reason>). Saved as Gmail draft instead — review and send manually.`
+
+### 7.3 Bad token
+
+**Given:** `N8N_WEBHOOK_URL` correct; `N8N_WEBHOOK_TOKEN="wrong"`.
+**When:** you run the skill.
+**Then:**
+
+- curl returns HTTP 403 with body `Authorization data is wrong!`.
+- Skill creates a Gmail draft.
+- Skill prints `n8n delivery failed (403/...). Saved as Gmail draft instead — review and send manually.`
+
+### 7.4 Unset env (backward compat)
+
+**Given:** both env vars are unset or empty.
+**When:** you run the skill.
+**Then:**
+
+- No curl attempt is made.
+- Skill creates a Gmail draft (identical to pre-change behavior).
+- Skill prints `Digest saved to Gmail draft — review and send when ready.`
+
+### 7.5 Isolated webhook sanity check (optional but recommended before testing the skill)
+
+Before running the full skill, prove the webhook works in isolation:
+
+```bash
+curl -sS -w '\n__HTTP__%{http_code}\n' \
+  -X POST "$N8N_WEBHOOK_URL" \
+  -H "Authorization: Bearer $N8N_WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "subject": "Skill-side smoke test",
+    "to": "arigsela@gmail.com",
+    "html_body": "<p>If you see this, the skill-side curl path works.</p>"
+  }'
+```
+
+Expect `HTTP 200` + an email. If that fails, the skill change won't work — stop and report before editing SKILL.md.
+
+---
+
+## 8. Constraints and nice-to-haves
+
+- **Don't add retries.** Single POST; fall back on any failure. (This was an explicit product decision — we'd rather fail fast to draft than stack latency.)
+- **Don't log the bearer token**, including in error messages. Log only `http_code` and, on success, `message_id`.
+- **Don't introduce new Python/npm dependencies.** Use curl and whatever's already in the sandbox for Markdown→HTML conversion.
+- **Don't broaden recipient support.** `to` stays `"arigsela@gmail.com"` in v1.
+- **Don't archive the digest elsewhere.** `markdown_body` is in the payload so n8n can archive it later if we decide to; the skill doesn't write anywhere except state.
+
+---
+
+## 9. Success criteria (what "done" looks like)
+
+- All four test scenarios in §7 pass.
+- Phases 1–5, Phase 7, and the rest of SKILL.md are byte-identical to before.
+- No bearer token appears in any log or error surface.
+- A diff of SKILL.md shows: new Configuration section near the top, rewritten Phase 6, one new bullet in Error handling, and optionally a one-line note in References about the inlined HTML wrapper.
+
+Report back with: the diff, the four test outputs, and a confirmation that the happy-path email arrived.

--- a/docs/plans/newsletter-digest-n8n-implementation-plan.md
+++ b/docs/plans/newsletter-digest-n8n-implementation-plan.md
@@ -1,0 +1,300 @@
+# Newsletter Digest → n8n Email Delivery — Implementation Plan
+
+**Source PRD:** `docs/plans/newsletter-digest-n8n-prd.md`
+**Owner:** Ari (DevOps Manager)
+**Status:** Approved — ready for implementation
+**Last updated:** 2026-04-22
+
+## Overview
+
+Replace the manual "send draft" step in the `newsletter-digest` skill with automated send via the self-hosted n8n webhook at `https://n8n.arigsela.com/webhook/newsletter-digest`. Preserve the Gmail draft path as a fallback so no digest is ever lost.
+
+## Success Criteria
+
+- [ ] Running the skill on a normal day sends an email to `arigsela@gmail.com` with no manual click.
+- [ ] n8n down / 401 / timeout → skill falls back to Gmail draft + inline warning.
+- [ ] `N8N_WEBHOOK_URL` unset → skill behaves exactly like today (draft-only).
+- [ ] n8n rejects unauthenticated POSTs with 401.
+- [ ] Workflow JSON is versioned in `n8n-workflows/newsletter-digest-send.json`.
+- [ ] End-to-end latency < 10s on happy path.
+
+## Research Findings
+
+### Relevant Files (this repo)
+
+- `docs/plans/newsletter-digest-n8n-prd.md` — source PRD.
+- `base-apps/n8n/nginx-ingress-webhook.yaml` — confirms `/webhook` is publicly reachable over HTTPS (no IP allowlist, TLS, 10 MB body, 60 s timeouts, 50 rps).
+- `base-apps/n8n/deployments.yaml` — confirms `WEBHOOK_URL=https://n8n.arigsela.com/` and Basic Auth is on for the admin UI (webhook ingress bypasses it).
+- `n8n-workflows/{claude-digest-generator,devops-digest-generator,feed-data-ingestion}.json` — export format to match.
+
+### Relevant Files (out of repo, skill lives here)
+
+- `<cowork-skills>/newsletter-digest/SKILL.md` — Phase 6 lines 133–144 to replace; Phase 7 unchanged.
+
+### Existing Patterns
+
+- Workflow JSON exports are checked into `n8n-workflows/` — we'll follow suit.
+- Ingress routing: anything under `/webhook/*` hits the n8n service — `/webhook/newsletter-digest` is the correct path.
+- Per-app secret management in this repo uses Vault, but n8n credentials (bearer token, Gmail OAuth) live inside n8n's own encrypted store — no Vault integration needed.
+
+### Dependencies
+
+- Existing `SMTP account` credential in n8n (smtp.gmail.com:465, Gmail App Password) — connection already tested.
+- n8n's Header Auth credential type for the bearer token.
+- `curl` inside the Cowork sandbox where the skill runs.
+
+## Architecture Decisions
+
+### Decision 1: Webhook path
+
+**Chosen:** `/webhook/newsletter-digest` — matches PRD, fits under the public `/webhook` prefix on the ingress. No ingress changes required.
+
+### Decision 2: HTML conversion inside the skill
+
+**Options:**
+- A. Depend on `references/html_template.md` (per PRD §6.1 step 2).
+- B. Inline a minimal wrapper (`<!doctype html><html><body>…</body></html>`) and convert Markdown inline with a small awk/python helper.
+
+**Chosen:** **B**. The reference template isn't present in the synced skill directory today, so depending on it is brittle. A minimal wrapper keeps the skill self-contained and still produces valid, Gmail-friendly HTML. (If the user later authors `references/html_template.md`, the skill can swap in a richer template without changing the plan.)
+
+### Decision 3: curl vs Python in the skill
+
+**Chosen:** `curl`. One-shot POST with `--fail-with-body --max-time 30 -w "%{http_code}"` captures status + body cleanly. No extra dependencies.
+
+### Decision 4: Send node and message_id extraction in n8n's "Respond to Webhook"
+
+**Chosen:** Use n8n's **Send Email (SMTP)** node bound to the existing `SMTP account` credential (smtp.gmail.com:465, Gmail App Password). An SMTP credential was already configured and tested in n8n, so reusing it avoids a fresh Gmail OAuth consent flow and keeps things moving. The PRD (§7.2 step 3) explicitly allows either Gmail node or SMTP node.
+
+SMTP's Send Email node returns nodemailer's output, where the message id is under `messageId` (RFC 5322 format, e.g. `<abc@smtp.gmail.com>`). The Respond node will reference `{{$('Send Email').item.json.messageId}}`. Task 1.4 verifies this field name on a live run.
+
+### Decision 5: No retry, no archive, no bearer-token storage guidance
+
+Per user direction: single POST, fall back to draft on any failure; no archive branch in v1; bearer-token storage on the skill side is Cowork's concern.
+
+## Implementation
+
+### Phase 1: Build and Export the n8n Workflow
+
+#### Task 1.1: Generate bearer token and create Header Auth credential in n8n
+
+**Files:** none (n8n UI operation)
+**Steps:**
+1. From an admin-allowlisted IP, log in to `https://n8n.arigsela.com`.
+2. Generate token locally: `openssl rand -hex 32`.
+3. In n8n UI: **Credentials → New → Header Auth**. Name: `Newsletter Digest Webhook Token`. Header name: `Authorization`. Header value: `Bearer <token>`.
+4. Store the raw token in the user's password manager for later injection into Cowork.
+
+**Testing:**
+- [ ] Credential appears in the n8n credentials list.
+- [ ] Token length is 64 hex chars.
+- [ ] Token value is not logged anywhere (check n8n execution logs after creation).
+
+#### Task 1.2: Verify SMTP credential in n8n
+
+**Files:** none (n8n UI)
+**Steps:**
+1. In n8n UI: **Credentials**. Verify the existing `SMTP account` credential (smtp.gmail.com:465, user `arigsela@gmail.com`) shows "Connection tested successfully".
+2. Note the credential name (`SMTP account`) for reuse in Task 1.3.
+
+**Testing:**
+- [x] Credential status shows "Connection tested successfully" (confirmed in existing credential screen).
+
+#### Task 1.3: Build the "Newsletter Digest — Send" workflow
+
+**Files:** none yet (built in n8n UI, exported in Task 1.5)
+**Steps:**
+1. **Webhook node**
+   - Method: `POST`, Path: `newsletter-digest`, Authentication: Header Auth (credential from 1.1).
+   - Response mode: "Using 'Respond to Webhook' node".
+   - Options: body parsing = JSON, raw body off.
+2. **IF — validate payload**
+   - Conditions (AND): `{{$json.subject}}` not empty, `{{$json.html_body}}` not empty, `{{$json.to}}` not empty.
+   - False branch → a **Respond to Webhook** node returning HTTP 400 with `{"error":"missing required fields"}`.
+3. **Send Email (SMTP)** (true branch)
+   - Credential: `SMTP account` (from Task 1.2).
+   - From Email: `arigsela@gmail.com`. To Email: `={{$json.to}}`. Subject: `={{$json.subject}}`. HTML: `={{$json.html_body}}`. Leave Text empty (HTML-only is fine; most MUAs auto-derive).
+4. **Respond to Webhook (success)**
+   - Response code: 200. Body:
+     ```json
+     {
+       "status": "sent",
+       "message_id": "={{$('Send Email').item.json.messageId}}",
+       "sent_at": "={{$now.toISO()}}"
+     }
+     ```
+5. **Error Trigger workflow** (separate, one-time): if none exists in this n8n instance, create a minimal one that emails `arigsela@gmail.com` on failure and bind it to the send workflow under **Workflow Settings → Error Workflow**. If one already exists, reuse it.
+
+**Testing:**
+- [ ] Activate the workflow. Hit the webhook via curl from an allowlisted host with a valid bearer + sample JSON payload → receive 200 JSON with `message_id` populated and an email in inbox.
+- [ ] Hit the webhook with missing `html_body` → receive 400 `{"error":"missing required fields"}`.
+- [ ] Hit the webhook with no Authorization header → n8n returns 401.
+- [ ] Hit the webhook with `Authorization: Bearer wrong` → n8n returns 401/403.
+- [ ] Temporarily break the Gmail credential (rotate offline) → error workflow fires; webhook returns 500.
+
+#### Task 1.4: Confirm the Send Email (SMTP) node output field for message_id
+
+**Files:** none (n8n UI)
+**Steps:**
+1. In the n8n execution list, open a successful run.
+2. Inspect the Send Email node output — confirm the message id is under `messageId`. If it's nested differently in this n8n version, update the Respond node expression accordingly and re-test.
+
+**Testing:**
+- [ ] Success response payload contains a non-null `message_id` (expected shape: `<something@smtp.gmail.com>`).
+
+#### Task 1.5: Export and commit workflow JSON
+
+**Files:** `n8n-workflows/newsletter-digest-send.json` (new)
+**Steps:**
+1. In n8n UI: **Workflow → Download** → save as `newsletter-digest-send.json`.
+2. Move to `/Users/arisela/git/kubernetes/n8n-workflows/newsletter-digest-send.json`.
+3. Verify no credential IDs or raw tokens are embedded (n8n exports reference credentials by ID only — confirm).
+
+**Testing:**
+- [ ] `grep -iE 'bearer|authorization|password' n8n-workflows/newsletter-digest-send.json` returns nothing suspicious.
+- [ ] `jq . n8n-workflows/newsletter-digest-send.json` parses cleanly.
+- [ ] Import the JSON into a scratch n8n instance (or re-import into the same instance under a different name) → workflow reconstructs without error.
+
+### Phase 2: Skill Modification (applied in Cowork, documented here)
+
+Scope note: this phase's edits land in the Cowork-synced skill directory, not in this git repo. The plan captures the exact diff so it's reproducible.
+
+#### Task 2.1: Replace Phase 6 in `newsletter-digest/SKILL.md`
+
+**Files:** `<cowork-skills>/newsletter-digest/SKILL.md` lines 133–144
+**Steps:**
+1. Replace the existing "Deliver both ways" block with:
+   - **Step 1 — Inline render** (unchanged).
+   - **Step 2 — Check env vars.** If `N8N_WEBHOOK_URL` or `N8N_WEBHOOK_TOKEN` is unset/empty → skip n8n, go straight to `Gmail:create_draft` (existing behavior) and log `"n8n not configured — saved as Gmail draft"`.
+   - **Step 3 — Build HTML body.** Wrap the Markdown summary in a minimal HTML shell. Convert headings, bold, links, and paragraphs (Markdown→HTML) with an inline python one-liner or equivalent — no dependency on `references/html_template.md`.
+   - **Step 4 — POST to n8n** via:
+     ```bash
+     curl -sS --fail-with-body --max-time 30 \
+       -X POST "$N8N_WEBHOOK_URL" \
+       -H "Authorization: Bearer $N8N_WEBHOOK_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @payload.json \
+       -w '\n__HTTP_CODE__%{http_code}\n'
+     ```
+     Payload matches PRD §5.1 (subject, to, html_body, markdown_body, meta).
+   - **Step 5 — Branch on HTTP code.**
+     - `2xx` → inline confirmation: `"Digest emailed via n8n — message_id: <id>."`
+     - Non-2xx or curl non-zero exit → fall through to `Gmail:create_draft` with same subject + html_body; inline warning: `"n8n delivery failed (<status>/<reason>). Saved as Gmail draft instead — review and send manually."`
+2. Add a short config section near the top of SKILL.md listing `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_TOKEN` (optional env vars) per PRD §6.2.
+3. Do NOT change Phases 1–5 or Phase 7.
+
+**Testing:** covered end-to-end in Phase 3.
+
+### Phase 3: End-to-End Testing
+
+#### Task 3.1: Happy path
+
+**Steps:**
+1. Set `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_TOKEN` in the Cowork session env.
+2. Run the skill against a real Gmail window that contains newsletters.
+3. Watch for inline "Digest emailed via n8n" confirmation with a message_id.
+
+**Testing:**
+- [ ] Email arrives in `arigsela@gmail.com` inbox within 10s.
+- [ ] Subject matches `Newsletter Digest — <Month DD, YYYY>`.
+- [ ] HTML renders correctly in Gmail web + mobile.
+- [ ] No Gmail draft is created.
+- [ ] n8n execution log shows a single successful run.
+
+#### Task 3.2: n8n unreachable
+
+**Steps:**
+1. Set `N8N_WEBHOOK_URL` to `https://n8n.arigsela.com/webhook/does-not-exist` (or a bogus host).
+2. Run the skill.
+
+**Testing:**
+- [ ] Skill reports "n8n delivery failed (…). Saved as Gmail draft instead".
+- [ ] A Gmail draft exists with the correct subject and HTML body.
+- [ ] Inline summary is still rendered.
+
+#### Task 3.3: Bad token
+
+**Steps:**
+1. Set `N8N_WEBHOOK_URL` correctly but `N8N_WEBHOOK_TOKEN` to `wrong`.
+2. Run the skill.
+
+**Testing:**
+- [ ] curl receives HTTP 401/403 from n8n.
+- [ ] Skill falls back to Gmail draft with warning.
+
+#### Task 3.4: Unset env (backward compat)
+
+**Steps:**
+1. Unset both env vars in the Cowork session.
+2. Run the skill.
+
+**Testing:**
+- [ ] No curl attempt made (check skill log).
+- [ ] Gmail draft created (identical to pre-change behavior).
+- [ ] Inline confirmation reads "Draft saved to Gmail — review and send when ready."
+
+#### Task 3.5: Empty digest (pre-existing safeguard)
+
+**Steps:**
+1. Run the skill against a time window with no matching newsletters.
+
+**Testing:**
+- [ ] Skill aborts before Phase 6 per existing logic — no webhook call, no draft.
+
+### Phase 4: Commit and Rollout
+
+#### Task 4.1: Commit workflow JSON
+
+**Files:** `n8n-workflows/newsletter-digest-send.json`
+**Steps:**
+1. `git add n8n-workflows/newsletter-digest-send.json`
+2. Commit with a clear message referencing the PRD.
+3. Push to `main` (this repo has no deploy impact from the workflow file — it's documentation/backup only; the live workflow lives in n8n).
+
+**Testing:**
+- [ ] `git log --oneline -1` shows the new commit.
+- [ ] PR or direct push reviewed.
+
+#### Task 4.2: Retire the manual "send draft" step
+
+**Steps:**
+1. Remove the daily-routine reminder/habit of opening Gmail drafts after a digest run.
+2. Keep an eye on the next ~3 daily runs for any fallback triggers.
+
+**Testing:**
+- [ ] No manual send needed for 3 consecutive days.
+- [ ] If a fallback fires, investigate the n8n execution log before disabling monitoring.
+
+## End-to-End Testing
+
+After all phases are complete, run one final end-to-end check on a normal morning: verify the digest email arrives, the inline skill output matches, and no draft was created. Spot-check the n8n execution log for a clean run.
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Send Email (SMTP) node output field shape differs between n8n versions | Low | Task 1.4 verifies on a live run before Phase 2. |
+| Gmail App Password on SMTP credential is revoked silently | Low | Error workflow (Task 1.3 step 5) emails on failure. |
+| Skill runs without `curl` available in Cowork sandbox | Very Low | PRD already prescribes curl; if absent, fall back to Python `urllib.request`. |
+| Bearer token leaks via skill logs | Low | curl `-sS` avoids progress output; skill should log `$http_code`, never the token. Document this in Phase 2. |
+| Let's Encrypt renewal gap breaks TLS | Very Low | cert-manager already manages renewal; if it happens, fallback path handles it cleanly. |
+| Markdown→HTML conversion misrenders in Gmail | Medium | Keep conversion minimal; verify visually in Task 3.1. |
+| Workflow JSON drifts from live n8n workflow | Medium | Any future edit to the workflow must re-export and commit. Call this out in the commit message. |
+
+## Out of Scope (per user direction)
+
+- Retry with backoff
+- Archive branch (GDrive/S3 of markdown_body)
+- Persistent multi-recipient support
+- IP allowlist tightening on the webhook ingress
+- Bearer-token storage guidance for the skill side (Cowork owns this)
+
+## Progress Tracking
+
+**Phases:** 1 / 4 complete
+**Tasks:** 5 / 13 complete
+
+### Phase Status
+- ✅ Phase 1: Build and Export the n8n Workflow (5/5)
+- ⬜ Phase 2: Skill Modification (0/1)
+- ⬜ Phase 3: End-to-End Testing (0/5)
+- ⬜ Phase 4: Commit and Rollout (0/2)

--- a/docs/plans/newsletter-digest-n8n-prd.md
+++ b/docs/plans/newsletter-digest-n8n-prd.md
@@ -1,0 +1,237 @@
+# PRD: Newsletter Digest → n8n Email Delivery
+
+**Owner:** Ari (DevOps Manager)
+**Status:** Draft — ready for implementation planning
+**Last updated:** 2026-04-22
+
+---
+
+## 1. Background
+
+We have an existing Claude skill, `newsletter-digest`, that runs on demand (and will soon run on a schedule) to:
+
+1. Pull recent newsletter emails from Gmail (TLDR, Substack, etc.)
+2. Rank and enrich stories through a DevOps / platform-engineering lens
+3. Produce a synthesized Markdown summary
+4. Save that summary as a **Gmail draft** addressed to `arigsela@gmail.com`
+
+**Problem:** The Gmail MCP connector available to the skill exposes only `create_draft` — no `send_message` tool. That means every run leaves a draft sitting in Gmail that requires manual "Send." The goal of having a daily digest land in the inbox automatically is not met today.
+
+We already run a self-hosted **n8n** instance, which is well suited to act as the send-side automation: it has mature Gmail / SMTP integrations and can expose an HTTP webhook that the skill can POST to.
+
+## 2. Goals
+
+- Deliver the daily digest to `arigsela@gmail.com` as a **sent email**, with no manual step.
+- Keep the skill's existing inline chat output unchanged (still the primary deliverable).
+- Offload the send responsibility to n8n so the skill itself never needs SMTP/OAuth credentials.
+- Produce a minimal, auditable workflow in n8n (≤ 5 nodes) that is easy to re-deploy.
+
+## 3. Non-Goals
+
+- No persistent archive of digests (out of scope; can be added later by extending the n8n workflow to write to GDrive / S3).
+- No support for multiple recipients in v1 — hard-coded to `arigsela@gmail.com`.
+- No attachment support in v1 — body-only HTML email.
+- Not replacing the Gmail draft path wholesale; draft-as-fallback is in scope (see §7).
+
+## 4. Proposed Architecture
+
+```
+┌──────────────────────────┐        HTTPS POST          ┌───────────────────────────┐
+│  newsletter-digest skill │ ─────────────────────────▶ │  n8n Webhook node         │
+│  (Cowork sandbox)        │   JSON body +              │  /webhook/newsletter-     │
+│                          │   Bearer auth header       │  digest                   │
+└──────────────────────────┘                            └────────────┬──────────────┘
+                                                                     │
+                                                                     ▼
+                                                        ┌───────────────────────────┐
+                                                        │  Gmail node (send)        │
+                                                        │  (or SMTP node)           │
+                                                        └────────────┬──────────────┘
+                                                                     │
+                                                                     ▼
+                                                        ┌───────────────────────────┐
+                                                        │  Respond to Webhook node  │
+                                                        │  200 OK + message_id      │
+                                                        └───────────────────────────┘
+```
+
+Design decisions and rationale:
+
+- **Webhook over file-drop.** A newsletter digest is 5–50 KB of HTML/Markdown — nowhere near n8n's default 16 MB webhook payload limit. A synchronous POST is simpler than a GDrive drop + polling workflow (3 nodes vs ~6) and gives the skill immediate success/failure feedback.
+- **n8n owns credentials.** The skill never touches SMTP creds or Gmail OAuth. Auth to n8n is a single bearer token.
+- **Gmail draft stays as fallback.** If the webhook POST fails (n8n down, network issue, auth rejected), the skill falls back to the existing `create_draft` behavior so the digest is never lost. Belt and suspenders.
+
+## 5. API Contract
+
+### 5.1 Request (skill → n8n)
+
+**Endpoint:** `POST https://<n8n-host>/webhook/newsletter-digest`
+
+**Headers:**
+
+```
+Content-Type: application/json
+Authorization: Bearer <N8N_WEBHOOK_TOKEN>
+```
+
+**Body (JSON):**
+
+```json
+{
+  "subject": "Newsletter Digest — April 22, 2026",
+  "to": "arigsela@gmail.com",
+  "html_body": "<!doctype html><html>...</html>",
+  "markdown_body": "# Newsletter Digest — April 22, 2026\n\n...",
+  "meta": {
+    "run_id": "2026-04-22T13:04:11Z",
+    "source_count": 5,
+    "sources": ["tldr.tech", "newsletter.platformengineer.io", "..."],
+    "top_pick_urls": ["https://...", "https://..."]
+  }
+}
+```
+
+Field notes:
+
+- `html_body` is the primary render used by the Gmail/SMTP node.
+- `markdown_body` is included for observability and future archival; n8n can ignore it.
+- `meta` is informational — useful for n8n logging, alerting on anomalous runs (e.g., `source_count == 0`), and future archival workflows.
+
+### 5.2 Response (n8n → skill)
+
+**Success (200):**
+
+```json
+{
+  "status": "sent",
+  "message_id": "<gmail-message-id>",
+  "sent_at": "2026-04-22T13:04:14Z"
+}
+```
+
+**Failure (4xx/5xx):** Any non-2xx response triggers the skill's fallback path (create Gmail draft instead).
+
+## 6. Skill Modification (`newsletter-digest`)
+
+Target file: `/sessions/.../mnt/.claude/skills/newsletter-digest/SKILL.md`
+
+### 6.1 Replace Phase 6 ("Deliver both ways")
+
+Current Phase 6 behavior:
+
+1. Render summary inline in chat ✅ keep
+2. `Gmail:create_draft` ← replace with webhook POST + draft fallback
+
+New Phase 6 behavior:
+
+1. Render summary inline in chat (unchanged).
+2. Convert Markdown → HTML using existing template at `references/html_template.md`.
+3. `POST` to n8n webhook with the payload defined in §5.1. Use `bash` + `curl`:
+   - Timeout: 30s.
+   - Read `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_TOKEN` from environment (set in skill config / session env).
+4. On 2xx: confirm inline with "Digest emailed via n8n — message_id: `<id>`."
+5. On non-2xx or timeout: fall back to `Gmail:create_draft` with the same subject and HTML body, and surface a warning inline: "n8n delivery failed (reason: `<http_status>` / `<error>`). Saved as Gmail draft instead — review and send manually."
+
+### 6.2 Config surface
+
+Document two required config values at the top of the skill:
+
+| Env var | Description | Example |
+|---|---|---|
+| `N8N_WEBHOOK_URL` | Full webhook URL (including path) | `https://n8n.example.com/webhook/newsletter-digest` |
+| `N8N_WEBHOOK_TOKEN` | Bearer token used in `Authorization` header | `<opaque random string, ≥32 chars>` |
+
+If either is unset at run time, the skill should **skip the n8n POST entirely** and fall straight through to the existing draft behavior (logging a one-line warning). This keeps the skill backward-compatible for anyone running it without n8n configured.
+
+### 6.3 No other phase changes
+
+Phases 1–5 (time window, discovery, fetch, rank, build summary) and Phase 7 (state update) are unchanged.
+
+## 7. n8n Workflow
+
+### 7.1 Workflow name
+
+`Newsletter Digest — Send`
+
+### 7.2 Nodes
+
+1. **Webhook**
+   - Method: `POST`
+   - Path: `newsletter-digest`
+   - Authentication: Header Auth — expects `Authorization: Bearer <token>` where token is stored as an n8n credential.
+   - Response mode: "Using 'Respond to Webhook' node"
+   - Options: body parsing = JSON, raw body = off.
+
+2. **IF — validate payload** (optional but recommended)
+   - Condition: `subject` AND `html_body` AND `to` all non-empty.
+   - True branch → Gmail node. False branch → Respond 400 with `{ "error": "missing required fields" }`.
+
+3. **Gmail — Send** (or SMTP node if preferred)
+   - Credential: existing Gmail OAuth credential in n8n.
+   - Operation: `Send`
+   - To: `{{ $json.to }}`
+   - Subject: `{{ $json.subject }}`
+   - Email Type: `HTML`
+   - Message: `{{ $json.html_body }}`
+
+4. **Respond to Webhook**
+   - Response code: `200`
+   - Response body:
+     ```json
+     {
+       "status": "sent",
+       "message_id": "={{ $node['Gmail'].json.id }}",
+       "sent_at": "={{ $now.toISO() }}"
+     }
+     ```
+
+5. **Error Trigger workflow** (separate, one-time setup)
+   - On any error in the main workflow, send a notification (email / Slack) so failed deliveries don't go silently missed. Suggest reusing existing n8n error-handling conventions if present.
+
+### 7.3 Security
+
+- n8n webhook **must** require the bearer token. Reject unauthenticated requests with 401.
+- Token generated once (≥32 bytes random, e.g., `openssl rand -hex 32`) and stored as an n8n credential + in the skill's env.
+- Webhook URL should be served over HTTPS only.
+- Consider IP allowlisting if the Cowork sandbox uses stable egress IPs (follow up; not a v1 blocker).
+
+## 8. Observability & Error Handling
+
+| Failure | Detection | User-visible behavior |
+|---|---|---|
+| n8n unreachable (network / DNS) | curl non-zero exit | Inline warning, Gmail draft fallback |
+| n8n returns 401 | HTTP 401 | Inline warning ("auth misconfigured"), draft fallback |
+| n8n returns 4xx (bad payload) | HTTP 4xx | Inline warning with response body, draft fallback |
+| Gmail node fails inside n8n | n8n error workflow fires | Skill sees 5xx → draft fallback. Ari gets error notification from n8n. |
+| Empty digest (zero newsletters found) | Already handled in Phase 2 | Skill aborts before Phase 6 — no webhook call. |
+
+Every run logs to stdout (visible in Cowork transcript): `POST status`, `http_code`, `message_id` on success, or fallback reason on failure.
+
+## 9. Success Criteria
+
+- ✅ Running the skill on a normal day results in a sent email to `arigsela@gmail.com` with the digest as HTML body, **without any manual Send click.**
+- ✅ Disabling / breaking n8n causes the skill to fall back to the existing draft flow with a clear inline warning. No run is lost.
+- ✅ The n8n workflow rejects unauthenticated POSTs with 401.
+- ✅ Skill changes are backward-compatible: running with `N8N_WEBHOOK_URL` unset behaves identically to today.
+- ✅ End-to-end latency (skill POST → email delivered) < 10 seconds on a healthy path.
+
+## 10. Open Questions / Decisions Needed
+
+1. **n8n network reachability.** Is the n8n instance already internet-accessible over HTTPS, or behind VPN only? If internal-only, we need a public URL (Cloudflare Tunnel / existing reverse proxy) before the skill sandbox can reach it.
+2. **Gmail node vs. SMTP node in n8n.** Gmail node is simpler but requires OAuth; SMTP is provider-agnostic. Preference?
+3. **Where to store the bearer token on the skill side?** Options: session env var set at Cowork startup, a file in the skill's directory that the skill reads at run time, or passed as a skill argument. Recommendation: session env var — no secret on disk, and the skill already runs in the session context.
+4. **Retry policy on transient failures.** v1 proposal: no retry in the skill itself (single POST; fall back to draft on any failure). Acceptable, or do you want one retry with backoff before falling back?
+5. **Archive.** Out of scope for v1, but worth flagging: a follow-on n8n branch could append the `markdown_body` to a GDrive folder for a searchable archive. Cheap to add later.
+
+## 11. Implementation Order
+
+1. Create n8n workflow per §7 with a test payload and verify end-to-end.
+2. Generate bearer token, store as n8n credential + in Cowork session env.
+3. Modify skill per §6. Test with n8n up → expect sent email.
+4. Test skill with n8n down / bad token → expect draft fallback + warning.
+5. Test skill with `N8N_WEBHOOK_URL` unset → expect original draft behavior.
+6. Roll out: retire the manual "send draft" step from daily routine.
+
+---
+
+**End of PRD.**

--- a/n8n-workflows/newsletter-digest-send.json
+++ b/n8n-workflows/newsletter-digest-send.json
@@ -1,0 +1,194 @@
+{
+  "name": "Newsletter Digest — Send",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "newsletter-digest",
+        "authentication": "headerAuth",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "079b06ce-7729-4624-a07d-2576bbcdc04f",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        -1088,
+        16
+      ],
+      "webhookId": "newsletter-digest",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "SaXQfVQf0KtjbuR6",
+          "name": "Newsletter Digest Webhook Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "subject-not-empty",
+              "leftValue": "={{ $json.body.subject }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "html-body-not-empty",
+              "leftValue": "={{ $json.body.html_body }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "to-not-empty",
+              "leftValue": "={{ $json.body.to }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "97542994-7664-4645-8366-614859e1cb1e",
+      "name": "Validate Payload",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        -864,
+        16
+      ]
+    },
+    {
+      "parameters": {
+        "fromEmail": "arigsela@gmail.com",
+        "toEmail": "={{ $json.body.to }}",
+        "subject": "={{ $json.body.subject }}",
+        "html": "={{ $json.body.html_body }}",
+        "options": {}
+      },
+      "id": "bf51dcbc-87c5-412f-84f9-21632e47fa36",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        -640,
+        -64
+      ],
+      "webhookId": "9004b83c-31a5-4f86-a918-7434666285d7",
+      "credentials": {
+        "smtp": {
+          "id": "DtjHnOSdz1h7Xpuw",
+          "name": "SMTP account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"sent\", \"message_id\": $('Send Email').item.json.messageId, \"sent_at\": $now.toISO() } }}",
+        "options": {}
+      },
+      "id": "dc516e30-a99c-41ac-ae77-047073df4086",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        -416,
+        -64
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"error\": \"missing required fields\" } }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "3c135b38-ec73-4cfc-9be3-4fddc9cac3b5",
+      "name": "Respond Missing Fields",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        -640,
+        112
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Payload": {
+      "main": [
+        [
+          {
+            "node": "Send Email",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Missing Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Email": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
+  },
+  "versionId": "1e1100d4-0c6f-48d3-8d26-3d4633aeb180",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "1ac1edd945dd6547c06503f16d68924976acb661550d12289650d4bae82f1e28"
+  },
+  "id": "qX9W779auOovEQe9",
+  "tags": []
+}


### PR DESCRIPTION
Add the n8n "Newsletter Digest — Send" workflow JSON and the PRD, implementation plan, and Cowork skill-handoff docs that describe the end-to-end delivery pipeline (newsletter-digest skill -> n8n webhook -> SMTP send -> Gmail inbox).

Phase 1 of the implementation plan is complete and verified: the workflow is active at
https://n8n.arigsela.com/webhook/newsletter-digest, sends real email via the existing SMTP credential, and rejects unauthenticated / malformed requests. The Cowork skill-side edits (Phase 2) are tracked in the handoff doc and land outside this repo.