### PR TITLE
chore(backstage): bump image to v1.0.4

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.3
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
## Summary

Bumps deployed Backstage tag `v1.0.3 → v1.0.4` to pick up the `catalog:register` removal from [arigsela/backstage#6](https://github.com/arigsela/backstage/pull/6) (already merged + image rebuilt).

## What flips on merge

ArgoCD detects the change in `base-apps/backstage/deployments.yaml`, rolls the Backstage Deployment to `v1.0.4`. Future runs of the **Application (Crossplane)** template will complete all scaffolder steps green (no failing trailing register).

## Test plan

- [ ] After ArgoCD reconciles, `kubectl -n backstage get pod -l app=backstage -o jsonpath='{.items[0].spec.containers[0].image}'` reports `...:v1.0.4`.
- [ ] Re-running the wizard on a throwaway name (e.g. `smoketest1`) completes all steps without the catalog:register error.

## Note on PR #204

[arigsela/kubernetes#204](https://github.com/arigsela/kubernetes/pull/204) (the prior `scaffold/helloapp` PR opened by the v1.0.3 wizard run) is still open. Its diff is fine and merging it is independent of this image bump — the artifacts that landed in the PR were correctly rendered. Recommended order: (1) merge this v1.0.4 bump, (2) merge #204 to validate the cluster reconcile end-to-end, (3) we then manually import helloapp's catalog-info via /catalog-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)