### PR TITLE
Phase 2: Composition Python script (TDD) for IDP template

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -121,16 +121,23 @@ spec:
               name = xr["metadata"]["name"]
               namespace = xr["metadata"]["namespace"]
 
+              # Integers from a protobuf Struct round-trip as Python floats
+              # (Struct's number_value is a double). Cast at the boundary so
+              # rendered YAML has true ints — Kubernetes rejects containerPort: 8080.0
+              # at apply time even though `crossplane render` accepts it.
+              port = int(spec["port"])
+              replicas = int(spec.get("replicas", 2))
+
               env_from = None  # no DB in this version of the script
 
               resource.update(
                   rsp.desired.resources["deployment"],
-                  make_deployment(name, namespace, spec["image"], spec["port"],
-                                  spec.get("replicas", 2), spec.get("env", []), env_from),
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []), env_from),
               )
               resource.update(
                   rsp.desired.resources["service"],
-                  make_service(name, namespace, spec["port"]),
+                  make_service(name, namespace, port),
               )
               resource.update(
                   rsp.desired.resources["ingress"],

--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -1,8 +1,7 @@
 # base-apps/crossplane-compositions/composition-application.yaml
 # Application — single Composition for XApplication.
 # Pipeline: one step, function-python, with the script that maps XR spec to
-# Deployment + Service + Ingress + optional CNPG Cluster.
-# In Phase 1 the script is intentionally empty; Phase 2 fills it in under TDD.
+# Deployment + Service + Ingress + (Phase 2.3) optional CNPG Cluster.
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
@@ -22,7 +21,118 @@ spec:
         apiVersion: python.fn.crossplane.io/v1beta1
         kind: Script
         script: |
-          # PHASE 1 STUB — replaced by Phase 2 Task 2.2.
+          from crossplane.function import resource
+
+          STD_LABELS_TEMPLATE = {
+              "app.kubernetes.io/name": None,
+              "app.kubernetes.io/managed-by": "crossplane",
+              "backstage.io/kubernetes-id": None,
+          }
+
+          def std_labels(name):
+              labels = dict(STD_LABELS_TEMPLATE)
+              labels["app.kubernetes.io/name"] = name
+              labels["backstage.io/kubernetes-id"] = name
+              return labels
+
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret):
+              container = {
+                  "name": "app",
+                  "image": image,
+                  "ports": [{"name": "http", "containerPort": port}],
+                  "resources": {
+                      "requests": {"cpu": "100m", "memory": "128Mi"},
+                      "limits":   {"cpu": "500m", "memory": "512Mi"},
+                  },
+                  "livenessProbe": {
+                      "httpGet": {"path": "/healthz", "port": port},
+                      "initialDelaySeconds": 30, "periodSeconds": 30,
+                  },
+                  "readinessProbe": {
+                      "httpGet": {"path": "/healthz", "port": port},
+                      "initialDelaySeconds": 5, "periodSeconds": 10,
+                  },
+              }
+              if env_list:
+                  container["env"] = [{"name": e["name"], "value": e["value"]} for e in env_list]
+              if env_from_secret:
+                  container.setdefault("env", []).append({
+                      "name": "DATABASE_URL",
+                      "valueFrom": {"secretKeyRef": {"name": env_from_secret, "key": "uri"}},
+                  })
+                  container["envFrom"] = [{"secretRef": {"name": env_from_secret}}]
+              return {
+                  "apiVersion": "apps/v1",
+                  "kind": "Deployment",
+                  "metadata": {"name": name, "namespace": namespace, "labels": std_labels(name)},
+                  "spec": {
+                      "replicas": replicas,
+                      "selector": {"matchLabels": {"app.kubernetes.io/name": name}},
+                      "template": {
+                          "metadata": {"labels": std_labels(name)},
+                          "spec": {
+                              "imagePullSecrets": [{"name": "ecr-auth"}],
+                              "containers": [container],
+                          },
+                      },
+                  },
+              }
+
+          def make_service(name, namespace, port):
+              return {
+                  "apiVersion": "v1",
+                  "kind": "Service",
+                  "metadata": {"name": name, "namespace": namespace, "labels": std_labels(name)},
+                  "spec": {
+                      "type": "ClusterIP",
+                      "selector": {"app.kubernetes.io/name": name},
+                      "ports": [{"name": "http", "port": 80, "targetPort": port}],
+                  },
+              }
+
+          def make_ingress(name, namespace, host):
+              return {
+                  "apiVersion": "networking.k8s.io/v1",
+                  "kind": "Ingress",
+                  "metadata": {
+                      "name": name, "namespace": namespace, "labels": std_labels(name),
+                      "annotations": {
+                          "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+                          "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                          "nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+                      },
+                  },
+                  "spec": {
+                      "ingressClassName": "nginx",
+                      "tls": [{"hosts": [host], "secretName": f"{name}-tls"}],
+                      "rules": [{
+                          "host": host,
+                          "http": {"paths": [{
+                              "path": "/", "pathType": "Prefix",
+                              "backend": {"service": {"name": name, "port": {"number": 80}}},
+                          }]},
+                      }],
+                  },
+              }
+
           def compose(req, rsp):
-              # Deliberately produce nothing so render.sh fails until Phase 2.
-              pass
+              xr = resource.struct_to_dict(req.observed.composite.resource)
+              spec = xr["spec"]
+              name = xr["metadata"]["name"]
+              namespace = xr["metadata"]["namespace"]
+
+              env_from = None  # no DB in this version of the script
+
+              resource.update(
+                  rsp.desired.resources["deployment"],
+                  make_deployment(name, namespace, spec["image"], spec["port"],
+                                  spec.get("replicas", 2), spec.get("env", []), env_from),
+              )
+              resource.update(
+                  rsp.desired.resources["service"],
+                  make_service(name, namespace, spec["port"]),
+              )
+              resource.update(
+                  rsp.desired.resources["ingress"],
+                  make_ingress(name, namespace, spec["host"]),
+              )

--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -115,6 +115,23 @@ spec:
                   },
               }
 
