### PR TITLE
feat(composition): v1.2.1 ergonomic fixes — healthCheckPath + 5m PushSecret refresh

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -92,7 +92,7 @@ spec:
                       "annotations": annotations,
                   },
                   "spec": {
-                      "refreshInterval": "1h",
+                      "refreshInterval": "5m",
                       "deletionPolicy": "Delete",
                       "secretStoreRefs": [
                           {"name": "vault-backend", "kind": "SecretStore"},
@@ -148,7 +148,7 @@ spec:
                   },
               }
 
-          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations):
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations, health_path):
               container = {
                   "name": "app",
                   "image": image,
@@ -158,11 +158,11 @@ spec:
                       "limits":   {"cpu": "500m", "memory": "512Mi"},
                   },
                   "livenessProbe": {
-                      "httpGet": {"path": "/healthz", "port": port},
+                      "httpGet": {"path": health_path, "port": port},
                       "initialDelaySeconds": 30, "periodSeconds": 30,
                   },
                   "readinessProbe": {
-                      "httpGet": {"path": "/healthz", "port": port},
+                      "httpGet": {"path": health_path, "port": port},
                       "initialDelaySeconds": 5, "periodSeconds": 10,
                   },
               }
@@ -281,7 +281,8 @@ spec:
                   rsp.desired.resources["deployment"],
                   make_deployment(name, namespace, spec["image"], port,
                                   replicas, spec.get("env", []), env_from,
-                                  annotations=std_annotations(xr_annotations, "deployment")),
+                                  annotations=std_annotations(xr_annotations, "deployment"),
+                                  health_path=spec.get("healthCheckPath", "/")),
               )
               resource.update(
                   rsp.desired.resources["service"],

--- a/base-apps/crossplane-compositions/xrd-application.yaml
+++ b/base-apps/crossplane-compositions/xrd-application.yaml
@@ -46,6 +46,15 @@ spec:
                   default: 2
                   minimum: 1
                   maximum: 10
+                healthCheckPath:
+                  type: string
+                  default: "/"
+                  pattern: "^/.*"
+                  description: |
+                    HTTP path for liveness and readiness probes. Defaults to '/'
+                    which works for most images (nginx, generic web servers).
+                    Override for images that expose a dedicated health endpoint
+                    (e.g. '/api/health', '/actuator/health').
                 env:
                   type: array
                   description: "Plain-text env vars; never use for secrets"

--- a/base-apps/crossplane-compositions/xrd-application.yaml
+++ b/base-apps/crossplane-compositions/xrd-application.yaml
@@ -62,8 +62,10 @@ spec:
                     type: object
                     required: [name, value]
                     properties:
-                      name:  { type: string }
-                      value: { type: string }
+                      name:
+                        type: string
+                      value:
+                        type: string
                 dbNeeded:
                   type: boolean
                   default: false

--- a/tests/composition/expected-xr-minimal.yaml
+++ b/tests/composition/expected-xr-minimal.yaml
@@ -53,7 +53,7 @@ spec:
         - image: nginxinc/nginx-unprivileged:1.25-alpine
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
@@ -63,7 +63,7 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -63,7 +63,7 @@ spec:
           image: nginxinc/nginx-unprivileged:1.25-alpine
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
@@ -73,7 +73,7 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -297,7 +297,7 @@ spec:
           remoteKey: platform-smoke/db
         secretKey: username
   deletionPolicy: Delete
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRefs:
     - kind: SecretStore
       name: vault-backend


### PR DESCRIPTION
## Summary

Three small fixes for v1.2's observable rough edges from e2e validation. Single Composition+XRD PR; companion Backstage scaffolder PR opens separately.

## Changes

| Change | File | Impact |
|---|---|---|
| Add `healthCheckPath` optional XR field, default `/` | `base-apps/crossplane-compositions/xrd-application.yaml` | Backwards-compatible — existing XRs get default `/` automatically |
| Composition Python threads `healthCheckPath` to liveness + readiness probes | `base-apps/crossplane-compositions/composition-application.yaml` | Replaces hardcoded `/healthz`; unblocks v1.2 AC-7 (nginx-unprivileged Pod ready) |
| PushSecret `refreshInterval` 1h → 5m | (same Composition file) | Snappier error recovery; trivial extra load at homelab scale |
| Goldens updated (probe paths + refreshInterval) | `tests/composition/expected-xr-{minimal,with-db}.yaml` | TDD — wrote failing test first, then implemented to pass |

## Test plan

- [x] `./tests/composition/render.sh xr-minimal` PASS (probe path `/` rendered)
- [x] `./tests/composition/render.sh xr-with-db` PASS (probe path `/` + refreshInterval `5m` rendered)
- [ ] After merge: companion arigsela/backstage PR for `healthCheckPath` form field + scaffolder trim
- [ ] User rebuilds Backstage image + bumps tag in `base-apps/backstage/deployments.yaml`
- [ ] Smoke validation with smoke-v121: deliberate trailing whitespace test (form trim) + Pod becomes Ready (probe fix)

## What this does NOT change

- No XRD apiVersion bump (additions are backwards-compat via `default`)
- No env var renames or other v1.2 behavior change
- chores-tracker and any existing v1.x apps unaffected

## v1.2.1 = ergonomic close-out

This is the v1.2 follow-up sweep noted in the v1.2 close-out run notes. Two more tiny things in scope (form-input trim, healthCheckPath form field) live in the companion arigsela/backstage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)