### PR TITLE
feat(smoke-v13): onboard via Crossplane Application

### DIFF
--- a/base-apps/smoke-v13.yaml
+++ b/base-apps/smoke-v13.yaml
@@ -1,0 +1,24 @@
+# ArgoCD Application for smoke-v13
+# Sync wave 10 ensures XRD/Composition land before this app's XR.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: smoke-v13
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/smoke-v13
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: smoke-v13
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/smoke-v13/application-xr.yaml
+++ b/base-apps/smoke-v13/application-xr.yaml
@@ -1,0 +1,24 @@
+# XApplication (Crossplane) for smoke-v13
+# metadata.annotations are read by TeraSky's kubernetes-ingestor and copied
+# onto every composed child by the cluster-side Composition (see
+# arigsela/kubernetes:base-apps/crossplane-compositions/composition-application.yaml).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-v13
+  namespace: smoke-v13
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v13
+spec:
+  image: mazon/aws-cli:latest
+  host: smoke-v13.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false
+  dbStorage: 1Gi
+  s3Needed: true

--- a/base-apps/smoke-v13/application-xr.yaml
+++ b/base-apps/smoke-v13/application-xr.yaml
@@ -15,7 +15,7 @@ metadata:
     terasky.backstage.io/system: platform
     backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v13
 spec:
-  image: mazon/aws-cli:latest
+  image: amazon/aws-cli:latest
   host: smoke-v13.arigsela.com
   port: 8080
   replicas: 1


### PR DESCRIPTION
Generated by Backstage `application-template`.
Owner: group:default/platform-engineering
Database: false