+          def make_cnpg_cluster(parent_name, namespace, instances, storage):
+              return {
+                  "apiVersion": "postgresql.cnpg.io/v1",
+                  "kind": "Cluster",
+                  "metadata": {
+                      "name": f"{parent_name}-db",
+                      "namespace": namespace,
+                      "labels": std_labels(parent_name),
+                  },
+                  "spec": {
+                      "instances": instances,
+                      "imageName": "ghcr.io/cloudnative-pg/postgresql:16",
+                      "bootstrap": {"initdb": {"database": "app", "owner": "app"}},
+                      "storage": {"size": storage},
+                  },
+              }
+
           def compose(req, rsp):
               xr = resource.struct_to_dict(req.observed.composite.resource)
               spec = xr["spec"]
@@ -128,7 +145,8 @@ spec:
               port = int(spec["port"])
               replicas = int(spec.get("replicas", 2))
 
-              env_from = None  # no DB in this version of the script
+              db_secret = f"{name}-db-app" if spec.get("dbNeeded") else None
+              env_from  = db_secret
 
               resource.update(
                   rsp.desired.resources["deployment"],
@@ -143,3 +161,10 @@ spec:
                   rsp.desired.resources["ingress"],
                   make_ingress(name, namespace, spec["host"]),
               )
+
+              if spec.get("dbNeeded"):
+                  resource.update(
+                      rsp.desired.resources["dbcluster"],
+                      make_cnpg_cluster(name, namespace,
+                                        instances=1, storage=spec.get("dbStorage", "1Gi")),
+                  )

