### PR TITLE
fix(backstage): grant SA read on apiextensions.k8s.io/customresourcedefinitions

### DIFF
--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -64,6 +64,14 @@ kind: ClusterRole
 metadata:
   name: backstage-crossplane-read
 rules:
+  # Kubernetes built-in CRD API — kubernetes-ingestor walks all CRDs at startup
+  # to discover what kinds to ingest (and to render entity types from XRDs).
+  # Without this, the ingestor logs Forbidden 403s in a loop and never ingests
+  # any annotated XRs.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
   # Crossplane core APIs — XRDs, Compositions, Functions, Operations
   - apiGroups: ["apiextensions.crossplane.io"]
     resources: ["compositeresourcedefinitions", "compositions", "compositionrevisions", "functions"]


### PR DESCRIPTION
## Why

After v1.1 deployed, the kubernetes-ingestor logs **Forbidden 403** in a tight loop:

```
Failed to fetch XRD objects for cluster homelab: Error: Failed to fetch Kubernetes resources:
with response {"size":0,"timeout":0} Forbidden for request to
/apis/apiextensions.k8s.io/v1/customresourcedefinitions
```

The plugin walks all CRDs at startup to discover what kinds to ingest. The v1.1 `backstage-crossplane-read` ClusterRole gave access to `apiextensions.crossplane.io/*` (Crossplane's own API) — but NOT to `apiextensions.k8s.io/customresourcedefinitions` (Kubernetes' built-in CRD API). Real RBAC gap missed in the v1.1 spec.

## Fix

Add a single rule to the existing ClusterRole granting `get/list/watch` on `apiextensions.k8s.io/customresourcedefinitions`. Cluster-wide because the ingestor walks ALL CRDs.

Server dry-run validates clean.

## After merge

ArgoCD applies the updated ClusterRole. The kubernetes-ingestor's next scheduled run (~30s cadence) succeeds; XApplication entities with `terasky.backstage.io/add-to-catalog: "true"` start auto-ingesting into the catalog within ~1–2 min.

The currently-stuck task can then be retried (or canceled and a fresh scaffolder run kicked off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)