### PR TITLE
docs: backport Phase 4 lessons + run notes for IDP v1 close-out

### DIFF
--- a/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
+++ b/docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md
@@ -484,6 +484,54 @@ spec:
 ```bash
 git add base-apps/crossplane-functions.yaml base-apps/crossplane-compositions.yaml
 git commit -m "feat(crossplane): wire ArgoCD apps for functions + compositions"
+```
+
+(Don't push yet — Task 1.5b adds one more file before the Phase 1 PR opens.)
+
+### Task 1.5b — RBAC ClusterRole for the Crossplane SA
+
+**Files:**
+- Create: `base-apps/crossplane-compositions/composition-rbac.yaml`
+
+> **Why this exists:** Crossplane v2 namespaced XRs use the controller's own ServiceAccount (`system:serviceaccount:crossplane-system:crossplane`) to apply composed resources into target namespaces. The default `crossplane` ClusterRole grants permissions for Deployments, Services, Secrets, ServiceAccounts, ConfigMaps — but **not** `networking.k8s.io/Ingress` or `postgresql.cnpg.io/Cluster`. Without this extension, our Composition produces Ingress-less workloads and the with-DB path fails on `forbidden: cannot patch resource "ingresses"`. **The first run of this plan missed this entirely** — the gap was caught during Phase 4 e2e on the first real workload.
+
+- [ ] **Step 1: Create `base-apps/crossplane-compositions/composition-rbac.yaml`**
+
+```yaml
+# base-apps/crossplane-compositions/composition-rbac.yaml
+# RBAC extension for the Crossplane controller's ServiceAccount.
+# The aggregate label causes the chart's rbac-manager to roll these rules
+# into the active `crossplane` ClusterRole automatically — no
+# ClusterRoleBinding needed.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:compositions:application
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+kubectl apply --dry-run=server -f base-apps/crossplane-compositions/composition-rbac.yaml
+# Expected: clusterrole.rbac.authorization.k8s.io/crossplane:compositions:application created (server dry run)
+```
+
+- [ ] **Step 3: Commit + push + open Phase 1 PR**
+
+```bash
+git add base-apps/crossplane-compositions/composition-rbac.yaml
+git commit -m "feat(crossplane): grant Crossplane SA RBAC for Ingress + CNPG Cluster"
 git push -u origin feat/crossplane-idp-application-template
 ```
 
@@ -523,6 +571,16 @@ kubectl get composition application
 kubectl explain xapplication.spec
 # Expected: lists fields image, host, port, replicas, env, dbNeeded, dbStorage
 ```
+
+- [ ] **Step 5: Confirm RBAC aggregation worked**
+
+```bash
+kubectl get clusterrole crossplane -o yaml | grep -B1 -A2 'ingresses\|cnpg.io'
+# Expected: shows the ingresses + postgresql.cnpg.io/clusters rules with verbs
+#           get/list/watch/create/update/patch/delete
+```
+
+If this is empty, the aggregate label on `crossplane:compositions:application` didn't take. Check that ClusterRole's labels.
 
 If any check fails — halt, inspect ArgoCD sync logs and Crossplane events, fix forward, do not start Phase 2.
 
@@ -1901,3 +1959,56 @@ Plan complete and saved to `docs/superpowers/plans/2026-04-28-backstage-crosspla
 **2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
 
 Which approach?
+
+---
+
+## Run Notes (2026-04-28 / 2026-04-29 execution)
+
+**Outcome:** v1 of the IDP shipped. Backstage `Application (Crossplane)` template lives at `examples/templates/application/` in `arigsela/backstage`; the `XApplication` XRD + `Application` Composition + `function-python` install + RBAC ClusterRole all live in `arigsela/kubernetes` under `base-apps/crossplane-{functions,compositions}/`.
+
+**End-to-end smoke** (`helloapp`, no DB):
+- ✅ Backstage form → PR `scaffold/helloapp` opened against `arigsela/kubernetes`
+- ✅ Master-app picked up `base-apps/helloapp.yaml` post-merge
+- ✅ Crossplane reconciled `XApplication/helloapp` via `Composition/application`
+- ✅ Composed Deployment + Service + Ingress all rendered with correct labels/ports/host
+- ✅ cert-manager autonomously started ACME flow on the Ingress
+- ⚠️ Pod `0/1 Ready` — `nginxinc/nginx-unprivileged` returns 404 on `/healthz` (the Composition's hardcoded probe path). Platform-side wire fully validated; the runtime probe issue is the known v1 contract limitation flagged in spec §6 (E).
+
+**Bugs caught during execution and fixed before v1 shipped:**
+
+| # | Bug | Where caught | Fix shipped in |
+|---|---|---|---|
+| 1 | Test golden filenames inconsistent with `render.sh` `${CASE}` derivation | Task 1.1 code review | initial commit on Phase 1 branch |
+| 2 | `apiextensions.crossplane.io/v2alpha1` doesn't exist; cluster serves stable `v2` | Task 1.2 cluster dry-run | `arigsela/kubernetes` on Phase 1 branch + spec/plan backport |
+| 3 | `req.observed.composite.resource` is a protobuf Struct, not a dict; `.get()` raises | Task 2.2 implementer | Composition Python on Phase 2 branch + spec/plan backport |
+| 4 | XR `port` and `replicas` come back as Python floats from struct → K8s rejects `containerPort: 8080.0` at apply time | Task 2.2 code review | Composition Python on Phase 2 branch + spec/plan backport |
+| 5 | `crossplane render` needs `-x`; ownerRefs + `crossplane.io/composite` label leak into output | Task 2.2 implementer | `tests/composition/render.sh` on Phase 2 branch + plan backport |
+| 6 | Backstage `app-config.production.yaml` overlay replaces the base `catalog.locations` array; the new template entry was silently dropped | Phase 4 e2e (template missing from UI) | [arigsela/backstage#5](https://github.com/arigsela/backstage/pull/5) + [kubernetes#202](https://github.com/arigsela/kubernetes/pull/202) plan backport |
+| 7 | Scaffolder `catalog:register` step references `repoContentsUrl` — output does NOT exist on `publish:github:pull-request` (only on direct-push `publish:github`) | Phase 4 e2e (Run of Application failed at step 3/3) | [arigsela/backstage#6](https://github.com/arigsela/backstage/pull/6) + [kubernetes#205](https://github.com/arigsela/kubernetes/pull/205) plan backport |
+| 8 | Scaffolder writes `catalog-info.yaml` (Backstage Component, not a CRD) into a directory ArgoCD scans → `no matches for kind Component` | Phase 4 e2e (helloapp ArgoCD app SyncFailed) | [kubernetes#207](https://github.com/arigsela/kubernetes/pull/207) (existing app fix) + [arigsela/backstage#7](https://github.com/arigsela/backstage/pull/7) (template fix) |
+| 9 | Crossplane SA missing RBAC for `networking.k8s.io/Ingress` and `postgresql.cnpg.io/Cluster` — Composition could compose Deployment + Service but not Ingress | Phase 4 e2e (Crossplane `ComposeResources` warning event) | [kubernetes#208](https://github.com/arigsela/kubernetes/pull/208) (Task 1.5b in plan) + spec §4 row 9 |
+
+**Final PR sequence (`arigsela/kubernetes`):**
+- #199 — Phase 1 platform foundations
+- #200 — Phase 2 Composition Python
+- #202 — plan backport: app-config.production.yaml gotcha
+- #203 — Backstage v1.0.3 tag bump (post-PR-fix-merge)
+- #204 — `scaffold/helloapp` (real e2e onboarding via the wizard)
+- #205 — plan backport: catalog:register removal
+- #206 — Backstage v1.0.4 tag bump
+- #207 — helloapp directory.exclude fix
+- #208 — Crossplane SA RBAC ClusterRole
+- #209 — helloapp teardown
+- (this PR) — final spec/plan backport + Phase 4 run notes
+
+**Decommission gotcha noted in spec §8:** when master-app prunes a per-app ArgoCD Application, the XApplication and its composed children are orphaned (the Application that managed them is gone before the prune cascade reaps them). Reliable decommission flow is `kubectl delete xapplication` first, *then* PR-delete the directory.
+
+**v2 follow-up candidates** (open thread for next IDP iteration):
+
+1. AWS resources in the Composition (S3 + IAM via the Upbound providers already installed). Spec §10 row 1.
+2. Vault round-trip for DB credentials. Spec §10 row 2.
+3. Source-code repo creation in the scaffolder (lean on existing `aws:ecr:create` + `aws:ecr:build-push` actions). Spec §10 row 3.
+4. **`healthCheckPath` as an XR field** (default `/healthz`). Eliminates the v1 nginx-unprivileged probe trap.
+5. **Auto-discovery of `base-apps/*/catalog-info.yaml`** in the Backstage GitHub provider — replaces the manual `/catalog-import` step.
+6. TeraSky/Roadie Crossplane Backstage plugin for live XR/managed-resource graph on the entity page. Spec §10 row 4.
+7. Decommission scaffolder template (calls `kubectl delete xapplication` and opens the teardown PR in one shot). Spec §10 row 5.

--- a/docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md
+++ b/docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md
@@ -71,10 +71,11 @@ Give a developer a self-service path from "I have a container image" to "my app 
 | 4 | Two new Argo CD parent apps | `arigsela/kubernetes` | `base-apps/crossplane-functions.yaml`, `base-apps/crossplane-compositions.yaml` | Picked up by master-app. Sync waves: function = `1`, composition = `2`. |
 | 5 | Backstage `Template` | `arigsela/backstage` | `examples/templates/application/template.yaml` | Form definition + scaffolder steps. |
 | 6 | Template content | `arigsela/backstage` | `examples/templates/application/content-k8s/` | Three Nunjucks-templated files: `catalog-info.yaml`, `application-xr.yaml`, `argocd-application.yaml`. |
-| 7 | `app-config.yaml` change | `arigsela/backstage` | `app-config.yaml` | One new `catalog.locations` entry for the new template. |
+| 7 | `app-config.yaml` AND `app-config.production.yaml` changes | `arigsela/backstage` | `app-config.yaml` + `app-config.production.yaml` | One new `catalog.locations` entry in **both** files. Production overlay replaces (not merges) the array; missing it in production silently drops the entry. |
 | 8 | Image rebuild + tag bump | `arigsela/backstage` (build) → `arigsela/kubernetes` (deploy) | `base-apps/backstage/deployments.yaml` | Bump `backstage-portal` tag (e.g. `v1.0.1` → `v1.1.0`). |
+| 9 | RBAC ClusterRole for the Crossplane SA | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-rbac.yaml` | Aggregates `networking.k8s.io/Ingress` + `postgresql.cnpg.io/Cluster` permissions into the `crossplane` ClusterRole via the `rbac.crossplane.io/aggregate-to-crossplane: "true"` label. Without this, Crossplane fails to compose Ingress (and the with-DB CNPG Cluster) into target namespaces. |
 
-**Sync ordering:** the per-app Argo CD Application (`base-apps/<name>.yaml`) carries `argocd.argoproj.io/sync-wave: "10"` so on a cold cluster the XRD/Composition/Function land before any XR.
+**Sync ordering:** the per-app Argo CD Application (`base-apps/<name>.yaml`) carries `argocd.argoproj.io/sync-wave: "10"` so on a cold cluster the XRD/Composition/Function land before any XR. The RBAC ClusterRole carries sync-wave `"1"` to land alongside the Function.
 
 ## 5. The `XApplication` XRD (developer-facing API)
 
@@ -205,6 +206,8 @@ App authors get individual fields (`username`, `password`, `host`, `port`, `dbna
 - `app.kubernetes.io/managed-by: crossplane`
 - `backstage.io/kubernetes-id: <name>` (so the Backstage Kubernetes plugin auto-discovers the workload on the entity page)
 
+**(E) Health probe path is hardcoded to `/healthz` — known v1 limitation.** Both `livenessProbe` and `readinessProbe` use `httpGet { path: /healthz, port: <spec.port> }`. Onboarded apps must serve HTTP 200 on `/healthz` or their Pods will CrashLoopBackOff (the platform pieces — XApplication, Composition, ArgoCD, cert-manager — still reconcile correctly; only the Pod readiness fails). v2 follow-up: expose `healthCheckPath` as an optional XR field with `/healthz` default.
+
 ## 7. The Backstage Template
 
 **File:** `arigsela/backstage:examples/templates/application/template.yaml`
@@ -263,35 +266,33 @@ spec:
         branchName: scaffold/${{ parameters.name }}
         title: "feat(${{ parameters.name }}): onboard via Crossplane Application"
         targetPath: ""
-    - id: register
-      name: Register in catalog
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: /base-apps/${{ parameters.name }}/catalog-info.yaml
+  # NOTE: no catalog:register step. publish:github:pull-request does NOT emit a
+  # repoContentsUrl output (only the direct-push publish:github does), and there
+  # is no clean URL to register pre-merge anyway. After PR merge the operator
+  # imports manually via /catalog-import. v2 follow-up: extend the Backstage
+  # GitHub provider to scan base-apps/*/catalog-info.yaml directly.
   output:
     links:
       - title: Pull request
         url: ${{ steps.publish.output.remoteUrl }}
-      - title: Catalog entry
-        icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
 ```
 
-**Content directory:** `examples/templates/application/content-k8s/`
+**Content directory:** `examples/templates/application/content-k8s/`. Source paths embed `${{ values.name }}` so `fetch:template` writes the rendered files to the correct destinations without an explicit move step:
 
 ```
 content-k8s/
-├── catalog-info.yaml          → base-apps/<name>/catalog-info.yaml
-├── application-xr.yaml        → base-apps/<name>/application-xr.yaml
-└── argocd-application.yaml    → base-apps/<name>.yaml          (top-level, picked up by master-app)
+└── base-apps/
+    ├── ${{ values.name }}.yaml                            → base-apps/<name>.yaml
+    └── ${{ values.name }}/
+        ├── catalog-info.yaml                              → base-apps/<name>/catalog-info.yaml
+        └── application-xr.yaml                            → base-apps/<name>/application-xr.yaml
 ```
 
-**`catalog-info.yaml`** — `kind: Component` with `metadata.name: <name>`, `spec.owner: <owner>`, `spec.type: service`, and annotations `github.com/project-slug: arigsela/kubernetes` + `backstage.io/kubernetes-id: <name>` (matches the Composition-stamped label).
+**`catalog-info.yaml`** — `kind: Component` with `metadata.name: <name>`, `spec.owner: <owner>`, `spec.type: service`, and annotations `github.com/project-slug: arigsela/kubernetes` + `backstage.io/kubernetes-id: <name>` (matches the Composition-stamped label). The `description` field is rendered via `${{ (values.description | default("...", true)) | dump }}` so user-supplied strings containing `:`, `"`, or `#` can't break YAML parsing.
 
 **`application-xr.yaml`** — the `XApplication` CR with the form values substituted.
 
-**`argocd-application.yaml`** — vanilla Argo CD `Application` with `spec.source.path: base-apps/<name>` and `argocd.argoproj.io/sync-wave: "10"`.
+**`argocd-application.yaml`** — vanilla Argo CD `Application` with `spec.source.path: base-apps/<name>`, `argocd.argoproj.io/sync-wave: "10"`, and **`spec.source.directory.exclude: 'catalog-info.yaml'`** (Backstage Component entity is not a Kubernetes resource — without the exclude, ArgoCD's directory source tries to apply it and fails with "no matches for kind Component in version backstage.io/v1alpha1").
 
 **`namespace == name`** (computed, not asked) for v1.
 
@@ -313,7 +314,17 @@ content-k8s/
 1. **No retries inside the Composition.** Crossplane reconciles again on the next loop; the Python script is deterministic given the XR.
 2. **Failures upstream of Crossplane are someone else's concern.** Image, cert-manager, cluster-storage failures are not platform-team triage paths.
 
-**Decommissioning in v1 is manual via PR:** developer opens a PR removing `base-apps/<name>/` and `base-apps/<name>.yaml`; Argo CD `prune` reaps the XR; Crossplane owner-references reap the rendered children; CNPG `Cluster` deletion does not auto-delete its PVC (CNPG default), so the PV remains until manually cleaned.
+**Decommissioning in v1 — manual three-step:**
+
+1. **Delete the XApplication first** (`kubectl -n <ns> delete xapplication <name>`). Crossplane's owner-references then reap the composed Deployment/Service/Ingress/Cluster cleanly. cert-manager's `Certificate` and ACME solver objects (children of the Ingress) GC along with it.
+2. **Open a PR removing `base-apps/<name>.yaml` + `base-apps/<name>/`.** Master-app prunes the per-app Argo CD Application; the now-empty source directory simply disappears.
+3. **`kubectl delete ns <name>`** — the namespace was created by `CreateNamespace=true` on the per-app Application; ArgoCD does NOT auto-delete it on Application removal.
+
+**Why delete the XApplication first** rather than just rely on ArgoCD's prune cascade: when master-app prunes the per-app Application, the XApplication and its composed children become orphaned (the Application that managed them is gone before the prune cascade reaps them). Deleting the XApplication explicitly first triggers Crossplane's owner-ref cascade synchronously.
+
+**CNPG PVC retention:** `Cluster` deletion does NOT auto-delete its PVC (CNPG default). When decommissioning a `dbNeeded: true` app, also clean up the PVC manually if you don't want to retain the data.
+
+**Backstage catalog Location cleanup:** if you registered the app via `/catalog-import`, that Location entity needs to be unregistered manually after PR merge — otherwise Backstage's refresh perpetually fails to fetch the deleted catalog-info.yaml URL.
 
 ## 9. Testing strategy
 


### PR DESCRIPTION
## Summary

Final docs commit for IDP v1. Updates the spec + plan so future re-execution starts from a corrected baseline that matches what actually shipped.

## Spec changes

- **§4 Components row 7 expanded** — calls out that BOTH `app-config.yaml` and `app-config.production.yaml` need the new `catalog.locations` entry (production overlay replaces the array, doesn't merge).
- **§4 Components NEW row 9** — RBAC ClusterRole for the Crossplane SA. This was a Phase 1 platform requirement we missed entirely on first run; caught only when the first real workload tried to compose an Ingress.
- **§6 NEW shape decision (E)** — flag the hardcoded `/healthz` probe path as a known v1 limitation; `healthCheckPath` as a v2 XR field.
- **§7 rewritten** — removed broken `catalog:register` step; corrected content directory layout to show the `${{ values.name }}`-embedded source paths; called out the `directory.exclude` and `| dump` requirements.
- **§8 decommissioning flow** — now describes the actual three-step sequence with the master-app orphan-cascade rationale and Backstage Location cleanup.

## Plan changes

- **NEW Task 1.5b** — RBAC ClusterRole for Crossplane SA, between Task 1.5 (PR open) and Task 1.6 (verify).
- **Task 1.6 Step 5** — verification grep for the aggregated ingresses/cnpg.io rules.
- **NEW Run Notes section** — outcome summary, e2e validation results, all 9 bugs caught (with fix PR links), final PR sequence, decommission gotcha, and 7 v2 follow-up candidates seeded for the next IDP iteration.

## What's NOT in this PR

Code changes — only docs. The actual fixes already shipped via the prior PRs (#199–#209 + the backstage repo PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)