--- a/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
+++ b/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
@@ -169,10 +169,19 @@ FUNCS="${ROOT}/functions.yaml"
 XR="${ROOT}/${CASE}.yaml"
 EXPECTED="${ROOT}/expected-${CASE}.yaml"
 
-ACTUAL="$(crossplane render "${XR}" "${COMPO}" "${FUNCS}" --extra-resources "${XRD}")"
+ACTUAL="$(crossplane render -x "${XR}" "${COMPO}" "${FUNCS}" --extra-resources "${XRD}")"
 
-# Normalize before diff (yq round-trip strips comments + sorts keys)
-diff <(yq -P 'sort_keys(..)' <<<"${ACTUAL}") <(yq -P 'sort_keys(..)' "${EXPECTED}")
+# Normalize both sides before diff:
+# - sort_by(.kind) makes document order deterministic (crossplane render emits
+#   composed resources alphabetically by kind, which differs from how a human
+#   typically orders the golden).
+# - del(.status) removes runtime-controller status (synthetic Ready=True the
+#   render emits on the XR) — we test composed children, not render-time status.
+# - del(.metadata.ownerReferences) and del(.metadata.labels."crossplane.io/composite")
+#   strip render-tooling plumbing crossplane render adds to composed resources.
+# - (... comments="") strips the file-header comments yq otherwise leaks through.
+NORMALIZE='[.] | sort_by(.kind) | .[] | (... comments="") | del(.status) | del(.metadata.ownerReferences) | del(.metadata.labels."crossplane.io/composite") | sort_keys(..)'
+diff <(yq ea -P "${NORMALIZE}" <<<"${ACTUAL}") <(yq ea -P "${NORMALIZE}" "${EXPECTED}")
 ```
 
 - [ ] **Step 3: Make it executable and add `tests/composition/README.md`**
@@ -817,21 +826,29 @@ spec:
               }
 
           def compose(req, rsp):
-              xr = req.observed.composite.resource
+              # struct_to_dict converts the protobuf Struct to a Python dict —
+              # raw req.observed.composite.resource doesn't support .get(), and
+              # int fields come back as floats (Struct stores numbers as doubles).
+              xr = resource.struct_to_dict(req.observed.composite.resource)
               spec = xr["spec"]
               name = xr["metadata"]["name"]
               namespace = xr["metadata"]["namespace"]
+
+              # Cast numeric fields back to int — K8s API server rejects
+              # containerPort: 8080.0 at apply time even though render accepts it.
+              port = int(spec["port"])
+              replicas = int(spec.get("replicas", 2))
 
               env_from = None  # no DB in this version of the script
 
               resource.update(
                   rsp.desired.resources["deployment"],
-                  make_deployment(name, namespace, spec["image"], spec["port"],
-                                  spec.get("replicas", 2), spec.get("env", []), env_from),
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []), env_from),
               )
               resource.update(
                   rsp.desired.resources["service"],
-                  make_service(name, namespace, spec["port"]),
+                  make_service(name, namespace, port),
               )
               resource.update(
                   rsp.desired.resources["ingress"],
@@ -1072,19 +1089,22 @@ b) Update `compose()` to use the DB. Note `make_cnpg_cluster(name, ...)` passes 
 
 ```python
 def compose(req, rsp):
-    xr = req.observed.composite.resource
+    xr = resource.struct_to_dict(req.observed.composite.resource)
     spec = xr["spec"]
     name = xr["metadata"]["name"]
     namespace = xr["metadata"]["namespace"]
+
+    port = int(spec["port"])
+    replicas = int(spec.get("replicas", 2))
 
     db_secret = f"{name}-db-app" if spec.get("dbNeeded") else None
     env_from  = db_secret
 
     resource.update(rsp.desired.resources["deployment"],
-        make_deployment(name, namespace, spec["image"], spec["port"],
-                        spec.get("replicas", 2), spec.get("env", []), env_from))
+        make_deployment(name, namespace, spec["image"], port,
+                        replicas, spec.get("env", []), env_from))
     resource.update(rsp.desired.resources["service"],
-        make_service(name, namespace, spec["port"]))
+        make_service(name, namespace, port))
     resource.update(rsp.desired.resources["ingress"],
         make_ingress(name, namespace, spec["host"]))
 

