### PR TITLE
feat(composition): v1.3 AWS S3 + IAM resources via s3Needed XR field

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -22,6 +22,7 @@ spec:
         kind: Script
         script: |
           from crossplane.function import resource
+          import json
 
           STD_LABELS_TEMPLATE = {
               "app.kubernetes.io/name": None,
@@ -52,6 +53,12 @@ spec:
           # separate v1 ergonomic improvement, NOT in v1.2 scope.)
           DB_SECRET_KEYS = ["dbname", "host", "jdbc-uri", "password",
                             "pgpass", "port", "uri", "username"]
+
+          # AWS account + region constants. Confirmed from existing default
+          # ProviderConfig (status shows 10 resources using it) + chores-tracker-backend
+          # ECR image refs. Single account for all v1.x infra.
+          AWS_ACCOUNT_ID = "852893458518"
+          AWS_REGION = "us-east-2"
 
           def make_secret_store(name, namespace, annotations):
               return {
@@ -148,7 +155,210 @@ spec:
                   },
               }
 
-          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations, health_path):
+          def make_s3_bucket(name, namespace, annotations):
+              # `namespace` accepted for interface uniformity but unused: AWS managed
+              # resources are cluster-scoped; Crossplane stamps the XR namespace at render time.
+              return {
+                  "apiVersion": "s3.aws.upbound.io/v1beta1",
+                  "kind": "Bucket",
+                  "metadata": {
+                      "name": f"{AWS_ACCOUNT_ID}-{name}",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "region": AWS_REGION,
+                          "forceDestroy": True,  # empties bucket on teardown — DATA LOSS by design
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+
+          def make_iam_user(name, namespace, annotations):
+              # `namespace` accepted for interface uniformity but unused (cluster-scoped AWS resource).
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "User",
+                  "metadata": {
+                      "name": f"{name}-app",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {},
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+
+          def make_iam_user_policy(name, namespace, annotations):
+              """Inline policy attached to the user — single resource (no separate Policy + Attachment).
+              `namespace` accepted for interface uniformity but unused (cluster-scoped AWS resource).
+              """
+              bucket_name = f"{AWS_ACCOUNT_ID}-{name}"
+              policy_doc = {
+                  "Version": "2012-10-17",
+                  "Statement": [{
+                      "Effect": "Allow",
+                      "Action": [
+                          "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+                      ],
+                      "Resource": [
+                          f"arn:aws:s3:::{bucket_name}",
+                          f"arn:aws:s3:::{bucket_name}/*",
+                      ],
+                  }],
+              }
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "UserPolicy",
+                  "metadata": {
+                      "name": f"{name}-s3-rw",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "userRef": {"name": f"{name}-app"},
+                          "policy": json.dumps(policy_doc, sort_keys=True),
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+
+          def make_iam_access_key(name, namespace, annotations):
+              """Creates AccessKey + auto-generated K8s Secret with attribute.id + attribute.secret keys."""
+              return {
+                  "apiVersion": "iam.aws.upbound.io/v1beta1",
+                  "kind": "AccessKey",
+                  "metadata": {
+                      "name": f"{name}-app-key",
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "forProvider": {
+                          "userRef": {"name": f"{name}-app"},
+                      },
+                      "writeConnectionSecretToRef": {
+                          "name": f"{name}-aws-key",
+                          "namespace": namespace,
+                      },
+                      "providerConfigRef": {"name": "default"},
+                  },
+              }
+
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+                      "secretStoreRefs": [
+                          {"name": "vault-backend", "kind": "SecretStore"},
+                      ],
+                      "selector": {
+                          "secret": {"name": f"{name}-aws-key"},
+                      },
+                      "data": [
+                          {
+                              "match": {
+                                  "secretKey": "attribute.id",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_ACCESS_KEY_ID",
+                                  },
+                              },
+                          },
+                          {
+                              "match": {
+                                  "secretKey": "attribute.secret",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_SECRET_ACCESS_KEY",
+                                  },
+                              },
+                          },
+                      ],
+                  },
+              }
+
+          def make_aws_external_secret(name, namespace, annotations):
+              """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "ExternalSecret",
+                  "metadata": {
+                      "name": f"{name}-aws",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "15s",
+                      "secretStoreRef": {
+                          "name": "vault-backend",
+                          "kind": "SecretStore",
+                      },
+                      "target": {
+                          "name": f"{name}-aws",
+                          "creationPolicy": "Owner",
+                      },
+                      "data": [
+                          {
+                              "secretKey": "AWS_ACCESS_KEY_ID",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_ACCESS_KEY_ID",
+                              },
+                          },
+                          {
+                              "secretKey": "AWS_SECRET_ACCESS_KEY",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_SECRET_ACCESS_KEY",
+                              },
+                          },
+                      ],
+                  },
+              }
+
+          def make_deployment(name, namespace, image, port, replicas, env_list, db_secret, aws_secret, health_path, annotations):
+              # Build envFrom dynamically based on what the app needs
+              env_from_blocks = []
+              if db_secret:
+                  env_from_blocks.append({"secretRef": {"name": db_secret}})
+              if aws_secret:
+                  env_from_blocks.append({"secretRef": {"name": aws_secret}})
+
+              # Database URL env var (preserve v1.2 behavior: secretKeyRef into uri key)
+              db_env = []
+              if db_secret:
+                  db_env.append({
+                      "name": "DATABASE_URL",
+                      "valueFrom": {"secretKeyRef": {"name": db_secret, "key": "uri"}},
+                  })
+
+              # Inject AWS configuration as static env vars (not via Vault — these aren't secrets)
+              aws_env = []
+              if aws_secret:  # implies s3Needed
+                  aws_env.extend([
+                      {"name": "AWS_REGION", "value": AWS_REGION},
+                      {"name": "BUCKET_NAME", "value": f"{AWS_ACCOUNT_ID}-{name}"},
+                  ])
+
+              container_env = [{"name": e["name"], "value": e["value"]} for e in env_list] + db_env + aws_env
+
               container = {
                   "name": "app",
                   "image": image,
@@ -166,14 +376,10 @@ spec:
                       "initialDelaySeconds": 5, "periodSeconds": 10,
                   },
               }
-              if env_list:
-                  container["env"] = [{"name": e["name"], "value": e["value"]} for e in env_list]
-              if env_from_secret:
-                  container.setdefault("env", []).append({
-                      "name": "DATABASE_URL",
-                      "valueFrom": {"secretKeyRef": {"name": env_from_secret, "key": "uri"}},
-                  })
-                  container["envFrom"] = [{"secretRef": {"name": env_from_secret}}]
+              if env_from_blocks:
+                  container["envFrom"] = env_from_blocks
+              if container_env:
+                  container["env"] = container_env
               return {
                   "apiVersion": "apps/v1",
                   "kind": "Deployment",
@@ -275,14 +481,15 @@ spec:
               replicas = int(spec.get("replicas", 2))
 
               db_secret = f"{name}-db" if spec.get("dbNeeded") else None
-              env_from  = db_secret
+              aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
 
               resource.update(
                   rsp.desired.resources["deployment"],
                   make_deployment(name, namespace, spec["image"], port,
-                                  replicas, spec.get("env", []), env_from,
-                                  annotations=std_annotations(xr_annotations, "deployment"),
-                                  health_path=spec.get("healthCheckPath", "/")),
+                                  replicas, spec.get("env", []),
+                                  db_secret, aws_secret,
+                                  health_path=spec.get("healthCheckPath", "/"),
+                                  annotations=std_annotations(xr_annotations, "deployment")),
               )
               resource.update(
                   rsp.desired.resources["service"],
@@ -295,17 +502,21 @@ spec:
                                annotations=std_annotations(xr_annotations, "ingress")),
               )
 
+              # SecretStore is shared between db and aws paths — emit once if EITHER is needed
+              needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+              if needs_secret_store:
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+
               if spec.get("dbNeeded"):
                   resource.update(
                       rsp.desired.resources["dbcluster"],
                       make_cnpg_cluster(name, namespace,
                                         instances=1, storage=spec.get("dbStorage", "1Gi"),
                                         annotations=std_annotations(xr_annotations, "dbcluster")),
-                  )
-                  resource.update(
-                      rsp.desired.resources["secretstore"],
-                      make_secret_store(name, namespace,
-                                        annotations=std_annotations(xr_annotations, "secretstore")),
                   )
                   resource.update(
                       rsp.desired.resources["pushsecret"],
@@ -316,4 +527,36 @@ spec:
                       rsp.desired.resources["externalsecret"],
                       make_external_secret(name, namespace,
                                            annotations=std_annotations(xr_annotations, "externalsecret")),
+                  )
+
+              if spec.get("s3Needed"):
+                  resource.update(
+                      rsp.desired.resources["bucket"],
+                      make_s3_bucket(name, namespace,
+                                     annotations=std_annotations(xr_annotations, "bucket")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamuser"],
+                      make_iam_user(name, namespace,
+                                    annotations=std_annotations(xr_annotations, "iamuser")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamuserpolicy"],
+                      make_iam_user_policy(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "iamuserpolicy")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["iamaccesskey"],
+                      make_iam_access_key(name, namespace,
+                                          annotations=std_annotations(xr_annotations, "iamaccesskey")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awspushsecret"],
+                      make_aws_push_secret(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "awspushsecret")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awsexternalsecret"],
+                      make_aws_external_secret(name, namespace,
+                                               annotations=std_annotations(xr_annotations, "awsexternalsecret")),
                   )

--- a/base-apps/crossplane-compositions/composition-rbac.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac.yaml
@@ -58,3 +58,25 @@ rules:
       - externalsecrets
       - externalsecrets/status
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # AWS S3 — v1.3 IDP apps with s3Needed:true. Crossplane SA composes Bucket
+  # resources into target namespaces. /status subresource needed for informer sync
+  # (same root cause as v1.2.1's CNPG /status fix).
+  - apiGroups: ["s3.aws.upbound.io"]
+    resources:
+      - buckets
+      - buckets/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # AWS IAM — v1.3 IDP apps with s3Needed:true. User, UserPolicy, AccessKey
+  # for dedicated per-app IAM credentials. /status subresource needed for informer
+  # sync (same root cause as v1.2.1's CNPG /status fix).
+  - apiGroups: ["iam.aws.upbound.io"]
+    resources:
+      - users
+      - users/status
+      - userpolicies
+      - userpolicies/status
+      - accesskeys
+      - accesskeys/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/base-apps/crossplane-compositions/xrd-application.yaml
+++ b/base-apps/crossplane-compositions/xrd-application.yaml
@@ -72,6 +72,17 @@ spec:
                 dbStorage:
                   type: string
                   default: "1Gi"
+                s3Needed:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true, the Composition provisions an S3 bucket + dedicated
+                    IAM user + S3-RW-on-own-bucket policy + access key, and routes
+                    AWS credentials through Vault. The workload Deployment receives
+                    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, and
+                    BUCKET_NAME env vars (zero application-side configuration).
+                    WARNING: bucket is forceDestroy:true — contents are permanently
+                    deleted on teardown.
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/tests/composition/expected-xr-with-s3.yaml
+++ b/tests/composition/expected-xr-with-s3.yaml
@@ -1,0 +1,351 @@
+# tests/composition/expected-xr-with-s3.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  host: smoke-s3-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+  s3Needed: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-s3-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-s3-app
+        backstage.io/kubernetes-id: smoke-s3-app
+    spec:
+      containers:
+        - env:
+            - name: AWS_REGION
+              value: us-east-2
+            - name: BUCKET_NAME
+              value: 852893458518-smoke-s3-app
+          envFrom:
+            - secretRef:
+                name: smoke-s3-app-aws
+          image: nginxinc/nginx-unprivileged:1.25-alpine
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          name: app
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      imagePullSecrets:
+        - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-s3-app
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: smoke-s3-app.arigsela.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: smoke-s3-app
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - smoke-s3-app.arigsela.com
+      secretName: smoke-s3-app-tls
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: secretstore
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: vault-backend
+  namespace: platform-smoke
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: platform-smoke
+          serviceAccountRef:
+            name: default
+      path: k8s-secrets
+      server: http://vault.vault.svc.cluster.local:8200
+      version: v2
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: bucket
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: 852893458518-smoke-s3-app
+  namespace: platform-smoke
+spec:
+  forProvider:
+    forceDestroy: true
+    region: us-east-2
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamuser
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-app
+  namespace: platform-smoke
+spec:
+  forProvider: {}
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicy
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamuserpolicy
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-s3-rw
+  namespace: platform-smoke
+spec:
+  forProvider:
+    policy: '{"Statement": [{"Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"], "Effect": "Allow", "Resource": ["arn:aws:s3:::852893458518-smoke-s3-app", "arn:aws:s3:::852893458518-smoke-s3-app/*"]}], "Version": "2012-10-17"}'
+    userRef:
+      name: smoke-s3-app-app
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: iamaccesskey
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-app-key
+  namespace: platform-smoke
+spec:
+  forProvider:
+    userRef:
+      name: smoke-s3-app-app
+  providerConfigRef:
+    name: default
+  writeConnectionSecretToRef:
+    name: smoke-s3-app-aws-key
+    namespace: platform-smoke
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awspushsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws-push
+  namespace: platform-smoke
+spec:
+  data:
+    - match:
+        remoteRef:
+          property: AWS_ACCESS_KEY_ID
+          remoteKey: platform-smoke/aws-creds
+        secretKey: attribute.id
+    - match:
+        remoteRef:
+          property: AWS_SECRET_ACCESS_KEY
+          remoteKey: platform-smoke/aws-creds
+        secretKey: attribute.secret
+  deletionPolicy: Delete
+  refreshInterval: 5m
+  secretStoreRefs:
+    - kind: SecretStore
+      name: vault-backend
+  selector:
+    secret:
+      name: smoke-s3-app-aws-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awsexternalsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws
+  namespace: platform-smoke
+spec:
+  data:
+    - remoteRef:
+        key: platform-smoke/aws-creds
+        property: AWS_ACCESS_KEY_ID
+      secretKey: AWS_ACCESS_KEY_ID
+    - remoteRef:
+        key: platform-smoke/aws-creds
+        property: AWS_SECRET_ACCESS_KEY
+      secretKey: AWS_SECRET_ACCESS_KEY
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: smoke-s3-app-aws

--- a/tests/composition/xr-with-s3.yaml
+++ b/tests/composition/xr-with-s3.yaml
@@ -1,0 +1,20 @@
+# tests/composition/xr-with-s3.yaml
+# TDD input: XApplication with AWS S3 bucket enabled (no DB).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-s3-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-s3-app.arigsela.com
+  port: 8080
+  replicas: 1
+  s3Needed: true


### PR DESCRIPTION
## Summary

Implements IDP v1.3 — adds self-service AWS S3 bucket provisioning to the IDP. When developer scaffolds with `s3Needed:true`, Composition emits 8 new resources: S3 Bucket + IAM User + UserPolicy + AccessKey + SecretStore + PushSecret + ExternalSecret + updated Deployment with new envFrom.

Mirrors v1.2's DB cred Vault round-trip pattern, applied to AWS. Workload gets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (via Vault), `AWS_REGION`, `BUCKET_NAME` (direct env vars) — zero application code changes; AWS SDK auto-detects credentials.

## Changes

| Change | File | Impact |
|---|---|---|
| Add `s3Needed: bool` optional XR field, default `false` | `base-apps/crossplane-compositions/xrd-application.yaml` | Backwards-compatible — existing XRs default to `false` |
| 4 new AWS resource helpers + 2 ESO helpers | `base-apps/crossplane-compositions/composition-application.yaml` | When `s3Needed:true`, emits 8 new composed resources |
| `compose()` SecretStore generalization | (same Composition file) | SecretStore now emit-once if EITHER `dbNeeded` or `s3Needed` is true |
| `make_deployment` envFrom + AWS env vars | (same Composition file) | Deployment supports both db and aws Secrets in envFrom; injects AWS_REGION + BUCKET_NAME directly |
| Crossplane RBAC: AWS API groups | `base-apps/crossplane-compositions/composition-rbac.yaml` | New rules for `s3.aws.upbound.io/{buckets,/status}` + `iam.aws.upbound.io/{users,userpolicies,accesskeys,/status}` |
| New test fixture + golden | `tests/composition/{xr-with-s3.yaml,expected-xr-with-s3.yaml}` | TDD — wrote failing test first, then implemented to pass |

## Test plan

- [x] `./tests/composition/render.sh xr-with-s3` PASS (8 new AWS resources rendered)
- [x] `./tests/composition/render.sh xr-minimal` PASS (s3Needed:false unchanged)
- [x] `./tests/composition/render.sh xr-with-db` PASS (db path still works after SecretStore generalization)
- [ ] Companion arigsela/backstage PR for s3Needed form input
- [ ] User rebuilds Backstage image
- [ ] User pre-creates Vault role for smoke-v13 namespace (reuses v1.2's app-namespace-rw)
- [ ] Smoke validation: scaffold smoke-v13 with s3Needed:true; verify bucket creation + Vault path + envFrom; exec into Pod and aws s3 cp to confirm access
- [ ] Teardown validates `forceDestroy: true` empties bucket + IAM cleanup + Vault GC

## Things explicitly NOT in v1.3 (per spec §10)

- Multiple buckets per app (single bucket; v1.4+ for multi)
- Custom IAM policies (single templated S3-RW)
- Bucket versioning, CORS, lifecycle rules
- SQS, SNS, RDS, etc. (v1.4+; same pattern)
- IRSA / Pod Identity (v2)
- Vault dynamic credentials (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)