### PR TITLE
chore(backstage): bump image to v1.0.3

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.2
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.3
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
## Summary

Bumps deployed Backstage tag `v1.0.2 → v1.0.3` to pick up the `application-template` registration in `app-config.production.yaml` shipped via [arigsela/backstage#5](https://github.com/arigsela/backstage/pull/5) (already merged + image rebuilt).

## What flips on merge

- ArgoCD detects the change in `base-apps/backstage/deployments.yaml`, rolls the Backstage Deployment to `v1.0.3`.
- New pod loads the corrected production config; `Location` entity for `./examples/templates/application/template.yaml` registers; the catalog indexes the entity.
- `backstage.arigsela.com/create` shows three template cards: Example Node.js, CrewAI Multi-Agent Project, **Application (Crossplane)**.

## Test plan

- [ ] After ArgoCD reconciles, `kubectl -n backstage get pod -l app=backstage -o jsonpath='{.items[0].spec.containers[0].image}'` reports `...:v1.0.3`.
- [ ] Postgres `final_entities` table contains `template:default/application-template`.
- [ ] /create page shows the new card alongside the existing two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)