### PR TITLE
feat(crossplane): add DeploymentRuntimeConfig for AWS providers

### DIFF
--- a/base-apps/crossplane-aws-provider/deployment-runtime-config.yaml
+++ b/base-apps/crossplane-aws-provider/deployment-runtime-config.yaml
@@ -1,0 +1,36 @@
+# DeploymentRuntimeConfig for Upbound AWS providers
+# Sets resource requests/limits on the provider Pod controllers, replacing
+# the v2-removed ControllerConfig type. Referenced by the Provider entries
+# in provider.yaml via spec.runtimeConfigRef.name.
+#
+# Why limits matter here: v2.5.x sub-providers (especially provider-aws-s3)
+# do an extensive CRD cache sync at startup. Without CPU guarantees, the
+# sync can time out on a constrained node, leaving the provider in a
+# crash loop. Conservative requests ensure the scheduler reserves enough
+# CPU; generous limits give the controller burst capacity for the cache
+# sync window.
+#
+# Sync-wave "0" so this lands before the Providers themselves at wave "1".
+
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: aws-provider-runtime
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  deploymentTemplate:
+    spec:
+      replicas: 1
+      selector: {}
+      template:
+        spec:
+          containers:
+            - name: package-runtime
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi

--- a/base-apps/crossplane-aws-provider/provider.yaml
+++ b/base-apps/crossplane-aws-provider/provider.yaml
@@ -20,6 +20,8 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
+  runtimeConfigRef:
+    name: aws-provider-runtime
 
 ---
 # AWS S3 Provider
@@ -36,6 +38,8 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
+  runtimeConfigRef:
+    name: aws-provider-runtime
 
 ---
 # AWS IAM Provider
@@ -52,3 +56,5 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
+  runtimeConfigRef:
+    name: aws-provider-runtime


### PR DESCRIPTION
## Summary
- Adds new \`base-apps/crossplane-aws-provider/deployment-runtime-config.yaml\` defining a \`DeploymentRuntimeConfig\` named \`aws-provider-runtime\`.
- Updates all three Provider entries in \`provider.yaml\` (\`upbound-provider-family-aws\`, \`provider-aws-s3\`, \`provider-aws-iam\`) to reference it via \`spec.runtimeConfigRef.name\`.
- Sync-wave \`"0"\` on the runtime config so it lands before the providers at wave \`"1"\`.

## Why

During the v2 upgrade rollout (PR #194), \`provider-aws-s3\` hit a CRD-cache-sync timeout pattern that caused 98 pod restarts before stabilizing. Root cause was no CPU guarantee during the (CPU-bound) startup cache sync. Setting explicit requests + generous limits via \`DeploymentRuntimeConfig\` gives the controller burst capacity for the sync window and prevents recurrence.

This also resolves the Kyverno \`require-resource-limits\` audit-mode PolicyViolation warnings that have been firing on every provider deployment reconcile.

## Resources chosen

| | requests | limits |
|---|---|---|
| CPU | 100m | 1000m |
| memory | 256Mi | 1Gi |

Requests match the existing \`crossplane.resourcesCrossplane\` values in the core chart for consistency. Limits are 4× higher than the core to absorb cache-sync CPU bursts on the constrained homelab node (~17% disk, single worker hosts all providers).

## Pre-merge dry-run

\`kubectl diff -f base-apps/crossplane-aws-provider/\` shows three meaningful changes:

1. **New \`DeploymentRuntimeConfig/aws-provider-runtime\`** created.
2. **\`runtimeConfigRef.name\`** flips from \`default\` (Crossplane's built-in DRC) to \`aws-provider-runtime\` on all three Providers.
3. \`generation: 2 → 3\` on each Provider (server-side increment, expected).

No CRD changes, no MR changes, no other resources affected.

## Expected post-merge effect

ArgoCD applies the new \`DeploymentRuntimeConfig\`, then patches the three Providers' \`runtimeConfigRef\`. Crossplane reconciles each Provider's underlying Deployment, which triggers a **rolling restart of all three provider pods** with the new resource limits applied.

⚠️ **Brief disruption**: each provider pod restarts (~30–60s per pod). MR reconciliation pauses momentarily but stored AWS state is unaffected. Conversion webhooks for \`s3.aws.upbound.io\` CRDs will return \`502 Bad Gateway\` for ~30s during the s3 provider restart — this is the same brief window we saw during PR #194 rollout, and ArgoCD recovers automatically.

## Post-merge verification (executor will run)

- [ ] \`kubectl get deploymentruntimeconfigs.pkg.crossplane.io\` — \`aws-provider-runtime\` present.
- [ ] \`kubectl -n crossplane-system get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].resources}{"\n"}{end}'\` — provider pods show the new requests/limits.
- [ ] All three providers HEALTHY=True after the rolling restart settles (~3 min).
- [ ] All managed resources still SYNCED=True, READY=True.
- [ ] Kyverno \`require-resource-limits\` events on provider deployments stop appearing (warning load drops).

## Rollback

\`git revert <merge-sha>\` and open PR. Providers' \`runtimeConfigRef\` reverts to \`default\` (Crossplane's built-in DRC) and the \`aws-provider-runtime\` DRC is pruned. Provider pods roll once more to pick up the change.

## Test plan
- [ ] CI / code scanning passes
- [ ] Dry-run output reviewed (above)
- [ ] Post-merge: pods restart cleanly with new resource limits, no provider regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)