### PR TITLE
docs(idp): v1.3 design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md
+++ b/docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md
@@ -1,0 +1,1771 @@
+# IDP v1.3 — AWS S3 + IAM Resources — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `s3Needed: bool` to the XApplication XRD; when true, Composition emits S3 bucket + IAM user + S3-RW-on-own-bucket policy + access key + ESO PushSecret/ExternalSecret to route AWS credentials through Vault. Workload Deployment receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BUCKET_NAME` env vars (zero application-side configuration).
+
+**Architecture:** Mirrors v1.2's DB credential round-trip pattern, applied to AWS. Composition Python adds 4 new AWS resource helpers (`make_s3_bucket`, `make_iam_user`, `make_iam_user_policy`, `make_iam_access_key`) and 2 AWS-flavored ESO helpers (`make_aws_push_secret`, `make_aws_external_secret`). `compose()` emits 8 new resources when `s3Needed:true`; `make_deployment` adds the AWS Secret to envFrom and injects AWS_REGION/BUCKET_NAME as static env vars. SecretStore is shared between DB and AWS paths (emit-once if either is needed). Crossplane SA RBAC extended with permissions on `s3.aws.upbound.io` + `iam.aws.upbound.io` API groups.
+
+**Tech Stack:** Crossplane v2.2.1 + function-python (composition), Crossplane provider-aws-s3 v2.5.3 + provider-aws-iam v2.5.3 + upbound-provider-family-aws v2.5.3 (already installed), External Secrets Operator (ESO), HashiCorp Vault, Backstage scaffolder (Nunjucks templating), `crossplane render` CLI + `yq` for goldens-based testing.
+
+**Spec:** [`docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md`](../specs/2026-05-01-idp-v1.3-aws-resources-design.md) (committed `a1a63f6`)
+
+---
+
+## Pre-flight (run once before Phase 1 starts)
+
+### P.1 — Verify the Composition test harness still works (sanity baseline)
+
+```bash
+cd /Users/arisela/git/kubernetes
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+Expected: both exit 0 with no diff output. If either fails, investigate before adding v1.3 changes — something broke between v1.2.1 and now.
+
+### P.2 — Confirm v1.2.1 is shipped (close-out PR #229 merged)
+
+```bash
+git fetch origin main
+git log origin/main --oneline | grep -E "v1.2.1 close-out|fa20484" | head -3
+```
+
+Expected: at least one commit referencing the v1.2.1 close-out. If not, merge PR #229 first — v1.3 builds on a stable v1.2.1 base.
+
+### P.3 — Verify provider-aws-iam AccessKey CRD shape (HARD GATE)
+
+This is the v1.3 spec §4 #15 verification call-out. The `make_aws_push_secret` helper assumes the AccessKey resource auto-creates a K8s Secret with keys `attribute.id` and `attribute.secret`. Confirm this matches reality:
+
+```bash
+kubectl get crd accesskeys.iam.aws.upbound.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.writeConnectionSecretToRef}{"\n"}'
+
+# Also: look at any existing AccessKey resource on the cluster for the actual Secret shape
+kubectl get accesskeys.iam.aws.upbound.io -A 2>&1 | head -3
+```
+
+If existing AccessKey resources exist (e.g., from `argo-workflows-aws-infrastructure/access-key.yaml`), inspect their target Secret:
+
+```bash
+# Find one
+EXAMPLE_AK=$(kubectl get accesskeys.iam.aws.upbound.io -A -o json | jq -r '.items[0] | "\(.spec.writeConnectionSecretToRef.namespace)/\(.spec.writeConnectionSecretToRef.name)"')
+echo "Example AK Secret: $EXAMPLE_AK"
+
+# Inspect its keys (don't dump values)
+NS=$(echo "$EXAMPLE_AK" | cut -d/ -f1)
+NM=$(echo "$EXAMPLE_AK" | cut -d/ -f2)
+kubectl -n "$NS" get secret "$NM" -o jsonpath='{.data}' | jq 'keys'
+```
+
+**Expected output: `["attribute.id", "attribute.secret"]`** (or similar — provider-aws-iam v2.5.3 standard).
+
+**If keys differ** (e.g., `["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]` directly): update `make_aws_push_secret` in Phase 1 Task 1.7 — the `data[].match.secretKey` values must match the actual keys.
+
+If no existing AccessKey resources to inspect: the keys WILL be `attribute.id` and `attribute.secret` per provider-aws-iam v2.x convention. Proceed; verify in Phase 4 smoke.
+
+### P.4 — Confirm AWS provider + ProviderConfig health
+
+```bash
+kubectl get providers 2>&1 | grep -iE "aws|family"
+# Expected: 3 providers all "INSTALLED=True, HEALTHY=True"
+
+kubectl get providerconfigs.aws.upbound.io 2>&1
+# Expected: "default" ProviderConfig exists
+
+kubectl -n crossplane-system get secret aws-secret 2>&1 | head -3
+# Expected: Secret exists; status output shows DATA count
+```
+
+If any check fails: AWS infrastructure isn't ready. Fix before proceeding.
+
+---
+
+## Phase 1 — Kubernetes repo (XRD + Composition + RBAC + new test golden, single PR)
+
+Branch: `feat/idp-v1.3-aws-resources` off `origin/main`.
+
+### Task 1.1: Set up the implementation branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main
+git checkout -b feat/idp-v1.3-aws-resources origin/main
+git branch --show-current
+# Expected: feat/idp-v1.3-aws-resources
+```
+
+---
+
+### Task 1.2: Create test input fixture xr-with-s3.yaml
+
+**Files:**
+- Create: `tests/composition/xr-with-s3.yaml`
+
+- [ ] **Step 1: Write the input XR for the new test case**
+
+Create `tests/composition/xr-with-s3.yaml` with this exact content:
+
+```yaml
+# tests/composition/xr-with-s3.yaml
+# TDD input: XApplication with AWS S3 bucket enabled (no DB).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-s3-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-s3-app.arigsela.com
+  port: 8080
+  replicas: 1
+  s3Needed: true
+```
+
+Notice: `s3Needed: true`, `dbNeeded` omitted (defaults to `false`). This isolates the S3 path without DB interference.
+
+---
+
+### Task 1.3: Create test golden expected-xr-with-s3.yaml (TDD: write the failing assertion FIRST)
+
+**Files:**
+- Create: `tests/composition/expected-xr-with-s3.yaml`
+
+This golden expresses the expected rendered output BEFORE we implement the Composition changes. The render test will FAIL initially (Composition doesn't yet emit AWS resources); after Task 1.5-1.10 implement the changes, the test will PASS.
+
+The golden has 11 documents:
+1. The XR itself (echoed through render)
+2. Deployment (with new envFrom: smoke-s3-app-aws + AWS_REGION/BUCKET_NAME env vars + healthCheckPath / )
+3. Service (unchanged pattern)
+4. Ingress (unchanged pattern)
+5. Bucket (new — AWS S3)
+6. User (new — AWS IAM)
+7. UserPolicy (new — AWS IAM)
+8. AccessKey (new — AWS IAM)
+9. SecretStore (vault-backend — shared with DB path; emit-once)
+10. PushSecret smoke-s3-app-aws-push (NEW)
+11. ExternalSecret smoke-s3-app-aws (NEW)
+
+- [ ] **Step 1: Create the golden file**
+
+Create `tests/composition/expected-xr-with-s3.yaml` with this content (11 YAML documents separated by `---`):
+
+```yaml
+# tests/composition/expected-xr-with-s3.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  host: smoke-s3-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+  s3Needed: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-s3-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-s3-app
+        backstage.io/kubernetes-id: smoke-s3-app
+    spec:
+      containers:
+      - env:
+        - name: AWS_REGION
+          value: us-east-2
+        - name: BUCKET_NAME
+          value: 852893458518-smoke-s3-app
+        envFrom:
+        - secretRef:
+            name: smoke-s3-app-aws
+        image: nginxinc/nginx-unprivileged:1.25-alpine
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: app
+        ports:
+        - containerPort: 8080
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      imagePullSecrets:
+      - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-s3-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: smoke-s3-app.arigsela.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: smoke-s3-app
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - smoke-s3-app.arigsela.com
+    secretName: smoke-s3-app-tls
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: secretstore
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: vault-backend
+  namespace: platform-smoke
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: platform-smoke
+          serviceAccountRef:
+            name: default
+      path: k8s-secrets
+      server: http://vault.vault.svc.cluster.local:8200
+      version: v2
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: bucket
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: 852893458518-smoke-s3-app
+spec:
+  forProvider:
+    forceDestroy: true
+    region: us-east-2
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamuser
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-app
+spec:
+  forProvider: {}
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicy
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamuserpolicy
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-s3-rw
+spec:
+  forProvider:
+    policy: '{"Statement": [{"Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"], "Effect": "Allow", "Resource": ["arn:aws:s3:::852893458518-smoke-s3-app", "arn:aws:s3:::852893458518-smoke-s3-app/*"]}], "Version": "2012-10-17"}'
+    userRef:
+      name: smoke-s3-app-app
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamaccesskey
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-app-key
+spec:
+  forProvider:
+    userRef:
+      name: smoke-s3-app-app
+  providerConfigRef:
+    name: default
+  writeConnectionSecretToRef:
+    name: smoke-s3-app-aws-key
+    namespace: platform-smoke
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awspushsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws-push
+  namespace: platform-smoke
+spec:
+  data:
+  - match:
+      remoteRef:
+        property: AWS_ACCESS_KEY_ID
+        remoteKey: platform-smoke/aws-creds
+      secretKey: attribute.id
+  - match:
+      remoteRef:
+        property: AWS_SECRET_ACCESS_KEY
+        remoteKey: platform-smoke/aws-creds
+      secretKey: attribute.secret
+  deletionPolicy: Delete
+  refreshInterval: 5m
+  secretStoreRefs:
+  - kind: SecretStore
+    name: vault-backend
+  selector:
+    secret:
+      name: smoke-s3-app-aws-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awsexternalsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws
+  namespace: platform-smoke
+spec:
+  data:
+  - remoteRef:
+      key: platform-smoke/aws-creds
+      property: AWS_ACCESS_KEY_ID
+    secretKey: AWS_ACCESS_KEY_ID
+  - remoteRef:
+      key: platform-smoke/aws-creds
+      property: AWS_SECRET_ACCESS_KEY
+    secretKey: AWS_SECRET_ACCESS_KEY
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: smoke-s3-app-aws
+```
+
+- [ ] **Step 2: Re-canonicalize via yq sort_keys**
+
+```bash
+yq -i -P 'sort_keys(..)' tests/composition/expected-xr-with-s3.yaml
+```
+
+- [ ] **Step 3: Quick sanity check — file parses cleanly into 11 documents**
+
+```bash
+yq 'document_index' tests/composition/expected-xr-with-s3.yaml | tail -1
+# Expected: 10 (zero-indexed; 11 docs total)
+```
+
+---
+
+### Task 1.4: Run xr-with-s3 render test → expect FAIL
+
+**Files:** none (running tests)
+
+- [ ] **Step 1: Run the new test case**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+**Expected: non-zero exit.** Diff shows the rendered output is missing all AWS resources (Bucket, User, UserPolicy, AccessKey, PushSecret, ExternalSecret) AND the Deployment lacks the new envFrom/env vars. SecretStore may also be missing because the current Composition only emits it when `dbNeeded:true`.
+
+If the test PASSES at this point: the implementation already exists somehow — STOP and investigate.
+
+---
+
+### Task 1.5: Add `s3Needed` field to XRD
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/xrd-application.yaml`
+
+- [ ] **Step 1: Add the field**
+
+Open `base-apps/crossplane-compositions/xrd-application.yaml`. Find the `dbNeeded:` property block (~line 67-69 in current state). Immediately AFTER the `dbStorage:` block (which follows `dbNeeded:`), add:
+
+```yaml
+                s3Needed:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true, the Composition provisions an S3 bucket + dedicated
+                    IAM user + S3-RW-on-own-bucket policy + access key, and routes
+                    AWS credentials through Vault. The workload Deployment receives
+                    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, and
+                    BUCKET_NAME env vars (zero application-side configuration).
+                    WARNING: bucket is forceDestroy:true — contents are permanently
+                    deleted on teardown.
+```
+
+(Indentation: 16 spaces, matching `dbNeeded:` and other sibling properties.)
+
+- [ ] **Step 2: Verify XRD still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/xrd-application.yaml > /dev/null && echo "XRD valid"
+```
+
+---
+
+### Task 1.6: Add 4 new AWS resource helpers to Composition Python
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+The Composition Python lives in `spec.pipeline[0].input.script` as a YAML literal block. Indentation: 10 spaces. Add the helpers AFTER the existing `make_cnpg_cluster` helper and BEFORE any ESO helpers (or at any position within the helpers block — Python doesn't care).
+
+- [ ] **Step 1: Add `import json` if not already present**
+
+Find the `import resource` line near the top of the script. If `import json` is not already there, add it on the next line:
+
+```python
+          import resource
+          import json   # NEW (needed for IAM policy serialization)
+```
+
+- [ ] **Step 2: Add AWS_ACCOUNT_ID + AWS_REGION constants**
+
+Find the `DB_SECRET_KEYS` constant (added in v1.2). Immediately AFTER it, add:
+
+```python
+          # AWS account + region constants. Confirmed from existing default
+          # ProviderConfig (status shows 10 resources using it) + chores-tracker-backend
+          # ECR image refs. Single account for all v1.x infra.
+          AWS_ACCOUNT_ID = "852893458518"
+          AWS_REGION = "us-east-2"
+```
+
+- [ ] **Step 3: Add `make_s3_bucket` helper**
+
+After the AWS constants, add:
+
+```python
+          def make_s3_bucket(name, namespace, annotations):
+              return {
+                  "apiVersion": "s3.aws.upbound.io/v1beta1",
+                  "kind": "Bucket",
+                  "metadata": {
+                      "name": f"{AWS_ACCOUNT_ID}-{name}",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "region": AWS_REGION,
+                          "forceDestroy": True,  # empties bucket on teardown — DATA LOSS by design
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+```
+
+- [ ] **Step 4: Add `make_iam_user` helper**
+
+```python
+          def make_iam_user(name, namespace, annotations):
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "User",
+                  "metadata": {
+                      "name": f"{name}-app",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {},
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+```
+
+- [ ] **Step 5: Add `make_iam_user_policy` helper**
+
+```python
+          def make_iam_user_policy(name, namespace, annotations):
+              """Inline policy attached to the user — single resource (no separate Policy + Attachment)."""
+              bucket_name = f"{AWS_ACCOUNT_ID}-{name}"
+              policy_doc = {
+                  "Version": "2012-10-17",
+                  "Statement": [{
+                      "Effect": "Allow",
+                      "Action": [
+                          "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+                      ],
+                      "Resource": [
+                          f"arn:aws:s3:::{bucket_name}",
+                          f"arn:aws:s3:::{bucket_name}/*",
+                      ],
+                  }],
+              }
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "UserPolicy",
+                  "metadata": {
+                      "name": f"{name}-s3-rw",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "userRef": {"name": f"{name}-app"},
+                          "policy": json.dumps(policy_doc),
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+```
+
+- [ ] **Step 6: Add `make_iam_access_key` helper**
+
+```python
+          def make_iam_access_key(name, namespace, annotations):
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "AccessKey",
+                  "metadata": {
+                      "name": f"{name}-app-key",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "userRef": {"name": f"{name}-app"},
+                      },
+                      "writeConnectionSecretToRef": {
+                          "name": f"{name}-aws-key",
+                          "namespace": namespace,
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+```
+
+- [ ] **Step 7: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/composition-application.yaml > /dev/null && echo "Composition YAML valid"
+```
+
+---
+
+### Task 1.7: Add 2 new ESO helpers (AWS-flavored) to Composition Python
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+Add the two new ESO helpers AFTER `make_iam_access_key` (or after the existing v1.2 ESO helpers — order doesn't matter for Python).
+
+- [ ] **Step 1: Add `make_aws_push_secret` helper**
+
+```python
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+                      "secretStoreRefs": [
+                          {"name": "vault-backend", "kind": "SecretStore"},
+                      ],
+                      "selector": {
+                          "secret": {"name": f"{name}-aws-key"},
+                      },
+                      "data": [
+                          {
+                              "match": {
+                                  "secretKey": "attribute.id",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_ACCESS_KEY_ID",
+                                  },
+                              },
+                          },
+                          {
+                              "match": {
+                                  "secretKey": "attribute.secret",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_SECRET_ACCESS_KEY",
+                                  },
+                              },
+                          },
+                      ],
+                  },
+              }
+```
+
+- [ ] **Step 2: Add `make_aws_external_secret` helper**
+
+```python
+          def make_aws_external_secret(name, namespace, annotations):
+              """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "ExternalSecret",
+                  "metadata": {
+                      "name": f"{name}-aws",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "15s",
+                      "secretStoreRef": {
+                          "name": "vault-backend",
+                          "kind": "SecretStore",
+                      },
+                      "target": {
+                          "name": f"{name}-aws",
+                          "creationPolicy": "Owner",
+                      },
+                      "data": [
+                          {
+                              "secretKey": "AWS_ACCESS_KEY_ID",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_ACCESS_KEY_ID",
+                              },
+                          },
+                          {
+                              "secretKey": "AWS_SECRET_ACCESS_KEY",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_SECRET_ACCESS_KEY",
+                              },
+                          },
+                      ],
+                  },
+              }
+```
+
+---
+
+### Task 1.8: Wire helpers into `compose()` + generalize SecretStore
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+Two changes inside `compose()`:
+
+- [ ] **Step 1: Generalize SecretStore emission to share between dbNeeded and s3Needed paths**
+
+Find the existing `if spec.get("dbNeeded"):` block in `compose()`. The first resource emitted inside is currently the SecretStore. We need to MOVE the SecretStore emission OUTSIDE the `if dbNeeded` block, and emit it if EITHER dbNeeded or s3Needed is true.
+
+Current shape (v1.2):
+```python
+              if spec.get("dbNeeded"):
+                  resource.update(
+                      rsp.desired.resources["dbcluster"],
+                      make_cnpg_cluster(...),
+                  )
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["pushsecret"],
+                      make_push_secret(...),
+                  )
+                  resource.update(
+                      rsp.desired.resources["externalsecret"],
+                      make_external_secret(...),
+                  )
+```
+
+New shape (v1.3) — add a separate `if needs_secret_store:` block BEFORE the dbNeeded block, and REMOVE the SecretStore emission from inside dbNeeded:
+
+```python
+              # SecretStore is shared between db and aws paths — emit once if EITHER is needed
+              needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+              if needs_secret_store:
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+
+              if spec.get("dbNeeded"):
+                  resource.update(
+                      rsp.desired.resources["dbcluster"],
+                      make_cnpg_cluster(...),
+                  )
+                  # NOTE: SecretStore emission removed from here — handled by the
+                  # shared `needs_secret_store` block above
+                  resource.update(
+                      rsp.desired.resources["pushsecret"],
+                      make_push_secret(...),
+                  )
+                  resource.update(
+                      rsp.desired.resources["externalsecret"],
+                      make_external_secret(...),
+                  )
+```
+
+- [ ] **Step 2: Add the s3Needed block**
+
+After the existing `if spec.get("dbNeeded"):` block, add:
+
+```python
+              if spec.get("s3Needed"):
+                  resource.update(
+                      rsp.desired.resources["bucket"],
+                      make_s3_bucket(name, namespace,
+                                     annotations=std_annotations(xr_annotations, "bucket")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamuser"],
+                      make_iam_user(name, namespace,
+                                    annotations=std_annotations(xr_annotations, "iamuser")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamuserpolicy"],
+                      make_iam_user_policy(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "iamuserpolicy")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamaccesskey"],
+                      make_iam_access_key(name, namespace,
+                                          annotations=std_annotations(xr_annotations, "iamaccesskey")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awspushsecret"],
+                      make_aws_push_secret(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "awspushsecret")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awsexternalsecret"],
+                      make_aws_external_secret(name, namespace,
+                                               annotations=std_annotations(xr_annotations, "awsexternalsecret")),
+                  )
+```
+
+---
+
+### Task 1.9: Update `make_deployment` for envFrom + AWS env vars
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+The current `make_deployment` accepts `env_from` (single Secret name) and `env_list` (caller-supplied env vars). Change to accept `db_secret` and `aws_secret` separately, build the envFrom array, and inject AWS_REGION/BUCKET_NAME static env vars.
+
+- [ ] **Step 1: Update `make_deployment` signature**
+
+Find the `def make_deployment(...)` line (current signature ends with `..., annotations, health_path)` per v1.2.1).
+
+Change from:
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, health_path, annotations):
+```
+
+To:
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, db_secret, aws_secret, health_path, annotations):
+```
+
+(Replaces single `env_from_secret` with two separate `db_secret`, `aws_secret` params.)
+
+- [ ] **Step 2: Update `make_deployment` body to build envFrom + env arrays**
+
+Inside the function body, find where the existing `envFrom` is set (currently a single secretRef block). Replace the env-construction logic with:
+
+```python
+              # Build envFrom dynamically based on what the app needs
+              env_from_blocks = []
+              if db_secret:
+                  env_from_blocks.append({"secretRef": {"name": db_secret}})
+              if aws_secret:
+                  env_from_blocks.append({"secretRef": {"name": aws_secret}})
+
+              # Inject AWS configuration as static env vars (not via Vault — these aren't secrets)
+              aws_env = []
+              if aws_secret:  # implies s3Needed
+                  aws_env.extend([
+                      {"name": "AWS_REGION", "value": AWS_REGION},
+                      {"name": "BUCKET_NAME", "value": f"{AWS_ACCOUNT_ID}-{name}"},
+                  ])
+
+              container_env = list(env_list) + aws_env
+```
+
+Then in the container spec dict, set:
+```python
+              "envFrom": env_from_blocks,
+              "env": container_env,
+```
+
+(Replace the existing single-secretRef envFrom + the existing `env: env_list` lines.)
+
+- [ ] **Step 3: Update the `make_deployment` call inside `compose()`**
+
+Find the existing `make_deployment` call inside `compose()`. Change it to pass `db_secret` and `aws_secret` separately:
+
+```python
+              db_secret = f"{name}-db" if spec.get("dbNeeded") else None
+              aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
+              resource.update(
+                  rsp.desired.resources["deployment"],
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []),
+                                  db_secret, aws_secret,
+                                  health_path=spec.get("healthCheckPath", "/"),
+                                  annotations=std_annotations(xr_annotations, "deployment")),
+              )
+```
+
+(Replace the existing `env_from=db_secret` argument with `db_secret, aws_secret` positional args.)
+
+- [ ] **Step 4: Verify YAML still parses + Python is syntactically valid**
+
+```bash
+yq '.' base-apps/crossplane-compositions/composition-application.yaml > /dev/null && echo "Composition YAML valid"
+```
+
+---
+
+### Task 1.10: Update Crossplane RBAC for AWS API groups
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-rbac.yaml`
+
+- [ ] **Step 1: Add two new rules at the end of the `rules:` array**
+
+Open `base-apps/crossplane-compositions/composition-rbac.yaml`. Find the end of the existing `rules:` array (after the `external-secrets.io` rule from v1.2.1). Append:
+
+```yaml
+  # AWS S3 — v1.3 IDP apps with s3Needed:true. Crossplane SA composes Bucket
+  # resources into target namespaces. /status subresource needed for informer sync
+  # (same root cause as v1.2.1's CNPG /status fix).
+  - apiGroups: ["s3.aws.upbound.io"]
+    resources:
+      - buckets
+      - buckets/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # AWS IAM — v1.3 IDP apps with s3Needed:true. User, UserPolicy, AccessKey
+  # for dedicated per-app IAM credentials.
+  - apiGroups: ["iam.aws.upbound.io"]
+    resources:
+      - users
+      - users/status
+      - userpolicies
+      - userpolicies/status
+      - accesskeys
+      - accesskeys/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+- [ ] **Step 2: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/composition-rbac.yaml > /dev/null && echo "RBAC valid"
+```
+
+---
+
+### Task 1.11: Run all render tests → expect PASS
+
+**Files:** none
+
+- [ ] **Step 1: Run new xr-with-s3 test (should now PASS)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+**Expected: exit 0, no diff.**
+
+If FAIL: read the diff. Common causes:
+- Helper missing one of the resources
+- Indent drift in Python (literal block in YAML)
+- AccessKey CRD shape mismatch (verify against P.3 finding)
+- Annotation copy missing on a resource (check `std_annotations` thread-through)
+- IAM policy JSON serialization differences (`json.dumps` produces specific key ordering — golden may differ; re-canonicalize via `yq -i -P 'sort_keys(..)'` on the rendered side OR adjust golden to match)
+
+- [ ] **Step 2: Run xr-minimal regression check (should still PASS)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+```
+
+**Expected: exit 0, no diff.** Proves `s3Needed:false` (default) doesn't leak any AWS resources into the no-s3 path.
+
+If FAIL: your `compose()` likely has a resource emission outside the `if spec.get("s3Needed"):` block.
+
+- [ ] **Step 3: Run xr-with-db regression check (should still PASS)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+**Expected: exit 0, no diff.** Proves the v1.2 DB path still works after SecretStore generalization (Task 1.8 Step 1).
+
+If FAIL: the SecretStore-shared logic broke db-path emission. Verify `needs_secret_store` triggers correctly.
+
+---
+
+### Task 1.12: Commit Phase 1
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+git add base-apps/crossplane-compositions/xrd-application.yaml \
+        base-apps/crossplane-compositions/composition-application.yaml \
+        base-apps/crossplane-compositions/composition-rbac.yaml \
+        tests/composition/xr-with-s3.yaml \
+        tests/composition/expected-xr-with-s3.yaml
+
+git status --short   # expect: 5 files (3 modified, 2 created)
+
+git commit -m "$(cat <<'EOF'
+feat(composition): v1.3 AWS S3 + IAM resources via s3Needed XR field
+
+Implements IDP v1.3 — adds self-service AWS S3 bucket provisioning to
+the IDP. When developer scaffolds with s3Needed:true, Composition
+emits 8 new resources alongside the existing app resources:
+
+  - S3 Bucket: <account-id>-<name> (us-east-2, forceDestroy:true)
+  - IAM User: <name>-app (dedicated per-app)
+  - IAM UserPolicy: <name>-s3-rw (S3 RW on its own bucket)
+  - IAM AccessKey: <name>-app-key (auto-creates K8s Secret
+    <name>-aws-key with attribute.id + attribute.secret)
+  - SecretStore: vault-backend (shared with db path; emit-once)
+  - PushSecret: <name>-aws-push (CNPG → Vault path
+    k8s-secrets/<name>/aws-creds with key remap to
+    AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)
+  - ExternalSecret: <name>-aws (Vault → namespace-local Secret
+    with AWS SDK-named keys)
+
+Deployment.envFrom now supports both db-secret and aws-secret;
+make_deployment also injects AWS_REGION + BUCKET_NAME as static
+env vars (configuration, not credentials — no Vault round-trip).
+
+Workload effective env vars when s3Needed:true:
+  AWS_ACCESS_KEY_ID       (from envFrom <name>-aws — Vault round-trip)
+  AWS_SECRET_ACCESS_KEY   (from envFrom <name>-aws — Vault round-trip)
+  AWS_REGION              (direct env var: us-east-2)
+  BUCKET_NAME             (direct env var: <account-id>-<name>)
+
+AWS SDK auto-detects credentials. App reads BUCKET_NAME and writes there.
+
+Crossplane SA RBAC extended with s3.aws.upbound.io/{buckets,...} +
+iam.aws.upbound.io/{users,userpolicies,accesskeys}/status to satisfy
+informer sync (same root cause as v1.2.1's cnpg /status fix).
+
+XRD apiVersion stays v1alpha1 (additive optional field with default).
+chores-tracker untouched. v1.2 db cred flow unchanged.
+
+PRE-FLIGHT REQUIREMENT: Verify provider-aws-iam AccessKey CRD's
+writeConnectionSecretToRef shape matches the assumed
+attribute.id/attribute.secret keys. Plan Phase 0 P.3.
+
+PER-NAMESPACE VAULT ROLE: Reuses v1.2's app-namespace-rw templated
+policy (no new policy needed — k8s-secrets/<ns>/* covers aws-creds
+sub-path automatically).
+
+Spec: docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git log -1 --stat
+```
+
+---
+
+### Task 1.13: Push branch + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/idp-v1.3-aws-resources
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+gh pr create --base main --head feat/idp-v1.3-aws-resources \
+  --title "feat(composition): v1.3 AWS S3 + IAM resources via s3Needed XR field" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements IDP v1.3 — adds self-service AWS S3 bucket provisioning to the IDP. When developer scaffolds with `s3Needed:true`, Composition emits 8 new resources: S3 Bucket + IAM User + UserPolicy + AccessKey + SecretStore + PushSecret + ExternalSecret + updated Deployment with new envFrom.
+
+Mirrors v1.2's DB cred Vault round-trip pattern, applied to AWS. Workload gets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (via Vault), `AWS_REGION`, `BUCKET_NAME` (direct env vars) — zero application code changes; AWS SDK auto-detects credentials.
+
+## Changes
+
+| Change | File | Impact |
+|---|---|---|
+| Add `s3Needed: bool` optional XR field, default `false` | `base-apps/crossplane-compositions/xrd-application.yaml` | Backwards-compatible — existing XRs default to `false` |
+| 4 new AWS resource helpers + 2 ESO helpers | `base-apps/crossplane-compositions/composition-application.yaml` | When `s3Needed:true`, emits 8 new composed resources |
+| `compose()` SecretStore generalization | (same Composition file) | SecretStore now emit-once if EITHER `dbNeeded` or `s3Needed` is true |
+| `make_deployment` envFrom + AWS env vars | (same Composition file) | Deployment supports both db and aws Secrets in envFrom; injects AWS_REGION + BUCKET_NAME directly |
+| Crossplane RBAC: AWS API groups | `base-apps/crossplane-compositions/composition-rbac.yaml` | New rules for `s3.aws.upbound.io/{buckets,/status}` + `iam.aws.upbound.io/{users,userpolicies,accesskeys,/status}` |
+| New test fixture + golden | `tests/composition/{xr-with-s3.yaml,expected-xr-with-s3.yaml}` | TDD — wrote failing test first, then implemented to pass |
+
+## Test plan
+
+- [x] `./tests/composition/render.sh xr-with-s3` PASS (8 new AWS resources rendered)
+- [x] `./tests/composition/render.sh xr-minimal` PASS (s3Needed:false unchanged)
+- [x] `./tests/composition/render.sh xr-with-db` PASS (db path still works after SecretStore generalization)
+- [ ] Companion arigsela/backstage PR for s3Needed form input
+- [ ] User rebuilds Backstage image
+- [ ] User pre-creates Vault role for smoke-v13 namespace (reuses v1.2's app-namespace-rw)
+- [ ] Smoke validation: scaffold smoke-v13 with s3Needed:true; verify bucket creation + Vault path + envFrom; exec into Pod and `aws s3 cp` to confirm access
+- [ ] Teardown validates `forceDestroy: true` empties bucket + IAM cleanup + Vault GC
+
+## Things explicitly NOT in v1.3 (per spec §10)
+
+- ❌ Multiple buckets per app (single bucket; v1.4+ for multi)
+- ❌ Custom IAM policies (single templated S3-RW)
+- ❌ Bucket versioning, CORS, lifecycle rules
+- ❌ SQS, SNS, RDS, etc. (v1.4+; same pattern)
+- ❌ IRSA / Pod Identity (v2)
+- ❌ Vault dynamic credentials (v2)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 2 — Backstage scaffolder (single PR)
+
+This phase touches the `arigsela/backstage` repo (separate from kubernetes). Local clone at `~/git/backstage` per v1.1+/v1.2/v1.2.1 precedent.
+
+### Task 2.1: Set up branch in arigsela/backstage
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Switch to backstage repo + branch**
+
+```bash
+cd ~/git/backstage
+git fetch origin main
+git checkout -b feat/idp-v1.3-s3needed origin/main
+git branch --show-current
+# Expected: feat/idp-v1.3-s3needed
+```
+
+---
+
+### Task 2.2: Add `s3Needed` form input to scaffolder template
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+The "Database (optional)" parameter group has `dbNeeded` + `dbStorage`. We'll add `s3Needed` to the same group. Optionally rename group to "Resources (optional)" since it now covers both DB and S3 — recommended for clarity.
+
+- [ ] **Step 1: Rename the group + add s3Needed field**
+
+Find the `- title: Database (optional)` parameter group. Change to:
+
+```yaml
+    - title: Resources (optional)
+      properties:
+        dbNeeded:
+          type: boolean
+          title: Provision a Postgres database (CloudNativePG)
+          default: false
+        dbStorage:
+          type: string
+          title: Database storage size
+          default: "1Gi"
+        s3Needed:
+          type: boolean
+          title: Provision an AWS S3 bucket (with dedicated IAM user)
+          description: |
+            When enabled, the platform creates an S3 bucket + IAM user + access
+            key for this app. Workload receives AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+            AWS_REGION, BUCKET_NAME env vars automatically (zero code changes — AWS SDK
+            auto-detects).
+            WARNING: bucket contents are deleted when the app is torn down (forceDestroy).
+          default: false
+```
+
+(Title rename is the only change to existing fields; `s3Needed` is new and added at the end of the group.)
+
+---
+
+### Task 2.3: Apply `| trim` to s3Needed not needed; add to fetch.values mapping
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+`s3Needed` is a boolean — Nunjucks `| trim` would error. Just add the line to the `fetch.values` mapping without trim.
+
+- [ ] **Step 1: Edit the fetch.values mapping**
+
+Find the `steps[id=fetch].input.values` block. Add `s3Needed:` line:
+
+```yaml
+        values:
+          name: ${{ parameters.name | trim }}
+          namespace: ${{ parameters.name | trim }}
+          owner: ${{ parameters.owner | trim }}
+          image: ${{ parameters.image | trim }}
+          host: ${{ parameters.host | trim }}
+          healthCheckPath: ${{ parameters.healthCheckPath | trim }}
+          port: ${{ parameters.port }}
+          replicas: ${{ parameters.replicas }}
+          dbNeeded: ${{ parameters.dbNeeded }}
+          dbStorage: ${{ parameters.dbStorage | trim }}
+          s3Needed: ${{ parameters.s3Needed }}
+```
+
+(Add `s3Needed:` line at the end. No `| trim` — boolean.)
+
+---
+
+### Task 2.4: Render `s3Needed` in content-k8s XR template
+
+**Files:**
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml`
+
+The XR template currently renders `image, host, port, replicas, [optional healthCheckPath], dbNeeded, dbStorage`. Add `s3Needed`.
+
+- [ ] **Step 1: Add s3Needed line to the rendered XR**
+
+Find the `spec:` block. Current shape (post-v1.2.1):
+
+```yaml
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  {%- if values.healthCheckPath and values.healthCheckPath != "/" %}
+  healthCheckPath: ${{ values.healthCheckPath }}
+  {%- endif %}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+```
+
+Add `s3Needed:` after `dbStorage:`:
+
+```yaml
+spec:
+  image: ${{ values.image }}
+  host: ${{ values.host }}
+  port: ${{ values.port }}
+  replicas: ${{ values.replicas }}
+  {%- if values.healthCheckPath and values.healthCheckPath != "/" %}
+  healthCheckPath: ${{ values.healthCheckPath }}
+  {%- endif %}
+  dbNeeded: ${{ values.dbNeeded }}
+  dbStorage: ${{ values.dbStorage }}
+  s3Needed: ${{ values.s3Needed }}
+```
+
+(Always emit `s3Needed` — both true and false cases. Unlike `healthCheckPath` we don't need conditional emission because it's a small boolean and explicit `s3Needed: false` is unambiguous.)
+
+---
+
+### Task 2.5: Commit Phase 2 + push + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+cd ~/git/backstage
+
+git add examples/templates/application/template.yaml \
+        "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/application-xr.yaml"
+
+git status --short   # expect: only those 2 files modified
+
+git commit -m "$(cat <<'EOF'
+feat(scaffolder): v1.3 add s3Needed form input
+
+Companion to arigsela/kubernetes v1.3 PR. Adds s3Needed to the
+"Resources (optional)" parameter group (renamed from "Database
+(optional)" since it now covers both DB and S3) and renders it
+in the content-k8s XR template.
+
+When developer enables s3Needed at scaffold time, the platform-side
+Composition emits S3 bucket + IAM user + access key + Vault
+round-trip — workload receives AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+AWS_REGION, BUCKET_NAME env vars automatically (AWS SDK auto-detects;
+zero code changes).
+
+Spec: docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md
+(in arigsela/kubernetes repo)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feat/idp-v1.3-s3needed
+
+gh pr create --base main --head feat/idp-v1.3-s3needed \
+  --title "feat(scaffolder): v1.3 add s3Needed form input" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Companion to arigsela/kubernetes v1.3 PR. Adds the Backstage scaffolder side: `s3Needed` form input + rendered XR field.
+
+## Changes
+
+| Change | File | Why |
+|---|---|---|
+| Rename "Database (optional)" group to "Resources (optional)" | `examples/templates/application/template.yaml` | Group now covers both DB and S3 |
+| Add `s3Needed` boolean form field | (same file) | Lets users opt into S3 bucket + IAM provisioning at scaffold time |
+| Add `s3Needed` to `fetch.values` mapping | (same file) | Threads form value to content-k8s template |
+| Render `s3Needed` in XR template | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | XR contains the field; cluster-side Composition reads it |
+
+## Test plan
+
+- [ ] After Backstage image rebuild, scaffold an app with `s3Needed: true` — verify XR rendered with `s3Needed: true`
+- [ ] Default behavior (s3Needed unchecked) → XR has `s3Needed: false` (existing apps unaffected)
+
+## Image rebuild needed?
+
+Yes. After this merges, the Backstage image needs to be rebuilt and `base-apps/backstage/deployments.yaml` tag bumped per CLAUDE.md user-owned image-rebuild flow.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 3 — USER GATE: Merge PRs + image rebuild + Vault role binding
+
+> **Subagent-driven-development pause point.** All Phase 3 actions require user-controlled steps: PR merge approvals, manual Backstage image rebuild, Vault role creation. Subagents cannot drive these.
+
+### Task 3.1: USER reviews + merges Phase 1 PR (kubernetes)
+
+- [ ] User merges PR opened by Task 1.13
+- [ ] Verify ArgoCD sync:
+
+```bash
+sleep 30
+kubectl -n argo-cd get application crossplane-compositions \
+  -o jsonpath='{.status.sync.status}: revision={.status.sync.revision}{"\n"}'
+# Expected: Synced; revision matches merge commit
+
+# Verify v1.3 marker is live
+kubectl get composition application -o yaml 2>&1 | grep -c "make_s3_bucket"
+# Expected: ≥1 (the new helper appears in the live Composition)
+```
+
+---
+
+### Task 3.2: USER reviews + merges Phase 2 PR (backstage)
+
+- [ ] User merges PR opened by Task 2.5
+- [ ] Note: merge alone doesn't change cluster behavior — image rebuild needed
+
+---
+
+### Task 3.3: USER rebuilds Backstage image + bumps tag (or reuses tag like v1.2.1)
+
+- [ ] User builds image (standard local docker buildx + push to ECR flow)
+- [ ] Either bump tag (e.g. `v1.2.0` → `v1.3.0`) OR reuse same tag and relaunch pod
+
+If reusing tag (faster):
+```bash
+kubectl -n backstage rollout restart deployment/backstage
+kubectl -n backstage rollout status deployment/backstage --timeout=2m
+```
+
+If bumping tag, follow the standard chore PR pattern:
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b chore/bump-backstage-v1.3.0
+# Edit base-apps/backstage/deployments.yaml — change image tag
+git add base-apps/backstage/deployments.yaml
+git commit -m "chore(backstage): bump image tag to v1.3.0 (v1.3 scaffolder updates)"
+git push -u origin chore/bump-backstage-v1.3.0
+gh pr create --base main --title "chore(backstage): bump image tag to v1.3.0" \
+  --body "Brings in v1.3 scaffolder changes (s3Needed form input)."
+# Then merge and verify rollout
+```
+
+- [ ] Verify the live Backstage Pod's template contains the new field:
+
+```bash
+BACKSTAGE_POD=$(kubectl -n backstage get pods -o name | head -1)
+kubectl -n backstage exec $BACKSTAGE_POD -- cat /app/examples/templates/application/template.yaml 2>&1 | grep -B 1 -A 3 "s3Needed"
+# Expected: shows the new field in the live template
+```
+
+---
+
+### Task 3.4: USER pre-creates Vault role for smoke-v13 namespace
+
+The smoke validation app's namespace will be `smoke-v13`. Use the same recovery-keys flow we established in v1.2 (or have the assistant run via kubectl exec) to create the Vault role bound to the existing `app-namespace-rw` policy.
+
+- [ ] **Step 1: Create the role**
+
+(Assistant can do this via the same recovery-keys + kubectl exec pattern from v1.2 Phase 3 Task 3.2.)
+
+```bash
+NAMESPACE=smoke-v13
+
+# (with VAULT_TOKEN exported)
+vault write auth/kubernetes/role/${NAMESPACE} \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=${NAMESPACE} \
+  policies="default,app-namespace-rw" \
+  ttl=1h
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+vault read auth/kubernetes/role/smoke-v13
+# Expected: policies=[default app-namespace-rw], bound_service_account_namespaces=[smoke-v13]
+```
+
+---
+
+## Phase 4 — Smoke validation (smoke-v13)
+
+> **Subagent-driven-development pause point.** Phase 4 requires Backstage UI form submission + scaffold PR review/merge.
+
+### Task 4.1: Scaffold smoke-v13 via Backstage
+
+**Files:** none (Backstage UI form + downstream PR)
+
+- [ ] **Step 1: Open Backstage**
+
+https://backstage.arigsela.com/create
+
+- [ ] **Step 2: Submit the Application (Crossplane) template with these values**
+
+| Field | Value |
+|---|---|
+| Application name | `smoke-v13` |
+| Owner | `group:default/platform-engineering` |
+| Container image | `amazon/aws-cli:latest` |
+| Public hostname | `smoke-v13.arigsela.com` |
+| Container port | `8080` |
+| Replicas | `1` |
+| Health check path (optional) | `/` (default) |
+| Provision a Postgres database | **NO** |
+| Provision an AWS S3 bucket | **YES** |
+
+(Note: image is `amazon/aws-cli:latest` instead of nginx, so we can `kubectl exec aws s3 ls` from inside the Pod to validate AC-8. The aws-cli image doesn't serve HTTP on port 8080 so the Pod won't be Ready=True via probes — that's expected for this smoke validation. We're testing the cred path, not the workload health.)
+
+- [ ] **Step 3: USER reviews + merges scaffold PR**
+
+---
+
+### Task 4.2: Verify ArgoCD sync + AWS resources composition
+
+```bash
+sleep 60  # let ArgoCD pick up + Crossplane compose
+
+kubectl -n argo-cd get application smoke-v13 \
+  -o jsonpath='{.status.sync.status}/{.status.health.status}{"\n"}'
+# Expected: Synced (Health may be Degraded since the aws-cli image doesn't serve HTTP — that's OK)
+
+kubectl -n smoke-v13 get xapplications,buckets.s3.aws.upbound.io,users.iam.aws.upbound.io,userpolicies.iam.aws.upbound.io,accesskeys.iam.aws.upbound.io,secretstores,pushsecrets,externalsecrets,deployments,services,ingresses,pods,secrets 2>&1
+# Expected: 1 of each composed resource
+```
+
+---
+
+### Task 4.3: AC-5 verify bucket created in AWS
+
+```bash
+# (with local AWS CLI configured for account 852893458518)
+aws s3 ls s3://852893458518-smoke-v13/ 2>&1
+# Expected: empty bucket; "TotalObjects: 0" or no error
+```
+
+If `bucket does not exist`: Crossplane provider-aws-s3 still working on it. `kubectl describe bucket 852893458518-smoke-v13` for status.
+
+---
+
+### Task 4.4: AC-6 verify Vault path populated
+
+Use the same recovery-keys flow (or local authenticated CLI):
+
+```bash
+vault kv get -mount=k8s-secrets smoke-v13/aws-creds 2>&1 | head -10
+# Expected: 2 keys (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY); custom_metadata managed-by:external-secrets
+```
+
+---
+
+### Task 4.5: AC-7 verify Deployment envFrom + AWS env vars
+
+```bash
+kubectl -n smoke-v13 get deployment smoke-v13 -o jsonpath='{.spec.template.spec.containers[0]}' | jq '{envFrom, env}'
+# Expected:
+#   envFrom: [{ secretRef: { name: smoke-v13-aws } }]
+#   env: [{ name: AWS_REGION, value: us-east-2 }, { name: BUCKET_NAME, value: 852893458518-smoke-v13 }]
+```
+
+---
+
+### Task 4.6: AC-8 verify workload can write to bucket
+
+Wait until ESO has projected the Secret (`<smoke-v13-aws>`); then exec into the Pod:
+
+```bash
+# Wait for projected Secret
+until kubectl -n smoke-v13 get secret smoke-v13-aws >/dev/null 2>&1; do sleep 5; done
+echo "Projected Secret exists"
+
+# Wait for Pod to start (will CrashLoopBackOff because aws-cli isn't an HTTP server, but
+# the container starts long enough to exec into)
+kubectl -n smoke-v13 wait --for=condition=Ready pod -l app.kubernetes.io/name=smoke-v13 --timeout=120s 2>&1
+# Or just find the running pod regardless of Ready state:
+POD=$(kubectl -n smoke-v13 get pod -l app.kubernetes.io/name=smoke-v13 -o name | head -1)
+echo "Pod: $POD"
+
+# Test S3 write
+kubectl -n smoke-v13 exec $POD -- sh -c 'echo "v1.3 smoke test from $HOSTNAME at $(date)" > /tmp/test.txt && aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v13-test.txt'
+# Expected: "upload: ../tmp/test.txt to s3://852893458518-smoke-v13/v13-test.txt"
+
+# Verify object exists in bucket
+aws s3 ls s3://852893458518-smoke-v13/
+# Expected: shows v13-test.txt
+```
+
+If the `aws s3 cp` returns `InvalidAccessKeyId`: AWS IAM eventual consistency (5-10s) — wait + retry.
+
+If it returns `AccessDenied` after retry: IAM policy may not be attached correctly. Inspect `kubectl describe userpolicy smoke-v13-s3-rw`.
+
+---
+
+### Task 4.7: Tear down smoke-v13
+
+(Same v1 spec §8 corrected order — PR-delete first, then `kubectl delete xapplication`.)
+
+- [ ] **Step 1: Open teardown PR**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b chore/teardown-smoke-v13
+git rm base-apps/smoke-v13.yaml
+git rm -r base-apps/smoke-v13
+git commit -m "chore: tear down v1.3 smoke validation app
+
+Tests: bucket forceDestroy:true (data loss expected by design),
+IAM cleanup, Vault entry GC."
+git push -u origin chore/teardown-smoke-v13
+gh pr create --base main --head chore/teardown-smoke-v13 \
+  --title "chore: tear down v1.3 smoke-v13 validation app" \
+  --body "Removes manifests for the smoke-v13 v1.3 validation app per v1 spec §8 corrected decommission order."
+```
+
+- [ ] **Step 2: USER merges teardown PR + waits for master-app prune (~30s)**
+
+```bash
+sleep 30
+kubectl -n argo-cd get application smoke-v13 2>&1
+# Expected: NotFound
+```
+
+- [ ] **Step 3: Delete orphaned XR** (Crossplane GCs all composed children including AWS resources)
+
+```bash
+kubectl -n smoke-v13 delete xapplication smoke-v13
+# Expected: deleted; takes 30-60s as AWS resources unwind
+```
+
+- [ ] **Step 4: AC-9 verify everything is gone**
+
+```bash
+# Bucket should be gone (forceDestroy emptied + deleted it)
+aws s3 ls s3://852893458518-smoke-v13/ 2>&1
+# Expected: "NoSuchBucket"
+
+# IAM user should be gone
+aws iam get-user --user-name smoke-v13-app 2>&1 | head -3
+# Expected: "NoSuchEntity"
+
+# Vault entry should be gone (deletionPolicy:Delete on PushSecret)
+vault kv get -mount=k8s-secrets smoke-v13/aws-creds 2>&1 | head -3
+# Expected: "No value found"
+```
+
+- [ ] **Step 5: Cleanup namespace + Vault role**
+
+```bash
+kubectl delete namespace smoke-v13
+
+# Optional: remove the Vault role
+vault delete auth/kubernetes/role/smoke-v13
+```
+
+---
+
+## Phase 5 — Close-out
+
+### Task 5.1: Append Run Notes to this plan
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md` (this file)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b docs/v1.3-close-out
+```
+
+- [ ] **Step 2: Append `## Run Notes` section to end of file**
+
+```markdown
+
+## Run Notes (YYYY-MM-DD)
+
+**Outcome:** v1.3 of the IDP shipped. `s3Needed: true` triggers Composition to provision S3 bucket + dedicated IAM user + access key, with credentials routed through Vault. Workloads receive AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, BUCKET_NAME env vars automatically. AWS SDK auto-detects creds — zero workload code changes for S3 access.
+
+**E2E validation** (`smoke-v13`, s3Needed:true, dbNeeded:false):
+
+- ✅ Bucket created at `s3://852893458518-smoke-v13/`
+- ✅ Vault path populated at `k8s-secrets/smoke-v13/aws-creds` (2 keys)
+- ✅ Deployment envFrom: smoke-v13-aws + AWS_REGION + BUCKET_NAME env vars
+- ✅ Workload exec'd `aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v13-test.txt` — succeeded
+- ✅ Teardown: bucket emptied + deleted (forceDestroy:true), IAM cleanup successful, Vault entry GC'd
+- ✅ Goldens still PASS for xr-minimal + xr-with-db (regression check)
+
+**Bugs caught during execution** (delete subsection if none):
+
+| # | Bug | Fix PR |
+|---|---|---|
+| 1 | <one-line description> | arigsela/kubernetes#<num> |
+
+**v1.4 / v2 follow-up candidates:**
+- v1.4 — Additional AWS resources (SQS, SNS), bucket sub-fields (versioning, lifecycle), custom IAM policy override
+- v2 — Vault-managed dynamic credentials for both DB (CNPG) and AWS (Vault AWS Secrets Engine); IRSA / Pod Identity exploration
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| docs/idp-v1.3-spec | docs: v1.3 design spec + plan |
+| feat/idp-v1.3-aws-resources (kubernetes) | feat(composition): v1.3 AWS S3 + IAM resources |
+| feat/idp-v1.3-s3needed (backstage) | feat(scaffolder): v1.3 add s3Needed form input |
+| chore/bump-backstage-v1.3.0 (or tag-reuse skipped) | chore(backstage): bump image tag |
+| chore/teardown-smoke-v13 | chore: tear down smoke validation app |
+| docs/v1.3-close-out (this branch) | docs: v1.3 run notes |
+
+**v1.3 status: shipped.**
+```
+
+- [ ] **Step 3: Commit + push + open PR**
+
+```bash
+git add docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md
+git commit -m "docs(idp): v1.3 close-out run notes"
+git push -u origin docs/v1.3-close-out
+gh pr create --base main --title "docs(idp): v1.3 close-out run notes" \
+  --body "Captures v1.3 outcome, smoke-v13 e2e validation, bug-fix PRs (if any), and v1.4/v2 follow-up candidates."
+```
+
+---
+
+## Plan execution mode
+
+**Recommended:** subagent-driven-development per v1.2 / v1.2.1 precedent.
+
+Phase boundaries:
+- **Phase 1 (Tasks 1.1–1.13)** — single subagent: TDD on goldens + XRD + Composition + RBAC + commit + open PR
+- **Phase 2 (Tasks 2.1–2.5)** — separate subagent (different repo): scaffolder template + content-k8s XR + commit + open PR
+- **Phase 3** — **HARD PAUSE** for subagent execution (user-merge gates + image rebuild per CLAUDE.md + Vault role binding)
+- **Phase 4** — user-driven smoke validation (form submission, PR review, AWS verification, S3 write test)
+- **Phase 5** — final close-out subagent
+
+Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents.

--- a/docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md
+++ b/docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md
@@ -1,0 +1,566 @@
+# IDP v1.3 — AWS S3 + IAM Resources — Design
+
+**Date:** 2026-05-01
+**Author:** Ari Sela (with Claude)
+**Status:** Approved for plan
+**Iteration:** v1.3 (third planned v1.x iteration following IDP v1.2 / v1.2.1)
+**Prerequisite:** [IDP v1.2](./2026-04-30-idp-v1.2-vault-credentials-design.md) shipped + [v1.2.1](./2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md) shipped
+
+## 1. Goal
+
+Add self-service AWS S3 bucket provisioning to the IDP. When a developer scaffolds a new app via Backstage and ticks `s3Needed: true`, the platform creates a dedicated S3 bucket, dedicated IAM user with least-privilege policy, and routes IAM access keys through Vault via the same ESO PushSecret/ExternalSecret pattern established in v1.2. The workload's container receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `BUCKET_NAME` env vars — zero application-side configuration code. AWS SDK auto-detects credentials. App writes to `s3://${BUCKET_NAME}` immediately.
+
+## 2. Current state (post-v1.2.1)
+
+| Component | Shape today |
+|---|---|
+| Crossplane AWS providers | `provider-aws-s3` v2.5.3 + `provider-aws-iam` v2.5.3 + `upbound-provider-family-aws` v2.5.3 — all installed, Healthy |
+| AWS account / region | `852893458518` / `us-east-2` (confirmed via existing default ProviderConfig + chores-tracker ECR refs) |
+| Default ProviderConfig | `aws-secret` Secret in `crossplane-system` namespace; status shows 10 resources currently using it |
+| Existing AWS resource patterns | `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` use full S3 bucket + IAM user + access key flow (manually written, NOT IDP-integrated) |
+| XApplication XRD | Has `image`, `host`, `port`, `replicas`, `env`, `dbNeeded`, `dbStorage`, `healthCheckPath` (added in v1.2.1) — no AWS-related fields |
+| `s3Needed:true` apps onboarded via IDP | None — v1.x IDP apps don't currently have AWS resource provisioning |
+| Vault path layout precedent | `k8s-secrets/<name>/db` (v1.2); `k8s-secrets/<name>/aws-creds` reserved for v1.3 |
+| Crossplane SA RBAC | Granted on `cnpg/clusters` + ESO resources (v1.2.1) — NOT on `s3.aws.upbound.io/*` or `iam.aws.upbound.io/*` |
+
+## 3. Target state — the wire
+
+```
+  XApplication <name>
+  ──────────────────
+  spec.s3Needed: true
+       │
+       ▼
+  Composition emits 8 new resources alongside any DB / app-deployment resources:
+       │
+       ├──► Bucket <account-id>-<name>           (AWS S3 — bucket lives in us-east-2)
+       │    forceDestroy: true                   (empties on teardown — DATA LOSS by design)
+       │
+       ├──► User <name>-app                      (AWS IAM — dedicated per-app user)
+       │
+       ├──► UserPolicy <name>-s3-rw              (AWS IAM — inline S3 RW on own bucket)
+       │
+       ├──► AccessKey <name>-app-key             (AWS IAM — auto-creates K8s Secret <name>-aws-key
+       │                                                  with attribute.id + attribute.secret)
+       │
+       ├──► SecretStore vault-backend            (ESO — shared with v1.2 db path; emit-once if either
+       │                                                dbNeeded or s3Needed is true)
+       │
+       ├──► PushSecret <name>-aws-push           (ESO — reads <name>-aws-key, pushes to
+       │                                                Vault path k8s-secrets/<name>/aws-creds
+       │                                                with key remap to AWS SDK names)
+       │
+       ├──► ExternalSecret <name>-aws            (ESO — reads from Vault, projects to K8s Secret
+       │                                                <name>-aws with AWS_ACCESS_KEY_ID etc.)
+       │
+       └──► Deployment <name>                    (UPDATED — envFrom now includes <name>-aws
+                                                          alongside <name>-db if dbNeeded;
+                                                          plus AWS_REGION + BUCKET_NAME as
+                                                          static env vars)
+```
+
+**Vault path layout for an app with both `dbNeeded:true` AND `s3Needed:true`:**
+
+```
+k8s-secrets/<name>/
+  ├── db                   (8 keys from CNPG; v1.2)
+  └── aws-creds            (2 keys: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY; v1.3)
+```
+
+Note: AWS_REGION + BUCKET_NAME are **NOT in Vault** — they're configuration, not credentials. They go directly as env vars on the Deployment spec.
+
+**Workload's effective env vars (when `s3Needed:true`):**
+
+```
+AWS_ACCESS_KEY_ID       (from envFrom <name>-aws — ESO-projected from Vault)
+AWS_SECRET_ACCESS_KEY   (from envFrom <name>-aws — ESO-projected from Vault)
+AWS_REGION              (direct env var on Deployment — value: us-east-2)
+BUCKET_NAME             (direct env var on Deployment — value: 852893458518-<name>)
+```
+
+AWS SDK auto-detects `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` — zero workload code changes. App reads `BUCKET_NAME` and writes there.
+
+**Three things that change in the v1.2.1 flow:**
+- XRD adds optional `s3Needed: bool` (default `false`) — backwards-compatible, no XRD apiVersion bump
+- Composition emits 8 new resources when `s3Needed: true`
+- `make_deployment`'s envFrom logic + AWS env-var injection — same Deployment, additive change
+
+**Invariants preserved:**
+- v1.2 DB cred flow unchanged when `dbNeeded: true`
+- v1.2.1 `healthCheckPath` default unchanged
+- v1.1 auto-ingestion (TeraSky annotations) extends to all 8 new resources
+- chores-tracker untouched
+- `s3Needed: false` apps render byte-identical to today (test via xr-minimal goldens)
+- Apps with both `dbNeeded` AND `s3Needed` set get BOTH cred paths in Vault — no interference
+- XApplication XRD apiVersion stays `v1alpha1` (additive field with default → backwards-compat)
+- Crossplane AWS providers unchanged (no version bump)
+- ESO operator unchanged
+
+## 4. Components
+
+| # | Artifact | Repo | Path | Action |
+|---|---|---|---|---|
+| 1 | XRD: add `s3Needed` field | `arigsela/kubernetes` | `base-apps/crossplane-compositions/xrd-application.yaml` | Add `s3Needed: bool` (default `false`) — optional, no XRD apiVersion bump |
+| 2 | Composition Python: 4 new AWS resource helpers | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-application.yaml` | Add `make_s3_bucket`, `make_iam_user`, `make_iam_user_policy`, `make_iam_access_key` |
+| 3 | Composition Python: 2 new AWS-flavored ESO helpers | (same file) | Add `make_aws_push_secret`, `make_aws_external_secret` (parallel to v1.2's `make_push_secret` / `make_external_secret`, parameterized for `aws-creds` Vault path + key remap) |
+| 4 | `compose()` wiring | (same file) | When `s3Needed: true`, emit the 8 new resources; SecretStore is shared between db and aws paths (emit-once if either is true) |
+| 5 | Deployment envFrom + AWS env vars | (same `compose()` + `make_deployment`) | If `s3Needed: true`, add `<name>-aws` to envFrom alongside `<name>-db` if also `dbNeeded`; add static AWS_REGION + BUCKET_NAME env vars |
+| 6 | Crossplane RBAC: AWS API groups | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-rbac.yaml` | Extend `crossplane:compositions:application` with `s3.aws.upbound.io/{buckets,buckets/status}` + `iam.aws.upbound.io/{users,userpolicies,accesskeys}` (+ /status for each) |
+| 7 | Test fixture (NEW) | `arigsela/kubernetes` | `tests/composition/xr-with-s3.yaml` | Input XR for `s3Needed:true, dbNeeded:false` test case |
+| 8 | Test golden (NEW) | `arigsela/kubernetes` | `tests/composition/expected-xr-with-s3.yaml` | Golden for the new test case |
+| 9 | Test goldens unchanged | `arigsela/kubernetes` | `tests/composition/expected-xr-{minimal,with-db}.yaml` | **No change** — `s3Needed:false` path identical to today |
+| 10 | Render harness | `arigsela/kubernetes` | `tests/composition/render.sh` | **No change** — script accepts test-name arg; verify it iterates over the new fixture |
+| 11 | Scaffolder template form field | `arigsela/backstage` | `examples/templates/application/template.yaml` | Add `s3Needed: bool` (default `false`) to the existing "Database (optional)" group → consider renaming group to "Resources (optional)" |
+| 12 | Scaffolder content-k8s XR | `arigsela/backstage` | `examples/templates/application/content-k8s/.../application-xr.yaml` | Render `s3Needed: ${{ values.s3Needed }}` in spec |
+| 13 | Backstage image | `arigsela/backstage` | n/a | Image rebuild needed (template change) — user-owned per CLAUDE.md |
+| 14 | Crossplane AWS providers | n/a | n/a | **No change** — provider-aws-s3 v2.5.3 + provider-aws-iam v2.5.3 already installed |
+| 15 | Default ProviderConfig | n/a | n/a | **No change** — `aws-secret` in `crossplane-system` already configured |
+
+**Things explicitly NOT in v1.3:**
+- ❌ Multiple buckets per app (single bucket only; `s3Needed` is a boolean, not an array)
+- ❌ Custom IAM policies (single templated S3-RW-on-own-bucket; v1.4+ as opt-in override)
+- ❌ Bucket versioning, CORS, lifecycle rules (v1.4+ as optional sub-fields)
+- ❌ SQS, SNS, RDS, DynamoDB, Lambda (v1.4+; will follow same pattern)
+- ❌ Cross-account access, multi-region buckets
+- ❌ IRSA / Pod Identity (v2 — needs OIDC issuer + AWS IDP setup)
+- ❌ Vault AWS Secrets Engine for dynamic credentials (v2 — rotation work)
+- ❌ Migration of existing apps' XRs (none have `s3Needed` field; default `false` kicks in automatically)
+- ❌ Combined `dbNeeded:true + s3Needed:true` test golden (combined behavior is additive; each path tested in isolation; smoke validates the combo)
+- ❌ Bucket retention opt-out (`s3.preserveBucket: true`) — v1.4+ if requested
+
+**One verification call-out for plan-time:** confirm Crossplane provider-aws-iam's `AccessKey` resource auto-creates a K8s Secret with `attribute.id` and `attribute.secret` keys (standard upbound provider behavior). If the keys are different in v2.5.3, the PushSecret data mapping in §6.3 needs updating accordingly:
+
+```bash
+kubectl get crd accesskeys.iam.aws.upbound.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.writeConnectionSecretToRef}'
+```
+
+## 5. AWS resource shapes (the four `make_*` helpers)
+
+### 5.1 Constants
+
+```python
+# Account ID confirmed from existing default ProviderConfig (status shows 10 resources)
+# + chores-tracker-backend ECR refs. Single account for all v1.x infra.
+AWS_ACCOUNT_ID = "852893458518"
+AWS_REGION = "us-east-2"
+```
+
+### 5.2 `make_s3_bucket`
+
+```python
+def make_s3_bucket(name, namespace, annotations):
+    return {
+        "apiVersion": "s3.aws.upbound.io/v1beta1",
+        "kind": "Bucket",
+        "metadata": {
+            "name": f"{AWS_ACCOUNT_ID}-{name}",  # globally-unique account-prefixed
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "forProvider": {
+                "region": AWS_REGION,
+                "forceDestroy": True,  # empties bucket on teardown — DATA LOSS by design
+            },
+            "providerConfigRef": {"name": "default"},
+        },
+    }
+```
+
+### 5.3 `make_iam_user`
+
+```python
+def make_iam_user(name, namespace, annotations):
+    return {
+        "apiVersion": "iam.aws.upbound.io/v1beta1",
+        "kind": "User",
+        "metadata": {
+            "name": f"{name}-app",
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "forProvider": {},
+            "providerConfigRef": {"name": "default"},
+        },
+    }
+```
+
+### 5.4 `make_iam_user_policy` (templated S3-RW-on-own-bucket)
+
+```python
+def make_iam_user_policy(name, namespace, annotations):
+    """Inline policy attached to the user — single resource (no separate Policy + Attachment)."""
+    bucket_name = f"{AWS_ACCOUNT_ID}-{name}"
+    policy_doc = {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+            ],
+            "Resource": [
+                f"arn:aws:s3:::{bucket_name}",
+                f"arn:aws:s3:::{bucket_name}/*",
+            ],
+        }],
+    }
+    return {
+        "apiVersion": "iam.aws.upbound.io/v1beta1",
+        "kind": "UserPolicy",
+        "metadata": {
+            "name": f"{name}-s3-rw",
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "forProvider": {
+                "userRef": {"name": f"{name}-app"},
+                "policy": json.dumps(policy_doc),  # provider expects stringified JSON
+            },
+            "providerConfigRef": {"name": "default"},
+        },
+    }
+```
+
+### 5.5 `make_iam_access_key`
+
+```python
+def make_iam_access_key(name, namespace, annotations):
+    """Creates AccessKey + auto-generated K8s Secret with attribute.id + attribute.secret keys."""
+    return {
+        "apiVersion": "iam.aws.upbound.io/v1beta1",
+        "kind": "AccessKey",
+        "metadata": {
+            "name": f"{name}-app-key",
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "forProvider": {
+                "userRef": {"name": f"{name}-app"},
+            },
+            "writeConnectionSecretToRef": {
+                "name": f"{name}-aws-key",
+                "namespace": namespace,
+            },
+            "providerConfigRef": {"name": "default"},
+        },
+    }
+```
+
+## 6. ESO push/external secret helpers (parameterized for AWS path)
+
+### 6.1 Why parallel helpers (not refactor of v1.2's)
+
+v1.2's `make_push_secret` and `make_external_secret` are tightly coupled to the DB cred path (8 keys, `<namespace>/db` Vault path, `<name>-db-app` source secret). Two paths forward:
+
+- **Refactor v1.2's helpers** to be parameterized — `make_push_secret(name, namespace, source_secret, vault_path, key_mapping, annotations)` — and call once per use case
+- **Duplicate as `make_aws_push_secret` / `make_aws_external_secret`** — slight code duplication, less risk of breaking v1.2's tested behavior
+
+For v1.3's 1-day budget and to minimize blast radius on v1.2's working flow, **duplicate**. v1.4 can refactor toward shared helpers if a third use case (e.g., SQS) emerges and the duplication becomes painful.
+
+### 6.2 `make_aws_push_secret`
+
+```python
+def make_aws_push_secret(name, namespace, annotations):
+    """Pushes 2 keys (id + secret) from <name>-aws-key to Vault path
+    k8s-secrets/<namespace>/aws-creds with key remap to AWS SDK convention."""
+    return {
+        "apiVersion": "external-secrets.io/v1alpha1",  # PushSecret is alpha
+        "kind": "PushSecret",
+        "metadata": {
+            "name": f"{name}-aws-push",
+            "namespace": namespace,
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "refreshInterval": "5m",  # matches v1.2.1 update
+            "deletionPolicy": "Delete",
+            "secretStoreRefs": [{"name": "vault-backend", "kind": "SecretStore"}],
+            "selector": {"secret": {"name": f"{name}-aws-key"}},
+            "data": [
+                {
+                    "match": {
+                        "secretKey": "attribute.id",
+                        "remoteRef": {
+                            "remoteKey": f"{namespace}/aws-creds",
+                            "property": "AWS_ACCESS_KEY_ID",
+                        },
+                    },
+                },
+                {
+                    "match": {
+                        "secretKey": "attribute.secret",
+                        "remoteRef": {
+                            "remoteKey": f"{namespace}/aws-creds",
+                            "property": "AWS_SECRET_ACCESS_KEY",
+                        },
+                    },
+                },
+            ],
+        },
+    }
+```
+
+### 6.3 `make_aws_external_secret`
+
+```python
+def make_aws_external_secret(name, namespace, annotations):
+    """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
+    return {
+        "apiVersion": "external-secrets.io/v1beta1",
+        "kind": "ExternalSecret",
+        "metadata": {
+            "name": f"{name}-aws",
+            "namespace": namespace,
+            "labels": std_labels(name),
+            "annotations": annotations,
+        },
+        "spec": {
+            "refreshInterval": "15s",
+            "secretStoreRef": {"name": "vault-backend", "kind": "SecretStore"},
+            "target": {
+                "name": f"{name}-aws",
+                "creationPolicy": "Owner",
+            },
+            "data": [
+                {
+                    "secretKey": "AWS_ACCESS_KEY_ID",
+                    "remoteRef": {
+                        "key": f"{namespace}/aws-creds",
+                        "property": "AWS_ACCESS_KEY_ID",
+                    },
+                },
+                {
+                    "secretKey": "AWS_SECRET_ACCESS_KEY",
+                    "remoteRef": {
+                        "key": f"{namespace}/aws-creds",
+                        "property": "AWS_SECRET_ACCESS_KEY",
+                    },
+                },
+            ],
+        },
+    }
+```
+
+## 7. `compose()` additions
+
+### 7.1 SecretStore sharing logic
+
+```python
+# Inside compose():
+needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+
+# v1.2 emitted SecretStore only when dbNeeded; v1.3 generalizes to "either path needs it"
+if needs_secret_store:
+    resource.update(
+        rsp.desired.resources["secretstore"],
+        make_secret_store(name, namespace,
+                          annotations=std_annotations(xr_annotations, "secretstore")),
+    )
+```
+
+### 7.2 AWS resource emission block
+
+```python
+if spec.get("s3Needed"):
+    resource.update(
+        rsp.desired.resources["bucket"],
+        make_s3_bucket(name, namespace,
+                       annotations=std_annotations(xr_annotations, "bucket")),
+    )
+    resource.update(
+        rsp.desired.resources["iamuser"],
+        make_iam_user(name, namespace,
+                      annotations=std_annotations(xr_annotations, "iamuser")),
+    )
+    resource.update(
+        rsp.desired.resources["iamuserpolicy"],
+        make_iam_user_policy(name, namespace,
+                             annotations=std_annotations(xr_annotations, "iamuserpolicy")),
+    )
+    resource.update(
+        rsp.desired.resources["iamaccesskey"],
+        make_iam_access_key(name, namespace,
+                            annotations=std_annotations(xr_annotations, "iamaccesskey")),
+    )
+    resource.update(
+        rsp.desired.resources["awspushsecret"],
+        make_aws_push_secret(name, namespace,
+                             annotations=std_annotations(xr_annotations, "awspushsecret")),
+    )
+    resource.update(
+        rsp.desired.resources["awsexternalsecret"],
+        make_aws_external_secret(name, namespace,
+                                 annotations=std_annotations(xr_annotations, "awsexternalsecret")),
+    )
+```
+
+### 7.3 `make_deployment` updates for envFrom + AWS env vars
+
+```python
+def make_deployment(name, namespace, image, port, replicas, env_list,
+                    db_secret, aws_secret, health_path, annotations):
+    # Build envFrom dynamically based on what the app needs
+    env_from_blocks = []
+    if db_secret:
+        env_from_blocks.append({"secretRef": {"name": db_secret}})
+    if aws_secret:
+        env_from_blocks.append({"secretRef": {"name": aws_secret}})
+
+    # Inject AWS configuration as static env vars (not via Vault — these aren't secrets)
+    aws_env = []
+    if aws_secret:  # implies s3Needed
+        aws_env.extend([
+            {"name": "AWS_REGION", "value": AWS_REGION},
+            {"name": "BUCKET_NAME", "value": f"{AWS_ACCOUNT_ID}-{name}"},
+        ])
+
+    container_env = list(env_list) + aws_env
+
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        # ... rest of structure unchanged from v1.2.1, with:
+        #   spec.template.spec.containers[0].envFrom = env_from_blocks
+        #   spec.template.spec.containers[0].env = container_env
+        #   probes use health_path (from v1.2.1)
+    }
+```
+
+```python
+# Inside compose() — make_deployment call:
+db_secret = f"{name}-db" if spec.get("dbNeeded") else None
+aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
+resource.update(
+    rsp.desired.resources["deployment"],
+    make_deployment(name, namespace, spec["image"], port, replicas,
+                    spec.get("env", []), db_secret, aws_secret,
+                    health_path=spec.get("healthCheckPath", "/"),
+                    annotations=std_annotations(xr_annotations, "deployment")),
+)
+```
+
+(Note: `make_deployment` signature gains `aws_secret` param; v1.2's `db_secret`-as-positional becomes named for clarity.)
+
+## 8. Crossplane RBAC additions
+
+Edit `base-apps/crossplane-compositions/composition-rbac.yaml`. Append two new rules to the existing `crossplane:compositions:application` ClusterRole's `rules:` array:
+
+```yaml
+  # AWS S3 — v1.3 IDP apps with s3Needed:true
+  - apiGroups: ["s3.aws.upbound.io"]
+    resources:
+      - buckets
+      - buckets/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # AWS IAM — v1.3 IDP apps with s3Needed:true (User, UserPolicy, AccessKey)
+  - apiGroups: ["iam.aws.upbound.io"]
+    resources:
+      - users
+      - users/status
+      - userpolicies
+      - userpolicies/status
+      - accesskeys
+      - accesskeys/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+Same `/status` rationale as v1.2.1: Crossplane's informer needs to read reconciled state; without `/status`, compose fails with `Timeout: failed waiting for *unstructured.Unstructured Informer to sync`.
+
+## 9. Failure modes
+
+| # | Failure | Symptom | Diagnosis | Fix |
+|---|---|---|---|---|
+| 1 | Bucket name collision | Bucket resource stuck in `Creating` with AWS error | `kubectl describe bucket <account>-<name>` shows `BucketAlreadyExists` | Choose a different `name` for the XR; re-scaffold |
+| 2 | Crossplane SA missing AWS RBAC | `cannot apply composed resource "bucket"` 403 | `kubectl describe xapplication <name>` events | Verify §8 RBAC rules merged + ArgoCD synced |
+| 3 | AccessKey Secret keys differ from spec | PushSecret 404 on `secretKey: attribute.id` | `kubectl get secret <name>-aws-key -o yaml` shows different keys | Update PushSecret data mapping per actual keys; this is the §4 #15 verification call-out |
+| 4 | Bootstrap chain stuck — Pod can't start | `secret <name>-aws not found` for ~60-120s | Bucket → IAM User → AccessKey → PushSecret → Vault → ExternalSecret → Secret takes time | **Expected** during first deploy; documented; Pod CrashLoopBackOff resolves once chain completes |
+| 5 | Bucket force-destroy data loss | After teardown, bucket contents gone | `forceDestroy: true` is by design | **Documented prominently** in spec, scaffolder form description, and PR template. v1.4 may add `s3.preserveBucket: true` for opt-in durability |
+| 6 | Vault role binding missing for new namespace | PushSecret 403 on first sync | Same as v1.2 issue 1 | User must create per-namespace Vault role binding the v1.2 `app-namespace-rw` policy BEFORE merging onboarding PR (Phase 4) |
+| 7 | IAM eventual consistency on first AWS API call | Workload's `aws s3 ls` returns `InvalidAccessKeyId` for ~5-10s after first deploy | AWS IAM propagation latency | Self-healing — retry logic in app; documented as known transient behavior |
+| 8 | AWS provider stuck syncing | All AWS resources `False/Pending` | provider-aws pod down OR `aws-secret` credential expired | `kubectl -n crossplane-system get pods` + check Secret freshness |
+| 9 | Pre-flight verification skipped | First v1.3 app fails with PushSecret key mismatch | Unverified AccessKey Secret shape | Pre-flight is HARD gate in implementation plan |
+
+## 10. Acceptance criteria
+
+| AC | Check | How to verify |
+|---|---|---|
+| 1 — Pre-flight | provider-aws-s3 + provider-aws-iam Healthy; default ProviderConfig in use | `kubectl get providers,providerconfigs.aws.upbound.io` |
+| 2 — With-s3 golden passes | Render of xr-with-s3 fixture matches expected | `./tests/composition/render.sh xr-with-s3` exit 0 |
+| 3 — Existing goldens unchanged | minimal + with-db pass | `./tests/composition/render.sh xr-{minimal,with-db}` exit 0 |
+| 4 — XRD field works | `s3Needed: true` in XR → 8 new resources composed | `kubectl describe xapplication smoke-v13` shows resourceRefs |
+| 5 — Bucket created in AWS | `aws s3 ls s3://852893458518-smoke-v13` returns OK | AWS CLI from local |
+| 6 — Vault path populated | `vault kv get -mount=k8s-secrets smoke-v13/aws-creds` returns 2 keys | Vault CLI |
+| 7 — envFrom + env vars correct | Deployment has `envFrom: <name>-aws` + `env: AWS_REGION + BUCKET_NAME` | `kubectl get deployment smoke-v13 -o yaml` |
+| 8 — Workload can write to bucket | Pod successfully `aws s3 cp /etc/hostname s3://$BUCKET_NAME/test.txt` | `kubectl exec -- aws s3 cp ...` from inside pod |
+| 9 — Teardown removes everything | After PR-delete + XR delete: bucket gone (was emptied), IAM user/policy/key gone, Vault entry gone | AWS console + `vault kv list k8s-secrets/smoke-v13` returns NotFound |
+| 10 — `s3Needed:false` apps unaffected | Compare against minimal goldens | xr-minimal goldens PASS |
+| 11 — Combined `dbNeeded:true + s3Needed:true` works | Both DB and AWS envFrom present; both creds in Vault | Manual smoke validation |
+| 12 — chores-tracker unchanged | Existing apps still healthy | spot-check ExternalSecret + pods |
+
+## 11. Sequencing
+
+```
+Phase 0 — Pre-flight
+   • Verify AccessKey CRD writeConnectionSecretToRef shape
+   • Confirm provider-aws-s3/iam Healthy + Default ProviderConfig in use
+       │
+       ▼
+Phase 1 (arigsela/kubernetes — single PR) ━━━━━ Phase 2 (arigsela/backstage — single PR)
+   • XRD: add s3Needed: bool                         • template.yaml: add s3Needed form input
+   • Composition: 4 AWS helpers + 2 ESO helpers      • content-k8s XR: render s3Needed
+   • compose() emits 8 new resources                 • → Subagent-friendly
+   • make_deployment: aws_secret + AWS env vars
+   • RBAC: extend cluster role for AWS APIs
+   • Test golden + fixture: xr-with-s3
+   • → Subagent-friendly, full TDD
+        │                                                      │
+        └────────────────┬─────────────────────────────────────┘
+                         ▼
+                Phase 3 — USER GATE
+   • User merges both PRs
+   • User rebuilds Backstage image (per CLAUDE.md)
+   • User pre-creates Vault role for smoke-v13 namespace
+                         │
+                         ▼
+Phase 4 — Smoke validation (smoke-v13)
+   • Scaffold via Backstage with s3Needed:true (no DB)
+   • Verify AC-2 through AC-9
+   • Optional: scaffold smoke-v13b with BOTH dbNeeded:true + s3Needed:true (AC-11)
+   • Tear down per v1 corrected §8 order
+   • Verify AC-9 — bucket emptied + deleted, Vault entry GC'd
+                         │
+                         ▼
+Phase 5 — Close-out
+   • Run notes appended to v1.3 plan
+```
+
+## 12. Decision rationale (Q1–Q7 summary)
+
+The seven brainstorming decisions, captured here so plan + future re-execution have the reasoning:
+
+| Q | Decision | Why |
+|---|---|---|
+| Q1 — scope | **S3 + IAM only** (A) | Smallest useful slice; covers the "my app needs object storage" use case; SQS/SNS/RDS slot cleanly into v1.4+ once pattern is established |
+| Q2 — XRD shape | **Extend XApplication with `s3Needed: bool`** (A) | Mirrors `dbNeeded` pattern (already proven); single XRD/Composition/scaffolder; smallest implementation surface for 1-day budget |
+| Q3 — workload AWS auth | **IAM user + access key + Vault round-trip** (A) | Pattern symmetry with v1.2's CNPG cred flow; reuses ESO infrastructure; rotation deferred to v2 |
+| Q4 — key naming | **AWS SDK env-var convention** (`AWS_ACCESS_KEY_ID` etc.) | Workload zero-config — AWS SDK auto-detects; consistent with each ecosystem's norm (CNPG lowercase, AWS uppercase) |
+| Q5 — IAM permission model | **Single templated S3-RW-on-own-bucket policy** (A) | Opinionated platform stance; safe default; v1.4+ can add custom-policy override non-breakingly |
+| Q6 — teardown semantics | **`forceDestroy: true`** (A) | Homelab transient-data context; matches v1.2 deletionPolicy:Delete pattern; documented data-loss tradeoff |
+| Q7 — bucket naming | **Account-prefix `<account-id>-<name>`** (A) | Globally unique guarantee + predictable; account ID isn't a secret in homelab context |
+
+## 13. v1.x roadmap
+
+| Iteration | Goal | Status |
+|---|---|---|
+| v1 | Scaffolder → XR → Composition → app live | Shipped (2026-04-28) |
+| v1.1 | Auto-ingestion via TeraSky plugins; Crossplane tab | Shipped (2026-04-29) |
+| v1.2 | Vault round-trip for DB credentials | Shipped (2026-05-01) |
+| v1.2.1 | Ergonomic close-out (healthCheckPath, 5m PushSecret refresh, scaffolder trim) | Shipped (2026-05-01) |
+| **v1.3** | **AWS S3 + IAM resources (this spec)** | **In progress (2026-05-01)** |
+| v1.4 | Additional AWS resources (SQS, SNS), bucket sub-fields (versioning, lifecycle), custom IAM policy override | Future |
+| v2 | Vault-managed dynamic credentials for both DB (CNPG) and AWS (Vault AWS Secrets Engine); IRSA / Pod Identity exploration | Future |


### PR DESCRIPTION
## Summary

Brings v1.3 brainstorming + planning out of conversation context into the repo. Spec captures the 7 architectural decisions made during brainstorming (Q1-Q7); plan turns them into bite-sized executable tasks ready for subagent-driven-development.

No code changes — pure docs.

## What's in this PR

| File | Lines | Purpose |
|---|---|---|
| `docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md` | 566 | Approved design spec |
| `docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md` | 1771 | 5-phase implementation plan |

## v1.3 in one paragraph

Adds self-service AWS S3 bucket provisioning to the IDP. Developer scaffolds with `s3Needed: true` → Composition emits S3 bucket + dedicated IAM user + S3-RW-on-own-bucket policy + access key, with credentials routed through Vault via the same ESO PushSecret/ExternalSecret pattern from v1.2. Workload receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BUCKET_NAME` env vars — zero application-side configuration. AWS SDK auto-detects credentials.

## Decisions captured (Q1-Q7)

| Q | Decision |
|---|---|
| Scope | S3 + IAM only (smallest useful slice) |
| XRD shape | Extend XApplication with `s3Needed: bool` (mirrors `dbNeeded`) |
| Workload AWS auth | IAM user + access key + Vault round-trip (pattern symmetry with v1.2) |
| Key naming | AWS SDK env-var convention (`AWS_ACCESS_KEY_ID` etc.) |
| IAM permission model | Single templated S3-RW-on-own-bucket policy |
| Teardown | `forceDestroy: true` (data-loss tradeoff documented) |
| Bucket naming | Account-prefix `<account-id>-<name>` |

## Implementation scope

- ~90 min implementation budget
- Two PRs: arigsela/kubernetes (XRD + Composition + RBAC + new test golden) and arigsela/backstage (scaffolder template + XR template)
- Phase 3 USER GATE: image rebuild + Vault role binding
- Phase 4 smoke validation: scaffold smoke-v13 with `amazon/aws-cli` image; exec `aws s3 cp` inside Pod to validate AWS access end-to-end

## Test plan

- [x] Spec brainstorming complete (Q1-Q7 approved)
- [x] Spec self-reviewed for placeholders + ambiguity
- [x] Plan self-reviewed against spec coverage + type consistency
- [ ] User reviews this PR
- [ ] User merges → execution begins per chosen mode (subagent-driven recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)