### PR TITLE
fix(crossplane): explicitly declare provider-family-aws v2.5.3

### DIFF
--- a/base-apps/crossplane-aws-provider/provider.yaml
+++ b/base-apps/crossplane-aws-provider/provider.yaml
@@ -3,6 +3,25 @@
 # Purpose: Enable declarative infrastructure management for Loki observability stack
 
 ---
+# AWS Family Provider — shared CRDs and base controllers for the AWS family.
+# Must be at the same major.minor as the sub-providers below. Declared
+# explicitly (rather than relying on implicit dependency resolution) because
+# v2.5.x sub-providers require family v2.5.x; the implicit auto-installed
+# family-aws lagged at v2.3.0 and triggered ResolveDependencies errors.
+# Sync-wave "0" so ArgoCD applies this before the sub-providers at wave "1".
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-family-aws
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.5.3
+  packagePullPolicy: IfNotPresent
+  revisionActivationPolicy: Automatic
+  revisionHistoryLimit: 1
+
+---
 # AWS S3 Provider
 # Manages S3 buckets, lifecycle configurations, and related resources
 # Note: Provider is a cluster-scoped resource and does not have a namespace


### PR DESCRIPTION
## Summary
Fix-forward for the dependency mismatch surfaced by PR #192's post-merge verification.

- Adds explicit \`upbound-provider-family-aws:v2.5.3\` Provider at sync-wave \`"0"\`.
- Sub-providers (\`provider-aws-s3\`, \`provider-aws-iam\`) stay at \`v2.5.3\` — unchanged.
- Crossplane adopts the existing in-cluster \`upbound-provider-family-aws\` resource (was at \`v2.3.0\`, auto-installed back when sub-providers were \`v1.12.0\`) and rolls it to \`v2.5.3\`.

## Why this is needed

After PR #192 merged, \`kubectl get providers.pkg.crossplane.io\` showed:

\`\`\`
NAME                          PACKAGE                                                  INSTALLED   HEALTHY
provider-aws-iam              xpkg.upbound.io/upbound/provider-aws-iam:v2.5.3          True        Unknown
provider-aws-s3               xpkg.upbound.io/upbound/provider-aws-s3:v2.5.3           True        Unknown
upbound-provider-family-aws   xpkg.upbound.io/upbound/provider-family-aws:v2.3.0       True        True
\`\`\`

The new ProviderRevisions emitted repeated \`ResolveDependencies\` warnings:
\`\`\`
cannot resolve package dependencies: incompatible dependencies: [xpkg.upbound.io/upbound/provider-family-aws]
\`\`\`

Data plane was unaffected — all 9 managed AWS resources stayed \`SYNCED=True, READY=True\` — but the ArgoCD application went \`Degraded\` and the new revisions could not stabilize.

The original \`provider.yaml\` never declared \`provider-family-aws\` explicitly; it was auto-installed as an implicit dependency of the sub-providers. With the v2 line, sub-providers require family at the matching minor version. Going forward, declaring family explicitly in this manifest avoids the same trap on every minor bump.

## Pre-merge dry-run

\`kubectl diff -f base-apps/crossplane-aws-provider/provider.yaml\` shows the only meaningful change is on the family Provider (existing in-cluster resource is adopted, not duplicated):

\`\`\`diff
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   creationTimestamp: "2026-01-20T18:50:59Z"
-  generation: 1
+  generation: 2
   name: upbound-provider-family-aws
 spec:
   ignoreCrossplaneConstraints: false
-  package: xpkg.upbound.io/upbound/provider-family-aws:v2.3.0
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.5.3
\`\`\`

(The \`creationTimestamp\` and \`uid\` matching the live resource confirms adoption — Crossplane is not creating a new Provider.)

The sub-providers also show in the dry-run diff but only the benign \`tracking-id\` annotation artifact (kubectl-diff dry-run doesn't carry ArgoCD's tracking annotation through; ArgoCD re-injects on real sync). No actual change to sub-providers.

## Post-merge verification

- [ ] \`upbound-provider-family-aws\` is at \`v2.5.3\` and \`HEALTHY=True\`.
- [ ] \`provider-aws-s3\` and \`provider-aws-iam\` flip from \`HEALTHY=Unknown\` to \`HEALTHY=True\`.
- [ ] Old v2.3.0 family ProviderRevision goes \`Inactive\`; new v2.5.3 revision is \`Active\`.
- [ ] No new \`ResolveDependencies\` warning events.
- [ ] All 9 managed resources still \`SYNCED=True, READY=True\`.
- [ ] ArgoCD \`crossplane-aws-provider\` app: \`sync=Synced, health=Healthy\`.

## Rollback

\`git revert <merge-sha>\` and open PR. Family provider would revert to \`v2.3.0\` declaration but the in-cluster Provider package field would persist at \`v2.5.3\` until ArgoCD reconciles back. Data plane is not at risk during rollback (sub-providers stayed operational throughout this incident).

## Test plan
- [ ] CI / code scanning passes
- [ ] kubectl diff above is the only real change

🤖 Generated with [Claude Code](https://claude.com/claude-code)