### PR TITLE
Phase 1 (v1.1): Composition annotations + Backstage Crossplane RBAC

### DIFF
--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -56,3 +56,52 @@ roleRef:
   kind: ClusterRole
   name: backstage-read-only
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-crossplane-read
+rules:
+  # Crossplane core APIs — XRDs, Compositions, Functions, Operations
+  - apiGroups: ["apiextensions.crossplane.io"]
+    resources: ["compositeresourcedefinitions", "compositions", "compositionrevisions", "functions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["pkg.crossplane.io"]
+    resources: ["providers", "providerrevisions", "configurations", "configurationrevisions", "functions", "functionrevisions"]
+    verbs: ["get", "list", "watch"]
+
+  # Our own platform XR API + any future namespaced/cluster XRs we add
+  - apiGroups: ["platform.arigsela.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Managed resource APIs — what XRs compose into. The kubernetes-ingestor
+  # walks the compositionRevision's resources to find these.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "poolers", "backups", "scheduledbackups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["s3.aws.upbound.io", "iam.aws.upbound.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Crossplane internal status resources used by the resources plugin's graph
+  - apiGroups: ["protection.crossplane.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-crossplane-read
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+roleRef:
+  kind: ClusterRole
+  name: backstage-crossplane-read
+  apiGroup: rbac.authorization.k8s.io

--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -35,7 +35,18 @@ spec:
               labels["backstage.io/kubernetes-id"] = name
               return labels
 
-          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret):
+          TERASKY_ANNOTATION_PREFIXES = ("terasky.backstage.io/", "backstage.io/")
+
+          def std_annotations(xr_annotations, resource_name):
+              """Copy TeraSky/Backstage annotations from the XR + add per-resource name."""
+              copied = {
+                  k: v for k, v in (xr_annotations or {}).items()
+                  if k.startswith(TERASKY_ANNOTATION_PREFIXES)
+              }
+              copied["crossplane.io/composition-resource-name"] = resource_name
+              return copied
+
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations):
               container = {
                   "name": "app",
                   "image": image,
@@ -64,7 +75,12 @@ spec:
               return {
                   "apiVersion": "apps/v1",
                   "kind": "Deployment",
-                  "metadata": {"name": name, "namespace": namespace, "labels": std_labels(name)},
+                  "metadata": {
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
                   "spec": {
                       "replicas": replicas,
                       "selector": {"matchLabels": {"app.kubernetes.io/name": name}},
@@ -78,11 +94,16 @@ spec:
                   },
               }
 
-          def make_service(name, namespace, port):
+          def make_service(name, namespace, port, annotations):
               return {
                   "apiVersion": "v1",
                   "kind": "Service",
-                  "metadata": {"name": name, "namespace": namespace, "labels": std_labels(name)},
+                  "metadata": {
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
                   "spec": {
                       "type": "ClusterIP",
                       "selector": {"app.kubernetes.io/name": name},
@@ -90,17 +111,21 @@ spec:
                   },
               }
 
-          def make_ingress(name, namespace, host):
+          def make_ingress(name, namespace, host, annotations):
+              base_annotations = {
+                  "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+                  "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                  "nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+              }
+              merged_annotations = {**base_annotations, **annotations}
               return {
                   "apiVersion": "networking.k8s.io/v1",
                   "kind": "Ingress",
                   "metadata": {
-                      "name": name, "namespace": namespace, "labels": std_labels(name),
-                      "annotations": {
-                          "cert-manager.io/cluster-issuer": "letsencrypt-prod",
-                          "nginx.ingress.kubernetes.io/ssl-redirect": "true",
-                          "nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
-                      },
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": merged_annotations,
                   },
                   "spec": {
                       "ingressClassName": "nginx",
@@ -115,7 +140,7 @@ spec:
                   },
               }
 
-          def make_cnpg_cluster(parent_name, namespace, instances, storage):
+          def make_cnpg_cluster(parent_name, namespace, instances, storage, annotations):
               return {
                   "apiVersion": "postgresql.cnpg.io/v1",
                   "kind": "Cluster",
@@ -123,6 +148,7 @@ spec:
                       "name": f"{parent_name}-db",
                       "namespace": namespace,
                       "labels": std_labels(parent_name),
+                      "annotations": annotations,
                   },
                   "spec": {
                       "instances": instances,
@@ -137,6 +163,7 @@ spec:
               spec = xr["spec"]
               name = xr["metadata"]["name"]
               namespace = xr["metadata"]["namespace"]
+              xr_annotations = xr["metadata"].get("annotations", {})
 
               # Integers from a protobuf Struct round-trip as Python floats
               # (Struct's number_value is a double). Cast at the boundary so
@@ -151,20 +178,24 @@ spec:
               resource.update(
                   rsp.desired.resources["deployment"],
                   make_deployment(name, namespace, spec["image"], port,
-                                  replicas, spec.get("env", []), env_from),
+                                  replicas, spec.get("env", []), env_from,
+                                  annotations=std_annotations(xr_annotations, "deployment")),
               )
               resource.update(
                   rsp.desired.resources["service"],
-                  make_service(name, namespace, port),
+                  make_service(name, namespace, port,
+                               annotations=std_annotations(xr_annotations, "service")),
               )
               resource.update(
                   rsp.desired.resources["ingress"],
-                  make_ingress(name, namespace, spec["host"]),
+                  make_ingress(name, namespace, spec["host"],
+                               annotations=std_annotations(xr_annotations, "ingress")),
               )
 
               if spec.get("dbNeeded"):
                   resource.update(
                       rsp.desired.resources["dbcluster"],
                       make_cnpg_cluster(name, namespace,
-                                        instances=1, storage=spec.get("dbStorage", "1Gi")),
+                                        instances=1, storage=spec.get("dbStorage", "1Gi"),
+                                        annotations=std_annotations(xr_annotations, "dbcluster")),
                   )

--- a/docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md
+++ b/docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md
@@ -1,0 +1,1510 @@
+# IDP v1.1 — TeraSky Crossplane Plugins + Auto-Ingestion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace IDP v1's manual `/catalog-import` workflow with auto-ingestion of Crossplane XRs as Backstage catalog entities, install live XR/managed-resource visualization on entity pages, and add scaffolder-driven update of existing XRs through a Backstage form.
+
+**Architecture:** Three TeraSky NPM plugins added to the Backstage source repo (kubernetes-ingestor for auto-ingestion + crossplane-resources for graph view + scaffolder-backend-module-terasky-utils for claim-updater). One new ClusterRole + binding gives the Backstage SA cluster-wide read on Crossplane API groups. Composition Python emits `terasky.backstage.io/*` annotations from the XR onto every composed child so the ingestor finds them. Scaffolder content drops the `catalog-info.yaml` Nunjucks file (auto-ingestion replaces it) and the `directory.exclude` line that became unnecessary.
+
+**Tech Stack:** TeraSky Backstage plugins (NPM), Backstage v1.48.0, Crossplane v2.2.1, function-python:v0.4.0, ArgoCD (GitOps), kubectl, GitHub MCP / `gh` CLI.
+
+**Source spec:** `docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md` (commit `8f6e38a`).
+
+**Repos touched:**
+- `arigsela/kubernetes` — Composition annotation flow, RBAC ClusterRole, image tag bump, plan run notes.
+- `arigsela/backstage` — plugin NPM install, plugin registration, app-config sections, scaffolder content cleanup.
+
+**Image rebuild is user-owned** per CLAUDE.md. The plan stops at "build me an image with these changes" handoff (Phase 3, Task 3.1).
+
+---
+
+## File Map
+
+### `arigsela/kubernetes` (this repo)
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `tests/composition/expected-xr-minimal.yaml` | Modify | Add 6 TeraSky/Backstage annotations on every child resource |
+| `tests/composition/expected-xr-with-db.yaml` | Modify | Same annotations on the 4th child (CNPG `Cluster`) too |
+| `base-apps/crossplane-compositions/composition-application.yaml` | Modify | New `std_annotations()` helper; thread `annotations=` through `make_*` helpers; `compose()` reads `xr.metadata.annotations` |
+| `base-apps/backstage/rbac.yaml` | Modify | Append `ClusterRole/backstage-crossplane-read` + `ClusterRoleBinding/backstage-crossplane-read` (existing `backstage-read-only` untouched) |
+| `base-apps/backstage/deployments.yaml:27` | Modify (Phase 3) | Bump `backstage-portal` image tag (e.g. `v1.0.4 → v1.1.0`) once the user produces the new image |
+
+### `arigsela/backstage` (cloned at `docs/reference/backstage/`)
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `packages/backend/package.json` | Modify | Add 3 backend NPM deps: `@terasky/backstage-plugin-kubernetes-ingestor`, `@terasky/backstage-plugin-crossplane-resources-backend`, `@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils` |
+| `packages/app/package.json` | Modify | Add 1 frontend NPM dep: `@terasky/backstage-plugin-crossplane-resources-frontend` |
+| `packages/backend/src/index.ts` | Modify | `backend.add(import('...'))` for the three backend plugins |
+| `packages/app/src/App.tsx` | Modify | Wire the `crossplane-resources` entity-page tab |
+| `packages/app/src/components/catalog/EntityPage.tsx` | Modify | Add the Crossplane Resources tab to `serviceEntityPage` |
+| `app-config.yaml` | Modify | New `kubernetesIngestor:`, `crossplane:`, and `scaffolder:` sections (per TeraSky docs) |
+| `app-config.production.yaml` | Modify | **Same** new sections — production overlay replaces (not merges) per IDP v1 lesson |
+| `examples/templates/application/content-k8s/base-apps/${{ values.name }}/catalog-info.yaml` | **Delete** | Auto-ingestion replaces this file |
+| `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml` | Modify | Remove `directory.exclude: 'catalog-info.yaml'` block (file no longer generated) |
+| `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | Modify | Add `metadata.annotations` block carrying `terasky.backstage.io/*` + `backstage.io/source-location` |
+| `examples/templates/application/template.yaml` | Modify | Drop the `description` form field (TeraSky derives it from XRD schema by default per spec §6) |
+
+---
+
+## Pre-flight (run once before Task 1.1)
+
+### P.1 — CLI prerequisites still valid from v1
+
+```bash
+crossplane version --client    # any modern release
+docker info >/dev/null && echo "docker ok"
+yq --version                    # v4
+gh --version                    # GitHub CLI for PR ops
+```
+
+### P.2 — Cluster access + v1 platform healthy
+
+```bash
+kubectl config current-context
+kubectl -n crossplane-system get deploy crossplane -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+# Expected: ...crossplane:v2.2.1
+
+kubectl get composition application -o jsonpath='{.metadata.name}{"\n"}'
+# Expected: application
+
+kubectl get clusterrole backstage-read-only -o jsonpath='{.metadata.name}{"\n"}'
+# Expected: backstage-read-only (the v1 ClusterRole that this plan does NOT modify)
+
+kubectl get clusterrole crossplane:compositions:application -o jsonpath='{.metadata.name}{"\n"}'
+# Expected: crossplane:compositions:application (v1 RBAC fix from PR #208)
+```
+
+### P.3 — Backstage repo clone is up to date
+
+```bash
+cd /Users/arisela/git/kubernetes/docs/reference/backstage
+git status --short          # clean (only pre-existing noise)
+git checkout main && git pull origin main
+git log --oneline -5
+# Expected: latest is the v1.1's prior PR (e.g. v1 cleanup), nothing diverged
+cd /Users/arisela/git/kubernetes
+```
+
+### P.4 — Branch strategy
+
+This plan opens **two PRs against `arigsela/kubernetes`** (Phase 1 + Phase 3 tag bump) and **one PR against `arigsela/backstage`** (Phase 2). Each phase gets its own branch:
+
+- `feat/idp-v1.1-composition-annotations` (Phase 1, kubernetes repo)
+- `feat/idp-v1.1-terasky-plugins` (Phase 2, Backstage repo)
+- `chore/backstage-v1.1.0` (Phase 3, kubernetes repo, post-image-build)
+
+### P.5 — Pin TeraSky plugin versions
+
+The TeraSky plugins are at <https://www.npmjs.com/~terasky>. Versions evolve. Visit the npm registry or the [TeraSky GitHub org](https://github.com/TeraSky-OSS) at plan-execution time and pin to the latest stable version of each:
+
+```bash
+# Quick lookup (no install):
+npm view @terasky/backstage-plugin-kubernetes-ingestor version
+npm view @terasky/backstage-plugin-crossplane-resources-backend version
+npm view @terasky/backstage-plugin-crossplane-resources-frontend version
+npm view @terasky/backstage-plugin-scaffolder-backend-module-terasky-utils version
+```
+
+Record the four versions in your worktree notes. Throughout this plan, `<INGESTOR_VER>`, `<XPRES_BACK_VER>`, `<XPRES_FRONT_VER>`, `<SCAF_UTILS_VER>` placeholders mean "the version you just looked up." If TeraSky publishes a v2 with breaking changes after this plan was written, halt and reassess scope.
+
+---
+
+## Phase 1 — kubernetes repo: RBAC + Composition annotations (TDD)
+
+**What this phase delivers:** New `backstage-crossplane-read` ClusterRole + binding live in cluster; Composition Python copies XR-supplied TeraSky annotations onto every composed child; both render-test goldens updated and green.
+
+**Phase 1 exit criteria:**
+- `kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage` → `yes`
+- `./tests/composition/render.sh xr-minimal` exits 0 with empty diff
+- `./tests/composition/render.sh xr-with-db` exits 0 with empty diff
+- `kubectl get clusterrolebinding backstage-crossplane-read -o yaml` shows binding to `backstage:backstage`
+
+### Task 1.1 — Update render-test goldens (TDD red)
+
+**Files:**
+- Modify: `tests/composition/expected-xr-minimal.yaml`
+- Modify: `tests/composition/expected-xr-with-db.yaml`
+
+> Write failing goldens FIRST. The Composition Python doesn't emit annotations yet; render output won't have them; diff fails. That's the red state Task 1.2 turns green.
+
+- [ ] **Step 1: Create the feature branch**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git checkout main && git pull origin main
+git checkout -b feat/idp-v1.1-composition-annotations
+git branch --show-current
+# Expected: feat/idp-v1.1-composition-annotations
+```
+
+- [ ] **Step 2: Add the smoke-test XR's annotation block**
+
+The test fixture `tests/composition/xr-minimal.yaml` is the input XR for the test. We won't change its `spec` — only add the TeraSky annotations to `metadata.annotations` so the Composition has something to copy:
+
+```bash
+sed -n '1,15p' tests/composition/xr-minimal.yaml
+```
+
+Edit `tests/composition/xr-minimal.yaml` to read:
+
+```yaml
+# tests/composition/xr-minimal.yaml
+# TDD input: smallest meaningful XApplication, no DB.
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-app.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false
+```
+
+- [ ] **Step 3: Add the same annotation block to `tests/composition/xr-with-db.yaml`**
+
+```yaml
+# tests/composition/xr-with-db.yaml
+# TDD input: XApplication with CNPG database enabled.
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-db-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-db-app.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: true
+  dbStorage: 1Gi
+```
+
+- [ ] **Step 4: Update `tests/composition/expected-xr-minimal.yaml` to expect annotations on every child**
+
+Each composed child's `metadata.annotations` must now include the 5 TeraSky annotations + `backstage.io/source-location`, alongside the existing `crossplane.io/composition-resource-name` and any per-resource annotations (cert-manager + nginx-ingress on the Ingress).
+
+Add the following annotations to **each child** in the file (alphabetical key order — yq normalizes anyway, but keep the file readable):
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
+    crossplane.io/composition-resource-name: deployment   # or service, or ingress
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+```
+
+The Ingress preserves its existing nginx-ingress + cert-manager annotations alongside these — the merged `metadata.annotations` block on the Ingress should look like:
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+```
+
+The XR document itself in the golden also gets the annotation block (it has it in the input file too — just verify):
+
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  name: smoke-app
+  namespace: platform-smoke
+spec:
+  ...  # unchanged
+```
+
+- [ ] **Step 5: Update `tests/composition/expected-xr-with-db.yaml` similarly**
+
+Same annotation block on every child, including the CNPG `Cluster` (resource name `dbcluster`). Use `smoke-db-app` for the source-location URL.
+
+The CNPG Cluster's annotations block becomes:
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+    crossplane.io/composition-resource-name: dbcluster
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+```
+
+- [ ] **Step 6: Verify the tests now FAIL (TDD red)**
+
+```bash
+export DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock 2>/dev/null
+./tests/composition/render.sh xr-minimal
+echo "EXIT=$?"
+./tests/composition/render.sh xr-with-db
+echo "EXIT=$?"
+```
+
+Expected: both exit non-zero (1). The diff output should show the new annotations on the expected (`>`) side and missing/empty on the actual (`<`) side, because the Composition Python doesn't emit them yet.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/composition/xr-minimal.yaml \
+        tests/composition/xr-with-db.yaml \
+        tests/composition/expected-xr-minimal.yaml \
+        tests/composition/expected-xr-with-db.yaml
+git commit -m "test(composition): add failing render tests for TeraSky annotations"
+```
+
+> `git add` scope: only those four files. The pre-existing `?? docs/reference/` must not be committed.
+
+### Task 1.2 — Implement Composition annotation flow (TDD green)
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+- [ ] **Step 1: Read the current `compose()` body**
+
+```bash
+sed -n '135,170p' base-apps/crossplane-compositions/composition-application.yaml
+```
+
+This shows the existing `compose(req, rsp)` function. We're going to:
+1. Add a `std_annotations()` helper above the existing `make_*` helpers.
+2. Modify each `make_*` to take an `annotations=` kwarg and merge it into `metadata.annotations`.
+3. Modify `compose()` to read `xr["metadata"].get("annotations", {})` and pass `std_annotations(...)` into each `make_*` call.
+
+- [ ] **Step 2: Add `std_annotations` helper near the top of the script**
+
+Insert after `def std_labels(name)` (around line 36) and BEFORE `def make_deployment(...)`:
+
+```python
+TERASKY_ANNOTATION_PREFIXES = ("terasky.backstage.io/", "backstage.io/")
+
+def std_annotations(xr_annotations, resource_name):
+    """Copy TeraSky/Backstage annotations from the XR + add per-resource name."""
+    copied = {
+        k: v for k, v in (xr_annotations or {}).items()
+        if k.startswith(TERASKY_ANNOTATION_PREFIXES)
+    }
+    copied["crossplane.io/composition-resource-name"] = resource_name
+    return copied
+```
+
+- [ ] **Step 3: Modify `make_deployment` to accept `annotations`**
+
+Change signature from:
+
+```python
+def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret):
+```
+
+to:
+
+```python
+def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations):
+```
+
+In the returned dict's `metadata`, add `"annotations": annotations`:
+
+```python
+return {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "name": name,
+        "namespace": namespace,
+        "labels": std_labels(name),
+        "annotations": annotations,
+    },
+    "spec": {
+        ...
+    },
+}
+```
+
+- [ ] **Step 4: Modify `make_service` similarly**
+
+```python
+def make_service(name, namespace, port, annotations):
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {"app.kubernetes.io/name": name},
+            "ports": [{"name": "http", "port": 80, "targetPort": port}],
+        },
+    }
+```
+
+- [ ] **Step 5: Modify `make_ingress` to MERGE the new annotations with existing ones**
+
+The Ingress already has cert-manager + nginx-ingress annotations. Don't replace them — merge:
+
+```python
+def make_ingress(name, namespace, host, annotations):
+    base_annotations = {
+        "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+        "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+        "nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+    }
+    merged_annotations = {**base_annotations, **annotations}
+    return {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": std_labels(name),
+            "annotations": merged_annotations,
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "tls": [{"hosts": [host], "secretName": f"{name}-tls"}],
+            "rules": [{
+                "host": host,
+                "http": {"paths": [{
+                    "path": "/", "pathType": "Prefix",
+                    "backend": {"service": {"name": name, "port": {"number": 80}}},
+                }]},
+            }],
+        },
+    }
+```
+
+- [ ] **Step 6: Modify `make_cnpg_cluster` to accept `annotations`**
+
+```python
+def make_cnpg_cluster(parent_name, namespace, instances, storage, annotations):
+    return {
+        "apiVersion": "postgresql.cnpg.io/v1",
+        "kind": "Cluster",
+        "metadata": {
+            "name": f"{parent_name}-db",
+            "namespace": namespace,
+            "labels": std_labels(parent_name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "instances": instances,
+            "imageName": "ghcr.io/cloudnative-pg/postgresql:16",
+            "bootstrap": {"initdb": {"database": "app", "owner": "app"}},
+            "storage": {"size": storage},
+        },
+    }
+```
+
+- [ ] **Step 7: Modify `compose()` to read XR annotations and pass them through**
+
+Update `compose()` to look like:
+
+```python
+def compose(req, rsp):
+    xr = resource.struct_to_dict(req.observed.composite.resource)
+    spec = xr["spec"]
+    name = xr["metadata"]["name"]
+    namespace = xr["metadata"]["namespace"]
+    xr_annotations = xr["metadata"].get("annotations", {})
+
+    # Integers from a protobuf Struct round-trip as Python floats
+    # (Struct's number_value is a double). Cast at the boundary so
+    # rendered YAML has true ints — Kubernetes rejects containerPort: 8080.0
+    # at apply time even though `crossplane render` accepts it.
+    port = int(spec["port"])
+    replicas = int(spec.get("replicas", 2))
+
+    db_secret = f"{name}-db-app" if spec.get("dbNeeded") else None
+    env_from  = db_secret
+
+    resource.update(
+        rsp.desired.resources["deployment"],
+        make_deployment(name, namespace, spec["image"], port,
+                        replicas, spec.get("env", []), env_from,
+                        annotations=std_annotations(xr_annotations, "deployment")),
+    )
+    resource.update(
+        rsp.desired.resources["service"],
+        make_service(name, namespace, port,
+                     annotations=std_annotations(xr_annotations, "service")),
+    )
+    resource.update(
+        rsp.desired.resources["ingress"],
+        make_ingress(name, namespace, spec["host"],
+                     annotations=std_annotations(xr_annotations, "ingress")),
+    )
+
+    if spec.get("dbNeeded"):
+        resource.update(
+            rsp.desired.resources["dbcluster"],
+            make_cnpg_cluster(name, namespace,
+                              instances=1, storage=spec.get("dbStorage", "1Gi"),
+                              annotations=std_annotations(xr_annotations, "dbcluster")),
+        )
+```
+
+- [ ] **Step 8: Run tests — both must now PASS (TDD green)**
+
+```bash
+export DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock 2>/dev/null
+./tests/composition/render.sh xr-minimal; echo "MIN_EXIT=$?"
+./tests/composition/render.sh xr-with-db; echo "DB_EXIT=$?"
+```
+
+Expected: `MIN_EXIT=0` and `DB_EXIT=0`, both with empty stdout.
+
+If either exits non-zero, the diff output tells you which annotations are missing/wrong. Iterate on the Python until both green. Do NOT modify the goldens — those are the spec.
+
+- [ ] **Step 9: Validate Composition with kubectl**
+
+```bash
+kubectl apply --dry-run=server -f base-apps/crossplane-compositions/composition-application.yaml
+# Expected: composition.apiextensions.crossplane.io/application configured (server dry run)
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add base-apps/crossplane-compositions/composition-application.yaml
+git commit -m "feat(crossplane): emit TeraSky annotations on every composed child"
+```
+
+### Task 1.3 — Add `backstage-crossplane-read` ClusterRole + Binding
+
+**Files:**
+- Modify: `base-apps/backstage/rbac.yaml` (append to existing file; do NOT touch the existing `backstage-read-only` ClusterRole)
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat base-apps/backstage/rbac.yaml
+```
+
+The file currently contains a ServiceAccount, a `backstage-read-only` ClusterRole, and a binding. Leave all three untouched. Append the new resources at the end.
+
+- [ ] **Step 2: Append the new ClusterRole + Binding**
+
+Append this exact block to `base-apps/backstage/rbac.yaml`:
+
+```yaml
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-crossplane-read
+rules:
+  # Crossplane core APIs — XRDs, Compositions, Functions, Operations
+  - apiGroups: ["apiextensions.crossplane.io"]
+    resources: ["compositeresourcedefinitions", "compositions", "compositionrevisions", "functions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["pkg.crossplane.io"]
+    resources: ["providers", "providerrevisions", "configurations", "configurationrevisions", "functions", "functionrevisions"]
+    verbs: ["get", "list", "watch"]
+
+  # Our own platform XR API + any future namespaced/cluster XRs we add
+  - apiGroups: ["platform.arigsela.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Managed resource APIs — what XRs compose into. The kubernetes-ingestor
+  # walks the compositionRevision's resources to find these.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "poolers", "backups", "scheduledbackups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["s3.aws.upbound.io", "iam.aws.upbound.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Crossplane internal status resources used by the resources plugin's graph
+  - apiGroups: ["protection.crossplane.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-crossplane-read
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+roleRef:
+  kind: ClusterRole
+  name: backstage-crossplane-read
+  apiGroup: rbac.authorization.k8s.io
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+kubectl apply --dry-run=server -f base-apps/backstage/rbac.yaml 2>&1 | tail -5
+# Expected (4 lines):
+#   serviceaccount/backstage configured (server dry run)
+#   clusterrole.rbac.authorization.k8s.io/backstage-read-only configured (server dry run)
+#   clusterrolebinding.rbac.authorization.k8s.io/backstage-read-only configured (server dry run)
+#   clusterrole.rbac.authorization.k8s.io/backstage-crossplane-read created (server dry run)
+#   clusterrolebinding.rbac.authorization.k8s.io/backstage-crossplane-read created (server dry run)
+```
+
+If anything errors, fix the YAML (most likely indentation under `rules:` or a typo in `apiGroups`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/backstage/rbac.yaml
+git commit -m "feat(backstage): add backstage-crossplane-read ClusterRole + binding"
+```
+
+### Task 1.4 — Open Phase 1 PR + verify post-merge
+
+**Files:** none (PR ops only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/idp-v1.1-composition-annotations
+```
+
+- [ ] **Step 2: Open the PR via `gh` (GitHub MCP fallback per CLAUDE.md)**
+
+```bash
+gh pr create --base main --head feat/idp-v1.1-composition-annotations \
+  --title "Phase 1 (v1.1): Composition annotations + Backstage Crossplane RBAC" \
+  --body "$(cat <<'EOF'
+## Summary
+
+First of two PRs for IDP v1.1. Lands the cluster-side prerequisites for TeraSky's `kubernetes-ingestor` to auto-ingest XRs as Backstage catalog entities.
+
+What lands in cluster on merge:
+
+- **`Composition/application` updated** to copy `terasky.backstage.io/*` and `backstage.io/*` annotations from the XR onto every composed child (Deployment, Service, Ingress, optional CNPG Cluster). The XR's annotations are the canonical set; composition is the propagator.
+- **New `ClusterRole/backstage-crossplane-read` + matching binding** giving the Backstage SA cluster-wide `get/list/watch` on Crossplane API groups, our `platform.arigsela.com` XR API, and managed-resource APIs (CNPG, AWS S3/IAM). Existing `backstage-read-only` ClusterRole is unchanged — purely additive.
+
+No new XRDs, no XR creation, no new ArgoCD apps.
+
+## Spec & plan
+
+- Design: `docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md`
+- Plan: `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md` (Phase 1 = Tasks 1.1–1.4)
+
+## TDD discipline
+
+Both render-test goldens (`tests/composition/expected-xr-{minimal,with-db}.yaml`) updated **first** to expect the new annotations on every child. Composition Python implementation makes them green. Both tests pass with empty diff pre-merge.
+
+## Why pre-emptive S3/IAM in the ClusterRole
+
+When the v1.3 AWS-resources iteration adds `XS3Bucket` and `XIAMUser` XRs, the `crossplane-resources` plugin's graph view will walk those resource types. Including them in the ClusterRole now avoids 403-driven UI gaps at v1.3 time. Read-only verbs only (`get/list/watch`); no mutations possible.
+
+## Verification (post-merge)
+
+\`\`\`bash
+# Composition is updated in cluster:
+kubectl get composition application -o jsonpath='{.spec.pipeline[0].input.script}' | grep -c "std_annotations"
+# Expected: > 0 (helper is present in the running script)
+
+# Backstage SA can list XRs:
+kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage
+# Expected: yes
+
+# RBAC aggregation rolled in:
+kubectl get clusterrolebinding backstage-crossplane-read -o jsonpath='subjects={.subjects[0].name}/{.subjects[0].namespace}{"\n"}'
+# Expected: subjects=backstage/backstage
+\`\`\`
+
+## Test plan
+
+- [ ] \`./tests/composition/render.sh xr-minimal\` exits 0 (verified pre-PR)
+- [ ] \`./tests/composition/render.sh xr-with-db\` exits 0 (verified pre-PR)
+- [ ] After merge, \`crossplane-compositions\` ArgoCD app stays Healthy + Synced
+- [ ] After merge, \`kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage\` returns \`yes\`
+- [ ] Phase 2 PR opens against \`arigsela/backstage\` immediately after this merges
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: DO NOT MERGE — user is the merge gate**
+
+Capture the PR URL. Stop. Wait for user to merge.
+
+- [ ] **Step 4 (post-merge): verify in cluster**
+
+```bash
+kubectl get clusterrolebinding backstage-crossplane-read \
+  -o jsonpath='{.subjects[0].kind}/{.subjects[0].name}/{.subjects[0].namespace}{"\n"}'
+# Expected: ServiceAccount/backstage/backstage
+
+kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage
+# Expected: yes
+
+kubectl auth can-i list compositions.apiextensions.crossplane.io \
+  --as system:serviceaccount:backstage:backstage
+# Expected: yes
+```
+
+If `auth can-i` returns `no` for either, the binding didn't take. Inspect ArgoCD events on the `backstage` Application.
+
+---
+
+## Phase 2 — Backstage repo: install plugins + scaffolder cleanup
+
+**What this phase delivers:** TeraSky's three plugins are added to the Backstage source repo (NPM deps, frontend/backend wiring, app-config sections); the scaffolder template stops generating `catalog-info.yaml` and stops applying `directory.exclude`; the rendered XR carries annotations the cluster-side Composition expects.
+
+**Phase 2 exit criteria:**
+- `arigsela/backstage` PR opens against `main` with all 7 file changes
+- YAML and TypeScript files compile / parse locally
+- User has merged the PR (gate before Phase 3 starts)
+
+**Working directory:** `/Users/arisela/git/kubernetes/docs/reference/backstage` (the cloned Backstage source repo).
+
+### Task 2.1 — Branch + add NPM deps
+
+**Files:**
+- Modify: `packages/backend/package.json`
+- Modify: `packages/app/package.json`
+
+- [ ] **Step 1: Branch in the Backstage repo**
+
+```bash
+cd /Users/arisela/git/kubernetes/docs/reference/backstage
+git status --short      # clean (or pre-existing noise only)
+git checkout main && git pull origin main
+git checkout -b feat/idp-v1.1-terasky-plugins
+git branch --show-current
+# Expected: feat/idp-v1.1-terasky-plugins
+```
+
+- [ ] **Step 2: Look up current TeraSky plugin versions**
+
+```bash
+npm view @terasky/backstage-plugin-kubernetes-ingestor version
+npm view @terasky/backstage-plugin-crossplane-resources-backend version
+npm view @terasky/backstage-plugin-crossplane-resources-frontend version
+npm view @terasky/backstage-plugin-scaffolder-backend-module-terasky-utils version
+```
+
+Record the four output strings; you'll paste them in the next step. Throughout, the placeholders are:
+
+| Placeholder | Where used |
+|---|---|
+| `<INGESTOR_VER>` | backend |
+| `<XPRES_BACK_VER>` | backend |
+| `<XPRES_FRONT_VER>` | frontend |
+| `<SCAF_UTILS_VER>` | backend |
+
+- [ ] **Step 3: Add 3 backend deps to `packages/backend/package.json`**
+
+Open `packages/backend/package.json`. Under `"dependencies": {`, add three new entries (alphabetical-by-key, matching the existing convention):
+
+```json
+"@terasky/backstage-plugin-crossplane-resources-backend": "^<XPRES_BACK_VER>",
+"@terasky/backstage-plugin-kubernetes-ingestor": "^<INGESTOR_VER>",
+"@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils": "^<SCAF_UTILS_VER>",
+```
+
+Replace each placeholder with the actual version from Step 2. Use `^` so we get patch updates without lockstep upgrades.
+
+- [ ] **Step 4: Add 1 frontend dep to `packages/app/package.json`**
+
+Open `packages/app/package.json`. Under `"dependencies": {`, add:
+
+```json
+"@terasky/backstage-plugin-crossplane-resources-frontend": "^<XPRES_FRONT_VER>",
+```
+
+- [ ] **Step 5: Install the deps**
+
+```bash
+yarn install --immutable=false
+# Expected: dependencies resolved without conflicts. If yarn reports peer-dep
+# warnings, note them but they are not blockers unless TeraSky's docs flag a
+# specific Backstage major-version requirement.
+```
+
+If yarn fails with a peer-dependency error, halt and reassess — TeraSky may have a Backstage version pin we don't satisfy. Check TeraSky's repo README or open an issue.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/backend/package.json packages/app/package.json yarn.lock
+git commit -m "feat(deps): add TeraSky Backstage plugins (kubernetes-ingestor + crossplane-resources + scaffolder-utils)"
+```
+
+### Task 2.2 — Backend plugin registration
+
+**Files:**
+- Modify: `packages/backend/src/index.ts`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+sed -n '1,80p' packages/backend/src/index.ts
+```
+
+The file currently has a series of `backend.add(import('...'))` calls registering the existing plugins (catalog, scaffolder, auth, etc.). We add three new ones at the end of that block (just before `backend.start()` or equivalent).
+
+- [ ] **Step 2: Add the three TeraSky backend plugin imports**
+
+Add these three lines, placed alphabetically among the existing `backend.add(...)` calls:
+
+```typescript
+backend.add(import('@terasky/backstage-plugin-crossplane-resources-backend'));
+backend.add(import('@terasky/backstage-plugin-kubernetes-ingestor'));
+backend.add(import('@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils'));
+```
+
+> Order matters only if TeraSky's docs say so (most don't). Place these among existing entries to maintain readability.
+
+- [ ] **Step 3: TypeScript compile check**
+
+```bash
+yarn tsc --noEmit packages/backend/src/index.ts 2>&1 | head -20
+# Expected: no output (clean compile) OR only deprecation warnings
+```
+
+If a real error appears (e.g., "Cannot find module"), the package is missing — recheck Task 2.1 Step 5. If it's a type mismatch on `backend.add(...)`, your Backstage core may need an update. Halt and reassess.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/backend/src/index.ts
+git commit -m "feat(backend): register TeraSky plugins (kubernetes-ingestor + crossplane-resources + scaffolder-utils)"
+```
+
+### Task 2.3 — Frontend plugin registration
+
+**Files:**
+- Modify: `packages/app/src/App.tsx`
+- Modify: `packages/app/src/components/catalog/EntityPage.tsx`
+
+- [ ] **Step 1: Locate the entity-page service component**
+
+```bash
+grep -n "serviceEntityPage\|EntityLayout" packages/app/src/components/catalog/EntityPage.tsx | head -10
+```
+
+The pattern: `EntityPage.tsx` defines `serviceEntityPage` (and possibly other variants). Each is a `<EntityLayout>` containing `<EntityLayout.Route ... />` children. We add one new Route for the Crossplane plugin.
+
+- [ ] **Step 2: Add the import at the top of `EntityPage.tsx`**
+
+Insert with the other plugin imports (typically near the top of the file):
+
+```typescript
+import { CrossplaneResourcesPage } from '@terasky/backstage-plugin-crossplane-resources-frontend';
+```
+
+> Verify the export name against the TeraSky plugin's README — they may name it differently (e.g. `EntityCrossplaneResourcesContent` or similar). Adjust if needed.
+
+- [ ] **Step 3: Add a Route to `serviceEntityPage`**
+
+Inside the `serviceEntityPage` `<EntityLayout>`, add a new Route alongside the existing ones (Kubernetes, CI/CD, etc.):
+
+```tsx
+<EntityLayout.Route path="/crossplane" title="Crossplane">
+  <CrossplaneResourcesPage />
+</EntityLayout.Route>
+```
+
+> Place after the Kubernetes route if one exists; otherwise alphabetical or by your preferred ordering.
+
+- [ ] **Step 4: TypeScript compile check**
+
+```bash
+yarn tsc --noEmit 2>&1 | head -30
+```
+
+Expected: clean (or only pre-existing warnings). If `CrossplaneResourcesPage` is "undefined" or has a different name, fix the import per the TeraSky plugin's README.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/App.tsx packages/app/src/components/catalog/EntityPage.tsx
+git commit -m "feat(frontend): add Crossplane Resources tab to service entity page"
+```
+
+### Task 2.4 — Plugin config in app-config + production overlay
+
+**Files:**
+- Modify: `app-config.yaml`
+- Modify: `app-config.production.yaml`
+
+> **From IDP v1's PR #5 lesson:** the production overlay's array fields **replace** the base config's, not merge. New top-level config sections must land in BOTH files.
+
+- [ ] **Step 1: Read TeraSky's expected config shape**
+
+Visit the three plugin READMEs at <https://github.com/TeraSky-OSS/backstage-plugins>. Each documents an `app-config.yaml` snippet to copy. Capture the three sections (`kubernetesIngestor:`, `crossplane:`, and `scaffolder:` extensions).
+
+> The exact content depends on TeraSky's current docs at execution time. The structure typically looks like:
+>
+> ```yaml
+> kubernetesIngestor:
+>   components:
+>     enabled: true
+>     taskRunner:
+>       frequency: 30
+>       timeout: 600
+>     onlyIngestAnnotatedResources: true
+>     excludedNamespaces: []
+> crossplane:
+>   enablePermissions: true
+> scaffolder:
+>   defaultAuthor:
+>     name: Backstage Scaffolder
+>     email: scaffolder@backstage.local
+> ```
+>
+> Pin to whatever TeraSky's docs say at execution time — the structure above is illustrative.
+
+- [ ] **Step 2: Add the three config sections to `app-config.yaml`**
+
+Find a stable insertion point (e.g., after the existing `kubernetes:` section). Add the three sections.
+
+- [ ] **Step 3: Add the SAME sections to `app-config.production.yaml`**
+
+Both files. Identical content (the production overlay does not need different values for these — TeraSky reads the merged config).
+
+- [ ] **Step 4: YAML parse check**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('app-config.yaml'))" && \
+python3 -c "import yaml; yaml.safe_load(open('app-config.production.yaml'))" && \
+echo "BOTH YAML OK"
+```
+
+Expected: `BOTH YAML OK`. If parsing fails, indentation is the most likely culprit.
+
+- [ ] **Step 5: Verify both files have all three keys**
+
+```bash
+yq eval '.kubernetesIngestor != null, .crossplane != null, .scaffolder != null' app-config.yaml
+yq eval '.kubernetesIngestor != null, .crossplane != null, .scaffolder != null' app-config.production.yaml
+# Expected: each yq command prints: true \n true \n true
+```
+
+If `app-config.production.yaml` shows any `false`, the production overlay is missing a section — go back to Step 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app-config.yaml app-config.production.yaml
+git commit -m "feat(config): add TeraSky plugin config to base + production overlays"
+```
+
+### Task 2.5 — Scaffolder content cleanup
+
+**Files:**
+- Delete: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/catalog-info.yaml`
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml` (remove `directory.exclude` block)
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` (add `metadata.annotations`)
+- Modify: `examples/templates/application/template.yaml` (drop `description` form field)
+
+- [ ] **Step 1: Delete the catalog-info.yaml Nunjucks file**
+
+```bash
+git rm 'examples/templates/application/content-k8s/base-apps/${{ values.name }}/catalog-info.yaml'
+```
+
+- [ ] **Step 2: Modify `${{ values.name }}.yaml` to remove the `directory.exclude` block**
+
+Open `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml`. Find:
+
+```yaml
+    path: base-apps/${{ values.name }}
+    # catalog-info.yaml is a Backstage Component entity (backstage.io/v1alpha1),
+    # not a Kubernetes resource. Backstage reads it directly from GitHub raw
+    # via /catalog-import. ArgoCD must skip it or sync fails with
+    # "no matches for kind Component".
+    directory:
+      exclude: 'catalog-info.yaml'
+  destination:
+```
+
+Replace with (delete the comment + directory block — catalog-info.yaml is no longer generated):
+
+```yaml
+    path: base-apps/${{ values.name }}
+  destination:
+```
+
+- [ ] **Step 3: Modify `application-xr.yaml` to add the annotations block**
+
+Open `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml`. Replace its full content with:
+
+```yaml
+# XApplication (Crossplane) for ${{ values.name }}
+# metadata.annotations are read by TeraSky's kubernetes-ingestor and copied
+# onto every composed child by the cluster-side Composition (see
+# arigsela/kubernetes:base-apps/crossplane-compositions/composition-application.yaml).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+```
+
+- [ ] **Step 4: Modify `template.yaml` to drop the `description` form field**
+
+Open `examples/templates/application/template.yaml`. Find the Identity parameter group:
+
+```yaml
+    - title: Identity
+      required: [name, owner]
+      properties:
+        name:
+          ...
+        description:
+          type: string
+          title: Description
+          description: One-line summary shown in the Backstage catalog.
+        owner:
+          ...
+```
+
+Remove the `description:` block (the entire 3 lines). The `Identity` group should now have only `name`, `owner` properties (and `description` is gone from `required` already since it never was).
+
+Also remove `description: ${{ parameters.description }}` from the `fetch.input.values` map further down in the file:
+
+```yaml
+    - id: fetch
+      name: Render manifests
+      action: fetch:template
+      input:
+        url: ./content-k8s
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.name }}
+          description: ${{ parameters.description }}    # ← DELETE THIS LINE
+          owner: ${{ parameters.owner }}
+          image: ${{ parameters.image }}
+          ...
+```
+
+- [ ] **Step 5: YAML parse check**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('examples/templates/application/template.yaml'))" && echo "TEMPLATE OK"
+python3 -c "import yaml; yaml.safe_load(open('examples/templates/application/content-k8s/base-apps/\${{ values.name }}.yaml'))" && echo "ARGOCD OK"
+python3 -c "import yaml; yaml.safe_load(open('examples/templates/application/content-k8s/base-apps/\${{ values.name }}/application-xr.yaml'))" && echo "XR OK"
+```
+
+Expected: `TEMPLATE OK`, `ARGOCD OK`, `XR OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/templates/application/template.yaml \
+        examples/templates/application/content-k8s/base-apps/'${{ values.name }}.yaml' \
+        examples/templates/application/content-k8s/base-apps/'${{ values.name }}/application-xr.yaml'
+# `git rm` from Step 1 already staged the deletion.
+git commit -m "feat(scaffolder): drop catalog-info.yaml + directory.exclude; add XR annotations for auto-ingestion"
+```
+
+### Task 2.6 — Open Phase 2 PR + hand off to image build
+
+**Files:** none (PR ops only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/idp-v1.1-terasky-plugins
+```
+
+- [ ] **Step 2: Open PR via `gh`**
+
+```bash
+gh pr create --base main --head feat/idp-v1.1-terasky-plugins \
+  --title "feat: IDP v1.1 — TeraSky Crossplane plugins + scaffolder cleanup" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 of IDP v1.1. Installs three TeraSky Backstage plugins, registers them, adds their config to base + production overlays, and cleans up the v1 scaffolder content that the new auto-ingestion makes unnecessary.
+
+Companion to [arigsela/kubernetes Phase 1 PR](https://github.com/arigsela/kubernetes/pulls?q=is%3Apr+is%3Aopen+head%3Afeat%2Fidp-v1.1-composition-annotations) (composition annotations + RBAC) which **must merge first**.
+
+## Plugins
+
+- **`@terasky/backstage-plugin-kubernetes-ingestor`** (backend) — Auto-ingests annotated K8s resources (XRs + composed children) as catalog entities.
+- **`@terasky/backstage-plugin-crossplane-resources-{backend,frontend}`** — Adds a "Crossplane" tab on entity pages showing the live XR + managed-resource graph.
+- **`@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils`** (backend) — Adds the claim-updater scaffolder action so users can edit existing XRs through Backstage forms.
+
+## Scaffolder content cleanup
+
+- **DELETE** `examples/templates/application/content-k8s/base-apps/\${{ values.name }}/catalog-info.yaml` — auto-ingestion replaces this file's role.
+- **REMOVE** `directory.exclude: 'catalog-info.yaml'` from the rendered ArgoCD Application — no longer needed since catalog-info.yaml isn't generated.
+- **ADD** `metadata.annotations` block on the rendered XApplication carrying `terasky.backstage.io/add-to-catalog`, `owner`, `component-type`, `lifecycle`, `system`, and `backstage.io/source-location`.
+- **DROP** `description` field from the form — TeraSky derives entity description from the XRD schema by default.
+
+## Production overlay note
+
+Per IDP v1's PR #5 lesson, the new \`kubernetesIngestor:\`, \`crossplane:\`, and \`scaffolder:\` config sections land in BOTH \`app-config.yaml\` and \`app-config.production.yaml\`. The production overlay's arrays replace base, not merge.
+
+## After merge
+
+User builds a new \`backstage-portal\` image (suggest tag \`v1.1.0\`). Then a tiny tag-bump PR opens against arigsela/kubernetes (Phase 3 of the IDP v1.1 plan).
+
+## Test plan
+
+- [ ] After arigsela/kubernetes Phase 1 PR + this Phase 2 PR are merged, image rebuilt, and tag bumped, scaffolding a test app via the live Backstage UI:
+  - Scaffolder run completes all 2 steps green (Render manifests + Open PR)
+  - PR has the XR with the new annotation block (no \`catalog-info.yaml\`)
+  - After ArgoCD reconciles, the entity auto-appears in Backstage **without** any \`/catalog-import\` action
+  - Entity page has a "Crossplane" tab showing the live XR + composed-child graph
+  - The "Update XApplication" scaffolder action opens an edit form for an existing XR
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: DO NOT MERGE — user is the merge gate**
+
+Capture the PR URL. Stop. Wait for user to merge.
+
+---
+
+## Phase 3 — Image build (USER) + tag bump
+
+**What this phase delivers:** the new Backstage image with TeraSky plugins running in cluster.
+
+**Phase 3 exit criteria:**
+- New image `backstage-portal:v1.1.0` (or whatever tag chosen) exists in ECR
+- `arigsela/kubernetes:base-apps/backstage/deployments.yaml:27` references the new tag
+- ArgoCD has rolled the new pod; old `v1.0.4` pod terminating
+
+### Task 3.1 — User rebuilds image (HARD GATE)
+
+**This task is for the user to perform.** Per CLAUDE.md, image builds are user-owned. The plan documents inputs and acceptance.
+
+- [ ] **Step 1: User waits for `arigsela/backstage` Phase 2 PR to merge**
+
+- [ ] **Step 2: User checks out `arigsela/backstage` main, builds + pushes new image**
+
+> The user runs the Docker build + push. The plan does not run this. Inputs:
+> - Source branch: `arigsela/backstage:main` (post-merge)
+> - Suggested target tag: `v1.1.0` (next minor after `v1.0.4`; alternatively `v1.0.5` if minor-version policy is conservative)
+> - Target registry: `852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal`
+>
+> Acceptance: image exists in ECR with the chosen tag and embeds `node_modules/@terasky/...` in the runtime layer.
+
+### Task 3.2 — Bump deployed tag in `arigsela/kubernetes`
+
+**Runs after Task 3.1 produces the new image.**
+
+**Files:**
+- Modify: `base-apps/backstage/deployments.yaml:27`
+
+- [ ] **Step 1: Branch and bump tag**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git checkout main && git pull origin main
+git checkout -b chore/backstage-v1.1.0
+```
+
+Edit `base-apps/backstage/deployments.yaml:27` (replace `<NEW_TAG>` with the actual tag the user just published — likely `v1.1.0`):
+
+```diff
+-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.4
++        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:<NEW_TAG>
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+kubectl apply --dry-run=server -f base-apps/backstage/deployments.yaml | tail -3
+# Expected: deployment.apps/backstage configured (server dry run)
+```
+
+- [ ] **Step 3: Commit + push**
+
+```bash
+git add base-apps/backstage/deployments.yaml
+git commit -m "chore(backstage): bump image to <NEW_TAG> for IDP v1.1"
+git push -u origin chore/backstage-v1.1.0
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --base main --head chore/backstage-v1.1.0 \
+  --title "chore(backstage): bump image to <NEW_TAG> for IDP v1.1" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Bumps deployed Backstage tag for IDP v1.1. Picks up the three TeraSky Crossplane plugins from arigsela/backstage:main (post-merge of the Phase 2 PR).
+
+## What flips on merge
+
+- ArgoCD detects the change in `base-apps/backstage/deployments.yaml`, rolls the Backstage Deployment to the new tag.
+- New pod loads `kubernetes-ingestor`, `crossplane-resources`, and `scaffolder-backend-module-terasky-utils`.
+- Within ~30–120s of pod ready, the catalog auto-ingests existing XApplications carrying `terasky.backstage.io/add-to-catalog: "true"` (none currently — only Phase 4 test apps will hit this).
+
+## Test plan
+
+- [ ] After ArgoCD reconciles, `kubectl -n backstage get pod -l app=backstage -o jsonpath='{.items[0].spec.containers[0].image}'` reports the new tag.
+- [ ] Backstage `/create` page still shows the existing 3 templates (Application (Crossplane), CrewAI Multi-Agent Project, Example Node.js Template) — regression check.
+- [ ] Phase 4 e2e proceeds.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: After PR merge, verify**
+
+```bash
+sleep 60   # let ArgoCD reconcile
+kubectl -n backstage get pod -l app=backstage -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\t"}{.status.phase}{"\n"}{end}'
+# Expected: a single pod on the new tag, status Running
+
+kubectl -n argo-cd get application backstage -o jsonpath='sync={.status.sync.status} health={.status.health.status}{"\n"}'
+# Expected: Synced + Healthy
+```
+
+If old + new pods both Running for >2 min after rollout, force-restart:
+
+```bash
+kubectl -n backstage rollout status deploy/backstage --timeout=180s
+```
+
+---
+
+## Phase 4 — Live e2e + cleanup
+
+**What this phase delivers:** the user-facing demo. A new test app gets onboarded via the live Backstage UI; the entity auto-appears in the catalog without manual import; the Crossplane plugin tab shows the live graph; the claim-updater action opens an edit form. Plus tear-down to leave the cluster clean.
+
+**Phase 4 exit criteria:** all 11 §10 acceptance criteria from the spec.
+
+### Task 4.1 — Pre-flight checks
+
+- [ ] **Step 1: Verify the new image is running**
+
+```bash
+kubectl -n backstage get pod -l app=backstage -o jsonpath='{.items[0].spec.containers[0].image}{"\n"}'
+# Expected: ...:<NEW_TAG>
+```
+
+- [ ] **Step 2: Verify Backstage SA has Crossplane RBAC**
+
+```bash
+kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage
+kubectl auth can-i list compositions.apiextensions.crossplane.io --as system:serviceaccount:backstage:backstage
+kubectl auth can-i list pods --as system:serviceaccount:backstage:backstage
+# Expected: yes for all three
+```
+
+- [ ] **Step 3: Verify the three TeraSky plugins loaded without errors**
+
+```bash
+kubectl -n backstage logs -l app=backstage --tail=200 2>&1 | grep -iE "terasky|kubernetes-ingestor|crossplane-resources" | head -10
+# Expected: at least a few lines indicating plugin init. NO "ECONNREFUSED",
+# "Failed to load", "401", "403" errors related to these plugins.
+```
+
+If you see 403s on Crossplane API calls, the RBAC binding didn't take. If you see "Failed to load plugin" errors, the image build was likely incomplete or the plugin imports in `index.ts` are wrong.
+
+### Task 4.2 — Scaffold a test app + verify auto-ingestion
+
+- [ ] **Step 1: Open Backstage `/create` and walk the wizard**
+
+Open https://backstage.arigsela.com/create. Click **Application (Crossplane)** → **Choose**. Fill:
+
+| Field | Value |
+|---|---|
+| Application name | `smoketest-v11` |
+| Owner | a Group from the picker (e.g. `group:default/platform-engineering`) |
+| Container image | `nginxinc/nginx-unprivileged:1.25-alpine` |
+| Public hostname | `smoketest-v11.arigsela.com` *(only if your DNS is wildcarded; otherwise pick a host that resolves to the cluster)* |
+| Port | `8080` |
+| Replicas | `1` |
+| Provision Postgres | unchecked |
+
+Click Review → Create. Both 2 scaffolder steps must complete green. **Note: there are now only 2 steps (no register step from v1) — that's expected.**
+
+- [ ] **Step 2: Inspect the resulting PR**
+
+A PR titled `feat(smoketest-v11): onboard via Crossplane Application` opens against `arigsela/kubernetes`. Verify:
+
+```bash
+gh pr view <PR_NUM> --json files --jq '.files[].path' 2>&1
+# Expected output: 2 files (NOT 3 — no catalog-info.yaml)
+#   base-apps/smoketest-v11.yaml
+#   base-apps/smoketest-v11/application-xr.yaml
+```
+
+If `catalog-info.yaml` is in the diff, the scaffolder content cleanup didn't take — image build is wrong.
+
+```bash
+gh pr diff <PR_NUM> 2>&1 | grep -A8 "metadata:" | head -25
+# Expected: the XR's metadata.annotations block contains
+# terasky.backstage.io/add-to-catalog: "true" etc.
+```
+
+If annotations are missing, the scaffolder Nunjucks template change didn't take.
+
+- [ ] **Step 3: Merge the PR**
+
+The user merges via GitHub UI. Or via `gh`:
+
+```bash
+gh pr merge <PR_NUM> --squash --delete-branch
+```
+
+- [ ] **Step 4: Watch ArgoCD reconcile**
+
+```bash
+sleep 30   # master-app + new app sync
+kubectl -n argo-cd get application smoketest-v11 -o jsonpath='sync={.status.sync.status} health={.status.health.status}{"\n"}'
+# Expected: Synced + Healthy
+
+kubectl -n smoketest-v11 get xapplications,deploy,svc,ingress,pod
+# Expected: XApplication, Deployment, Service, Ingress, Pod (Pod likely 0/1 Ready due to /healthz probe — anticipated v1 limitation)
+```
+
+- [ ] **Step 5: Verify auto-ingestion (the v1.1 win)**
+
+Wait 30–120 seconds for the kubernetes-ingestor refresh interval. Then open https://backstage.arigsela.com/catalog and filter by `kind:component`. The **`smoketest-v11`** entity should appear automatically. **NO MANUAL `/catalog-import` performed.**
+
+If the entity does NOT appear within 3 minutes:
+
+```bash
+kubectl -n backstage logs -l app=backstage --tail=300 2>&1 | grep -iE "ingestor|smoketest" | tail -20
+```
+
+Look for ingestor activity or 403s. Common issues: RBAC, missing annotation on XR, plugin config mismatch.
+
+### Task 4.3 — Verify Crossplane plugin tab + claim-updater
+
+- [ ] **Step 1: Open the entity page**
+
+https://backstage.arigsela.com/catalog/default/component/smoketest-v11
+
+- [ ] **Step 2: Click the "Crossplane" tab**
+
+Expected:
+- Table showing the `XApplication/smoketest-v11` XR
+- The composed children: Deployment + Service + Ingress
+- A graph view showing the relationships
+- No 403 / "Failed to load" errors
+
+If the graph is empty but the table shows the XR, the plugin's RBAC for managed resources is incomplete. Check `kubectl auth can-i list ingresses --as system:serviceaccount:backstage:backstage`.
+
+- [ ] **Step 3: Test the claim-updater scaffolder action**
+
+Open https://backstage.arigsela.com/create. Look for an "Update Application (Crossplane)" template (TeraSky's scaffolder-utils registers this automatically based on the XR). Click it. Select `smoketest-v11`. The form should appear pre-populated with the XR's current values.
+
+Change `replicas: 1 → 2`. Submit. The scaffolder opens a PR with the change. Don't merge yet — just verify the diff is clean (only the `replicas` line changed).
+
+> If TeraSky's claim-updater pattern requires a different invocation (e.g., a button on the entity page rather than a /create entry), follow whatever the plugin's README says.
+
+### Task 4.4 — CrewAI regression
+
+- [ ] **Step 1: Open `/create`, click CrewAI Multi-Agent Project**
+
+Walk through the existing CrewAI form with throwaway values. **Do not submit** (don't actually create a CrewAI project — just verify the form loads and renders). The goal: confirm the v1.1 plugin install didn't break the v1 template.
+
+If the form fails to load or renders weirdly, halt — there's a TeraSky plugin × Backstage core compat issue.
+
+### Task 4.5 — Tear down + run notes
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md` (append run notes)
+
+- [ ] **Step 1: Open a PR removing the smoketest-v11 files**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git checkout main && git pull origin main
+git checkout -b chore/teardown-smoketest-v11
+git rm base-apps/smoketest-v11.yaml
+git rm -r base-apps/smoketest-v11
+git commit -m "chore: tear down smoketest-v11 after IDP v1.1 e2e"
+git push -u origin chore/teardown-smoketest-v11
+gh pr create --base main --head chore/teardown-smoketest-v11 \
+  --title "chore: tear down smoketest-v11 after IDP v1.1 e2e" \
+  --body "Removes the smoketest-v11 onboarded during Phase 4 e2e. Per IDP v1's spec §8 decommission flow: the user should run \`kubectl -n smoketest-v11 delete xapplication smoketest-v11\` BEFORE merging this PR, otherwise the master-app prune will orphan the composed children. After merge, run \`kubectl delete ns smoketest-v11\` to remove the lingering namespace."
+```
+
+- [ ] **Step 2: Per spec §8 — delete the XR FIRST**
+
+```bash
+kubectl -n smoketest-v11 delete xapplication smoketest-v11
+sleep 5
+kubectl -n smoketest-v11 get all
+# Expected: composed children gone (deployment, service, ingress, pod)
+```
+
+- [ ] **Step 3: Merge the teardown PR**
+
+User merges via GitHub UI. Or `gh pr merge <PR_NUM> --squash --delete-branch`.
+
+- [ ] **Step 4: Verify auto-deingestion in Backstage**
+
+Wait 30–120 seconds (TeraSky ingestor refresh). Open `/catalog` and filter `kind:component`. **`smoketest-v11` should disappear automatically** — auto-deingestion is the inverse of auto-ingestion. NO manual unregister needed.
+
+> This is a meaningful win over IDP v1: in v1, the manually-imported Location entity persisted forever and required manual unregister. v1.1's auto-deingestion makes the lifecycle symmetric.
+
+- [ ] **Step 5: Delete the namespace**
+
+```bash
+kubectl delete ns smoketest-v11
+```
+
+- [ ] **Step 6: Append run notes to the plan**
+
+Open `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md`. Append a `## Run Notes` section at the end with:
+
+```markdown
+## Run Notes (YYYY-MM-DD execution)
+
+**Outcome:** v1.1 of the IDP shipped. Three TeraSky plugins added to Backstage; XRs auto-ingest as catalog entities; live XR/managed-resource graph visible on entity pages; claim-updater action lets users edit existing XRs through Backstage forms.
+
+**E2E validation** (smoketest-v11):
+- ✅ Backstage form → PR opened (NO catalog-info.yaml in the diff — auto-ingestion replaces it)
+- ✅ XR has the 6 TeraSky/Backstage annotations
+- ✅ ArgoCD synced; Composition rendered Deployment + Service + Ingress with annotations stamped
+- ✅ Entity auto-appeared in Backstage `/catalog` within ~XXs (no manual /catalog-import)
+- ✅ Crossplane plugin tab on entity page rendered the resource graph
+- ✅ Claim-updater scaffolder action opened an edit form pre-populated with XR values; saving opened a clean diff PR
+- ✅ CrewAI template still loads cleanly (regression)
+- ✅ Tear-down auto-deingested the entity from Backstage; no manual unregister needed
+
+**Bugs caught during execution:** [fill in]
+
+**TeraSky plugin versions pinned:**
+- `@terasky/backstage-plugin-kubernetes-ingestor`: `<INGESTOR_VER>`
+- `@terasky/backstage-plugin-crossplane-resources-backend`: `<XPRES_BACK_VER>`
+- `@terasky/backstage-plugin-crossplane-resources-frontend`: `<XPRES_FRONT_VER>`
+- `@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils`: `<SCAF_UTILS_VER>`
+
+**v1.2 follow-ups confirmed:**
+- Vault round-trip for DB credentials (Q3.5 still needs ESO-vs-VSO resolution)
+- AWS resources (v1.3) — S3 + IAM with IRSA-on-homelab caveat (Q2.6)
+- healthCheckPath as XR field (still relevant; v1's `/healthz` probe limitation persists)
+```
+
+- [ ] **Step 7: Commit the run notes**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git checkout main && git pull origin main
+git checkout -b docs/v1.1-run-notes
+git add docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md
+git commit -m "docs(plan): add IDP v1.1 run notes"
+git push -u origin docs/v1.1-run-notes
+gh pr create --base main --head docs/v1.1-run-notes \
+  --title "docs(plan): add IDP v1.1 run notes" \
+  --body "Captures Phase 4 e2e validation results, bugs caught, plugin versions pinned, and v1.2 follow-up confirmations. Pure docs commit."
+```
+
+User merges. v1.1 is officially done.
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+| Spec section | Plan task |
+|---|---|
+| §3 Wire diagram | Phase 1 + Phase 4 (full e2e) |
+| §4 Components row 1 (kubernetes-ingestor backend dep) | Task 2.1 |
+| §4 Components row 2 (crossplane-resources frontend dep) | Task 2.1 |
+| §4 Components row 3 (Backend plugin registration) | Task 2.2 |
+| §4 Components row 4 (Frontend plugin registration) | Task 2.3 |
+| §4 Components row 5 (Plugin config — base + production) | Task 2.4 |
+| §4 Components row 6 (Delete catalog-info.yaml) | Task 2.5 Step 1 |
+| §4 Components row 7 (Remove directory.exclude) | Task 2.5 Step 2 |
+| §4 Components row 8 (XR annotations) | Task 2.5 Step 3 |
+| §4 Components row 9 (RBAC ClusterRole + binding) | Task 1.3 |
+| §4 Components row 10 (Composition annotations) | Task 1.2 |
+| §4 Components row 11 (Test goldens) | Task 1.1 |
+| §4 Components row 12 (Image rebuild + tag bump) | Task 3.1 + 3.2 |
+| §5 RBAC ClusterRole shape | Task 1.3 Step 2 (verbatim) |
+| §6 Composition annotation flow | Tasks 1.1 + 1.2 (TDD red→green) |
+| §6 Scaffolder XR template change | Task 2.5 Step 3 (verbatim) |
+| §7 Failure modes | Task 4.1 (pre-flight) + halt-and-reassess instructions throughout |
+| §8 Layer 1 testing | Tasks 1.1 + 1.2 |
+| §8 Layer 2 testing (local Backstage smoke) | Implicit in Task 2.x compile checks; full local smoke is optional and deferred to user |
+| §8 Layer 3 testing (in-cluster e2e) | Phase 4 |
+| §10 All 11 acceptance criteria | Phase 4 Tasks 4.1–4.4 |
+| §12 Sequencing dependencies | Phase numbering matches §12 numbering |
+
+**No placeholders:** every step contains the actual command, code, or YAML. Two version-sensitive items (`<NEW_TAG>` and `<*_VER>` placeholders for TeraSky NPM packages) are documented as plan-time lookups with explicit `npm view` commands rather than left as TBD.
+
+**Type / name consistency:** spot-checked. `std_annotations` signature is consistent across Tasks 1.1, 1.2, and the spec. ClusterRole name `backstage-crossplane-read` is consistent across Tasks 1.3, 1.4, and the spec. Annotation key prefixes (`terasky.backstage.io/`, `backstage.io/`) match in goldens, Composition Python, scaffolder template, and spec §6.
+
+**Branch / PR strategy:** four PRs total — Phase 1 (composition + RBAC) on the kubernetes repo, Phase 2 (plugins + scaffolder cleanup) on the Backstage repo, Phase 3 (tag bump) on the kubernetes repo, plus the e2e teardown PR + run-notes PR in Phase 4. Each phase is independently reviewable and revertable.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md
+++ b/docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md
@@ -1,0 +1,335 @@
+# IDP v1.1 — TeraSky Crossplane Plugins + Auto-Ingestion — Design
+
+**Date:** 2026-04-29
+**Author:** Ari Sela (with Claude)
+**Status:** Approved for plan
+**Iteration:** v1.1 (first of three planned v1.x iterations following IDP v1)
+**Prerequisite:** [IDP v1](./2026-04-28-backstage-crossplane-idp-design.md) shipped and validated
+
+## 1. Goal
+
+Replace v1's manual `/catalog-import` workflow with **auto-ingestion of Crossplane XRs as Backstage catalog entities**, install **live XR/managed-resource visualization** on entity pages, and add **scaffolder-driven update of existing XRs** through a Backstage form. End state: a developer onboarding a new app via the v1 wizard sees their app appear in the Backstage catalog without any post-merge manual action, complete with a Crossplane resource graph and the ability to edit the XR through the same UI.
+
+## 2. Current state (post-v1)
+
+| Component | Shape today |
+|---|---|
+| Catalog ingestion | Manual `/catalog-import` for each scaffolded app, pasting `https://github.com/arigsela/kubernetes/blob/main/base-apps/<name>/catalog-info.yaml` |
+| Entity → cluster link | Backstage Kubernetes plugin (existing) shows Pod/Deployment status via `backstage.io/kubernetes-id` label |
+| XR visibility in Backstage | None — XRs and managed resources invisible to operators in the UI |
+| Updating an existing XR | Manual: edit `application-xr.yaml` in repo, push PR |
+| Backstage RBAC for cluster reads | `backstage-read-only` ClusterRole — covers core+apps kinds (Deployment, Pod, Service, Ingress, ConfigMap, etc.); **no Crossplane API groups** |
+| Backstage image | `backstage-portal:v1.0.4` (deployed) |
+| Scaffolder template content | `examples/templates/application/content-k8s/` writes 3 files: `catalog-info.yaml` (Backstage Component), `application-xr.yaml` (XR), `<name>.yaml` (ArgoCD App, with `directory.exclude: 'catalog-info.yaml'`) |
+
+## 3. Target state — the wire
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Backstage (image bumped, +3 TeraSky plugins, +1 ClusterRole binding)         │
+│   - kubernetes-ingestor      (auto-ingests annotated K8s resources)           │
+│   - crossplane-resources     (entity-page tab: XR + managed-resource graph)   │
+│   - scaffolder claim-updater (form-driven XR edit, opens PR)                  │
+└────────────────────────────────┬─────────────────────────────────────────────┘
+                                 │ ingestor watches cluster on refresh interval
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Cluster                                                                     │
+│   - XApplication metadata.annotations carry terasky.backstage.io/* + owner    │
+│   - Composition copies those annotations onto each composed child            │
+│   - ingestor sees the annotated XR + walks composition revision to find      │
+│     the composed children for the resource graph                             │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Backstage UI — auto-discovered entity                                       │
+│   - /catalog/component/<name>                                                │
+│   - K8s tab (existing Backstage K8s plugin)                                  │
+│   - Crossplane tab (NEW): XR status + composed-child graph                   │
+│   - "Update XApplication" scaffolder action (NEW): re-renders the v1 form    │
+│     with current values, opens an edit PR on save                            │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Three things that disappear from the v1 flow:**
+- `catalog-info.yaml` Nunjucks file (deleted)
+- `directory.exclude: 'catalog-info.yaml'` on the rendered ArgoCD Application (no longer needed)
+- The "after PR merge → /catalog-import" step in spec §7+§8 (replaced by auto-ingestion)
+
+**Invariants preserved:**
+- v1's XApplication XRD shape (no schema change; `description` and `owner` plumb through XR `metadata.annotations` instead of a `Component` entity file)
+- All v1 fixes (RBAC ClusterRole for Crossplane SA, production overlay duplication, int casts, etc.)
+- Existing CrewAI template untouched
+- Existing `backstage-read-only` ClusterRole untouched (a NEW ClusterRole layers on top)
+
+## 4. Components
+
+| # | Artifact | Repo | Path | Action |
+|---|----------|------|------|--------|
+| 1 | TeraSky plugin frontend deps | `arigsela/backstage` | `packages/app/package.json` | Add `@terasky/backstage-plugin-crossplane-resources-frontend` + `@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils` (frontend half if any) |
+| 2 | TeraSky plugin backend deps | `arigsela/backstage` | `packages/backend/package.json` | Add `@terasky/backstage-plugin-kubernetes-ingestor` + `@terasky/backstage-plugin-crossplane-resources-backend` + `@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils` |
+| 3 | Frontend plugin registration | `arigsela/backstage` | `packages/app/src/App.tsx` | Wire the `crossplane-resources` entity-page route + claim-updater scaffolder field extension |
+| 4 | Backend plugin registration | `arigsela/backstage` | `packages/backend/src/index.ts` | `backend.add(import('@terasky/...'))` for ingestor + resources backend + scaffolder utils |
+| 5 | Plugin config | `arigsela/backstage` | `app-config.yaml` + `app-config.production.yaml` | New `kubernetes-ingestor:`, `crossplane:`, and `scaffolder:` sections per TeraSky docs. **Both files** (production overlay rule from v1) |
+| 6 | Scaffolder content cleanup (delete) | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/catalog-info.yaml` | **Delete** — auto-ingestion replaces it |
+| 7 | Scaffolder ArgoCD template | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml` | Remove `directory.exclude: 'catalog-info.yaml'` block (file no longer generated) |
+| 8 | Scaffolder XR template | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | Add `metadata.annotations` carrying `terasky.backstage.io/add-to-catalog`, `owner`, `component-type`, `lifecycle`, `system`, plus `backstage.io/source-location` |
+| 9 | RBAC ClusterRole + Binding | `arigsela/kubernetes` | `base-apps/backstage/rbac.yaml` | Add `ClusterRole/backstage-crossplane-read` + matching binding (preserves existing `backstage-read-only`) |
+| 10 | Composition annotation logic | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-application.yaml` | Add `std_annotations(xr_annotations, resource_name)` helper; thread it through `make_deployment/service/ingress/cnpg_cluster` |
+| 11 | Composition test goldens | `arigsela/kubernetes` | `tests/composition/expected-xr-{minimal,with-db}.yaml` | Update goldens to expect the new annotations on every child (TDD discipline preserved) |
+| 12 | Image rebuild + tag bump | `arigsela/backstage` (build) → `arigsela/kubernetes` (deploy) | `base-apps/backstage/deployments.yaml` | Bump `backstage-portal` tag (e.g. `v1.0.4 → v1.1.0`) once user produces the new image |
+
+**Things explicitly NOT in v1.1:**
+- ❌ AWS resources in the Composition (v1.3)
+- ❌ Vault round-trip for DB credentials (v1.2)
+- ❌ XApplication XRD schema changes (no new fields)
+- ❌ Removal or modification of the `backstage-read-only` ClusterRole
+- ❌ Replacement of External Secrets Operator with Vault Secrets Operator
+
+**One verification call-out for plan-time:** TeraSky's plugin set evolves; pin specific NPM versions and confirm against latest docs at plan-writing time. Initial pin target: `@terasky/...@1.x` whatever's current.
+
+## 5. RBAC ClusterRole shape
+
+The new `backstage-crossplane-read` ClusterRole + binding lives in `base-apps/backstage/rbac.yaml`:
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-crossplane-read
+rules:
+  # Crossplane core APIs — XRDs, Compositions, Functions, Operations
+  - apiGroups: ["apiextensions.crossplane.io"]
+    resources: ["compositeresourcedefinitions", "compositions", "compositionrevisions", "functions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["pkg.crossplane.io"]
+    resources: ["providers", "providerrevisions", "configurations", "configurationrevisions", "functions", "functionrevisions"]
+    verbs: ["get", "list", "watch"]
+
+  # Our own platform XR API + any future namespaced/cluster XRs we add
+  - apiGroups: ["platform.arigsela.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Managed resource APIs — what XRs compose into. The kubernetes-ingestor
+  # walks the compositionRevision's resources to find these.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "poolers", "backups", "scheduledbackups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["s3.aws.upbound.io", "iam.aws.upbound.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Crossplane internal status resources used by the resources plugin's graph
+  - apiGroups: ["protection.crossplane.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-crossplane-read
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+roleRef:
+  kind: ClusterRole
+  name: backstage-crossplane-read
+  apiGroup: rbac.authorization.k8s.io
+```
+
+**Design choices:**
+- Wildcard verbs scoped to `get/list/watch` only — read-only, no mutations
+- Wildcards on `platform.arigsela.com` and AWS API groups so they grow as we add XRs/AWS resources in v1.2/v1.3 without revisiting RBAC
+- S3/IAM included pre-emptively to avoid graph-view 403s when v1.3 lands
+- Existing `backstage-read-only` ClusterRole untouched — purely additive
+
+## 6. Composition annotation flow
+
+### Annotation taxonomy
+
+| Annotation | Set by | Purpose |
+|---|---|---|
+| `terasky.backstage.io/add-to-catalog: "true"` | Scaffolder template (XR `metadata.annotations`) | Tells `kubernetes-ingestor` to ingest the resource |
+| `terasky.backstage.io/owner: <group:platform-engineering>` | Scaffolder template (from form input) | Backstage entity owner |
+| `terasky.backstage.io/system: platform` | Scaffolder template (constant) | Backstage System reference |
+| `terasky.backstage.io/component-type: service` | Scaffolder template (constant) | Component type for entity |
+| `terasky.backstage.io/lifecycle: experimental` | Scaffolder template (constant) | Lifecycle field |
+| `backstage.io/source-location: url:<repo>/...` | Scaffolder template | Links entity back to its `application-xr.yaml` in the GitOps repo |
+
+### Scaffolder template change
+
+`examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml`:
+
+```yaml
+# XApplication (Crossplane) for ${{ values.name }}
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+```
+
+The v1 `description` form field is **dropped from v1.1** — TeraSky derives the entity description from the XRD schema by default. We can re-introduce a custom description annotation later if it becomes a real ergonomic gap.
+
+### Composition Python change
+
+Two additions to `composition-application.yaml`:
+
+**(1) New `std_annotations` helper:**
+
+```python
+TERASKY_ANNOTATION_PREFIXES = ("terasky.backstage.io/", "backstage.io/")
+
+def std_annotations(xr_annotations, resource_name):
+    """Copy TeraSky/Backstage annotations from the XR + add per-resource name."""
+    copied = {
+        k: v for k, v in (xr_annotations or {}).items()
+        if k.startswith(TERASKY_ANNOTATION_PREFIXES)
+    }
+    copied["crossplane.io/composition-resource-name"] = resource_name
+    return copied
+```
+
+**(2) Thread `annotations=` through `compose()` and the `make_*` helpers** so every child's `metadata.annotations` includes XR-inherited TeraSky + Backstage annotations alongside its existing per-resource annotations (cert-manager, nginx-ingress, etc.).
+
+```python
+def compose(req, rsp):
+    xr = resource.struct_to_dict(req.observed.composite.resource)
+    spec = xr["spec"]
+    name = xr["metadata"]["name"]
+    namespace = xr["metadata"]["namespace"]
+    xr_annotations = xr["metadata"].get("annotations", {})
+
+    port = int(spec["port"])
+    replicas = int(spec.get("replicas", 2))
+    db_secret = f"{name}-db-app" if spec.get("dbNeeded") else None
+    env_from = db_secret
+
+    resource.update(
+        rsp.desired.resources["deployment"],
+        make_deployment(name, namespace, spec["image"], port, replicas,
+                        spec.get("env", []), env_from,
+                        annotations=std_annotations(xr_annotations, "deployment")),
+    )
+    resource.update(
+        rsp.desired.resources["service"],
+        make_service(name, namespace, port,
+                     annotations=std_annotations(xr_annotations, "service")),
+    )
+    resource.update(
+        rsp.desired.resources["ingress"],
+        make_ingress(name, namespace, spec["host"],
+                     annotations=std_annotations(xr_annotations, "ingress")),
+    )
+
+    if spec.get("dbNeeded"):
+        resource.update(
+            rsp.desired.resources["dbcluster"],
+            make_cnpg_cluster(name, namespace, instances=1,
+                              storage=spec.get("dbStorage", "1Gi"),
+                              annotations=std_annotations(xr_annotations, "dbcluster")),
+        )
+```
+
+Each `make_*` helper takes a new `annotations=` kwarg and merges it into the resource's `metadata.annotations`, preserving cert-manager / nginx-ingress annotations that already live there.
+
+## 7. Failure modes
+
+| Failure | Visibility | Recovery |
+|---|---|---|
+| TeraSky NPM install fails at image build | Backstage Docker build log; image build aborts | Pin compatible plugin versions; check Backstage compat matrix; retry build |
+| Plugins build but fail to load at startup | Backstage pod CrashLoopBackOff; plugin init errors in logs | Roll image back; inspect logs; usually a config-shape mismatch in `app-config.yaml` |
+| `kubernetes-ingestor` 403s on Crossplane APIs | Backstage pod logs show RBAC denials; entities don't appear | Verify `backstage-crossplane-read` binding landed; `kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage` |
+| XR has no `terasky.backstage.io/add-to-catalog` annotation | Resource not ingested; nothing appears | Confirm scaffolder template renders the annotation block; verify with `kubectl get xapplication -o yaml` |
+| Composition Python regression after annotation change | `crossplane render` test exits non-zero pre-merge; or XApplication `Synced=False` post-deploy | Layer 1 tests catch pre-merge; if it slips, `kubectl describe xapplication` shows function-python error |
+| `crossplane-resources` plugin graph view fails | Entity page Crossplane tab shows error | Check plugin's RBAC; `protection.crossplane.io` covered, but TeraSky may need others |
+| Scaffolder claim-updater fails to read existing XR | Form fails to load when "Update XApplication" triggered | Plugin needs `platform.arigsela.com/xapplications` read; covered by ClusterRole. Check plugin auth config |
+| Stale catalog entities from v1's manual `/catalog-import` | Backstage shows duplicate or orphaned entities | Manually unregister via Backstage UI (catalog → kind:Location → unregister) — one-time cleanup |
+
+**Two principles same as v1:**
+1. **Failures upstream of the platform are not platform concerns.** Image build issues are user-owned per CLAUDE.md; plugin auth issues are the integration's.
+2. **Auto-ingestion is eventually consistent** — TeraSky's ingestor refresh interval matters. New entities may take ~30–120s to appear after XR creation. Document this in the template README.
+
+## 8. Testing strategy
+
+**Layer 1 — `crossplane render` regression (existing harness, updated goldens).** Update both `expected-xr-minimal.yaml` and `expected-xr-with-db.yaml` to expect the 6 annotations on every child resource. TDD discipline: write updated goldens FIRST, watch tests fail, then implement Composition Python changes.
+
+**Layer 2 — Local Backstage smoke (optional, recommended).** After plugin install, run Backstage locally (`yarn dev`) against a sandbox repo + cluster context. Walk the wizard, confirm: scaffold succeeds; new XR has annotations; backend ingestor picks it up; entity appears in `/catalog`.
+
+**Layer 3 — In-cluster e2e (the demo gate):**
+1. Apply the new ClusterRole/Binding manually first; verify with `kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage`.
+2. Apply the updated Composition manually (or via PR merge); verify `kubectl describe xapplication` clean.
+3. Bump Backstage image; verify plugin tabs appear on entity pages for any pre-existing apps in the catalog.
+4. Scaffold a new test app via the live wizard (e.g. `smoketest-v1`):
+   - Scaffolder run succeeds with NO `catalog-info.yaml` in the resulting PR
+   - PR merges; ArgoCD picks up the per-app dir; Pod comes up (or probe-fails, anticipated)
+   - Entity auto-appears in Backstage **without** any `/catalog-import` action
+   - Entity page has Crossplane plugin tab showing live XR + composed children graph
+   - Edit XR via claim-updater scaffolder action — opens form, allows field change, opens PR
+5. Tear down via the v1 decommission flow (delete XR first, then PR-delete) — verify entity disappears from Backstage automatically (no manual unregister)
+
+**Regression check:** existing CrewAI template scaffolder still works after image rebuild.
+
+## 9. Out of scope (named explicitly)
+
+| Topic | Why deferred | When |
+|---|---|---|
+| AWS resources (S3, IAM) | Big design surface (XR shape, IAM auth pattern, region scoping) | **v1.3** |
+| Vault round-trip for DB credentials | Mechanism choice (VSO vs ESO+Job vs scaffolder vault:setup) needs validation | **v1.2** |
+| `healthCheckPath` as XR field | Real platform decision; orthogonal to TeraSky work | Later (probably alongside v1.3) |
+| Decommission scaffolder template | Different scaffolder pattern from onboarding; standalone work | Later |
+| XApplication XRD schema changes | None needed for v1.1 | Future when the API surface grows |
+| Crossplane plugin alternatives (Roadie's variant) | TeraSky's full suite picked in brainstorming | Reconsider only if TeraSky becomes unmaintained |
+| Custom description annotation | TeraSky derives description from XRD schema by default | Re-introduce only if real ergonomic gap surfaces |
+
+## 10. Acceptance criteria (v1.1 done)
+
+- [ ] `kubectl get clusterrolebinding backstage-crossplane-read` exists and binds to `backstage:backstage`
+- [ ] `kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage` returns `yes`
+- [ ] Composition Python emits the 6 TeraSky/Backstage annotations on every child (verified via `crossplane render` golden tests)
+- [ ] `tests/composition/render.sh xr-minimal` and `xr-with-db` both exit 0 with empty diff against updated goldens
+- [ ] New Backstage image (e.g. `v1.1.0`) baked with all 3 TeraSky NPM plugins; tag bump merged
+- [ ] `backstage-portal:v1.1.0` running in cluster; `kubectl get pod -l app=backstage` shows the new image
+- [ ] Scaffolding a test app produces an entity in Backstage **without** manual `/catalog-import`
+- [ ] Crossplane plugin tab on the entity page renders the resource graph without 403s
+- [ ] Claim-updater scaffolder action opens an edit form for an existing XR
+- [ ] CrewAI template still works (regression)
+- [ ] Spec + plan updated with v1.1 deltas
+- [ ] Helloapp's stale catalog Location entity (if it lingers) cleaned up manually
+
+## 11. Open follow-ups (not blocking v1.1)
+
+- Pin specific TeraSky NPM versions at plan-writing time (verify against TeraSky's docs).
+- Decide if `description` deserves to come back as a custom annotation (gather usage feedback from a few onboarded apps first).
+- Consider if Roadie's Crossplane plugin offers anything TeraSky doesn't (revisit only if TeraSky becomes unmaintained).
+- v1.2 spec + plan once v1.1 ships and the Vault question (Q3.5) is resolved.
+
+## 12. Sequencing dependencies
+
+1. Spec + plan land (this doc + plan)
+2. PR #N: ClusterRole + Composition annotation update (Layer 1 tests pre-merge)
+3. PR #N+1: Backstage repo PR (plugin install + config + scaffolder content cleanup)
+4. **Hard gate (user-owned per CLAUDE.md):** image rebuild for `v1.1.0`
+5. PR #N+2: tag bump in `arigsela/kubernetes:base-apps/backstage/deployments.yaml`
+6. Phase 4-style live e2e: scaffold a test app, verify all acceptance criteria
+7. Tear down test app
+8. Run notes appended to plan

--- a/tests/composition/expected-xr-minimal.yaml
+++ b/tests/composition/expected-xr-minimal.yaml
@@ -4,6 +4,13 @@
 apiVersion: platform.arigsela.com/v1alpha1
 kind: XApplication
 metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   name: smoke-app
   namespace: platform-smoke
 spec:
@@ -17,7 +24,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
     crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-app
@@ -68,7 +81,13 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
     crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-app
@@ -88,10 +107,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
     cert-manager.io/cluster-issuer: letsencrypt-prod
     crossplane.io/composition-resource-name: ingress
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-app

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -4,6 +4,13 @@
 apiVersion: platform.arigsela.com/v1alpha1
 kind: XApplication
 metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   name: smoke-db-app
   namespace: platform-smoke
 spec:
@@ -18,7 +25,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
     crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-db-app
@@ -78,7 +91,13 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
     crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-db-app
@@ -98,10 +117,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
     cert-manager.io/cluster-issuer: letsencrypt-prod
     crossplane.io/composition-resource-name: ingress
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-db-app
@@ -130,7 +155,13 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
     crossplane.io/composition-resource-name: dbcluster
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
   labels:
     app.kubernetes.io/managed-by: crossplane
     app.kubernetes.io/name: smoke-db-app

--- a/tests/composition/xr-minimal.yaml
+++ b/tests/composition/xr-minimal.yaml
@@ -5,6 +5,13 @@ kind: XApplication
 metadata:
   name: smoke-app
   namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-app
 spec:
   image: nginxinc/nginx-unprivileged:1.25-alpine
   host: smoke-app.arigsela.com

--- a/tests/composition/xr-with-db.yaml
+++ b/tests/composition/xr-with-db.yaml
@@ -5,6 +5,13 @@ kind: XApplication
 metadata:
   name: smoke-db-app
   namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
 spec:
   image: nginxinc/nginx-unprivileged:1.25-alpine
   host: smoke-db-app.arigsela.com


### PR DESCRIPTION
## Summary

First of two PRs for IDP v1.1. Lands the cluster-side prerequisites for TeraSky's `kubernetes-ingestor` to auto-ingest XRs as Backstage catalog entities.

What lands in cluster on merge:

- **`Composition/application` updated** to copy `terasky.backstage.io/*` and `backstage.io/*` annotations from the XR onto every composed child (Deployment, Service, Ingress, optional CNPG Cluster). The XR's annotations are the canonical set; the Composition is the propagator.
- **New `ClusterRole/backstage-crossplane-read` + matching binding** giving the Backstage SA cluster-wide `get/list/watch` on Crossplane API groups, our `platform.arigsela.com` XR API, and managed-resource APIs (CNPG, AWS S3/IAM). Existing `backstage-read-only` ClusterRole is unchanged — purely additive.

No new XRDs, no XR creation, no new ArgoCD apps.

## Spec & plan

- Design: `docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md` (Phase 1 = Tasks 1.1–1.4)

## TDD discipline

Both render-test goldens (`tests/composition/expected-xr-{minimal,with-db}.yaml`) updated **first** to expect the new annotations on every child. Composition Python implementation makes them green. Both tests pass with empty diff pre-merge.

## Why pre-emptive S3/IAM in the ClusterRole

When the v1.3 AWS-resources iteration adds `XS3Bucket` and `XIAMUser` XRs, the `crossplane-resources` plugin's graph view will walk those resource types. Including them in the ClusterRole now avoids 403-driven UI gaps at v1.3 time. Read-only verbs only (`get/list/watch`); no mutations possible.

## Verification (post-merge)

\`\`\`bash
# Composition is updated in cluster:
kubectl get composition application -o jsonpath='{.spec.pipeline[0].input.script}' | grep -c "std_annotations"
# Expected: > 0 (helper is present in the running script)

# Backstage SA can list XRs:
kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage
# Expected: yes

# RBAC binding landed:
kubectl get clusterrolebinding backstage-crossplane-read -o jsonpath='subjects={.subjects[0].name}/{.subjects[0].namespace}{"\n"}'
# Expected: subjects=backstage/backstage
\`\`\`

## Test plan

- [ ] \`./tests/composition/render.sh xr-minimal\` exits 0 (verified pre-PR)
- [ ] \`./tests/composition/render.sh xr-with-db\` exits 0 (verified pre-PR)
- [ ] After merge, \`crossplane-compositions\` ArgoCD app stays Healthy + Synced
- [ ] After merge, \`kubectl auth can-i list xapplications --as system:serviceaccount:backstage:backstage\` returns \`yes\`
- [ ] Phase 2 PR opens against \`arigsela/backstage\` immediately after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)