### PR TITLE
docs(idp): v1.2.1 design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md
+++ b/docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md
@@ -1,0 +1,971 @@
+# IDP v1.2.1 — Ergonomic Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three observable rough edges from v1.2's e2e validation: hardcoded `/healthz` probe trap, sluggish PushSecret refresh, and Backstage form input passing trailing whitespace through to rendered XR.
+
+**Architecture:** Three small targeted edits with no architectural change. (1) `XApplication` XRD adds optional `healthCheckPath` field with `default: "/"`; Composition Python `make_deployment` reads it and threads through liveness + readiness probes. (2) PushSecret `refreshInterval` drops from `1h` to `5m`. (3) Scaffolder template applies Nunjucks `| trim` filter to text-form-input values; content-k8s XR template gains a conditional `healthCheckPath` emission. No XRD apiVersion bump (additions are backwards-compatible via `default`); no new resource kinds.
+
+**Tech Stack:** Crossplane v2.2.1 + function-python (composition), Backstage scaffolder (Nunjucks templating), `crossplane render` CLI + `yq` for goldens-based testing.
+
+**Spec:** [`docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md`](../specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md) (committed `e1982483`)
+
+---
+
+## Pre-flight (run once before Phase 1 starts)
+
+### P.1 — Verify the Composition test harness still works (sanity baseline)
+
+```bash
+cd /Users/arisela/git/kubernetes
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+Expected: both exit 0 with no diff output. If either fails, investigate before adding v1.2.1 changes — something broke between v1.2 and now.
+
+### P.2 — Confirm v1.2 is shipped (close-out PR #224 merged)
+
+```bash
+git fetch origin main
+git log origin/main --oneline | grep -E "v1.2 close-out|92f9ea4" | head -3
+```
+
+Expected: at least one commit referencing the v1.2 close-out. If not, merge PR #224 first — v1.2.1 builds on a stable v1.2 base.
+
+---
+
+## Phase 1 — Kubernetes repo (XRD + Composition + goldens, single PR)
+
+Branch: `feat/idp-v1.2.1-healthcheckpath` off `origin/main`.
+
+### Task 1.1: Set up the implementation branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main
+git checkout -b feat/idp-v1.2.1-healthcheckpath origin/main
+git branch --show-current
+# Expected: feat/idp-v1.2.1-healthcheckpath
+```
+
+---
+
+### Task 1.2: Update goldens (TDD: write the failing assertion FIRST)
+
+**Files:**
+- Modify: `tests/composition/expected-xr-minimal.yaml`
+- Modify: `tests/composition/expected-xr-with-db.yaml`
+
+Both goldens have probe paths hardcoded as `/healthz`. Both need to change to `/`. The with-db golden also needs PushSecret `refreshInterval: 1h` → `5m`.
+
+- [ ] **Step 1: Update probe paths in xr-minimal golden**
+
+Open `tests/composition/expected-xr-minimal.yaml`. Find both `livenessProbe` and `readinessProbe` blocks. For each, change:
+
+```yaml
+httpGet:
+  path: /healthz   # CHANGE
+  port: 8080
+```
+
+to:
+
+```yaml
+httpGet:
+  path: /
+  port: 8080
+```
+
+(Two replacements in this file — one per probe.)
+
+- [ ] **Step 2: Update probe paths in xr-with-db golden**
+
+Same change in `tests/composition/expected-xr-with-db.yaml` — two replacements (`/healthz` → `/`).
+
+- [ ] **Step 3: Update PushSecret refreshInterval in xr-with-db golden**
+
+In the same file (`expected-xr-with-db.yaml`), find the `kind: PushSecret` document and change:
+
+```yaml
+spec:
+  data:
+  - match:
+    # ...
+  deletionPolicy: Delete
+  refreshInterval: 1h   # CHANGE
+```
+
+to:
+
+```yaml
+spec:
+  data:
+  - match:
+    # ...
+  deletionPolicy: Delete
+  refreshInterval: 5m
+```
+
+- [ ] **Step 4: Re-canonicalize both goldens**
+
+```bash
+yq -i -P 'sort_keys(..)' tests/composition/expected-xr-minimal.yaml
+yq -i -P 'sort_keys(..)' tests/composition/expected-xr-with-db.yaml
+
+git diff --stat tests/composition/
+# Expected: 2 files modified, ~6-8 line changes total (2 path changes per probe × 2 probes × 2 files = 4 files but only 4 line changes for paths, +1 for refreshInterval)
+```
+
+---
+
+### Task 1.3: Run render tests → expect FAIL
+
+**Files:** none (running tests)
+
+- [ ] **Step 1: Run xr-minimal**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+```
+
+**Expected: non-zero exit.** Diff shows the rendered output still has `path: /healthz` while the golden expects `path: /`.
+
+- [ ] **Step 2: Run xr-with-db**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+**Expected: non-zero exit.** Diff shows: probe paths AND PushSecret `refreshInterval` both don't match.
+
+If either test PASSES at this point: the implementation is already there OR the golden didn't actually change. STOP and investigate — likely the YAML edit didn't land cleanly.
+
+---
+
+### Task 1.4: Add `healthCheckPath` to the XRD
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/xrd-application.yaml`
+
+The XRD's `spec.properties` block has `image`, `host`, `port`, `replicas`, `env`, `dbNeeded`, `dbStorage`. Add `healthCheckPath` as an optional property with default value (no required-list change).
+
+- [ ] **Step 1: Insert healthCheckPath property**
+
+Open `base-apps/crossplane-compositions/xrd-application.yaml`. Find the `replicas` property block. Immediately AFTER the `replicas:` block (and before `env:`), insert:
+
+```yaml
+                healthCheckPath:
+                  type: string
+                  default: "/"
+                  description: |
+                    HTTP path for liveness and readiness probes. Defaults to '/'
+                    which works for most images (nginx, generic web servers).
+                    Override for images that expose a dedicated health endpoint
+                    (e.g. '/api/health', '/actuator/health').
+                  pattern: "^/.*"
+```
+
+(Indentation: 16 spaces, matching the surrounding `image:`, `host:`, etc.)
+
+- [ ] **Step 2: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/xrd-application.yaml > /dev/null && echo "XRD valid"
+# Expected: "XRD valid"
+```
+
+If yq fails: indentation drifted. Check the surrounding properties for the right indent depth.
+
+---
+
+### Task 1.5: Update Composition Python — add `health_path` to `make_deployment` + thread from `compose()`
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+Two changes inside the embedded Python block:
+
+- [ ] **Step 1: Add `health_path` parameter to `make_deployment` signature**
+
+Find the `def make_deployment(...)` line in the file (~line 100-120 area, in the helpers block). Current signature:
+
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from, annotations):
+```
+
+Change to:
+
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from, annotations, health_path):
+```
+
+(Add `health_path` as the LAST positional parameter.)
+
+- [ ] **Step 2: Use `health_path` in both probes (replace `/healthz`)**
+
+In the same `make_deployment` body, find both probe blocks (lines ~161 and ~165 per current state):
+
+```python
+                  "livenessProbe": {
+                      "httpGet": {"path": "/healthz", "port": port},
+                      "initialDelaySeconds": 30, "periodSeconds": 30,
+                  },
+                  "readinessProbe": {
+                      "httpGet": {"path": "/healthz", "port": port},
+                      "initialDelaySeconds": 5, "periodSeconds": 10,
+                  },
+```
+
+Change BOTH `/healthz` to `health_path`:
+
+```python
+                  "livenessProbe": {
+                      "httpGet": {"path": health_path, "port": port},
+                      "initialDelaySeconds": 30, "periodSeconds": 30,
+                  },
+                  "readinessProbe": {
+                      "httpGet": {"path": health_path, "port": port},
+                      "initialDelaySeconds": 5, "periodSeconds": 10,
+                  },
+```
+
+- [ ] **Step 3: Update `compose()` to read `healthCheckPath` from spec + pass to `make_deployment`**
+
+Find the `make_deployment` call inside `compose()` (single call, in the always-emitted resources block). Current call:
+
+```python
+              resource.update(
+                  rsp.desired.resources["deployment"],
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []), env_from,
+                                  annotations=std_annotations(xr_annotations, "deployment")),
+              )
+```
+
+Change to:
+
+```python
+              resource.update(
+                  rsp.desired.resources["deployment"],
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []), env_from,
+                                  annotations=std_annotations(xr_annotations, "deployment"),
+                                  health_path=spec.get("healthCheckPath", "/")),
+              )
+```
+
+(Adds `health_path=spec.get("healthCheckPath", "/")` as a kwarg. The `"/"` default is defensive — XRD admission webhook will backfill the field, but Python-side default mirrors the XRD's intent.)
+
+- [ ] **Step 4: Update PushSecret `refreshInterval` from 1h to 5m**
+
+Find `make_push_secret` helper. In its returned dict's `spec` block, change:
+
+```python
+                  "spec": {
+                      "refreshInterval": "1h",
+                      ...
+                  }
+```
+
+to:
+
+```python
+                  "spec": {
+                      "refreshInterval": "5m",
+                      ...
+                  }
+```
+
+(Single character class change: `1h` → `5m`.)
+
+- [ ] **Step 5: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/composition-application.yaml > /dev/null && echo "Composition YAML valid"
+```
+
+---
+
+### Task 1.6: Run render tests → expect PASS
+
+**Files:** none
+
+- [ ] **Step 1: Run xr-minimal**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+```
+
+**Expected: exit 0, no diff.**
+
+If FAIL: read the diff. Common issues:
+- `path: /` not appearing in rendered output → `make_deployment` didn't accept the `health_path` kwarg (check signature)
+- Indentation drift in Python helpers
+- xr-minimal input fixture has explicit `healthCheckPath` — it shouldn't (test relies on Python default `"/"`); verify `tests/composition/xr-minimal.yaml` doesn't set the field
+
+- [ ] **Step 2: Run xr-with-db**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+**Expected: exit 0, no diff.**
+
+If FAIL: probe path AND/OR PushSecret refreshInterval issues — diff will show which.
+
+---
+
+### Task 1.7: Commit Phase 1
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+git add base-apps/crossplane-compositions/xrd-application.yaml \
+        base-apps/crossplane-compositions/composition-application.yaml \
+        tests/composition/expected-xr-minimal.yaml \
+        tests/composition/expected-xr-with-db.yaml
+
+git status --short   # expect: only those 4 files modified
+
+git commit -m "$(cat <<'EOF'
+feat(composition): v1.2.1 ergonomic fixes — healthCheckPath + 5m PushSecret refresh
+
+Three small fixes for v1.2's observable rough edges:
+
+  1. healthCheckPath as optional XR field (default '/').
+     XRD adds backwards-compatible optional string property.
+     Composition Python's make_deployment threads it through
+     liveness + readiness probes. Existing XRs without the field
+     get the XRD default automatically — no migration needed.
+
+     Replaces hardcoded /healthz that was breaking nginx-unprivileged
+     and any minimal image not exposing that path. Unblocks v1.2
+     AC-7 (app responds at host).
+
+  2. PushSecret refreshInterval 1h -> 5m.
+     Snappier recovery on transient ESO/Vault errors. At homelab
+     scale (~10 dbNeeded apps), 12 refreshes/hr/app is trivial
+     load on Vault.
+
+  3. Goldens updated for both above (xr-minimal probe path /;
+     xr-with-db probe path / + refreshInterval 5m).
+
+No XRD apiVersion bump — all changes are additive + backwards-compat.
+chores-tracker untouched.
+
+Spec: docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git log -1 --stat
+```
+
+---
+
+### Task 1.8: Push branch + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/idp-v1.2.1-healthcheckpath
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+gh pr create --base main --head feat/idp-v1.2.1-healthcheckpath \
+  --title "feat(composition): v1.2.1 ergonomic fixes — healthCheckPath + 5m PushSecret refresh" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Three small fixes for v1.2's observable rough edges from e2e validation. Single Composition+XRD PR; companion Backstage scaffolder PR opened separately.
+
+## Changes
+
+| Change | File | Impact |
+|---|---|---|
+| Add \`healthCheckPath\` optional XR field, default \`/\` | \`base-apps/crossplane-compositions/xrd-application.yaml\` | Backwards-compatible — existing XRs get default \`/\` automatically |
+| Composition Python threads \`healthCheckPath\` to liveness + readiness probes | \`base-apps/crossplane-compositions/composition-application.yaml\` | Replaces hardcoded \`/healthz\`; unblocks v1.2 AC-7 (nginx-unprivileged Pod ready) |
+| PushSecret \`refreshInterval\` 1h → 5m | (same Composition file) | Snappier error recovery; trivial extra load at homelab scale |
+| Goldens updated (probe paths + refreshInterval) | \`tests/composition/expected-xr-{minimal,with-db}.yaml\` | TDD — wrote failing test first, then implemented to pass |
+
+## Test plan
+
+- [x] \`./tests/composition/render.sh xr-minimal\` PASS (probe path \`/\` rendered)
+- [x] \`./tests/composition/render.sh xr-with-db\` PASS (probe path \`/\` + refreshInterval \`5m\` rendered)
+- [ ] After merge: companion arigsela/backstage PR for healthCheckPath form field + scaffolder trim
+- [ ] User rebuilds Backstage image + bumps tag in \`base-apps/backstage/deployments.yaml\`
+- [ ] Smoke validation with smoke-v121: deliberate trailing whitespace test (form trim) + Pod becomes Ready (probe fix)
+
+## What this does NOT change
+
+- No XRD apiVersion bump (additions are backwards-compat via \`default\`)
+- No env var renames or other v1.2 behavior change
+- \`chores-tracker\` and any existing v1.x apps unaffected
+
+## v1.2.1 = ergonomic close-out
+
+This is the v1.2 follow-up sweep noted in the v1.2 close-out run notes. Two more tiny things in scope (form-input trim, healthCheckPath form field) live in the companion arigsela/backstage PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# Capture PR number
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 2 — Backstage scaffolder (single PR)
+
+This phase touches the `arigsela/backstage` repo (separate from this kubernetes repo). The reference clone in `docs/reference/backstage/` is read-only — actual edits happen in the source repo.
+
+**Working dir setup (assumes `arigsela/backstage` cloned at `~/git/backstage` per v1.1/v1.2 precedent — adjust if path differs).**
+
+Branch: `feat/idp-v1.2.1-healthcheckpath` off `origin/main` in `arigsela/backstage`.
+
+### Task 2.1: Set up branch in arigsela/backstage
+
+**Files:** none (git only; assumes `~/git/backstage` exists)
+
+- [ ] **Step 1: Switch to the backstage repo + branch**
+
+```bash
+cd ~/git/backstage   # adjust path if your local clone is elsewhere
+git fetch origin main
+git checkout -b feat/idp-v1.2.1-healthcheckpath origin/main
+git branch --show-current
+# Expected: feat/idp-v1.2.1-healthcheckpath
+```
+
+---
+
+### Task 2.2: Add `healthCheckPath` form input to scaffolder template
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+The "Workload" parameter group has `image`, `host`, `port`, `replicas`. Add `healthCheckPath` as an optional input.
+
+- [ ] **Step 1: Add the form field**
+
+Open `examples/templates/application/template.yaml`. Find the `- title: Workload` block. Inside its `properties:`, AFTER the `replicas:` field, add:
+
+```yaml
+        healthCheckPath:
+          type: string
+          title: Health check path (optional)
+          description: HTTP path for liveness/readiness probes. Defaults to '/' which works for most images (nginx, generic web servers).
+          default: "/"
+          pattern: "^/.*"
+```
+
+(Indentation: 8 spaces — matches the sibling `replicas:`, `port:`, etc.)
+
+---
+
+### Task 2.3: Apply `| trim` filter to text fields in fetch.values mapping
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+The `steps[id=fetch].input.values` block hands form parameters into the content-k8s templating. Apply Nunjucks `| trim` to text fields (numbers and booleans don't need trimming).
+
+- [ ] **Step 1: Edit the fetch.values mapping**
+
+Find the `values:` block under the `fetch` step. Current shape:
+
+```yaml
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+          image: ${{ parameters.image }}
+          host: ${{ parameters.host }}
+          port: ${{ parameters.port }}
+          replicas: ${{ parameters.replicas }}
+          dbNeeded: ${{ parameters.dbNeeded }}
+          dbStorage: ${{ parameters.dbStorage }}
+```
+
+Change to:
+
+```yaml
+        values:
+          name: ${{ parameters.name | trim }}
+          namespace: ${{ parameters.name | trim }}
+          owner: ${{ parameters.owner | trim }}
+          image: ${{ parameters.image | trim }}
+          host: ${{ parameters.host | trim }}
+          healthCheckPath: ${{ parameters.healthCheckPath | trim }}
+          port: ${{ parameters.port }}
+          replicas: ${{ parameters.replicas }}
+          dbNeeded: ${{ parameters.dbNeeded }}
+          dbStorage: ${{ parameters.dbStorage | trim }}
+```
+
+(Added `healthCheckPath` line + `| trim` filter on text fields. `port` / `replicas` / `dbNeeded` skip trim because they're not strings — Nunjucks `| trim` on a number throws.)
+
+---
+
+### Task 2.4: Conditional `healthCheckPath` emission in content-k8s XR
+
+**Files:**
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml`
+
+The XR template currently renders all `spec` fields verbatim. Add a conditional block for `healthCheckPath` so it's only emitted when user picks a non-default value (cleaner XR YAML for the common case).
+
+- [ ] **Step 1: Add conditional emission block**
+
+Open the XR template. Find the `spec:` block. Current shape:
+
+```yaml
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+```
+
+Change to:
+
+```yaml
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  {%- if values.healthCheckPath and values.healthCheckPath != "/" %}
+  healthCheckPath: ${{ values.healthCheckPath }}
+  {%- endif %}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+```
+
+(Nunjucks `{%- if ... %}...{%- endif %}` block. Leading `-` strips preceding whitespace so the rendered XR doesn't have extra blank lines when the field isn't emitted.)
+
+---
+
+### Task 2.5: Commit Phase 2 + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+cd ~/git/backstage   # ensure you're in the backstage repo
+
+git add examples/templates/application/template.yaml \
+        examples/templates/application/content-k8s/base-apps/\${{\ values.name\ }}/application-xr.yaml
+
+git status --short   # expect: only those 2 files modified
+
+git commit -m "$(cat <<'EOF'
+feat(scaffolder): v1.2.1 ergonomic fixes — healthCheckPath + form trim
+
+Companion to arigsela/kubernetes v1.2.1 PR. Two small scaffolder
+template improvements:
+
+  1. healthCheckPath optional form input (default '/').
+     New field in the "Workload" group; threaded through to
+     fetch.values; conditionally emitted in the rendered XR
+     (only when user chooses non-default value, for cleaner
+     PR diffs).
+
+  2. Nunjucks | trim filter on all text-form-input values
+     (name, owner, image, host, healthCheckPath, dbStorage).
+     Sanitizes form-data whitespace at the right layer — XR
+     yaml emerges clean; PR diff is review-friendly.
+
+  Discovered during v1.2 e2e validation (PR arigsela/kubernetes#220
+  had host: "smoke-v12.arigsela.com " with trailing space).
+
+No backend code changes; no plugin work; no permissions changes.
+This template ships in the next Backstage image rebuild.
+
+Spec: docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md
+(in the arigsela/kubernetes repo)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feat/idp-v1.2.1-healthcheckpath
+
+gh pr create --base main --head feat/idp-v1.2.1-healthcheckpath \
+  --title "feat(scaffolder): v1.2.1 ergonomic fixes — healthCheckPath + form trim" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Companion to [arigsela/kubernetes v1.2.1 PR](https://github.com/arigsela/kubernetes) — adds the Backstage scaffolder side of the v1.2 close-out fixes.
+
+## Changes
+
+| Change | File | Why |
+|---|---|---|
+| Add \`healthCheckPath\` optional form input in "Workload" group | \`examples/templates/application/template.yaml\` | Lets users override the default \`/\` probe path for images that expose dedicated health endpoints |
+| Apply Nunjucks \`\| trim\` filter to text values (name, owner, image, host, healthCheckPath, dbStorage) | \`examples/templates/application/template.yaml\` (steps.fetch.input.values) | Sanitizes form-input whitespace before it lands in XR yaml — discovered during v1.2 validation when PR \`scaffold/smoke-v12\` had \`host: "smoke-v12.arigsela.com "\` |
+| Conditional emission of \`healthCheckPath\` in rendered XR | \`examples/templates/application/content-k8s/base-apps/\${{ values.name }}/application-xr.yaml\` | Only emit when user picks non-default — keeps XR yaml clean for the common case |
+
+## Test plan
+
+- [ ] After merge + Backstage image rebuild, scaffold a new app with deliberate trailing whitespace on \`host\` field — verify scaffold PR has clean values
+- [ ] Default healthCheckPath path: form populated with \`/\` → XR omits the field (XRD default kicks in)
+- [ ] Override healthCheckPath: form set to e.g. \`/api/health\` → XR includes the field
+
+## Companion PR
+
+Composition / XRD side: arigsela/kubernetes (link added when that PR is open)
+
+## Image rebuild needed?
+
+Yes. After this merges, the Backstage image needs to be rebuilt and \`base-apps/backstage/deployments.yaml\` tag bumped per the CLAUDE.md user-owned image-rebuild flow.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 3 — USER GATE: image rebuild + tag bump
+
+> **Subagent-driven-development pause point.** All Phase 3 actions require user-controlled steps: PR merge approvals, manual Backstage image rebuild (per CLAUDE.md), tag bump in deployments.yaml. Subagents cannot drive these.
+
+### Task 3.1: USER reviews + merges Phase 1 PR (kubernetes)
+
+**Files:** none
+
+- [ ] **Step 1: User reviews diff in PR opened by Task 1.8 + merges**
+- [ ] **Step 2: Wait for ArgoCD master-app to detect + reconcile (~30s)**
+
+```bash
+kubectl -n argo-cd get application crossplane-compositions \
+  -o jsonpath='{.status.sync.status}: revision={.status.sync.revision}{"\n"}'
+# Expected: Synced; revision should match the merge commit
+```
+
+- [ ] **Step 3: Verify v1.2.1 marker is live in cluster Composition**
+
+```bash
+kubectl get composition application -o yaml 2>&1 | grep -c "health_path" 
+# Expected: ≥1 (the new parameter name appears in the live Composition)
+```
+
+---
+
+### Task 3.2: USER reviews + merges Phase 2 PR (backstage)
+
+**Files:** none
+
+- [ ] **Step 1: User reviews diff in PR opened by Task 2.5 + merges**
+
+(Backstage image is NOT yet rebuilt at this point — the merge alone doesn't change cluster behavior. Step 3.3 handles that.)
+
+---
+
+### Task 3.3: USER rebuilds Backstage image + bumps deployment tag
+
+**Files:**
+- Modify: `base-apps/backstage/deployments.yaml` (in arigsela/kubernetes)
+
+Per CLAUDE.md: image rebuilds are user-owned. After Phase 2 PR merges, the new template lives in `arigsela/backstage:main` but isn't bundled into a deployable image until the user rebuilds.
+
+- [ ] **Step 1: User rebuilds the image**
+
+(Follow the user's standard build process — likely `docker buildx` + push to ECR. Outside the scope of automated tasks. Tag the new image — for example `v1.2.0` if the previous tag was `v1.1.0`.)
+
+- [ ] **Step 2: User bumps tag in deployments.yaml + opens a PR**
+
+```bash
+# In arigsela/kubernetes:
+cd /Users/arisela/git/kubernetes
+git fetch origin main
+git checkout -b chore/bump-backstage-v1.2.0 origin/main
+
+# Edit base-apps/backstage/deployments.yaml — change the image tag line
+# from e.g. v1.1.0 to v1.2.0
+
+git add base-apps/backstage/deployments.yaml
+git commit -m "chore(backstage): bump image tag to v1.2.0 (v1.2.1 scaffolder updates)"
+git push -u origin chore/bump-backstage-v1.2.0
+gh pr create --base main --title "chore(backstage): bump image tag to v1.2.0" \
+  --body "Brings in v1.2.1 scaffolder changes (healthCheckPath form field + form-input trim)."
+```
+
+- [ ] **Step 3: User merges; ArgoCD picks up the new image (~30s)**
+
+```bash
+kubectl -n backstage rollout status deployment/backstage --timeout=2m
+# Expected: deployment "backstage" successfully rolled out
+```
+
+---
+
+## Phase 4 — Smoke validation (smoke-v121)
+
+> **Subagent-driven-development pause point.** All Phase 4 tasks require user-controlled actions: Backstage UI form submission, scaffold PR review + merge.
+
+### Task 4.1: Pre-create Vault role for smoke-v121
+
+**Files:** none (Vault server)
+
+(Same pattern as v1.2 Phase 3 Task 3.2 — Vault role must exist BEFORE PushSecret first-sync, otherwise 403 stalls until role appears.)
+
+- [ ] **Step 1: User runs the role creation snippet**
+
+The vault CLI in vault-0 needs an authenticated token. Use the same recovery-keys flow we established in v1.2 (or have the assistant run it via kubectl exec):
+
+```bash
+# Option A: assistant runs via kubectl exec recovery-keys flow
+# Option B: user does it from authenticated local CLI:
+
+NAMESPACE=smoke-v121
+
+# (with VAULT_TOKEN exported to a valid root or admin token)
+vault write auth/kubernetes/role/${NAMESPACE} \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=${NAMESPACE} \
+  policies="default,app-namespace-rw" \
+  ttl=1h
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+vault read auth/kubernetes/role/smoke-v121
+# Expected: policies=[default app-namespace-rw], bound_service_account_namespaces=[smoke-v121]
+```
+
+---
+
+### Task 4.2: Scaffold smoke-v121 with deliberate trailing whitespace (test trim AC-5)
+
+**Files:** none (Backstage UI form + downstream PR)
+
+- [ ] **Step 1: Open Backstage**
+
+https://backstage.arigsela.com/create
+
+- [ ] **Step 2: Submit Application (Crossplane) template with these values**
+
+| Field | Value |
+|---|---|
+| Application name | `smoke-v121` |
+| Owner | `group:default/platform-engineering` |
+| Container image | `nginxinc/nginx-unprivileged:1.25-alpine` |
+| Public hostname | `smoke-v121.arigsela.com   ` ← **deliberately add 3 trailing spaces** |
+| Container port | `8080` |
+| Replicas | `1` |
+| Health check path (optional) | `/` (default; leave as-is) |
+| Provision a Postgres database | **NO** (skip db; we're testing the probe fix + form trim, not the round-trip) |
+
+(Note: dbNeeded:false simplifies validation — no Vault role binding scramble, no PushSecret retry dynamics. The Vault role created in Task 4.1 is unused for this run; it's there in case you also want to test dbNeeded:true.)
+
+- [ ] **Step 3: Inspect the resulting scaffold PR diff (verify AC-5)**
+
+```bash
+gh pr list --state open --search "smoke-v121 in:title" --json number --jq '.[0].number' \
+  | xargs -I{} gh pr diff {}
+```
+
+**Verify in the diff:**
+- `host: smoke-v121.arigsela.com` (NO trailing whitespace; trim filter worked)
+- `healthCheckPath` line is NOT in the rendered XR (default `/` was selected → conditional emission skipped)
+- All other fields look normal
+
+**If the diff still shows trailing whitespace on host:** the `| trim` filter isn't applied. Check Phase 2 Task 2.3 implementation; the Backstage image may need a re-pull. Stop and investigate.
+
+- [ ] **Step 4: USER merges scaffold PR**
+
+---
+
+### Task 4.3: Verify Pod becomes Ready=True (AC-6 — the headline /healthz fix)
+
+**Files:** none
+
+- [ ] **Step 1: Wait for ArgoCD sync + Pod startup (~60s)**
+
+```bash
+kubectl -n argo-cd get application smoke-v121 \
+  -o jsonpath='{.status.sync.status}/{.status.health.status}{"\n"}'
+# Expected (eventual): Synced/Healthy
+
+kubectl -n smoke-v121 get pods
+# Expected: 1 Pod, Running, 1/1 Ready
+```
+
+- [ ] **Step 2: Verify probe configuration**
+
+```bash
+kubectl -n smoke-v121 get deployment smoke-v121 \
+  -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}{"\n"}'
+# Expected: /
+
+kubectl -n smoke-v121 get deployment smoke-v121 \
+  -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}{"\n"}'
+# Expected: /
+```
+
+- [ ] **Step 3: Verify zero restart count (proves liveness probe is now passing)**
+
+```bash
+sleep 90  # let liveness probe cycle a few times
+kubectl -n smoke-v121 get pod -l app.kubernetes.io/name=smoke-v121 \
+  -o jsonpath='{.items[0].status.containerStatuses[*].restartCount}{"\n"}'
+# Expected: 0 (was getting 1+ every ~90s with the /healthz trap)
+```
+
+If restart count is still climbing: probe path didn't change. Check Composition logs and `kubectl describe pod` for current liveness probe config.
+
+---
+
+### Task 4.4: Tear down smoke-v121
+
+**Files:** PR + cluster mutations
+
+(Same pattern as v1.2 — PR-delete first per v1 spec §8 corrected order.)
+
+- [ ] **Step 1: Open teardown PR**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git checkout main && git pull origin main
+git checkout -b chore/teardown-smoke-v121
+git rm base-apps/smoke-v121.yaml
+git rm -r base-apps/smoke-v121
+git commit -m "chore: tear down v1.2.1 smoke validation app"
+git push -u origin chore/teardown-smoke-v121
+gh pr create --base main --head chore/teardown-smoke-v121 \
+  --title "chore: tear down v1.2.1 smoke-v121 validation app" \
+  --body "Removes manifests after v1.2.1 smoke validation per v1 spec §8 corrected decommission order."
+```
+
+- [ ] **Step 2: USER merges teardown PR**
+
+- [ ] **Step 3: Wait for master-app prune; delete orphan XR**
+
+```bash
+sleep 30
+kubectl -n argo-cd get application smoke-v121 2>&1 | head -3
+# Expected: NotFound
+
+kubectl -n smoke-v121 delete xapplication smoke-v121
+# Expected: deleted
+
+kubectl delete namespace smoke-v121
+# Expected: terminating, then gone
+```
+
+- [ ] **Step 4: Optional — clean up Vault role**
+
+```bash
+# (with authenticated CLI)
+vault delete auth/kubernetes/role/smoke-v121
+# (smoke-v121 used dbNeeded:false so no Vault entry to GC; role is the only Vault state to remove)
+```
+
+---
+
+## Phase 5 — Close-out
+
+### Task 5.1: Append Run Notes to this plan
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md` (this file)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b docs/v1.2.1-close-out
+```
+
+- [ ] **Step 2: Append `## Run Notes` section to end of file**
+
+Append (template — fill in actual data after Phase 4 completes):
+
+```markdown
+
+## Run Notes (YYYY-MM-DD)
+
+**Outcome:** v1.2.1 of the IDP shipped. `healthCheckPath` is now an optional XR field defaulting to `/`; nginx-unprivileged and similar minimal images become Ready=True out of the box. PushSecret refresh dropped to 5m for snappier error recovery. Backstage scaffolder template trims form-input whitespace at the form-data boundary.
+
+**E2E validation** (`smoke-v121`, dbNeeded:false):
+
+- ✅ Backstage form submitted with deliberate trailing whitespace on host → scaffold PR diff shows clean `host:` field (no whitespace) — AC-5 trim works
+- ✅ Rendered Deployment uses `path: /` on both liveness + readiness probes — AC-2/AC-6 healthCheckPath default works
+- ✅ Pod becomes 1/1 Ready within ~60s; restart count stays at 0 over 90s+ — AC-6 unblocked (was the v1.2 AC-7 blocker)
+- ✅ Default `healthCheckPath` not emitted in scaffold XR (conditional emission works) — AC-3 indirect verification
+- ✅ chores-tracker still healthy — AC-7 regression check
+- ✅ Goldens still PASS for both xr-minimal and xr-with-db — AC-1
+
+**Bugs caught during execution** (delete subsection if none):
+
+| # | Bug | Fix PR |
+|---|---|---|
+| 1 | <one-line description> | arigsela/kubernetes#<num> |
+
+**v1.3 / v2 follow-up candidates** (carried forward from v1.2 close-out):
+- v1.3 — AWS resources via Upbound providers (S3, IAM)
+- v2 — VSO + Vault Database secrets engine for dynamic Postgres creds (rotation)
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| docs/idp-v1.2.1-spec | docs: v1.2.1 design spec + plan |
+| feat/idp-v1.2.1-healthcheckpath (kubernetes) | feat(composition): healthCheckPath + 5m PushSecret + goldens |
+| feat/idp-v1.2.1-healthcheckpath (backstage) | feat(scaffolder): healthCheckPath form + trim filter |
+| chore/bump-backstage-v1.2.0 | chore(backstage): bump image tag |
+| chore/teardown-smoke-v121 | chore: tear down smoke validation app |
+| docs/v1.2.1-close-out (this branch) | docs: v1.2.1 run notes |
+
+**v1.2.1 status: shipped.**
+```
+
+- [ ] **Step 3: Commit + push + open PR**
+
+```bash
+git add docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md
+git commit -m "docs(idp): v1.2.1 close-out run notes"
+git push -u origin docs/v1.2.1-close-out
+gh pr create --base main --title "docs(idp): v1.2.1 close-out run notes" \
+  --body "Captures v1.2.1 outcome, smoke-v121 e2e validation, bug-fix PRs (if any), and reaffirmed v1.3/v2 follow-up candidates."
+```
+
+---
+
+## Plan execution mode
+
+**Recommended:** subagent-driven-development per v1.2 precedent.
+
+Phase boundaries:
+- **Phase 1 (Tasks 1.1–1.8)** — single subagent: TDD on goldens → XRD + Composition → tests pass → commit + open PR
+- **Phase 2 (Tasks 2.1–2.5)** — separate subagent (different repo): scaffolder template + content-k8s XR → commit + open PR
+- **Phase 3** — **HARD PAUSE** for subagent execution (user-merge gates + image rebuild per CLAUDE.md)
+- **Phase 4** — user-driven smoke validation (form submission, PR review)
+- **Phase 5** — final close-out subagent
+
+Phases 1 and 2 are independent — can run in parallel as two subagents (different repos, no shared files). Phase 5 runs after Phase 4 user-confirms outcome.

