### PR TITLE
docs(idp): backport v1.1 lessons + correct v1 §8 decommission order

### DIFF
--- a/docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md
+++ b/docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-plugins.md
@@ -109,6 +109,41 @@ npm view @terasky/backstage-plugin-scaffolder-backend-module-terasky-utils versi
 
 Record the four versions in your worktree notes. Throughout this plan, `<INGESTOR_VER>`, `<XPRES_BACK_VER>`, `<XPRES_FRONT_VER>`, `<SCAF_UTILS_VER>` placeholders mean "the version you just looked up." If TeraSky publishes a v2 with breaking changes after this plan was written, halt and reassess scope.
 
+### P.6 — Postgres `template1` collation refresh (idempotent)
+
+The TeraSky `crossplane-resources-backend` plugin creates its own database (`backstage_plugin_crossplane`) on first startup. If the Postgres `template1` database has a collation version mismatch (common after Postgres image OS updates), `CREATE DATABASE` fails with `template database "template1" has a collation version mismatch`. This causes a `BackendStartupError` that silently breaks the scaffolder TaskWorker — tasks stack up in `status=open` with no worker pickup.
+
+Run BEFORE deploying v1.1:
+
+```bash
+# Find the Postgres pod and admin user (likely the bootstrap user from pod env)
+PG_POD=$(kubectl -n postgresql get pod -o jsonpath='{.items[0].metadata.name}')
+PG_USER=$(kubectl -n postgresql exec "$PG_POD" -- printenv POSTGRES_USER)
+
+# Refresh template1 first (must connect via a different DB; can't ALTER while connected)
+kubectl -n postgresql exec "$PG_POD" -- psql -U "$PG_USER" -d postgres -c \
+  "ALTER DATABASE template1 REFRESH COLLATION VERSION;"
+
+# Refresh the postgres DB itself (must connect via template1)
+kubectl -n postgresql exec "$PG_POD" -- psql -U "$PG_USER" -d template1 -c \
+  "ALTER DATABASE postgres REFRESH COLLATION VERSION;"
+
+# Refresh any existing backstage_plugin_* DBs that also warn
+for DB in $(kubectl -n postgresql exec "$PG_POD" -- psql -U "$PG_USER" -d postgres -tAc \
+  "SELECT datname FROM pg_database WHERE datname LIKE 'backstage_plugin%';"); do
+  [ -n "$DB" ] && kubectl -n postgresql exec "$PG_POD" -- psql -U "$PG_USER" -d postgres -c \
+    "ALTER DATABASE \"$DB\" REFRESH COLLATION VERSION;"
+done
+```
+
+Verify clean:
+
+```bash
+kubectl -n postgresql exec "$PG_POD" -- psql -U "$PG_USER" -d template1 -c "SELECT 1;" 2>&1 | grep -i "collation" || echo "template1 clean"
+```
+
+If the verify step shows nothing, you're good.
+
 ---
 
 ## Phase 1 — kubernetes repo: RBAC + Composition annotations (TDD)
@@ -537,6 +572,14 @@ kind: ClusterRole
 metadata:
   name: backstage-crossplane-read
 rules:
+  # Kubernetes built-in CRD API — kubernetes-ingestor walks all CRDs at startup
+  # to discover what kinds to ingest. Without this, the ingestor logs Forbidden
+  # 403s in a loop and never ingests any annotated XRs (real bug shipped in
+  # v1.1's first deploy; caught and fixed via PR #214).
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
   # Crossplane core APIs — XRDs, Compositions, Functions, Operations
   - apiGroups: ["apiextensions.crossplane.io"]
     resources: ["compositeresourcedefinitions", "compositions", "compositionrevisions", "functions"]
@@ -880,6 +923,16 @@ git commit -m "feat(frontend): add Crossplane Resources tab to service entity pa
 - [ ] **Step 1: Read TeraSky's expected config shape**
 
 Visit the three plugin READMEs at <https://github.com/TeraSky-OSS/backstage-plugins>. Each documents an `app-config.yaml` snippet to copy. Capture the three sections (`kubernetesIngestor:`, `crossplane:`, and `scaffolder:` extensions).
