### PR TITLE
docs(crossplane): append v2 migration findings to upgrade spec

### DIFF
--- a/docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md
+++ b/docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md
@@ -228,3 +228,102 @@ This design is approved when both PRs:
 1. Merge cleanly with the verification block in the PR body.
 2. Reach the post-merge sign-off criteria in §8 within the stated time bounds.
 3. Do not require any edit to MRs, ProviderConfig, ESO, or Terraform.
+
+---
+
+## Appendix A: Migration findings (executed 2026-04-26 to 2026-04-27)
+
+The upgrade was executed in **four PRs**, not the planned two, plus three operational hotfixes that this spec did not anticipate. Recording them here so a future upgrader knows the real shape.
+
+### PRs that actually shipped
+
+| # | Branch | Purpose | Why it was needed |
+|---|---|---|---|
+| #191 | `docs-crossplane-v2-upgrade-design-and-plan` | Add this spec + the implementation plan | Branch protection blocks direct push to `main`; docs go through their own PR |
+| #192 | `crossplane-providers-v2.5.3` | Bump `provider-aws-s3` and `provider-aws-iam` to `v2.5.3` | Per the original plan |
+| **#193** | `crossplane-family-aws-v2.5.3` | **Explicitly declare `upbound-provider-family-aws v2.5.3`** | Spec gap (see Finding 1) |
+| #194 | `crossplane-core-v2` | Bump core Helm subchart to `2.2.1` | Per the original plan |
+
+### Finding 1 — Implicit family-provider dependency
+
+**What the spec missed.** The original `provider.yaml` declared only the two sub-providers (`provider-aws-s3`, `provider-aws-iam`). The spec assumed Crossplane's package manager would auto-resolve the `upbound-provider-family-aws` dependency to a compatible version when the sub-providers were bumped. It does not — it stuck at the previously auto-installed `v2.3.0` (compatible with `v1.12.0` sub-providers, **incompatible** with `v2.5.x`).
+
+**Symptom.** After PR #192 merged, both sub-provider ProviderRevisions stayed `HEALTHY=Unknown` with repeated `ResolveDependencies` warning events. Data plane (managed AWS resources) stayed `SYNCED=True, READY=True` throughout.
+
+**Fix.** PR #193 added the family provider explicitly to `provider.yaml` at sync-wave `"0"`:
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-family-aws
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.5.3
+```
+Crossplane adopted the existing in-cluster Provider resource (matched by name) and rolled it `v2.3.0 → v2.5.3`.
+
+**Lesson.** When upgrading Upbound family-prefixed providers, pin the family explicitly. The implicit auto-resolved family is fine on initial install but drifts during version churn.
+
+### Finding 2 — `BucketLifecycleConfiguration.status.atProvider` schema break
+
+**What the spec missed.** The spec assumed Upbound providers would convert v1beta1↔v1beta2 cleanly. They cannot when stored data uses incompatible types.
+
+**Symptom.** After PR #194 merged, ArgoCD's cluster cache failed to load with:
+```
+conversion webhook for s3.aws.upbound.io/v1beta1, Kind=BucketLifecycleConfiguration failed:
+json: cannot unmarshal string into Go struct field
+RuleFilterObservation.status.atProvider.rule.filter.objectSizeGreaterThan
+of type float64
+```
+The `loki-logs-lifecycle` resource had `objectSizeGreaterThan: ""` (empty string) in `.status.atProvider`, written by the v1.12.0 controller. The v2.5.3 schema typed this field as `float64`. The conversion webhook couldn't parse the empty string. ArgoCD couldn't list the resource → couldn't compute sync state → couldn't apply PR #194's chart bump. **Circular block.**
+
+**Fix.** Surgical operational hotfix:
+1. Backup the CRD's conversion config: `kubectl get crd bucketlifecycleconfigurations.s3.aws.upbound.io -o jsonpath='{.spec.conversion}' > /tmp/blc-conversion-backup.json`
+2. Disable the webhook: `kubectl patch crd bucketlifecycleconfigurations.s3.aws.upbound.io --type=merge -p '{"spec":{"conversion":{"strategy":"None","webhook":null}}}'`
+3. Clear the offending status field: `kubectl patch bucketlifecycleconfiguration.s3.aws.upbound.io loki-logs-lifecycle --subresource=status --type=merge -p '{"status":{"atProvider":null}}'`
+4. Restore the webhook: `kubectl patch crd bucketlifecycleconfigurations.s3.aws.upbound.io --type=merge -p "{\"spec\":{\"conversion\":$(cat /tmp/blc-conversion-backup.json)}}"`
+5. Trigger ArgoCD refresh — cluster state now loadable, PR #194 applies.
+
+**Lesson.** Before merging the core chart bump, dry-run probe the CRD conversion paths for any resource type whose schema may have shifted between v1beta1 (the legacy stored version) and v1beta2 (the new served version). For Upbound `s3.aws.upbound.io` and `iam.aws.upbound.io` v2.5.x, watch specifically for fields that changed from `string` to `float64` or other type-narrowing changes.
+
+### Finding 3 — `environmentconfigs.apiextensions.crossplane.io` storedVersion conflict
+
+**What the spec missed.** Crossplane v2 promoted `EnvironmentConfig` past `v1alpha1`, but the in-cluster CRD still listed `v1alpha1` in `status.storedVersions`. The v2.2.1 init container's CRD spec doesn't include `v1alpha1`, and Kubernetes refuses to update a CRD that drops a stored version while data may exist.
+
+**Symptom.** After ArgoCD applied PR #194, the new `crossplane:v2.2.1` Pod entered `Init:CrashLoopBackOff` with:
+```
+crossplane: error: cannot initialize core: cannot apply crd:
+CustomResourceDefinition.apiextensions.k8s.io "environmentconfigs.apiextensions.crossplane.io"
+is invalid: status.storedVersions[0]: Invalid value: "v1alpha1":
+missing from spec.versions
+```
+
+**Fix.**
+1. Confirm zero `EnvironmentConfig` resources exist (we had none): `kubectl get environmentconfigs.apiextensions.crossplane.io -A`
+2. Delete the CRD entirely: `kubectl delete crd environmentconfigs.apiextensions.crossplane.io`
+3. The v2.2.1 init container recreates it cleanly with the new spec on its next retry.
+
+**Lesson.** Before the core chart bump, audit `status.storedVersions` on Crossplane-owned CRDs for `v1alpha1` versions that v2 has graduated past. Common candidates: `EnvironmentConfig`, `Usage`, `Lock`. If no resources of those kinds exist, the CRD can be deleted to let v2 init recreate it. If resources exist, a real storage migration is needed before the upgrade.
+
+### Finding 4 — Old vs new ReplicaSet fight during rolling update
+
+**What the spec missed.** While the new v2.2.1 Pod was looping in init due to Finding 3, the old v1.15.0 ReplicaSet remained at `replicas=1` (rolling-update preservation logic). The old v1.15.0 init kept re-creating the `environmentconfigs` CRD with `v1alpha1` in spec.versions, perpetuating Finding 3.
+
+**Fix.**
+```bash
+kubectl -n crossplane-system scale rs <old-replicaset-name> --replicas=0
+```
+Then re-do the CRD delete from Finding 3. The v2.2.1 init then runs unobstructed and succeeds.
+
+**Lesson.** During Crossplane core upgrades that involve CRD schema graduations, expect the old ReplicaSet to actively undo the new init's work. Be ready to manually scale the old RS to 0 if the rolling update stalls.
+
+### What the data plane did throughout
+
+All 10 managed AWS resources (`Bucket`, `User`, `AccessKey`, `Policy`, `UserPolicyAttachment`, `BucketLifecycleConfiguration` across Loki and argo-workflows) **stayed `SYNCED=True, READY=True` throughout the entire upgrade window**, including all four findings above. The control-plane troubles were entirely package-manager / CRD layer; the existing AWS resources reconciled fine via cached desired state on whichever provider revision was Active at the moment.
+
+### Total elapsed
+
+- Plan creation: ~30 minutes
+- PRs #191 + #192 + #193 + verification: ~1 hour spread across two sessions
+- PR #194 + Findings 2/3/4 + verification: ~1.5 hours across two sessions, including the operational hotfixes


### PR DESCRIPTION
## Summary
Adds **Appendix A: Migration findings (executed 2026-04-26 to 2026-04-27)** to \`docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md\`.

The original spec planned a clean two-PR upgrade. Reality required **four PRs and three operational hotfixes**. The appendix records what actually happened so a future upgrader (or future-you) doesn't have to re-discover the same issues.

## What's documented

1. **Implicit family-provider dependency drift** — \`upbound-provider-family-aws\` stuck at \`v2.3.0\` after sub-provider bump; required PR #193 fix-forward.
2. **\`BucketLifecycleConfiguration.status.atProvider\` schema break** — v1.12.0 wrote \`objectSizeGreaterThan: ""\`; v2.5.3 expects \`float64\`. Conversion webhook failed → ArgoCD couldn't compute state → PR #194 couldn't apply. Surgical fix included.
3. **\`environmentconfigs\` CRD storedVersion conflict** — v1alpha1 stuck in \`status.storedVersions\`; v2.2.1 init crash-looped. Resolved by deleting the (empty) CRD.
4. **Old vs new ReplicaSet fight** during the rolling update — old v1.15.0 init kept undoing the new v2.2.1 init's CRD work.

Each finding has the symptom, the fix commands used, and a takeaway lesson for future upgrades.

## Files
- \`docs/superpowers/specs/2026-04-26-crossplane-v2-upgrade-design.md\` (added Appendix A; sections 1-11 unchanged)

## Test plan
- [ ] CI / code scanning passes
- [ ] Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)