### PR TITLE
feat(smoketest-v11): onboard via Crossplane Application

### DIFF
--- a/base-apps/smoketest-v11.yaml
+++ b/base-apps/smoketest-v11.yaml
@@ -1,0 +1,30 @@
+# ArgoCD Application for smoketest-v11
+# Sync wave 10 ensures XRD/Composition land before this app's XR.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: smoketest-v11
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/smoketest-v11
+    # catalog-info.yaml is a Backstage Component entity (backstage.io/v1alpha1),
+    # not a Kubernetes resource. Backstage reads it directly from GitHub raw
+    # via /catalog-import. ArgoCD must skip it or sync fails with
+    # "no matches for kind Component".
+    directory:
+      exclude: 'catalog-info.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: smoketest-v11
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/smoketest-v11/application-xr.yaml
+++ b/base-apps/smoketest-v11/application-xr.yaml
@@ -1,0 +1,13 @@
+# XApplication (Crossplane) for smoketest-v11
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoketest-v11
+  namespace: smoketest-v11
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine 
+  host: smoketest-v11.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false
+  dbStorage: 1Gi

--- a/base-apps/smoketest-v11/catalog-info.yaml
+++ b/base-apps/smoketest-v11/catalog-info.yaml
@@ -1,0 +1,17 @@
+# Backstage Component for smoketest-v11
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: smoketest-v11
+  description: "Managed via XApplication Composition"
+  annotations:
+    github.com/project-slug: arigsela/kubernetes
+    backstage.io/kubernetes-id: smoketest-v11
+  tags:
+    - crossplane
+    - xapplication
+spec:
+  type: service
+  lifecycle: experimental
+  owner: group:default/platform-engineering
+  system: platform


### PR DESCRIPTION
Generated by Backstage `application-template`.
Owner: group:default/platform-engineering
Database: false
