### PR TITLE
feat(snometest-v11c): onboard via Crossplane Application

### DIFF
--- a/base-apps/snometest-v11c.yaml
+++ b/base-apps/snometest-v11c.yaml
@@ -1,0 +1,24 @@
+# ArgoCD Application for snometest-v11c
+# Sync wave 10 ensures XRD/Composition land before this app's XR.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snometest-v11c
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/snometest-v11c
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: snometest-v11c
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/snometest-v11c/application-xr.yaml
+++ b/base-apps/snometest-v11c/application-xr.yaml
@@ -1,0 +1,23 @@
+# XApplication (Crossplane) for snometest-v11c
+# metadata.annotations are read by TeraSky's kubernetes-ingestor and copied
+# onto every composed child by the cluster-side Composition (see
+# arigsela/kubernetes:base-apps/crossplane-compositions/composition-application.yaml).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: snometest-v11c
+  namespace: snometest-v11c
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/snometest-v11c
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine 
+  host: smoketest-v11c.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false
+  dbStorage: 1Gi


### PR DESCRIPTION
Generated by Backstage `application-template`.
Owner: group:default/platform-engineering
Database: false
