### PR TITLE
feat(cnpg): install CloudNativePG operator under GitOps

### DIFF
--- a/base-apps/cnpg-system.yaml
+++ b/base-apps/cnpg-system.yaml
@@ -1,0 +1,53 @@
+# CloudNativePG operator (cnpg-system)
+#
+# Installs the CNPG operator + webhook via the upstream Helm chart so that
+# Crossplane Compositions producing postgresql.cnpg.io/Cluster resources
+# (e.g. v1+ IDP apps with `dbNeeded: true`) have a controller available
+# to reconcile them.
+#
+# Discovery context: v1.2 IDP smoke validation found the operator was
+# manually installed at some point in the past and subsequently removed,
+# leaving only the CRDs and a webhook Service stub. This Application
+# brings CNPG back under GitOps so it can't drift again.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg-system
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://cloudnative-pg.github.io/charts
+    chart: cloudnative-pg
+    targetRevision: 0.22.1
+    helm:
+      releaseName: cnpg
+      values: |
+        # Pin operator + webhook to infrastructure nodes per cluster convention
+        # (cert-manager / external-secrets follow the same selector + tolerations).
+        nodeSelector:
+          node.kubernetes.io/workload: infrastructure
+        tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+
+        # CRDs already installed on this cluster from a prior manual install
+        # (dating back to 2025-12-03). The Helm chart's hook-based CRD install
+        # would conflict; let upstream chart manage them on subsequent upgrades.
+        crds:
+          create: true
+
+        # Default monitoring / metrics off for now — observability stack
+        # integration can be a follow-up.
+        monitoring:
+          podMonitorEnabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Adds the CloudNativePG operator as a GitOps-managed ArgoCD Application using the upstream Helm chart. Brings the operator + admission webhook back into the cluster so Crossplane Compositions producing \`postgresql.cnpg.io/Cluster\` resources (v1+ IDP apps with \`dbNeeded: true\`) have a controller to reconcile them.

## How this was discovered

During IDP v1.2 smoke validation (PR #220 + #219 just merged), the \`smoke-v12\` XR rendered correctly but Crossplane couldn't apply the CNPG Cluster resource:

\`\`\`
Internal error occurred: failed calling webhook \"mcluster.cnpg.io\":
no endpoints available for service \"cnpg-webhook-service\"
\`\`\`

Investigation:
- \`cnpg-system\` namespace exists but has zero pods
- \`postgresql.cnpg.io\` CRDs are installed (creation 2025-12-03)
- \`cnpg-webhook-service\` Service exists with **no endpoints** (148 days old)

The operator was apparently manually installed at some point and removed since, leaving stale infrastructure. v1.1 dbNeeded:true probably also wouldn't have worked, but it wasn't tested with a fresh smoke app — chores-tracker uses a different DB path.

## What this changes

- Adds \`base-apps/cnpg-system.yaml\` — ArgoCD Application sourcing the upstream Helm chart
- Pins chart to **0.22.1** (operator v1.24.0) — matches the CRD generation already on cluster
- Node selector + toleration follow \`cert-manager\` / \`external-secrets\` convention (pinned to infra nodes)
- \`ServerSideApply: true\` to handle the existing CRD ownership cleanly

## What this does NOT change

- No CRD recreation — chart picks them up
- No application-level config — operator runs with defaults
- No monitoring integration (PodMonitor disabled; deferred to a future observability sweep)
- No changes to v1.2 Composition or any IDP app code

## Test plan

- [ ] Merge → ArgoCD master-app picks up new Application within ~30s
- [ ] \`cnpg-system\` namespace has running operator + webhook pods
- [ ] \`kubectl -n cnpg-system get endpoints cnpg-webhook-service\` returns endpoints
- [ ] Resume v1.2 smoke validation — \`smoke-v12\` XR re-reconciles, CNPG Cluster bootstraps, full chain (CNPG → PushSecret → Vault → ExternalSecret → projected Secret → Pod) completes
- [ ] If Crossplane SA still 403s on \`clusters/status.postgresql.cnpg.io/v1\` after operator is up, that's a separate Crossplane RBAC fix (small follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)