--- a/docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md
@@ -1,0 +1,340 @@
+# IDP v1.2.1 — Ergonomic Fixes — Design
+
+**Date:** 2026-05-01
+**Author:** Ari Sela (with Claude)
+**Status:** Approved for plan
+**Iteration:** v1.2.1 (close-out polish for v1.2; small ergonomic sweep)
+**Prerequisite:** [IDP v1.2](./2026-04-30-idp-v1.2-vault-credentials-design.md) shipped and validated
+
+## 1. Goal
+
+Close out v1.2's three observable rough edges discovered during e2e validation:
+
+1. **Hardcoded `/healthz` liveness/readiness probe** breaks any image that doesn't serve that path (including `nginxinc/nginx-unprivileged`, the default smoke image). This is the AC-7 blocker from v1.2 — every v1+ scaffolded app since v1 has been silently CrashLoopBackOff'ing on liveness for weeks. Replace with `healthCheckPath` XR field, default `/`.
+2. **PushSecret `refreshInterval: 1h`** makes error recovery sluggish — when Push errors transiently, retry waits up to an hour. Drop to `5m` for snappier recovery without flooding ESO/Vault APIs.
+3. **Backstage form input passes through with trailing whitespace**, leaking into rendered XR YAML and ingress hostnames. Add Nunjucks `| trim` filters in scaffolder template.
+
+## 2. Current state (post-v1.2)
+
+| Component | Shape today |
+|---|---|
+| Liveness/readiness probes | Hardcoded `path: /healthz` on both, applied to ALL `XApplication` instances regardless of image |
+| PushSecret refresh | `refreshInterval: 1h` — once errored, retry latency up to 60min unless manually annotated |
+| Scaffolder host field | `${{ values.host }}` rendered verbatim from form input, no normalization |
+| XApplication XRD | `image`, `host`, `port`, `replicas`, `dbNeeded`, `dbStorage`, `env` — no `healthCheckPath` |
+| AC-7 (v1.2 acceptance) | ❌ Blocked: nginx-unprivileged Pod stuck in CrashLoopBackOff after readiness probe failures |
+
+## 3. Components
+
+| # | Artifact | Repo | Path | Action |
+|---|---|---|---|---|
+| 1 | XRD: add `healthCheckPath` | `arigsela/kubernetes` | `base-apps/crossplane-compositions/xrd-application.yaml` | Add optional `healthCheckPath` string property with `default: "/"`, `pattern: "^/.*"`, description |
+| 2 | Composition: thread `healthCheckPath` through probes | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-application.yaml` | `make_deployment` reads `spec.get("healthCheckPath", "/")`; both liveness + readiness probes use that value |
+| 3 | Composition: drop PushSecret `refreshInterval` 1h → 5m | `arigsela/kubernetes` | (same file, `make_push_secret`) | One-line change |
+| 4 | Goldens: probes use `/` | `arigsela/kubernetes` | `tests/composition/expected-xr-{minimal,with-db}.yaml` | Both goldens get `path: /` on liveness + readiness |
+| 5 | Goldens: PushSecret 5m | `arigsela/kubernetes` | `tests/composition/expected-xr-with-db.yaml` | Update `refreshInterval: 5m` |
+| 6 | Scaffolder template: trim form inputs | `arigsela/backstage` | `examples/templates/application/template.yaml` | Apply `\| trim` to `host`, `image`, `name`, `owner` in `fetch.values` mapping |
+| 7 | Scaffolder template: optional `healthCheckPath` field | `arigsela/backstage` | `examples/templates/application/template.yaml` | New optional form input in "Workload" group; default `/` |
+| 8 | Scaffolder rendered XR: emit `healthCheckPath` if set | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | Conditional Nunjucks block: only emit `healthCheckPath` line if value differs from default |
+| 9 | Backstage image rebuild + tag bump | user-owned | `base-apps/backstage/deployments.yaml` | Bump tag (e.g. `v1.1.0` → `v1.2.0`) once user produces new image (per CLAUDE.md) |
+
+**Files touched:**
+- `arigsela/kubernetes`: 4 files (XRD + Composition + 2 goldens) — single PR
+- `arigsela/backstage`: 2 files (template.yaml + content-k8s XR template) — single PR
+- Backstage deployment manifest tag bump: 1 file in `arigsela/kubernetes` — separate PR or bundled with kubernetes-side work
+
+**Things explicitly NOT in v1.2.1:**
+- ❌ Image-family-specific default health paths (e.g., FastAPI auto-detect → `/api/health`) — too opinionated; v2+ concern
+- ❌ Disabling probes entirely (rejected during brainstorming as anti-pattern for production)
+- ❌ Composition Python defensive trim of input strings (rejected — composition shouldn't normalize input)
+- ❌ XRD `pattern` validation rejecting whitespace (rejected — admission rejection has worse UX than form-trim)
+- ❌ Migration of existing XRs (none have `healthCheckPath`; default kicks in automatically; no XRD version bump)
+- ❌ Re-validation of full v1.2 acceptance criteria (only AC-7 needs re-validation; the rest are already green)
+- ❌ Probe-tuning beyond path (initialDelaySeconds, periodSeconds, etc. stay v1 defaults)
+
+## 4. `healthCheckPath` XR field
+
+### 4.1 XRD schema addition
+
+```yaml
+# In xrd-application.yaml under spec.versions[0].schema.openAPIV3Schema.properties.spec.properties:
+healthCheckPath:
+  type: string
+  default: "/"
+  description: |
+    HTTP path for liveness and readiness probes. Defaults to '/' which works
+    for most images (nginx, generic web servers). Override for images that
+    expose a dedicated health endpoint (e.g. '/api/health', '/actuator/health').
+  pattern: "^/.*"
+```
+
+**Why optional + default `/`:**
+- Backwards-compatible: existing XRs without the field automatically get `/`
+- No XRD apiVersion bump needed (`v1alpha1` continues)
+- Matches the principle "defaults that work for the most common case; explicit override for the minority"
+
+**Validation pattern `^/.*`:**
+- Must start with `/` (absolute path)
+- Avoids common typo (forgetting leading slash)
+- Doesn't restrict character set beyond that (allows `/api/v1/health`, `/.well-known/health`, etc.)
+
+### 4.2 Composition Python change
+
+```python
+# Inside make_deployment (helper):
+def make_deployment(name, namespace, image, port, replicas, env_list,
+                   env_from, annotations, health_path):
+    return {
+        # ... existing structure ...
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [{
+                        # ... existing fields ...
+                        "livenessProbe": {
+                            "httpGet": {"path": health_path, "port": port},
+                            "initialDelaySeconds": 30, "periodSeconds": 30,
+                        },
+                        "readinessProbe": {
+                            "httpGet": {"path": health_path, "port": port},
+                            "initialDelaySeconds": 5, "periodSeconds": 10,
+                        },
+                    }],
+                },
+            },
+        },
+    }
+```
+
+```python
+# Inside compose():
+health_path = spec.get("healthCheckPath", "/")  # XRD default kicks in via apiserver
+                                                # but defensive default here too
+resource.update(
+    rsp.desired.resources["deployment"],
+    make_deployment(name, namespace, spec["image"], port, replicas,
+                    spec.get("env", []), env_from,
+                    annotations=std_annotations(xr_annotations, "deployment"),
+                    health_path=health_path),
+)
+```
+
+**Why pass `health_path` rather than reading `spec` inside `make_deployment`:**
+- Keeps helpers pure (no `spec` access) — same pattern as `make_service(port)`, `make_ingress(host)`, etc.
+- Easy to test in isolation (one input → one output)
+- Composition Python style consistency with v1.1 / v1.2
+
+## 5. PushSecret `refreshInterval: 5m`
+
+```python
+# Inside make_push_secret (helper):
+def make_push_secret(name, namespace, annotations):
+    return {
+        # ... existing structure ...
+        "spec": {
+            "refreshInterval": "5m",  # was "1h"
+            # ... rest unchanged ...
+        },
+    }
+```
+
+**Why 5m:**
+- Re-validation work at homelab scale (≤10 apps with `dbNeeded: true`): 12 refreshes/hr × 10 apps = 120 calls/hr to Vault. Trivial impact.
+- Error recovery: 5min is "I'll grab coffee and it'll have retried" — not actively babysit
+- Matches common ESO ergonomic patterns in community deploys
+- CNPG creds don't rotate (yet) — when v2 dynamic creds land via VSO, this resource changes anyway
+
+**Alternatives considered:** `30s` (overkill), `2m` (aggressive but reasonable), `15m` (sluggish on errors), `1h` (current; problem we're fixing).
+
+## 6. Scaffolder trim
+
+### 6.1 Where to apply
+
+Edit `examples/templates/application/template.yaml` in `arigsela/backstage`. The template's `steps` block has a `fetch.values` mapping that hands form parameters to the content-k8s templating layer. Apply `| trim` Nunjucks filter to text fields:
+
+```yaml
+# Before:
+steps:
+  - id: fetch
+    name: Render manifests
+    action: fetch:template
+    input:
+      url: ./content-k8s
+      values:
+        name: ${{ parameters.name }}
+        namespace: ${{ parameters.name }}
+        owner: ${{ parameters.owner }}
+        image: ${{ parameters.image }}
+        host: ${{ parameters.host }}
+        # ... etc.
+
+# After:
+steps:
+  - id: fetch
+    name: Render manifests
+    action: fetch:template
+    input:
+      url: ./content-k8s
+      values:
+        name: ${{ parameters.name | trim }}
+        namespace: ${{ parameters.name | trim }}
+        owner: ${{ parameters.owner | trim }}
+        image: ${{ parameters.image | trim }}
+        host: ${{ parameters.host | trim }}
+        healthCheckPath: ${{ parameters.healthCheckPath | trim }}
+        # numbers/booleans stay as-is — trim only applies to strings:
+        port: ${{ parameters.port }}
+        replicas: ${{ parameters.replicas }}
+        dbNeeded: ${{ parameters.dbNeeded }}
+        dbStorage: ${{ parameters.dbStorage | trim }}
+```
+
+**Why this layer (not Composition Python or XRD validation):**
+- Sanitize at the form-data boundary — exactly where humans introduce whitespace
+- Scaffold PR diff is clean (operator review-friendly); no broken XRs land in main
+- TeraSky's auto-generated XApplication form doesn't go through this template — but that's a deliberate "advanced power-user" path, not the curated UX. If it bites someone, that's a v1.3 concern.
+
+### 6.2 New `healthCheckPath` form field
+
+Add to "Workload" parameter group in the same template:
+
+```yaml
+parameters:
+  # ... existing groups (Identity, Workload, Database (optional)) ...
+  - title: Workload
+    required: [image, host, port]
+    properties:
+      # ... existing image, host, port, replicas ...
+      healthCheckPath:
+        type: string
+        title: Health check path (optional)
+        description: HTTP path for liveness/readiness probes. Defaults to '/' which works for most images.
+        default: "/"
+        pattern: "^/.*"
+```
+
+### 6.3 Conditional emission in content-k8s XR
+
+```yaml
+# In content-k8s/base-apps/${{ values.name }}/application-xr.yaml:
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  {%- if values.healthCheckPath and values.healthCheckPath != "/" %}
+  healthCheckPath: ${{ values.healthCheckPath }}
+  {%- endif %}
+  dbNeeded: ${{ values.dbNeeded }}
+  {%- if values.dbNeeded %}
+  dbStorage: ${{ values.dbStorage }}
+  {%- endif %}
+```
+
+**Why conditional emission:** if user accepts the default `/`, omitting `healthCheckPath` from the rendered XR means the XRD's default value applies — slightly cleaner XR YAML, easier to review.
+
+## 7. Acceptance criteria
+
+| AC | Check | How to verify |
+|---|---|---|
+| 1 — Goldens regenerated | Both `expected-xr-{minimal,with-db}` PASS | `./tests/composition/render.sh xr-{minimal,with-db}` exit 0 |
+| 2 — Default `healthCheckPath` works | xr-minimal golden shows `path: /` on liveness + readiness | Inspect golden post-update |
+| 3 — Override `healthCheckPath` works | XR with explicit value renders the value through to probes | Optional new `xr-custom-health.yaml` golden, OR trust the Python loop (see §11) |
+| 4 — PushSecret 5m | `refreshInterval: 5m` in rendered output | xr-with-db golden contains the value |
+| 5 — Form trim works | Submit Backstage form with deliberate trailing whitespace on `host` (e.g. `smoke-v121.arigsela.com   `) → scaffold PR has clean value (no trailing spaces) | Live test during smoke validation |
+| 6 — AC-7 unblocked | nginx-unprivileged smoke-v121 Pod becomes `Ready=True`, restart count stays 0 | `kubectl get pod -o wide` after 2 min |
+| 7 — chores-tracker still healthy | Existing apps unaffected | ExternalSecret Ready, pods stable |
+| 8 — TeraSky auto-form still works | Auto-generated XApplication form (from `ingestAllXRDs: true`) shows the new `healthCheckPath` field with default `/` populated | Visual check in Backstage UI |
+
+## 8. Failure modes
+
+| # | Failure | Symptom | Diagnosis | Fix |
+|---|---|---|---|---|
+| 1 | XRD default not applied to existing XRs | Existing XRs reconcile with `healthCheckPath: null`, Composition's `spec.get(..., "/")` Python default catches it | Inspect rendered Deployment probes | Defensive Python default mitigates; if absent, XRD `defaulting` admission webhook should backfill — verify with `kubectl get xapplications -o yaml \| grep healthCheckPath` post-deploy |
+| 2 | Backstage image not rebuilt; scaffolder still serves old template | New form fields don't appear; trim filter not applied | Inspect Backstage Pod image tag | User rebuilds image + bumps tag in `deployments.yaml`; this is documented Phase 3 USER GATE per CLAUDE.md |
+| 3 | TeraSky auto-form regression | XApplication auto-generated form breaks (field renamed, validation tightened) | Visual UI check | Roll back XRD change, investigate; not expected (we're adding optional field, not modifying existing) |
+| 4 | Render harness regression | Goldens fail on no real change | Post-edit `yq sort_keys(..)` produces unexpected order | Re-canonicalize with `yq -i -P 'sort_keys(..)'`; this is a known TDD-flow quirk, not a bug |
+| 5 | Pod still in CrashLoopBackOff after AC-6 fix attempt | nginx-unprivileged might have other startup issues unrelated to probe path | `kubectl logs --previous` | Out of v1.2.1 scope; v1.2.1 only fixes the probe path, not arbitrary container startup issues |
+
+## 9. Sequencing
+
+```
+Phase 1 (arigsela/kubernetes — single PR)        Phase 2 (arigsela/backstage — single PR)
+   • XRD: add healthCheckPath optional field         • template.yaml: add healthCheckPath form input
+   • Composition: thread spec.get("healthCheckPath") • template.yaml: | trim filter on host/image/name
+     to make_deployment probes                       • content-k8s XR: render healthCheckPath if set
+   • PushSecret refreshInterval: 1h → 5m             • (No backend code, no plugin work)
+   • Goldens (both) updated
+   → Subagent-friendly, full TDD discipline           → Subagent-friendly
+        │                                                      │
+        ├─ User merges → ArgoCD syncs Composition              ├─ User merges → image rebuild needed
+        │                                                      │
+        ▼                                                      ▼
+                            Phase 3 (USER GATE)
+                  • User rebuilds Backstage image
+                  • Bump base-apps/backstage/deployments.yaml tag
+                  • ArgoCD picks up
+        │
+        ▼
+Phase 4 — Smoke validation (smoke-v121)
+   • Scaffold via Backstage with deliberate trailing whitespace on host (test trim)
+   • Verify scaffold PR has clean values
+   • Merge → ArgoCD → Pod becomes Ready=True (proves /healthz fix)
+   • Tear down (PR-delete + orphan XR delete; verify Vault GC same as v1.2)
+        │
+        ▼
+Phase 5 — Close-out
+   • Run notes appended to v1.2.1 plan
+```
+
+## 10. Things explicitly NOT in v1.2.1
+
+- ❌ Image-family-specific default `healthCheckPath` (FastAPI → `/api/health`, etc.) — too opinionated; v2+ concern
+- ❌ Disabling probes entirely via XR field (`disableHealthProbes: true`) — anti-pattern for platform discipline
+- ❌ Composition Python defensive trim of all input strings — rejected; composition shouldn't normalize input
+- ❌ XRD `pattern` validation rejecting whitespace — rejected; worse UX than form-trim
+- ❌ `initialDelaySeconds` / `periodSeconds` tuning — out of scope
+- ❌ Probe protocol changes (TCP, gRPC) — out of scope
+- ❌ Vault Secrets Operator (VSO) introduction — v2 concern
+- ❌ AWS resources — v1.3 concern
+- ❌ Migration scripts for existing XRs — none needed (default kicks in automatically)
+
+## 11. Decision rationale (Q1–Q3 summary)
+
+The three brainstorming decisions, captured here so plan and any future re-execution have the reasoning:
+
+| Q | Decision | Why |
+|---|---|---|
+| Q1 — `/healthz` fix | **Add `healthCheckPath` XR field, default `/`** (B) | Right fix at the right layer (per-XR knows the image); backwards-compatible (no XRD bump); pays for v2 dynamic-creds work too |
+| Q2 — PushSecret refresh | **5m** | Sweet spot for homelab — 12/hr/app load is trivial; 5min error-recovery is acceptable without active babysitting |
+| Q3 — trim approach | **Scaffolder template `\| trim` only** (A) | Sanitize at form-data boundary; PR diff is clean; rejecting via XRD pattern would create worse "submitted form, broken XR" UX |
+
+## 12. v1.x roadmap
+
+| Iteration | Goal | Status |
+|---|---|---|
+| v1 | Scaffolder → XR → Composition → app live; manual catalog-import | Shipped (2026-04-28) |
+| v1.1 | Auto-ingestion via TeraSky plugins; Crossplane tab | Shipped (2026-04-29) |
+| v1.2 | Vault round-trip for DB credentials | Shipped (2026-05-01) |
+| **v1.2.1** | **Ergonomic close-out fixes (this spec)** | **In progress (2026-05-01)** |
+| v1.3 | AWS resources (S3, IAM via Upbound providers) | Future |
+| v2 | Vault-managed dynamic credentials (VSO + Database secrets engine); cred rotation | Future |
+
+## 13. Test golden update strategy
+
+Two acceptable paths for updating the goldens (both follow TDD discipline; pick one):
+
+**A) Manual-edit-then-regenerate** (recommended; matches v1.2's plan):
+1. Edit existing goldens to update `path: /healthz → /` and `refreshInterval: 1h → 5m`
+2. Run `yq -i -P 'sort_keys(..)'` to re-canonicalize
+3. Run render test → expect FAIL
+4. Implement Composition + XRD changes
+5. Run render test → expect PASS
+
+**B) Regenerate-then-verify** (faster but loses TDD discipline):
+1. Implement Composition + XRD changes
+2. Regenerate goldens via the README's `crossplane render | yq -P 'sort_keys(..)' > expected-...` command
+3. Inspect diffs to confirm only expected changes (probe paths, refreshInterval) appear
+4. Run render test → expect PASS
+
+The plan should follow **A** — TDD is cheap protection against accidentally regenerating goldens that include a regression we then can't notice.


### PR DESCRIPTION
## Summary

Brings v1.2.1 brainstorming + planning out of conversation context into the repo. Spec captures the 3 brainstorming decisions (Q1-Q3); plan turns them into bite-sized executable tasks.

No code changes — pure docs.

## What's in this PR

| File | Lines | Purpose |
|---|---|---|
| \`docs/superpowers/specs/2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md\` | 340 | Approved design spec for v1.2.1 |
| \`docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md\` | 971 | 5-phase implementation plan |

## v1.2.1 in one paragraph

Three small ergonomic fixes for v1.2's observable rough edges:
1. \`healthCheckPath\` as optional XR field with default \`/\` — replaces hardcoded \`/healthz\` that was breaking nginx-unprivileged. Backwards-compatible (no XRD apiVersion bump). Unblocks v1.2 AC-7.
2. PushSecret \`refreshInterval\` 1h → 5m for snappier error recovery at trivial homelab-scale load.
3. Backstage scaffolder template applies Nunjucks \`| trim\` filter to text form-input values — sanitizes whitespace at the form-data boundary.

## Decisions captured (Q1-Q3)

| Q | Decision |
|---|---|
| /healthz fix | XR field with default \`/\` (B), backwards-compatible |
| PushSecret refresh value | 5m |
| Form-trim approach | Scaffolder template only (\`| trim\` Nunjucks filter) |

## Implementation scope

- ~30 min implementation budget
- Two PRs: arigsela/kubernetes (XRD + Composition + goldens) and arigsela/backstage (scaffolder template + XR template)
- Phase 3 USER GATE: image rebuild + tag bump (per CLAUDE.md user-owned image workflow)
- Phase 4 smoke validation: deliberate trailing-whitespace test + Pod Ready check

## Test plan

- [x] Spec brainstorming complete (Q1-Q3 approved)
- [x] Spec self-reviewed for placeholders + ambiguity
- [x] Plan self-reviewed against spec coverage + type consistency
- [ ] User reviews this PR
- [ ] User merges → execution begins per chosen mode (subagent-driven recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)