### PR TITLE
docs(idp): v1.2 close-out — run notes + spec §5.1 metadata caps backport

### DIFF
--- a/docs/superpowers/plans/2026-04-30-idp-v1.2-vault-credentials.md
+++ b/docs/superpowers/plans/2026-04-30-idp-v1.2-vault-credentials.md
@@ -1183,3 +1183,66 @@ Optionally, on a separate iteration, if Phase 3 surfaced bugs (analogous to v1.1
 - Phase 4 — subagent-friendly after user confirms Phase 3 outcome
 
 Dispatching boundaries: Phases 1 + 2 as one continuous subagent run; Phase 3 user-driven; Phase 4 as a final close-out subagent.
+
+---
+
+## Run Notes (2026-05-01)
+
+**Outcome:** v1.2 of the IDP shipped. ESO `PushSecret` routes CNPG-generated DB credentials through Vault; `ExternalSecret` projects them back into the namespace as `<name>-db`. Workloads now read DB credentials via the ESO-projected Secret instead of directly from the CNPG-owned Secret. Vault path layout `k8s-secrets/<name>/db` established for v1+ scaffolded apps; `chores-tracker`'s flat layout untouched per spec.
+
+**E2E validation** (`smoke-v12`):
+
+| AC | Status | Notes |
+|---|---|---|
+| 1 — Pre-flight | ✅ | accessor `auth_kubernetes_4b2d98fc` recorded, identity-alias metadata verified (`service_account_namespace` populates correctly) |
+| 2 — Templated policy active | ✅ | `app-namespace-rw` applied (with corrected metadata caps after live patch) |
+| 3 — Self-service deploy | ✅ | Backstage form → PR #220 → ArgoCD → smoke-v12 live |
+| 4 — Vault path populated | ✅ | All 8 keys at `k8s-secrets/data/smoke-v12/db` (custom_metadata `managed-by: external-secrets`) |
+| 5 — Workload reads via ESO path | ✅ | Deployment `envFrom: smoke-v12-db` (NOT `smoke-v12-db-app`) |
+| 6 — PushSecret + ExternalSecret healthy | ✅ | Both `Synced` / `SecretSynced` after policy correction |
+| 7 — App responds at host | ❌ | **Blocked by v1 `/healthz` hardcoded liveness probe trap** — out-of-scope per spec §11 (queued for v1.2.1) |
+| 8 — Backstage auto-ingestion | ✅ | `Component/smoke-v12` discovered; Crossplane tab visualizes the 3 v1.2 resources |
+| 9 — Teardown removes Vault data | ✅ | **Fully GC'd including metadata** — `vault kv list k8s-secrets/smoke-v12` returns "No value found" after `deletionPolicy: Delete` fired |
+| 10 — `dbNeeded:false` unaffected | ✅ | `xr-minimal` goldens PASS — no leakage |
+| 11 — chores-tracker still working | ✅ | ExternalSecret `Ready=True`, vault path intact, pods stable (0-2 restarts over 13-19d) |
+
+**10/11 ACs green.** AC-7 explicitly out-of-scope and blocked by a known v1 issue.
+
+**Bugs caught during execution** (and the fix PRs):
+
+| # | Bug | How surfaced | Fix |
+|---|---|---|---|
+| 1 | Spec §5.1 templated policy was missing `create`/`update` on the `metadata/<ns>/*` path | PushSecret 403'd on every first-sync (`could not write remote ref dbname ... permission denied`) | Live-patched policy via recovery-keys flow; spec backport in this close-out PR |
+| 2 | CNPG operator was never in GitOps — manually installed in 2025-12, manually removed at some point, leaving stale CRDs + webhook-Service-with-no-endpoints | `failed calling webhook "mcluster.cnpg.io": no endpoints available for service "cnpg-webhook-service"` on first compose | [PR #221](https://github.com/arigsela/kubernetes/pull/221) — added `base-apps/cnpg-system.yaml` ArgoCD Helm Application |
+| 3 | Crossplane SA missing RBAC on `postgresql.cnpg.io/clusters/status` AND on the new `external-secrets.io/{secretstores,pushsecrets,externalsecrets}` (and their `/status` subresources) | Once CNPG was back: `failed waiting for *unstructured.Unstructured Informer to sync` (Crossplane informer couldn't read CNPG `/status`); ESO resources would have failed next | [PR #222](https://github.com/arigsela/kubernetes/pull/222) — extended `composition-rbac.yaml` ClusterRole |
+| 4 | Vault root token in `vault-unseal-keys` Secret was stale/invalid | Phase 0 attempt failed with "invalid token" even using the supposedly-root token from the Secret | Re-minted via recovery-keys generate-root flow (key1 + key2 of 3); re-stored in Secret. Cluster ops follow-up — no PR. |
+| 5 | First scaffolder run had trailing whitespace in the `host` form value (`"smoke-v12.arigsela.com "`) | Visible in scaffold logs; would have caused ingress validation issues | User merged anyway — no real impact in this case (nginx-ingress trims). Minor scaffolder template hardening candidate. |
+| 6 | PushSecret `refreshInterval: 1h` — once Errored, won't auto-retry until the 1h tick | Required `kubectl annotate` to kick a retry after the policy was patched | Worth dropping to `5m` in v1.2.1 for snappier recovery from transient errors. |
+
+**Things that worked unexpectedly well:**
+- The recovery-keys-mint-then-revoke pattern handled both Phase 0 (initial policy write) and the live policy patch + Vault role binding without any token ever being echoed to tool output. Same pattern is reusable for any future Vault admin operation needing transient elevated access.
+- ESO's `PushSecret` deletionPolicy fully GC'd the Vault entry on teardown — no soft-delete tombstone, no version history left over. Cleaner than expected.
+- The 4 cluster-environmental bugs (CNPG missing, RBAC gaps, stale Vault token, policy text wrong) all surfaced in <1 hour of validation rather than weeks of confusion. v1.1's "validate on every iteration" pattern paid off again.
+
+**v1.3 / v2 follow-up candidates:**
+
+- **v1.2.1 (small ergonomic fixes):**
+  - Fix `/healthz` hardcoded liveness probe → `/` or `healthCheckPath` as XR field (unblocks AC-7 + makes nginx-unprivileged + similar minimal images work out of the box)
+  - Drop PushSecret `refreshInterval` from `1h` to `5m` for faster recovery from transient errors
+  - Consider trimming whitespace in scaffolder template's `fetch.values` mapping
+- **v1.3 (next iteration):** AWS resources at `k8s-secrets/<name>/aws-creds` — the hierarchical layout pays off
+- **v2 (rotation):** VSO + Vault Database secrets engine for dynamic Postgres creds
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| [#218](https://github.com/arigsela/kubernetes/pull/218) | docs: v1.2 design spec + plan + Phase 0 bootstrap script |
+| [#219](https://github.com/arigsela/kubernetes/pull/219) | feat(composition): v1.2 Vault round-trip implementation |
+| [#220](https://github.com/arigsela/kubernetes/pull/220) | feat(smoke-v12): scaffold via Backstage for v1.2 e2e validation |
+| [#221](https://github.com/arigsela/kubernetes/pull/221) | feat(cnpg): install CloudNativePG operator under GitOps |
+| [#222](https://github.com/arigsela/kubernetes/pull/222) | fix(crossplane): grant SA on cnpg /status + ESO resources |
+| [#223](https://github.com/arigsela/kubernetes/pull/223) | chore: tear down v1.2 smoke-v12 validation app |
+| (this PR) | docs: v1.2 close-out — run notes + spec §5.1 metadata caps backport |
+
+**v1.2 status: shipped.**

--- a/docs/superpowers/specs/2026-04-30-idp-v1.2-vault-credentials-design.md
+++ b/docs/superpowers/specs/2026-04-30-idp-v1.2-vault-credentials-design.md
@@ -110,13 +110,16 @@ This is the one-time bootstrap that allows per-app onboarding to work with no Va
 # `service_account_namespace` is auto-populated by the K8s auth method into the
 # alias metadata at login time. This means: regardless of which namespace's SA
 # is reading/writing, they ONLY get access to k8s-secrets/<their-namespace>/*.
+
 path "k8s-secrets/data/{{identity.entity.aliases.<K8S_AUTH_ACCESSOR>.metadata.service_account_namespace}}/*" {
-  capabilities = ["create", "read", "update", "patch"]
+  capabilities = ["create", "read", "update", "patch", "delete"]
 }
 path "k8s-secrets/metadata/{{identity.entity.aliases.<K8S_AUTH_ACCESSOR>.metadata.service_account_namespace}}/*" {
-  capabilities = ["list", "read", "delete"]
+  capabilities = ["create", "read", "update", "list", "delete"]
 }
 ```
+
+**Why `create` + `update` on the metadata path:** ESO's `PushSecret` does a `PUT` to `metadata/<path>` (for KV-v2 versioning state) BEFORE writing the `data/<path>` payload. Without `create`/`update` capabilities on the metadata path, every PushSecret first-sync 403s. Discovered during v1.2 e2e validation — fixed live via the recovery-keys flow, then backported here.
 
 `<K8S_AUTH_ACCESSOR>` is replaced with the actual accessor ID (e.g., `auth_kubernetes_a1b2c3d4`), which is fixed unless the auth method is re-mounted.
 


### PR DESCRIPTION
## Summary

Closes out IDP v1.2 with run notes capturing what we learned during e2e shakeout, plus one real spec correction backported from the live patch we applied during validation.

No code changes — pure docs.

## Spec correction

§5.1 templated policy was missing \`create\` and \`update\` capabilities on the \`metadata/<ns>/*\` path. ESO \`PushSecret\` PUTs to metadata BEFORE writing data (KV-v2 versioning), so without those caps every first-sync 403'd. Caught and live-patched via the recovery-keys flow during smoke validation; this PR backports the corrected text.

## Run notes (added to plan)

- **10/11 ACs green** — AC-7 (app responds at host) blocked by known v1 \`/healthz\` probe trap, explicitly out-of-scope per spec §11
- **6 bugs caught during execution:**
  - Spec §5.1 metadata capabilities (fixed in this PR)
  - CNPG operator missing from GitOps → fixed via #221
  - Crossplane SA missing RBAC on \`cnpg/status\` + ESO resources → fixed via #222
  - Stale \`vault-unseal-keys.root-token\` field → re-minted live (no PR)
  - Trailing whitespace in scaffolder form input (cosmetic)
  - PushSecret 1h refreshInterval blocks Errored-retry (workaround documented)
- **v1.2.1 / v1.3 / v2 follow-up candidates** captured

## What this PR does NOT change

- No code changes. v1.2 implementation (PR #219) is unchanged and working in production.
- No additional infrastructure changes (CNPG + Crossplane RBAC fixes already merged via #221/#222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)