### PR TITLE
feat(idp): v1.2 Vault round-trip for DB credentials

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -46,6 +46,108 @@ spec:
               copied["crossplane.io/composition-resource-name"] = resource_name
               return copied
 
+          # Canonical keys CNPG auto-generates in <name>-db-app. Names are preserved
+          # verbatim through Vault → ESO → projected Secret so workload env vars stay
+          # byte-identical to v1.1 behavior. (Renaming uri→DATABASE_URL etc. is a
+          # separate v1 ergonomic improvement, NOT in v1.2 scope.)
+          DB_SECRET_KEYS = ["dbname", "host", "jdbc-uri", "password",
+                            "pgpass", "port", "uri", "username"]
+
+          def make_secret_store(name, namespace, annotations):
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "SecretStore",
+                  "metadata": {
+                      "name": "vault-backend",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "provider": {
+                          "vault": {
+                              "server": "http://vault.vault.svc.cluster.local:8200",
+                              "path": "k8s-secrets",
+                              "version": "v2",
+                              "auth": {
+                                  "kubernetes": {
+                                      "mountPath": "kubernetes",
+                                      "role": namespace,
+                                      "serviceAccountRef": {"name": "default"},
+                                  },
+                              },
+                          },
+                      },
+                  },
+              }
+
+          def make_push_secret(name, namespace, annotations):
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-db-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "1h",
+                      "deletionPolicy": "Delete",
+                      "secretStoreRefs": [
+                          {"name": "vault-backend", "kind": "SecretStore"},
+                      ],
+                      "selector": {
+                          "secret": {"name": f"{name}-db-app"},
+                      },
+                      "data": [
+                          {
+                              "match": {
+                                  "secretKey": k,
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/db",
+                                      "property": k,
+                                  },
+                              },
+                          }
+                          for k in DB_SECRET_KEYS
+                      ],
+                  },
+              }
+
+          def make_external_secret(name, namespace, annotations):
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "ExternalSecret",
+                  "metadata": {
+                      "name": f"{name}-db",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "15s",
+                      "secretStoreRef": {
+                          "name": "vault-backend",
+                          "kind": "SecretStore",
+                      },
+                      "target": {
+                          "name": f"{name}-db",
+                          "creationPolicy": "Owner",
+                      },
+                      "data": [
+                          {
+                              "secretKey": k,
+                              "remoteRef": {
+                                  "key": f"{namespace}/db",
+                                  "property": k,
+                              },
+                          }
+                          for k in DB_SECRET_KEYS
+                      ],
+                  },
+              }
+
           def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations):
               container = {
                   "name": "app",
@@ -172,7 +274,7 @@ spec:
               port = int(spec["port"])
               replicas = int(spec.get("replicas", 2))
 
-              db_secret = f"{name}-db-app" if spec.get("dbNeeded") else None
+              db_secret = f"{name}-db" if spec.get("dbNeeded") else None
               env_from  = db_secret
 
               resource.update(
@@ -198,4 +300,19 @@ spec:
                       make_cnpg_cluster(name, namespace,
                                         instances=1, storage=spec.get("dbStorage", "1Gi"),
                                         annotations=std_annotations(xr_annotations, "dbcluster")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["pushsecret"],
+                      make_push_secret(name, namespace,
+                                       annotations=std_annotations(xr_annotations, "pushsecret")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["externalsecret"],
+                      make_external_secret(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "externalsecret")),
                   )

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -56,10 +56,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: uri
-                  name: smoke-db-app-db-app
+                  name: smoke-db-app-db
           envFrom:
             - secretRef:
-                name: smoke-db-app-db-app
+                name: smoke-db-app-db
           image: nginxinc/nginx-unprivileged:1.25-alpine
           livenessProbe:
             httpGet:
@@ -177,3 +177,160 @@ spec:
   instances: 1
   storage:
     size: 1Gi
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+    crossplane.io/composition-resource-name: externalsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app-db
+  namespace: platform-smoke
+spec:
+  data:
+    - remoteRef:
+        key: platform-smoke/db
+        property: dbname
+      secretKey: dbname
+    - remoteRef:
+        key: platform-smoke/db
+        property: host
+      secretKey: host
+    - remoteRef:
+        key: platform-smoke/db
+        property: jdbc-uri
+      secretKey: jdbc-uri
+    - remoteRef:
+        key: platform-smoke/db
+        property: password
+      secretKey: password
+    - remoteRef:
+        key: platform-smoke/db
+        property: pgpass
+      secretKey: pgpass
+    - remoteRef:
+        key: platform-smoke/db
+        property: port
+      secretKey: port
+    - remoteRef:
+        key: platform-smoke/db
+        property: uri
+      secretKey: uri
+    - remoteRef:
+        key: platform-smoke/db
+        property: username
+      secretKey: username
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: smoke-db-app-db
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+    crossplane.io/composition-resource-name: pushsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: smoke-db-app-db-push
+  namespace: platform-smoke
+spec:
+  data:
+    - match:
+        remoteRef:
+          property: dbname
+          remoteKey: platform-smoke/db
+        secretKey: dbname
+    - match:
+        remoteRef:
+          property: host
+          remoteKey: platform-smoke/db
+        secretKey: host
+    - match:
+        remoteRef:
+          property: jdbc-uri
+          remoteKey: platform-smoke/db
+        secretKey: jdbc-uri
+    - match:
+        remoteRef:
+          property: password
+          remoteKey: platform-smoke/db
+        secretKey: password
+    - match:
+        remoteRef:
+          property: pgpass
+          remoteKey: platform-smoke/db
+        secretKey: pgpass
+    - match:
+        remoteRef:
+          property: port
+          remoteKey: platform-smoke/db
+        secretKey: port
+    - match:
+        remoteRef:
+          property: uri
+          remoteKey: platform-smoke/db
+        secretKey: uri
+    - match:
+        remoteRef:
+          property: username
+          remoteKey: platform-smoke/db
+        secretKey: username
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: SecretStore
+      name: vault-backend
+  selector:
+    secret:
+      name: smoke-db-app-db-app
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-db-app
+    crossplane.io/composition-resource-name: secretstore
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-db-app
+    backstage.io/kubernetes-id: smoke-db-app
+  name: vault-backend
+  namespace: platform-smoke
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: platform-smoke
+          serviceAccountRef:
+            name: default
+      path: k8s-secrets
+      server: http://vault.vault.svc.cluster.local:8200
+      version: v2


### PR DESCRIPTION
## Summary

Implements IDP v1.2 — routes Postgres DB credentials for v1+ scaffolded apps through Vault by inserting an ESO `PushSecret` (CNPG → Vault) and `ExternalSecret` (Vault → namespace-local Secret) into the read path. Workloads consume creds from the ESO-projected Secret instead of the CNPG-generated one directly.

## What this does

When `dbNeeded: true`, Composition now emits 3 new resources:

| Resource | Purpose |
|---|---|
| `SecretStore vault-backend` (per-namespace) | Connects ESO to Vault via K8s auth, role=`<namespace>` |
| `PushSecret <name>-db-push` | Reads CNPG-generated `<name>-db-app`, pushes 8 keys to `k8s-secrets/<name>/db`. `deletionPolicy: Delete` GCs the Vault entry on teardown |
| `ExternalSecret <name>-db` | Reads from Vault, projects to K8s Secret `<name>-db` (15s refresh) |

Deployment `envFrom` switches from `<name>-db-app` → `<name>-db` (single var rename in `compose()`). CNPG Secret stays untouched.

## Pre-flight already done

Phase 0 ran on 2026-04-30:
- K8s auth accessor: `auth_kubernetes_4b2d98fc`
- Templated `app-namespace-rw` policy applied to Vault
- Identity-alias metadata verified populated

## Per-namespace role binding (operator action)

New v1.2 apps need a Vault role bound to `app-namespace-rw` BEFORE the onboarding PR merges. Captured in plan Phase 0 Task 0.3:

```bash
NAMESPACE=<smoke-app-namespace>
kubectl -n vault exec vault-0 -- vault write auth/kubernetes/role/${NAMESPACE} \
  bound_service_account_names=default \
  bound_service_account_namespaces=${NAMESPACE} \
  policies="default,app-namespace-rw" \
  ttl=1h
```

## Test plan

- [x] `./tests/composition/render.sh xr-with-db` — golden updated, PASSES
- [x] `./tests/composition/render.sh xr-minimal` — golden unchanged, PASSES (regression baseline preserved)
- [x] Phase 0 pre-flight verified before merge
- [ ] Smoke onboarding via Backstage with `dbNeeded: true` after merge:
  - [ ] Vault role created BEFORE smoke-app PR merge (per-namespace policy binding)
  - [ ] App deploys end-to-end within 5 min
  - [ ] `vault kv get k8s-secrets/<smoke-name>/db` returns all 8 keys
  - [ ] Deployment `envFrom` shows `<smoke-name>-db` (ESO-projected)
  - [ ] PushSecret + ExternalSecret status = healthy
  - [ ] Backstage Crossplane tab shows the 3 new resources
  - [ ] Teardown PR + orphan-XR delete: `vault kv get` returns NotFound (deletionPolicy Delete validation)
  - [ ] chores-tracker continues working (regression)

## Things explicitly NOT in v1.2

- ❌ Cred rotation (deferred to v2/C — VSO + Vault Database secrets engine)
- ❌ chores-tracker migration to hierarchical layout (its flat path stays)
- ❌ AWS resources (v1.3)
- ❌ XRD changes, env var renames, healthCheckPath fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)