+
+> **Backend auth requirement:** v1.1's first deploy hit `401 Missing credentials` on internal kubernetes-ingestor calls because Backstage v1.x's modern backend system requires plugins to authenticate when calling each other internally. For single-process homelab Backstage, the fix is to also add a `backend.auth` block to BOTH `app-config.yaml` and `app-config.production.yaml`:
+>
+> ```yaml
+> backend:
+>   auth:
+>     dangerouslyDisableDefaultAuthPolicy: true
+> ```
+>
+> This is the documented escape hatch for single-process Backstage. For multi-process or multi-tenant production, switch to real service-tokens via `backend.auth.keys` + a Vault-backed shared secret. **Add this block alongside the three plugin-config sections below — both in base config and in production overlay.**
 
 > The exact content depends on TeraSky's current docs at execution time. The structure typically looks like:
 >
@@ -1508,3 +1561,47 @@ Plan complete and saved to `docs/superpowers/plans/2026-04-29-idp-v1.1-terasky-p
 **2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
 
 Which approach?
+
+## Run Notes (2026-04-30)
+
+**Outcome:** v1.1 of the IDP shipped. Three TeraSky Backstage plugins (`kubernetes-ingestor` + `crossplane-resources` frontend/backend + `scaffolder-backend-module-terasky-utils`) installed at versions `3.14.0` / `2.17.0` / `1.15.0` / `2.7.0` respectively. Composition Python emits `terasky.backstage.io/*` annotations from XR onto every composed child. New `backstage-crossplane-read` ClusterRole grants the Backstage SA cluster-wide read on Crossplane + managed-resource APIs.
+
+**E2E validation** (`snometest-v11c`):
+
+- ✅ Backstage form → PR #215 opened with **only 2 files** (no `catalog-info.yaml`)
+- ✅ XR carries the 6 TeraSky/Backstage annotations
+- ✅ ArgoCD synced; Composition rendered Deployment + Service + Ingress with annotations stamped
+- ✅ Entity auto-appeared in `backstage.arigsela.com/catalog` after ~60s — no manual `/catalog-import`
+- ✅ Crossplane plugin tab on entity page rendered: 4 resources (XApplication XR + Deployment + Service + Ingress), Crossplane v2 Resource Graph, XR Scope: `Namespaced`
+- ✅ Tear-down auto-deingested the entity from Backstage within ~30–120s of XR deletion (no manual unregister) — the v1.1 lifecycle-symmetry win
+
+**Bugs caught during execution** (and fixed via follow-up PRs):
+
+| # | Bug | Fix PR |
+|---|---|---|
+| 1 | `apiextensions.k8s.io/customresourcedefinitions` missing from `backstage-crossplane-read` ClusterRole — kubernetes-ingestor 403'd on every CRD-discovery run | [arigsela/kubernetes#214](https://github.com/arigsela/kubernetes/pull/214) |
+| 2 | Backstage v1.x service-to-service auth requirement broke internal kubernetes-ingestor proxy calls with `401 Missing credentials` | [arigsela/backstage#9](https://github.com/arigsela/backstage/pull/9) — adds `backend.auth.dangerouslyDisableDefaultAuthPolicy: true` |
+| 3 | Postgres `template1` collation version mismatch caused `crossplane-resources-backend` plugin's `CREATE DATABASE` to fail at startup, leaving the scaffolder TaskWorker silently broken | One-time `ALTER DATABASE template1 REFRESH COLLATION VERSION;` on the Postgres pod (now documented as Pre-flight P.6) |
+| 4 | First scaffolder run (PR #213) raced against the v1.0.4-pod-still-running-during-roll and produced v1.0.4-shaped manifests | Re-run after roll completed; PR #215 has the v1.1-shaped manifests. No code fix needed; flagged in deploy notes. |
+| 5 | Browser cached old chunk hashes after image rebuild → Crossplane tab didn't appear until incognito/hard-reload | No code fix; confirmed Cmd+Shift+R or incognito unblocks it |
+
+**Spec correction (real v1 bug discovered during v1.1 teardown):** v1 spec §8 said *delete XR first, then PR-delete*. That doesn't work in GitOps with `selfHeal: true` — ArgoCD immediately re-applies the XR from the still-in-repo manifest before kubectl can finish. Corrected order is *PR-delete first, then kubectl delete the orphan*. v1 spec §8 has been updated.
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| arigsela/kubernetes#211 | Phase 1 — Composition annotations + RBAC |
+| arigsela/backstage#8 | Phase 2 — TeraSky plugins + scaffolder cleanup |
+| arigsela/kubernetes#212 | Tag bump v1.0.4 → v1.1.0 |
+| arigsela/kubernetes#214 | Fix RBAC for `apiextensions.k8s.io/customresourcedefinitions` |
+| arigsela/backstage#9 | Fix `dangerouslyDisableDefaultAuthPolicy` |
+| arigsela/kubernetes#215 | scaffold/snometest-v11c e2e onboard |
+| arigsela/kubernetes#216 | Teardown e2e smoke app |
+| (this PR) | docs backport: v1 spec §8 correction + v1.1 lessons learned + run notes |
+
+**v2 follow-up candidates** (queued for next iteration):
+
+- **v1.2** — Vault round-trip for DB credentials (Q3.5 from brainstorming still needs ESO-vs-VSO resolution)
+- **v1.3** — AWS resources (S3 + IAM with IRSA-on-homelab caveat from Q2.6)
+- **`healthCheckPath` as XR field** — replaces v1's hardcoded `/healthz`; eliminates the nginx-unprivileged probe-fail trap

--- a/docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md
+++ b/docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md
@@ -314,17 +314,21 @@ content-k8s/
 1. **No retries inside the Composition.** Crossplane reconciles again on the next loop; the Python script is deterministic given the XR.
 2. **Failures upstream of Crossplane are someone else's concern.** Image, cert-manager, cluster-storage failures are not platform-team triage paths.
 
-**Decommissioning in v1 — manual three-step:**
+**Decommissioning in v1 — manual three-step (CORRECTED — original ordering caused selfHeal recreation):**
 
-1. **Delete the XApplication first** (`kubectl -n <ns> delete xapplication <name>`). Crossplane's owner-references then reap the composed Deployment/Service/Ingress/Cluster cleanly. cert-manager's `Certificate` and ACME solver objects (children of the Ingress) GC along with it.
-2. **Open a PR removing `base-apps/<name>.yaml` + `base-apps/<name>/`.** Master-app prunes the per-app Argo CD Application; the now-empty source directory simply disappears.
+1. **PR-delete the manifests FIRST.** Open a PR removing `base-apps/<name>.yaml` + `base-apps/<name>/`. Merge it. Master-app reconciles within ~30s and prunes the per-app Argo CD Application that was managing the XR.
+2. **Once the per-app Application is gone, the XR is orphaned** — no controller is reconciling it back. NOW run:
+   ```bash
+   kubectl -n <name> delete xapplication <name>
+   ```
+   Crossplane's owner-references then reap the composed Deployment / Service / Ingress / Cluster cleanly. cert-manager's Certificate and ACME solver objects (children of the Ingress) GC along with it.
 3. **`kubectl delete ns <name>`** — the namespace was created by `CreateNamespace=true` on the per-app Application; ArgoCD does NOT auto-delete it on Application removal.
 
-**Why delete the XApplication first** rather than just rely on ArgoCD's prune cascade: when master-app prunes the per-app Application, the XApplication and its composed children become orphaned (the Application that managed them is gone before the prune cascade reaps them). Deleting the XApplication explicitly first triggers Crossplane's owner-ref cascade synchronously.
+**Why this order matters** (the original v1 spec had it backwards): the per-app ArgoCD Application has `syncPolicy.automated.selfHeal: true`. If you `kubectl delete xapplication` before merging the teardown PR, ArgoCD detects the drift and re-applies the XR from the still-in-repo manifest within seconds — the delete is undone instantly. The PR-first order ensures that by the time you `kubectl delete xapplication`, no controller is reconciling it back.
 
 **CNPG PVC retention:** `Cluster` deletion does NOT auto-delete its PVC (CNPG default). When decommissioning a `dbNeeded: true` app, also clean up the PVC manually if you don't want to retain the data.
 
-**Backstage catalog Location cleanup:** if you registered the app via `/catalog-import`, that Location entity needs to be unregistered manually after PR merge — otherwise Backstage's refresh perpetually fails to fetch the deleted catalog-info.yaml URL.
+**Backstage catalog Location cleanup (v1 only — superseded by v1.1):** if you registered the app via `/catalog-import` in v1, the Location entity needs to be unregistered manually after PR merge. v1.1's TeraSky `kubernetes-ingestor` makes this automatic — entities auto-deingest within ~30–120s of the XR being deleted.
 
 ## 9. Testing strategy
 

--- a/docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md
+++ b/docs/superpowers/specs/2026-04-29-idp-v1.1-terasky-plugins-design.md
@@ -333,3 +333,66 @@ Each `make_*` helper takes a new `annotations=` kwarg and merges it into the res
 6. Phase 4-style live e2e: scaffold a test app, verify all acceptance criteria
 7. Tear down test app
 8. Run notes appended to plan
+
+## 13. Lessons learned (post-shakeout)
+
+Four real gaps surfaced during v1.1's e2e shakeout. All were fixed in code via follow-up PRs; documenting them here so a future re-execution starts from a corrected baseline.
+
+### 13.1 Postgres `template1` collation prerequisite
+
+The `crossplane-resources-backend` plugin creates its own database (`backstage_plugin_crossplane`) on first startup. If the Postgres `template1` database has a collation version mismatch (common after Postgres OS-image updates where the OS locale changed), the `CREATE DATABASE` fails with:
+
+```
+template database "template1" has a collation version mismatch
+```
+
+This raises an unhandled rejection during plugin init that cascades into `BackendStartupError` — the entire backend fails to fully initialize, including the scaffolder TaskWorker, which silently never picks up tasks. Symptoms: scaffolder tasks stuck in `status=open` with empty `last_heartbeat_at`.
+
+**Pre-deploy fix (idempotent):**
+
+```bash
+PG_USER=$(kubectl -n postgresql exec <postgres-pod> -- printenv POSTGRES_USER)
+kubectl -n postgresql exec <postgres-pod> -- psql -U "$PG_USER" -d template1 -c \
+  "ALTER DATABASE template1 REFRESH COLLATION VERSION;"
+kubectl -n postgresql exec <postgres-pod> -- psql -U "$PG_USER" -d template1 -c \
+  "ALTER DATABASE postgres REFRESH COLLATION VERSION;"
+# Optional — refresh existing backstage_plugin_* DBs if they also warn
+for DB in $(kubectl -n postgresql exec <postgres-pod> -- psql -U "$PG_USER" -d postgres -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'backstage_plugin%';"); do
+  kubectl -n postgresql exec <postgres-pod> -- psql -U "$PG_USER" -d postgres -c \
+    "ALTER DATABASE \"$DB\" REFRESH COLLATION VERSION;"
+done
+```
+
+### 13.2 `backend.auth.dangerouslyDisableDefaultAuthPolicy: true` is required
+
+Backstage v1.x requires backend plugins to authenticate to each other when making internal API calls. With `permission.enabled: true` and no shared secret (`backend.auth.keys`), scheduled-task plugins like the kubernetes-ingestor fail with `401 Missing credentials` on calls to `/api/kubernetes/proxy/...`. The result: zero CRDs ingested → zero entities discovered → auto-ingestion silently never works.
+
+For single-process homelab Backstage where all plugins run in one Node.js process, the documented escape hatch is:
+
+```yaml
+backend:
+  auth:
+    dangerouslyDisableDefaultAuthPolicy: true
+```
+
+Add this to BOTH `app-config.yaml` and `app-config.production.yaml` (production-overlay rule applies).
+
+For multi-process or multi-tenant production Backstage, replace with a real shared secret via `backend.auth.keys` + a Vault-backed `BACKEND_SECRET`. v1.1 explicitly scopes to single-process homelab.
+
+### 13.3 RBAC: `apiextensions.k8s.io/customresourcedefinitions` is required
+
+The `kubernetes-ingestor` walks ALL CRDs at startup to discover what kinds to ingest. The original v1.1 `backstage-crossplane-read` ClusterRole granted `apiextensions.crossplane.io/*` (Crossplane's own API) but missed `apiextensions.k8s.io/customresourcedefinitions` (Kubernetes' built-in CRD API). Result: the ingestor logs Forbidden 403s in a tight loop and never discovers anything.
+
+Add the rule to the ClusterRole:
+
+```yaml
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+```
+
+### 13.4 Browser cache when iterating with same image tag
+
+Backstage's static JS chunks have content-hashed filenames so they SHOULD bust on rebuild. However, iterating on frontend changes (e.g. `EntityPage.tsx` route additions) and pushing to the same image tag (`v1.1.0` → re-tag) can leave browsers serving the previously-cached `index.html` that references old chunk hashes. The Crossplane tab won't appear until the browser fetches the fresh `index.html`.
+
+**Test in incognito** (bypasses all cache including service workers) before debugging deeper. If incognito shows the change but a regular window doesn't, it's purely browser cache — `Cmd+Shift+R` hard reload typically clears it.


### PR DESCRIPTION
## Summary

Single docs-only PR closing out IDP v1.1. Captures the four real gaps caught during the e2e shakeout (all already fixed in code via prior PRs) plus a real v1 spec bug discovered while tearing down the v1.1 smoke app.

No code changes here.

## v1 spec §8 correction

The v1 design spec said `delete XR first, then PR-delete`. Doesn't work with GitOps + `selfHeal: true` — ArgoCD re-applies the XR from the still-in-repo manifest before `kubectl` finishes the delete. Caught when tearing down `snometest-v11c`. Correct order: PR-delete first → master-app prunes the per-app Application → XR becomes orphaned → `kubectl delete xapplication` succeeds without recreation.

## v1.1 lessons (new spec §13)

| Lesson | Discovered when | Already-shipped fix |
|---|---|---|
| Postgres `template1` collation prerequisite (silent BackendStartupError on first run) | first `v1.1.0` deploy | One-time `ALTER DATABASE`; now in plan Pre-flight P.6 |
| `backend.auth.dangerouslyDisableDefaultAuthPolicy: true` required for single-process Backstage | first scaffolder task hung | arigsela/backstage#9 |
| RBAC needs `apiextensions.k8s.io/customresourcedefinitions` | ingestor 403 loop after first run | arigsela/kubernetes#214 |
| Browser cache stickiness when iterating frontend with same image tag | Crossplane tab missing in regular Chrome window, present in incognito | (no code fix; documented for the runbook) |

## v1.1 plan corrections

- **Pre-flight P.6** — Postgres collation refresh commands.
- **Task 1.3** — ClusterRole snippet now includes the missing `apiextensions.k8s.io` rule.
- **Task 2.4** — `backend.auth` block to add to both base + production app-config.
- **Run Notes section** appended: outcome summary, e2e validation, bug-fix PR list, v2 candidates.

## What's NOT in this PR

- Any actual code changes (those shipped via prior PRs already merged).
- v2 spec/plan (Vault round-trip / AWS resources / healthCheckPath) — queued in run notes for next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)