### PR TITLE
docs(plan): record catalog:register pitfall (companion to backstage#6)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
+++ b/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
@@ -1366,20 +1366,23 @@ spec:
           Database: ${{ parameters.dbNeeded }}
         targetPath: ""
 
-    - id: register
-      name: Register in catalog
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: /base-apps/${{ parameters.name }}/catalog-info.yaml
+  # NOTE: do NOT add a catalog:register step here. `publish:github:pull-request`
+  # does NOT emit a `repoContentsUrl` output (only the direct-push `publish:github`
+  # action does), so the obvious register input fails JSON-schema validation.
+  # Even with a working URL, registering pre-merge points the catalog at a feature
+  # branch that disappears after squash-merge → orphaned entity.
+  # The CrewAI sibling template uses the same publish:github:pull-request action
+  # and also omits catalog:register for this reason.
+  # Workflow: after the PR merges, the operator manually imports via
+  # /catalog-import using the URL:
+  #   https://github.com/arigsela/kubernetes/blob/main/base-apps/<name>/catalog-info.yaml
+  # Future improvement: extend the GitHub catalog provider to scan
+  # `base-apps/*/catalog-info.yaml` so registration becomes automatic.
 
   output:
     links:
       - title: Pull request
         url: ${{ steps.publish.output.remoteUrl }}
-      - title: Catalog entry
-        icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
 ```
 
 - [ ] **Step 3: Write `examples/templates/application/README.md`**


### PR DESCRIPTION
Updates Task 3.1 to drop the catalog:register step from the prescribed template, matching the actual fix in [arigsela/backstage#6](https://github.com/arigsela/backstage/pull/6). Includes a comment explaining the trade-off and the manual /catalog-import workflow.

Caught during Phase 4 e2e on PR #204 (helloapp scaffold) — the (correctly-opened) PR #204 is fine, only the trailing register step was broken in the template.

Plain docs change. Merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)