--- a/tests/composition/expected-xr-minimal.yaml
+++ b/tests/composition/expected-xr-minimal.yaml
@@ -12,8 +12,6 @@ spec:
   image: nginxinc/nginx-unprivileged:1.25-alpine
   port: 8080
   replicas: 1
-status:
-  conditions: []
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/composition/expected-xr-minimal.yaml
+++ b/tests/composition/expected-xr-minimal.yaml
@@ -1,0 +1,119 @@
+# tests/composition/expected-xr-minimal.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  dbNeeded: false
+  host: smoke-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+status:
+  conditions: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: deployment
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-app
+    backstage.io/kubernetes-id: smoke-app
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-app
+        backstage.io/kubernetes-id: smoke-app
+    spec:
+      containers:
+        - image: nginxinc/nginx-unprivileged:1.25-alpine
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          name: app
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      imagePullSecrets:
+        - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: service
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-app
+    backstage.io/kubernetes-id: smoke-app
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-app
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-app
+    backstage.io/kubernetes-id: smoke-app
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: smoke-app.arigsela.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: smoke-app
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - smoke-app.arigsela.com
+      secretName: smoke-app-tls

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -1,0 +1,148 @@
+# tests/composition/expected-xr-with-db.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-db-app
+  namespace: platform-smoke
+spec:
+  dbNeeded: true
+  dbStorage: 1Gi
+  host: smoke-db-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: deployment
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-db-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-db-app
+        backstage.io/kubernetes-id: smoke-db-app
+    spec:
+      containers:
+        - env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: uri
+                  name: smoke-db-app-db-app
+          envFrom:
+            - secretRef:
+                name: smoke-db-app-db-app
+          image: nginxinc/nginx-unprivileged:1.25-alpine
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          name: app
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      imagePullSecrets:
+        - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: service
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app
+  namespace: platform-smoke
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-db-app
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: smoke-db-app.arigsela.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: smoke-db-app
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - smoke-db-app.arigsela.com
+      secretName: smoke-db-app-tls
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: dbcluster
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app-db
+  namespace: platform-smoke
+spec:
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  storage:
+    size: 1Gi

--- a/tests/composition/render.sh
+++ b/tests/composition/render.sh
@@ -16,12 +16,15 @@ FUNCS="${ROOT}/functions.yaml"
 XR="${ROOT}/${CASE}.yaml"
 EXPECTED="${ROOT}/expected-${CASE}.yaml"
 
-ACTUAL="$(crossplane render "${XR}" "${COMPO}" "${FUNCS}" --extra-resources "${XRD}")"
+ACTUAL="$(crossplane render -x "${XR}" "${COMPO}" "${FUNCS}" --extra-resources "${XRD}")"
 
 # Normalize both sides before diff:
 # - sort_keys(..) makes key order deterministic (yq round-trip also strips comments).
 # - del(.status) removes runtime-controller status (e.g., the synthetic Ready=True
 #   condition `crossplane render` stamps on the XR). The test verifies Composition
 #   *output* (composed children), not render-time XR status.
-NORMALIZE='del(.status) | sort_keys(..)'
-diff <(yq -P "${NORMALIZE}" <<<"${ACTUAL}") <(yq -P "${NORMALIZE}" "${EXPECTED}")
+# - del(.metadata.ownerReferences) and the composite label removal strip render-tooling
+#   plumbing that crossplane render adds to composed resources. We assert what the
+#   Composition produces, not the runtime owner-ref wiring.
+NORMALIZE='[.] | sort_by(.kind) | .[] | (... comments="") | del(.status) | del(.metadata.ownerReferences) | del(.metadata.labels."crossplane.io/composite") | sort_keys(..)'
+diff <(yq ea -P "${NORMALIZE}" <<<"${ACTUAL}") <(yq ea -P "${NORMALIZE}" "${EXPECTED}")

