### PR TITLE
chore(backstage): bump image to v1.1.0 for IDP v1.1

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.0.4
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
## Summary

Bumps deployed Backstage tag \`v1.0.4 → v1.1.0\` to pick up the three TeraSky Crossplane plugins from [arigsela/backstage#8](https://github.com/arigsela/backstage/pull/8) (already merged + image rebuilt).

## What flips on merge

ArgoCD detects the change in \`base-apps/backstage/deployments.yaml\`, rolls the Backstage Deployment to \`v1.1.0\`. The new pod loads:

- \`kubernetes-ingestor\` — auto-ingests XRs carrying \`terasky.backstage.io/add-to-catalog: \"true\"\` as catalog entities (~30–120s refresh window).
- \`crossplane-resources\` — adds a \"Crossplane\" tab on service entity pages with live XR + composed-children graph + table.
- \`scaffolder-backend-module-terasky-utils\` — claim-updater scaffolder action lets users edit existing XRs through Backstage forms.

No new XRs are created in this PR. Until the next scaffolded app, there's nothing for the ingestor to ingest — Phase 4 e2e tests this with a fresh \`smoketest-v11\` onboarding.

## Test plan

- [ ] After ArgoCD reconciles, \`kubectl -n backstage get pod -l app=backstage -o jsonpath='{.items[0].spec.containers[0].image}'\` reports \`...:v1.1.0\`.
- [ ] Backstage \`/create\` page still shows the existing 3 templates (Application (Crossplane), CrewAI Multi-Agent Project, Example Node.js Template) — regression check.
- [ ] Phase 4 e2e proceeds with a \`smoketest-v11\` onboarding to verify auto-ingestion + Crossplane tab + claim-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)