### PR TITLE
fix(crossplane): grant SA permissions on cnpg /status + ESO resources

### DIFF
--- a/base-apps/crossplane-compositions/composition-rbac.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac.yaml
@@ -36,6 +36,25 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # CNPG Cluster + status. The /status subresource is required for Crossplane's
+  # informer to sync — without it, compose fails with:
+  #   "Timeout: failed waiting for *unstructured.Unstructured Informer to sync"
+  # because Crossplane can't read back the Cluster's reconciled state.
   - apiGroups: ["postgresql.cnpg.io"]
-    resources: ["clusters"]
+    resources: ["clusters", "clusters/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # External Secrets Operator resources — v1.2 IDP apps with `dbNeeded: true`
+  # have the Composition emit SecretStore / PushSecret / ExternalSecret per
+  # namespace to round-trip CNPG-generated DB creds through Vault. Crossplane
+  # needs full lifecycle access plus /status for readiness signaling.
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - secretstores
+      - secretstores/status
+      - pushsecrets
+      - pushsecrets/status
+      - externalsecrets
+      - externalsecrets/status
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary

Two missing RBAC rules surfaced during v1.2 smoke validation. Both block \`smoke-v12\` (and any future \`dbNeeded: true\` IDP app) from bootstrapping.

## What was broken

After PR #221 brought the CNPG operator back online, \`smoke-v12\` re-tried compose and hit:

\`\`\`
cannot compose resources: cannot get existing composed resources:
cannot get composed resource: Timeout: failed waiting for
*unstructured.Unstructured Informer to sync
\`\`\`

Plus the older error from before the operator was installed:

\`\`\`
system:serviceaccount:crossplane-system:crossplane is not allowed
to [get, list, watch, create, update, patch, delete] resource
clusters/status.postgresql.cnpg.io/v1 in namespace smoke-v12
\`\`\`

Root cause: Crossplane's informer needs to read the \`/status\` subresource of every composed resource type to determine readiness. \`postgresql.cnpg.io/clusters/status\` was missing from the aggregated ClusterRole. Same gap exists for the v1.2 ESO resources (\`secretstores\`, \`pushsecrets\`, \`externalsecrets\`) which were never granted at all — they're new in v1.2.

## What this changes

\`base-apps/crossplane-compositions/composition-rbac.yaml\` adds two rule additions to the existing \`crossplane:compositions:application\` aggregated ClusterRole:

1. \`postgresql.cnpg.io\` — added \`clusters/status\` resource
2. \`external-secrets.io\` — new rule covering \`secretstores\`, \`pushsecrets\`, \`externalsecrets\` (and their /status subresources)

## Why it was missed

The original v1 RBAC was written when only Ingress + CNPG Cluster were composed. \`/status\` requirement isn't immediately obvious unless you read Crossplane's runtime carefully. v1.2's spec called out the new resources but the RBAC implication was deferred to a separate concern (this PR is that concern).

## Test plan

- [ ] Merge → ArgoCD master-app reconciles the rule update (~30s)
- [ ] \`smoke-v12\` XR auto-retries the compose loop (Crossplane retries every 30-60s on its own)
- [ ] CNPG Cluster bootstraps successfully
- [ ] PushSecret + ExternalSecret + SecretStore are created
- [ ] Bootstrap chain completes (CNPG → PushSecret → Vault → ExternalSecret → projected Secret → Pod)
- [ ] Resume v1.2 acceptance criteria sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)