--- a/tests/composition/render.sh
+++ b/tests/composition/render.sh
@@ -18,5 +18,10 @@ EXPECTED="${ROOT}/expected-${CASE}.yaml"
 
 ACTUAL="$(crossplane render "${XR}" "${COMPO}" "${FUNCS}" --extra-resources "${XRD}")"
 
-# Normalize before diff (yq round-trip strips comments + sorts keys)
-diff <(yq -P 'sort_keys(..)' <<<"${ACTUAL}") <(yq -P 'sort_keys(..)' "${EXPECTED}")
+# Normalize both sides before diff:
+# - sort_keys(..) makes key order deterministic (yq round-trip also strips comments).
+# - del(.status) removes runtime-controller status (e.g., the synthetic Ready=True
+#   condition `crossplane render` stamps on the XR). The test verifies Composition
+#   *output* (composed children), not render-time XR status.
+NORMALIZE='del(.status) | sort_keys(..)'
+diff <(yq -P "${NORMALIZE}" <<<"${ACTUAL}") <(yq -P "${NORMALIZE}" "${EXPECTED}")

--- a/tests/composition/xr-minimal.yaml
+++ b/tests/composition/xr-minimal.yaml
@@ -1,0 +1,13 @@
+# tests/composition/xr-minimal.yaml
+# TDD input: smallest meaningful XApplication, no DB.
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-app.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false

--- a/tests/composition/xr-with-db.yaml
+++ b/tests/composition/xr-with-db.yaml
@@ -1,0 +1,14 @@
+# tests/composition/xr-with-db.yaml
+# TDD input: XApplication with CNPG database enabled.
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-db-app
+  namespace: platform-smoke
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-db-app.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: true
+  dbStorage: 1Gi


### PR DESCRIPTION
## Summary

Second of four phases for the Backstage + Crossplane IDP `application-template`. This PR fills in the **Composition's Python script** under TDD against committed golden YAML, then validates against the live cluster via `kubectl apply --dry-run=server`.

What lands in cluster on merge:

