### PR TITLE
fix(crossplane): grant Crossplane SA RBAC for Ingress + CNPG Cluster

### DIFF
--- a/base-apps/crossplane-compositions/composition-rbac.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac.yaml
@@ -1,0 +1,41 @@
+# base-apps/crossplane-compositions/composition-rbac.yaml
+# RBAC extension for the Crossplane controller's ServiceAccount.
+#
+# Why this exists:
+#   Crossplane v2 namespaced XRs use the controller's own SA
+#   (system:serviceaccount:crossplane-system:crossplane) to apply composed
+#   resources into target namespaces. The default `crossplane` ClusterRole
+#   shipped by the chart covers Deployments, Services, Secrets, ServiceAccounts,
+#   ConfigMaps — but NOT Ingresses or CNPG Clusters.
+#
+#   Without this extension, our `application` Composition fails to compose its
+#   Ingress child with:
+#     ingresses.networking.k8s.io is forbidden:
+#     User "system:serviceaccount:crossplane-system:crossplane" cannot patch
+#     resource "ingresses" in API group "networking.k8s.io" in the namespace ...
+#
+#   And the dbNeeded path would similarly fail on postgresql.cnpg.io/clusters.
+#
+# How it works:
+#   The `rbac.crossplane.io/aggregate-to-crossplane: "true"` label causes the
+#   Crossplane chart's rbac-manager to aggregate these rules into the active
+#   `crossplane` ClusterRole. No ClusterRoleBinding is needed — the existing
+#   binding to the `crossplane` SA picks up the aggregated rules automatically.
+#
+# Sync wave 1 ensures this lands alongside / before the Function (also wave 1)
+# and the Composition (wave 3) inside this ArgoCD app.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:compositions:application
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Why

Phase 4 e2e on helloapp surfaced a real platform bug. The Composition wants to render 3 children:

| Resource | Status |
|---|---|
| Deployment | ✅ Created |
| Service | ✅ Created |
| Ingress | ❌ **Forbidden** |

Crossplane events on `xapplication/helloapp`:
```
Warning  ComposeResources  cannot compose resources: cannot apply composed resource "ingress":
  ingresses.networking.k8s.io "helloapp" is forbidden: User
  "system:serviceaccount:crossplane-system:crossplane" cannot patch resource "ingresses"
  in API group "networking.k8s.io" in the namespace "helloapp"
```

## Root cause

In Crossplane v2 with **namespaced XRs**, the controller uses its own SA (`system:serviceaccount:crossplane-system:crossplane`) to apply composed resources into target namespaces. The default `crossplane` ClusterRole grants permission for Deployments, Services, Secrets, ServiceAccounts, ConfigMaps — but **not** `networking.k8s.io/Ingress`. The dbNeeded path will hit the same wall on `postgresql.cnpg.io/Cluster`.

## Fix

A new ClusterRole `crossplane:compositions:application` with the `rbac.crossplane.io/aggregate-to-crossplane: "true"` label. The chart's rbac-manager auto-aggregates these rules into the active `crossplane` ClusterRole — no new ClusterRoleBinding needed.

Grants on:
- `networking.k8s.io/Ingress` (verbs: get/list/watch/create/update/patch/delete)
- `postgresql.cnpg.io/Cluster` (same verbs; pre-empts the with-DB issue before it bites)

Server dry-run validates against the cluster.

## After merge

ArgoCD applies the new ClusterRole → rbac-manager aggregates → Crossplane retries the helloapp XApplication on its next reconcile loop → Ingress appears in the helloapp namespace.

## Plan-doc backport coming

This was an undocumented gap in the plan's Phase 1 platform setup. Will backport once we've verified the fix works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)