### PR TITLE
docs(idp): v1.3 PAUSED run notes — architectural blocker

### DIFF
--- a/docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md
+++ b/docs/superpowers/plans/2026-05-01-idp-v1.3-aws-resources.md
@@ -1769,3 +1769,88 @@ Phase boundaries:
 - **Phase 5** — final close-out subagent
 
 Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents.
+
+---
+
+## Run Notes (2026-05-02) — v1.3 PAUSED
+
+**Status: NOT shipped.** Implementation merged but reverted after smoke validation surfaced an architectural blocker. v1.3 will be re-attempted as v1.3.1 with a different design.
+
+### What was tried
+
+Phase 1 + 2 + 3 ran successfully per the plan above:
+- Phase 1 PR ([arigsela/kubernetes#231](https://github.com/arigsela/kubernetes/pull/231)): merged. Added 4 AWS resource helpers + 2 ESO helpers + s3Needed XRD field + RBAC + xr-with-s3 test golden. All TDD checks PASSED.
+- Phase 2 PR ([arigsela/backstage#11](https://github.com/arigsela/backstage/pull/11)): merged. Added s3Needed form input, fetch.values trim, conditional XR emission.
+- Phase 3 user-gate: image rebuilt + tag reused; pod relaunched; Vault role for smoke-v13 namespace created via stored root token.
+- Phase 4 smoke validation: scaffold PR opened ([#232](https://github.com/arigsela/kubernetes/pull/232)) with one user typo (`mazon/aws-cli` → fixed via push to scaffold branch); merged.
+
+### What went wrong (the architectural blocker)
+
+When the smoke-v13 XR reconciled, Crossplane refused to create the AWS resources:
+
+```
+cannot apply cluster scoped composed resource "bucket"
+(a Bucket named 852893458518-smoke-v13)
+for a namespaced composite resource.
+```
+
+**The XApplication XRD has been `scope: Namespaced` since v1.** Crossplane v2 enforces a strict scope-mismatch check: namespaced composite resources cannot compose cluster-scoped resources. **Every AWS provider CRD in upbound provider-aws-* v2.5.3 is cluster-scoped** (verified via `kubectl get crd -o jsonpath='{.spec.scope}'` — Bucket, User, Policy, AccessKey, etc., all `Cluster`-scoped).
+
+This invalidates the v1.3 spec's core architecture (Composition emits AWS resources directly when `s3Needed: true`). The render-test goldens passed because `crossplane render` doesn't enforce the scope-mismatch check — that's a runtime apply-time check by the actual Crossplane controller. The smoke validation was the first place this surfaced.
+
+### What we missed during brainstorming
+
+The Q1-Q7 architectural decisions during v1.3 brainstorming didn't surface the namespaced-vs-cluster-scoped constraint because:
+1. We focused on functional design (which AWS resources, what fields, how creds flow) without checking Crossplane's composition-scope enforcement
+2. Existing AWS resources in the cluster (`loki-aws-infrastructure/`, `argo-workflows-aws-infrastructure/`) are applied as raw manifests, NOT as Composition output — so the precedent we drew from didn't have this problem
+3. Test fixtures + goldens give false confidence: `crossplane render` produces the desired-state output without checking apply-time validity. A real smoke validation step earlier in the design (rather than at the end of Phase 4) would have caught this.
+
+### Separate spec bug (smaller, but real)
+
+Independent of the scope issue: the spec's `make_iam_user_policy` helper assumed an inline `UserPolicy` CRD exists in upbound provider-aws-iam v2.5.3. **It doesn't.** Available IAM CRDs are `policies` (standalone Policy resource) + `userpolicyattachments` (binds Policy to User). The `loki-aws-infrastructure/iam-policy.yaml` + `iam-policy-attachment.yaml` files use the correct two-resource pattern. Discovery: this would have been caught by Phase 0 P.3 if it had checked CRD AVAILABILITY in addition to AccessKey Secret shape — only the latter was verified.
+
+### What's reverted
+
+| PR | Action |
+|---|---|
+| arigsela/kubernetes#233 | Tear down smoke-v13 manifests + cluster cleanup |
+| arigsela/kubernetes#234 | Revert PR #231's Composition + RBAC additions; delete test fixture + golden |
+| (no PR for backstage) | Backstage PR #11 stays merged — `s3Needed` form input is harmless without Composition support; re-used by v1.3.1 |
+
+### What's kept (not reverted)
+
+- **`s3Needed: bool` XRD field stays.** Composition ignores it post-revert; allows Backstage scaffolder PR #11's rendered XRs to keep validating against the API server.
+- **All v1.x prior art** (v1.2 db cred flow, v1.2.1 healthCheckPath, etc.) — untouched by the revert.
+
+### v1.3.1 — Option B architecture (next session)
+
+When v1.3 is re-attempted:
+
+**Architecture:** Backstage scaffolder emits cluster-scoped AWS resources as **raw manifests** in `base-apps/<name>/aws-resources.yaml` (conditional on `s3Needed: true`). Composition stays out of AWS resource emission entirely; only handles workload-side envFrom wiring + AWS env var injection.
+
+**Pattern alignment:** matches the existing `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` directories — proven to work in this cluster. ArgoCD's `prune: true` + `selfHeal: true` handles teardown of the raw manifests when the per-app Application is pruned.
+
+**Brainstorming items for v1.3.1:**
+1. Lifecycle ownership: with raw manifests, AWS resource teardown depends on ArgoCD prune order. Need to verify Crossplane provider-aws-* properly unwinds resources (esp. Bucket force-destroy) when ArgoCD removes them.
+2. The per-namespace `SecretStore` is currently emitted by the Composition (when `dbNeeded`). For s3Needed-only apps (no DB), who emits the SecretStore? Options: (a) Composition keeps the SecretStore generalization across both flags, (b) scaffolder emits SecretStore in `aws-resources.yaml`. Option (a) is simpler.
+3. The `aws_secret = f"{name}-aws"` reference in `make_deployment` came back during the revert. v1.3.1 will need to re-introduce minimal Composition changes for the workload-side wiring.
+4. A more rigorous Phase 0 pre-flight: verify EVERY assumed CRD exists at the kind-name level, not just AccessKey's writeConnectionSecretToRef shape.
+5. Add a "render then apply" validation step (early Phase 1) that catches scope-mismatch issues before TDD goldens are crafted.
+
+**Estimated v1.3.1 budget:** ~2 hours — most of the design work is already done; the implementation pivots to Backstage scaffolder + minimal Composition changes.
+
+### Final PR sequence (this attempt)
+
+| PR | Status |
+|---|---|
+| [#225 spec/plan v1.2.1](https://github.com/arigsela/kubernetes/pull/225) | Merged (predecessor) |
+| [#229 v1.2.1 close-out](https://github.com/arigsela/kubernetes/pull/229) | Merged (predecessor) |
+| [#230 v1.3 spec/plan](https://github.com/arigsela/kubernetes/pull/230) | Merged |
+| [#231 v1.3 Composition](https://github.com/arigsela/kubernetes/pull/231) | Merged → REVERTED |
+| [arigsela/backstage#11 v1.3 scaffolder](https://github.com/arigsela/backstage/pull/11) | Merged (kept; s3Needed field stays) |
+| [#232 smoke-v13 scaffold](https://github.com/arigsela/kubernetes/pull/232) | Merged → torn down |
+| [#233 smoke-v13 teardown](https://github.com/arigsela/kubernetes/pull/233) | Open |
+| [#234 v1.3 revert](https://github.com/arigsela/kubernetes/pull/234) | Open |
+| (this PR) | docs: v1.3 paused notes |
+
+**v1.3 status: PAUSED — re-attempt as v1.3.1 with Option B architecture in next session.**


### PR DESCRIPTION
Captures v1.3's paused state: implementation merged but reverted after smoke validation surfaced a Crossplane v2 architectural constraint. v1.3 will be re-attempted as v1.3.1 next session.

## TL;DR

- **v1.3 is NOT shipped** — implementation works at `crossplane render` time but Crossplane refuses to apply at runtime.
- **Architectural blocker:** namespaced XApplication XR cannot compose cluster-scoped AWS resources. Every AWS provider CRD in v2.5.3 is cluster-scoped.
- **Companion PRs:** arigsela/kubernetes#233 (smoke-v13 teardown), arigsela/kubernetes#234 (Composition revert).
- **Backstage scaffolder PR #11 stays merged** — `s3Needed` form field is harmless without Composition support; reused by v1.3.1.

## v1.3.1 plan (next session)

Pivot to **Option B architecture**: Backstage scaffolder emits cluster-scoped AWS resources as raw manifests in `base-apps/<name>/aws-resources.yaml` (matches existing `loki-aws-infrastructure/` pattern). Composition stays out of AWS emission; only handles workload-side envFrom + AWS env var injection. ~2 hour budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)