### PR TITLE
fix(helloapp): exclude catalog-info.yaml from ArgoCD sync

### DIFF
--- a/base-apps/helloapp.yaml
+++ b/base-apps/helloapp.yaml
@@ -13,6 +13,12 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/helloapp
+    # catalog-info.yaml is a Backstage Component entity, not a Kubernetes
+    # resource. Backstage reads it directly from GitHub (via /catalog-import
+    # or auto-discovery). ArgoCD must skip it or sync fails with
+    # "no matches for kind Component in version backstage.io/v1alpha1".
+    directory:
+      exclude: 'catalog-info.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: helloapp


### PR DESCRIPTION
## The bug

ArgoCD app `helloapp` is `SyncFailed`:
```
The Kubernetes API could not find backstage.io/Component for requested resource
helloapp/helloapp. Make sure the Component CRD is installed on the destination
cluster.
```

`base-apps/helloapp/catalog-info.yaml` (scaffolder-generated) is a Backstage `Component` entity, not a Kubernetes resource. ArgoCD's directory source applies every YAML in the path → tries to apply the Component → fails because no such CRD exists.

## Fix

Add `directory.exclude: 'catalog-info.yaml'` on the helloapp Application's source. ArgoCD skips the file; Backstage still reads it directly from GitHub raw via /catalog-import.

Verified with `kubectl apply --dry-run=server` against the modified manifest.

## Companion fix (separate PR coming)

The Nunjucks `argocd-application.yaml` template in arigsela/backstage will get the same line so future scaffolds bake it in. Then v1.0.5 image rebuild + tag bump.

## After merge

ArgoCD reconciles → `XApplication/helloapp` lands → Composition renders Deployment/Service/Ingress in the `helloapp` namespace. Pod will probe-fail on `/healthz` (nginx-unprivileged doesn't serve that path — known limitation in v1; we still validate that the platform-side Composition + Crossplane reconcile work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)