### PR TITLE
docs(idp): v1.2.1 close-out run notes

### DIFF
--- a/docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md
+++ b/docs/superpowers/plans/2026-05-01-idp-v1.2.1-ergonomic-fixes.md
@@ -969,3 +969,56 @@ Phase boundaries:
 - **Phase 5** — final close-out subagent
 
 Phases 1 and 2 are independent — can run in parallel as two subagents (different repos, no shared files). Phase 5 runs after Phase 4 user-confirms outcome.
+
+---
+
+## Run Notes (2026-05-01)
+
+**Outcome:** v1.2.1 of the IDP shipped. `healthCheckPath` is now an optional XR field defaulting to `/`; nginx-unprivileged and similar minimal images become Ready=True out of the box. PushSecret refresh dropped to 5m for snappier error recovery. Backstage scaffolder template trims form-input whitespace at the form-data boundary.
+
+**E2E validation** (`smoke-v121`, dbNeeded:false, healthCheckPath default `/`):
+
+- ✅ Pod went `1/1 Ready` within ~60s of XR creation; **stayed Ready for 150 minutes with 0 restarts** — AC-6 unblocked (was the v1.2 AC-7 blocker)
+- ✅ Rendered Deployment uses `path: /` on both liveness + readiness probes — AC-2 default works
+- ✅ HTTP 200 on `/` from Pod IP (kubelet's probe target) — kubelet probes pass
+- ✅ Default `healthCheckPath` not emitted in scaffold XR (conditional emission `{%- if values.healthCheckPath != "/" %}` worked) — AC-3 indirect
+- ✅ `host` field clean (no trailing whitespace) in scaffold PR — AC-5 trim works
+- ✅ Backstage Pod image rebuilt + relaunched with same tag (`v1.1.0`) — image SHA confirmed updated; new template content visible on Pod filesystem
+- ✅ Goldens still PASS for both xr-minimal and xr-with-db — AC-1
+- (AC-4 PushSecret 5m verified in Phase 1 goldens; not exercised live this run since dbNeeded:false)
+
+**Bugs caught during execution:**
+
+| # | Bug | Severity | Fix |
+|---|---|---|---|
+| 1 | yaml-lint failure on PR #226 — pre-existing inline `name: { type: string }` style violation in env block, surfaced because we touched the file | minor | Separate `style(xrd):` commit `91bdffa` on the same PR; expanded to standard mapping form |
+| 2 | User-typed trailing period (`.`) in scaffold PR's host field — would have caused cert-manager challenge issues even with the trim filter (period isn't whitespace) | minor (UX/typo) | Pushed `640618b` directly to scaffold/smoke-v121 branch removing the period |
+| 3 | yaml-lint + kubernetes-validate CI checks fail on pure-delete PRs (file-not-found) — same issue affected v1.2's teardown PR #223 | minor (CI workflow) | Not fixed here; queued as follow-up CI workflow improvement |
+| 4 | cert-manager Certificate stuck `pending` because Let's Encrypt HTTP-01 challenge was created with the trailing-period hostname (before fix #2 landed); challenge was never retried for the corrected hostname | minor (separate from v1.2.1) | Would have self-recovered eventually OR via `kubectl delete certificate`; teardown removed it anyway |
+
+**Things that worked unexpectedly well:**
+
+- Reusing the same Backstage image tag (`v1.1.0`) and relaunching the Pod was sufficient to deploy v1.2.1's scaffolder changes — no tag-bump PR needed for this iteration. Image SHA verification (`kubectl get pod -o jsonpath='{.status.containerStatuses[0].imageID}'`) confirmed the rebuild without a version string change.
+- The conditional emission block in the XR template (`{%- if values.healthCheckPath != "/" %}`) worked as designed — when user kept the default `/`, the field was correctly omitted from the rendered XR, and the XRD's own default kicked in server-side. Cleaner XR PRs for the common case.
+- Subagent + spec-compliance review caught the parameter-order inconsistency (`health_path` after `annotations`) and the XRD key-ordering nit before merge — small polish that improves future maintainability without code-review back-and-forth.
+
+**v1.3 / v2 follow-up candidates** (carried forward):
+
+- **CI workflow improvement**: filter `git diff --name-only` output to existing files before piping to yamllint/kubeconform, so pure-delete PRs don't fail spuriously
+- **cert-manager retry-on-typo**: investigate stuck-Certificate retry behavior; small operational annoyance during smoke validation runs
+- **v1.3 — AWS resources** via Upbound providers (S3, IAM); Vault path layout `k8s-secrets/<name>/aws-creds` already designed for this
+- **v2 — VSO + Vault Database secrets engine** for dynamic Postgres creds (rotation)
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| [#225](https://github.com/arigsela/kubernetes/pull/225) | docs: v1.2.1 design spec + implementation plan |
+| [#226](https://github.com/arigsela/kubernetes/pull/226) | feat(composition): healthCheckPath + 5m PushSecret + 2 reviewer-suggested polish nits + style(xrd) yaml-lint fix |
+| [arigsela/backstage#10](https://github.com/arigsela/backstage/pull/10) | feat(scaffolder): healthCheckPath form input + Nunjucks `\| trim` + conditional XR emission |
+| (image rebuild — same tag v1.1.0, no manifest PR) | User rebuilt + relaunched in-place |
+| [#227](https://github.com/arigsela/kubernetes/pull/227) | scaffold/smoke-v121 + trailing-period typo fix |
+| [#228](https://github.com/arigsela/kubernetes/pull/228) | chore: tear down smoke-v121 validation app |
+| (this PR) | docs: v1.2.1 close-out run notes |
+
+**v1.2.1 status: shipped.**


### PR DESCRIPTION
Captures v1.2.1 outcome, smoke-v121 e2e validation results, bug-fix references, and v1.3/v2 follow-up candidates.

## Outcome

v1.2.1 shipped. `healthCheckPath` default `/` works (Pod stable Ready=True for 150 min with 0 restarts in smoke validation — was the v1.2 AC-7 blocker). PushSecret refresh dropped to 5m. Backstage scaffolder template trims form-input whitespace at the form-data boundary.

## Bugs caught during execution (all referenced in run notes)

1. yaml-lint pre-existing violation in env block — fixed via separate commit on PR #226
2. User-typo trailing period in scaffold host — fixed via push to scaffold branch
3. CI workflow fails on pure-delete PRs — queued as follow-up
4. cert-manager Certificate stuck pending due to typo'd challenge — separate concern

## Things that worked unexpectedly well

- Reusing same Backstage image tag + Pod relaunch sufficient to deploy v1.2.1
- Conditional XR emission worked exactly as designed
- Subagent reviews caught parameter-order + XRD key-ordering nits pre-merge

## v1.3 / v2 candidates carried forward

- CI workflow improvement (filter to existing files)
- v1.3 AWS resources via Upbound providers
- v2 VSO + Vault Database secrets engine for cred rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)