- The `application` Composition (already deployed via Phase 1 #199, currently with an empty `pass` script) gets its real Python implementation: produces **Deployment + Service + Ingress** for any `XApplication`, plus an optional **CloudNativePG `Cluster`** when `spec.dbNeeded: true`.
- A new local TDD test harness (`tests/composition/render.sh`) plus two regression cases (`xr-minimal.yaml` no-DB; `xr-with-db.yaml` with-DB).

No new Argo CD apps. No new XRDs. No XRs are created in this PR — the Composition just gets ready to render when an XR shows up (Phase 3 ships the Backstage template that creates them).

## Spec & plan

- **Design:** `docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md`
- **Plan:** `docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md` (Phase 2 = Tasks 2.1–2.4)

Phase 1 PR #199 introduced the platform foundations (XRD, Function CR, ArgoCD apps) and is already merged.

## What the Composition produces

Given an `XApplication` like:

```yaml
apiVersion: platform.arigsela.com/v1alpha1
kind: XApplication
metadata:
  name: smoke-app
  namespace: platform-smoke
spec:
  image: nginx:1.25
  host: smoke-app.arigsela.com
  port: 8080
  replicas: 1
  dbNeeded: true       # optional
  dbStorage: "1Gi"     # optional, default "1Gi"
```

The Composition renders:

| Resource | Notes |
|---|---|
| `Deployment/<name>` | Standard labels, `imagePullSecrets: [ecr-auth]`, resource limits, `/healthz` probes. When `dbNeeded: true`, container also gets `envFrom: <name>-db-app` Secret + `DATABASE_URL` env var sourced from same Secret's `uri` key. |
| `Service/<name>` | ClusterIP, port 80 → targetPort `<port>` |
| `Ingress/<name>` | `nginx` ingress class, `cert-manager.io/cluster-issuer: letsencrypt-prod`, TLS secret `<name>-tls` |
| `postgresql.cnpg.io/Cluster/<name>-db` | Only when `dbNeeded: true`. PostgreSQL 16 (`ghcr.io/cloudnative-pg/postgresql:16`), `instances: 1`, `bootstrap.initdb {database: app, owner: app}`, `storage.size: <dbStorage>`. |

All composed resources carry standard labels: `app.kubernetes.io/name`, `app.kubernetes.io/managed-by: crossplane`, `backstage.io/kubernetes-id` — the last one wires the rendered workload to a Backstage entity page automatically once Phase 3 lands.

## Three real bugs caught during implementation (and fixed inline)

The plan as authored had three issues that only surfaced when the Python actually ran:

1. **`req.observed.composite.resource` is a protobuf `Struct`, not a dict** — `.get()` raises. Fix: `xr = resource.struct_to_dict(req.observed.composite.resource)`.
2. **Numeric XR fields come back as Python floats** — Struct stores numbers as doubles. K8s API server rejects `containerPort: 8080.0` at apply time. Fix: `port = int(spec["port"])`, `replicas = int(spec.get("replicas", 2))`.
3. **`crossplane render` requires `-x` to emit XR spec**, AND adds `metadata.ownerReferences` + `crossplane.io/composite` labels to composed resources, AND emits resources alphabetically by kind. The Task 2.1 harness's plain `yq sort_keys` diff missed all of this. Fix: richer NORMALIZE filter and `yq ea -P` for multi-document streams.

All three fixes shipped in this PR; the plan doc was updated retroactively to reflect them.

## TDD discipline

`tests/composition/` contains:
- `xr-minimal.yaml` + `expected-xr-minimal.yaml` — no-DB case; 3 composed children.
- `xr-with-db.yaml` + `expected-xr-with-db.yaml` — with-DB case; 4 composed children.
- `render.sh` — wraps `crossplane render`, normalizes both sides via `yq ea`, diffs.
- `functions.yaml` — `function-python:v0.4.0` reference for local renders.
- `README.md` — usage + how to regenerate goldens when the Composition intentionally changes.

Both `xr-minimal` and `xr-with-db` were committed as failing tests before the corresponding Python was added. Both currently exit 0 with empty diff against their goldens.

## Verification (post-merge)

```bash
# Composition is updated in cluster:
kubectl get composition application -o jsonpath='{.spec.pipeline[0].input.script}' | head -3
# Expected: starts with "from crossplane.function import resource"

# Composition apply still healthy:
kubectl -n argo-cd get application crossplane-compositions
# Expected: SYNC=Synced HEALTH=Healthy

# Local regression (post-clone, anywhere with crossplane CLI + Docker + yq):
./tests/composition/render.sh xr-minimal    # exit 0
./tests/composition/render.sh xr-with-db    # exit 0
```

Phase 2 does not deploy any XRs to cluster; the safest acceptance test is to confirm the existing `crossplane-compositions` Argo CD app stays healthy after the Composition's `script:` content swaps in.

## Out of scope (deferred to v2 per spec §10)

- AWS resources (S3, IAM) in the Composition
- Vault round-trip for DB credentials
- Source-code repo creation in the scaffolder template
- TeraSky/Roadie Crossplane Backstage plugin

## Test plan

- [ ] `./tests/composition/render.sh xr-minimal` exits 0 (already verified pre-PR).
- [ ] `./tests/composition/render.sh xr-with-db` exits 0 (already verified pre-PR).
- [ ] After merge, `crossplane-compositions` ArgoCD app stays Healthy + Synced.
- [ ] Phase 3 PR (Backstage template) opens against arigsela/backstage immediately after this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
