### PR TITLE
feat(crossplane): bump Upbound AWS providers to v2.5.3

### DIFF
--- a/base-apps/crossplane-aws-provider/provider.yaml
+++ b/base-apps/crossplane-aws-provider/provider.yaml
@@ -1,5 +1,5 @@
 # Crossplane AWS Providers for managing AWS resources via GitOps
-# Version: v1.12.0 (from provider-family-aws v2.1.1)
+# Version: v2.5.3
 # Purpose: Enable declarative infrastructure management for Loki observability stack
 
 ---
@@ -13,7 +13,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"  # Install providers first
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.12.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v2.5.3
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
@@ -29,7 +29,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"  # Install providers first
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.12.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.5.3
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1


### PR DESCRIPTION
## Summary
- Upbound \`provider-aws-s3\`: \`v1.12.0\` → \`v2.5.3\`
- Upbound \`provider-aws-iam\`: \`v1.12.0\` → \`v2.5.3\`
- Crossplane core stays on \`v1.15.0\` in this PR — v2 providers run on v1.x core.

This is **PR 1 of 2** in the Crossplane v2 upgrade. PR 2 (core chart bump) is gated on this PR's post-merge verification.

Spec: [\`docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md\`](../blob/main/docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md)
Plan: [\`docs/superpowers/plans/2026-04-26-crossplane-v2-upgrade.md\`](../blob/main/docs/superpowers/plans/2026-04-26-crossplane-v2-upgrade.md)

## Pre-merge dry-run

Ran \`kubectl diff -f base-apps/crossplane-aws-provider/provider.yaml\` against the live cluster. The only meaningful change is \`spec.package\` on both Provider resources:

\`\`\`diff
 spec:
   ignoreCrossplaneConstraints: false
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.12.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.5.3
\`\`\`

(Same shape on \`provider-aws-s3\`.)

The dry-run output also contains two diff-rendering artifacts that are **not** real cluster changes:
- \`generation: 1 → 2\` — server-side auto-increment on any spec change.
- \`argocd.argoproj.io/tracking-id\` annotation appears removed in dry-run output. \`kubectl diff\` doesn't carry ArgoCD's tracking annotation through the apply simulation; ArgoCD re-injects it on real sync.

Both are well-understood Kubernetes/ArgoCD behaviors.

## Why this is low-risk

Of the five major Crossplane v2 breaking changes, four don't apply (no Compositions/XRDs, no \`ControllerConfig\`, no Crossplane External Secret Stores, no XR connection details). The fifth — namespaced MRs — is additive in Upbound v2 providers; \`v1beta1\` cluster-scoped MRs continue to work and are unchanged in this repo.

## Post-merge verification (executor will run)

- [ ] \`kubectl get providers.pkg.crossplane.io\` — both providers \`INSTALLED=True\`, \`HEALTHY=True\` at v2.5.3 within 5 min of ArgoCD sync.
- [ ] \`kubectl get providerrevisions.pkg.crossplane.io\` — latest revision per provider has \`STATE=Active\`.
- [ ] \`kubectl get buckets.s3.aws.upbound.io,users.iam.aws.upbound.io,accesskeys.iam.aws.upbound.io,policies.iam.aws.upbound.io,userpolicyattachments.iam.aws.upbound.io -A\` — all rows \`SYNCED=True, READY=True\`.
- [ ] No \`Warning\` events on existing MRs.

## Rollback

\`git revert <merge-sha> && open PR\`. v2 providers retain v1beta1 APIs, so MRs do not need mutation.

## Test plan
- [ ] CI / code scanning passes
- [ ] Dry-run output reviewed (above)
- [ ] Post-merge verification checklist (above) executed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)