### PR TITLE
docs(idp): v1.3.1 design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md
+++ b/docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md
@@ -1,0 +1,1498 @@
+# IDP v1.3.1 — AWS S3 + IAM via Raw Manifests (Option B) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement IDP v1.3.1 with the Option B architecture (raw manifests via Backstage scaffolder). Re-add the Composition Python code reverted in PR #234, plus a NEW content-k8s file in arigsela/backstage that emits 5 cluster-scoped AWS resources when `s3Needed:true`.
+
+**Architecture:** Backstage scaffolder emits cluster-scoped AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey) as raw manifests. Composition stays out of AWS resource emission entirely; only handles workload-side envFrom + AWS env var injection + the namespaced ESO config (SecretStore + PushSecret + ExternalSecret). Cross-resource references via Crossplane label selectors (matches existing loki/argo-workflows pattern proven on cluster).
+
+**Tech Stack:** Crossplane v2.2.1 + function-python (composition), Crossplane provider-aws-s3 v2.5.3 + provider-aws-iam v2.5.3 (already installed), External Secrets Operator (ESO), HashiCorp Vault, Backstage scaffolder (Nunjucks templating), `crossplane render` CLI + `yq` for goldens-based testing.
+
+**Spec:** [`docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md`](../specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md) (committed `7ceb8d6`)
+
+---
+
+## Pre-flight (run once before Phase 1 starts)
+
+### P.1 — Verify the Composition test harness still works (sanity baseline)
+
+```bash
+cd /Users/arisela/git/kubernetes
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+Expected: both exit 0 with no diff output. If either fails, investigate before adding v1.3.1 changes.
+
+### P.2 — Confirm v1.3 revert (PR #234) merged on main
+
+```bash
+git fetch origin main
+git log origin/main --oneline | grep -E "revert.*v1.3|3977f56" | head -3
+```
+
+Expected: at least one commit referencing the v1.3 revert. If not, merge PR #234 first — v1.3.1 builds on a clean v1.2.1-baseline state.
+
+### P.3 — Verify ALL 5 AWS CRDs exist by NAME (HARD GATE — lesson from v1.3)
+
+The v1.3 spec assumed `UserPolicy` (inline) CRD existed; it doesn't. v1.3.1 verifies every assumed CRD by name BEFORE writing any code:
+
+```bash
+for crd in \
+  buckets.s3.aws.upbound.io \
+  users.iam.aws.upbound.io \
+  policies.iam.aws.upbound.io \
+  userpolicyattachments.iam.aws.upbound.io \
+  accesskeys.iam.aws.upbound.io; do
+  kubectl get crd $crd -o jsonpath='{.spec.scope}: {.metadata.name}{"\n"}' 2>&1 || echo "MISSING: $crd"
+done
+```
+
+**Expected output:** all 5 lines show `Cluster: <crd>` (every AWS CRD is cluster-scoped — that's the architectural reason we need Option B).
+
+**If any CRD is MISSING:** STOP. Investigate the AWS provider version. The v1.3.1 architecture depends on these specific kinds.
+
+### P.4 — Confirm AWS provider + ProviderConfig health
+
+```bash
+kubectl get providers 2>&1 | grep -iE "aws|family"
+# Expected: 3 providers all "INSTALLED=True, HEALTHY=True"
+
+kubectl get providerconfigs.aws.upbound.io 2>&1
+# Expected: "default" ProviderConfig exists
+
+kubectl -n crossplane-system get secret aws-secret 2>&1 | head -3
+# Expected: Secret exists with DATA count > 0
+```
+
+If any check fails: AWS infrastructure isn't ready. Fix before proceeding.
+
+---
+
+## Phase 1 — Kubernetes repo (Composition + tests, single PR)
+
+Branch: `feat/idp-v1.3.1-aws-eso-config` off `origin/main`.
+
+### Task 1.1: Set up the implementation branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main
+git checkout -b feat/idp-v1.3.1-aws-eso-config origin/main
+git branch --show-current
+# Expected: feat/idp-v1.3.1-aws-eso-config
+```
+
+---
+
+### Task 1.2: Re-create test fixture xr-with-s3.yaml
+
+**Files:**
+- Create: `tests/composition/xr-with-s3.yaml`
+
+This file was deleted in PR #234. Re-create with the same content as v1.3's attempt.
+
+- [ ] **Step 1: Create the fixture**
+
+Create `tests/composition/xr-with-s3.yaml`:
+
+```yaml
+# tests/composition/xr-with-s3.yaml
+# TDD input: XApplication with AWS S3 bucket enabled (no DB).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-s3-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-s3-app.arigsela.com
+  port: 8080
+  replicas: 1
+  s3Needed: true
+```
+
+---
+
+### Task 1.3: Re-create test golden expected-xr-with-s3.yaml (TDD: write failing assertion FIRST, REDUCED scope)
+
+**Files:**
+- Create: `tests/composition/expected-xr-with-s3.yaml`
+
+The golden has **7 documents** (NOT 11 like v1.3 attempted):
+1. The XR itself (echoed)
+2. Deployment (with envFrom on `smoke-s3-app-aws` + AWS_REGION/BUCKET_NAME env vars + healthCheckPath /)
+3. Service (unchanged shape from v1.x)
+4. Ingress (unchanged shape from v1.x)
+5. SecretStore vault-backend (Composition-emitted; shared with db path)
+6. PushSecret smoke-s3-app-aws-push (Composition-emitted)
+7. ExternalSecret smoke-s3-app-aws (Composition-emitted)
+
+**NOT included in golden** (those are scaffolder-emitted raw manifests, NOT Composition output): Bucket, User, Policy, UserPolicyAttachment, AccessKey.
+
+- [ ] **Step 1: Create the golden file**
+
+Create `tests/composition/expected-xr-with-s3.yaml` with this exact content:
+
+```yaml
+# tests/composition/expected-xr-with-s3.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  host: smoke-s3-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+  s3Needed: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-s3-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-s3-app
+        backstage.io/kubernetes-id: smoke-s3-app
+    spec:
+      containers:
+      - env:
+        - name: AWS_REGION
+          value: us-east-2
+        - name: BUCKET_NAME
+          value: 852893458518-smoke-s3-app
+        envFrom:
+        - secretRef:
+            name: smoke-s3-app-aws
+        image: nginxinc/nginx-unprivileged:1.25-alpine
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: app
+        ports:
+        - containerPort: 8080
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      imagePullSecrets:
+      - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-s3-app
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: smoke-s3-app.arigsela.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: smoke-s3-app
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - smoke-s3-app.arigsela.com
+    secretName: smoke-s3-app-tls
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: secretstore
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: vault-backend
+  namespace: platform-smoke
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: platform-smoke
+          serviceAccountRef:
+            name: default
+      path: k8s-secrets
+      server: http://vault.vault.svc.cluster.local:8200
+      version: v2
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awspushsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws-push
+  namespace: platform-smoke
+spec:
+  data:
+  - match:
+      remoteRef:
+        property: AWS_ACCESS_KEY_ID
+        remoteKey: platform-smoke/aws-creds
+      secretKey: attribute.id
+  - match:
+      remoteRef:
+        property: AWS_SECRET_ACCESS_KEY
+        remoteKey: platform-smoke/aws-creds
+      secretKey: attribute.secret
+  deletionPolicy: Delete
+  refreshInterval: 5m
+  secretStoreRefs:
+  - kind: SecretStore
+    name: vault-backend
+  selector:
+    secret:
+      name: smoke-s3-app-aws-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awsexternalsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws
+  namespace: platform-smoke
+spec:
+  data:
+  - remoteRef:
+      key: platform-smoke/aws-creds
+      property: AWS_ACCESS_KEY_ID
+    secretKey: AWS_ACCESS_KEY_ID
+  - remoteRef:
+      key: platform-smoke/aws-creds
+      property: AWS_SECRET_ACCESS_KEY
+    secretKey: AWS_SECRET_ACCESS_KEY
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: smoke-s3-app-aws
+```
+
+- [ ] **Step 2: Re-canonicalize via yq sort**
+
+```bash
+yq -i -P 'sort_keys(..)' tests/composition/expected-xr-with-s3.yaml
+```
+
+- [ ] **Step 3: Sanity check — file parses cleanly into 7 documents**
+
+```bash
+yq 'document_index' tests/composition/expected-xr-with-s3.yaml | tail -1
+# Expected: 6 (zero-indexed; 7 docs total)
+```
+
+---
+
+### Task 1.4: Run xr-with-s3 render test → expect FAIL
+
+**Files:** none (running tests)
+
+- [ ] **Step 1: Run the new test case**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+**Expected: non-zero exit.** Diff shows the rendered output is missing the SecretStore + PushSecret + ExternalSecret AND the Deployment lacks the new envFrom/env vars (because Composition Python is currently at v1.2.1 baseline state post-revert).
+
+If the test PASSES at this point: the implementation is already there — STOP and investigate.
+
+---
+
+### Task 1.5: Re-add Composition Python — constants, ESO helpers, make_deployment, compose() additions
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml`
+
+This task re-adds code that was reverted in PR #234. The complete code is in the v1.3 spec at `docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md` §5–§7. Reference that spec while implementing.
+
+The Composition Python lives inside `spec.pipeline[0].input.script` as a YAML literal block. Indentation: 10 spaces.
+
+- [ ] **Step 1: Add `AWS_ACCOUNT_ID` + `AWS_REGION` constants**
+
+Find the `DB_SECRET_KEYS` constant (added in v1.2). Immediately AFTER it, add:
+
+```python
+          # AWS account + region constants. Confirmed from existing default
+          # ProviderConfig (status shows 10 resources using it) + chores-tracker-backend
+          # ECR image refs. Single account for all v1.x infra.
+          AWS_ACCOUNT_ID = "852893458518"
+          AWS_REGION = "us-east-2"
+```
+
+- [ ] **Step 2: Add `make_aws_push_secret` helper**
+
+Add after the existing v1.2 `make_external_secret` helper:
+
+```python
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+                      "secretStoreRefs": [
+                          {"name": "vault-backend", "kind": "SecretStore"},
+                      ],
+                      "selector": {
+                          "secret": {"name": f"{name}-aws-key"},
+                      },
+                      "data": [
+                          {
+                              "match": {
+                                  "secretKey": "attribute.id",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_ACCESS_KEY_ID",
+                                  },
+                              },
+                          },
+                          {
+                              "match": {
+                                  "secretKey": "attribute.secret",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_SECRET_ACCESS_KEY",
+                                  },
+                              },
+                          },
+                      ],
+                  },
+              }
+```
+
+- [ ] **Step 3: Add `make_aws_external_secret` helper**
+
+```python
+          def make_aws_external_secret(name, namespace, annotations):
+              """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "ExternalSecret",
+                  "metadata": {
+                      "name": f"{name}-aws",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "15s",
+                      "secretStoreRef": {
+                          "name": "vault-backend",
+                          "kind": "SecretStore",
+                      },
+                      "target": {
+                          "name": f"{name}-aws",
+                          "creationPolicy": "Owner",
+                      },
+                      "data": [
+                          {
+                              "secretKey": "AWS_ACCESS_KEY_ID",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_ACCESS_KEY_ID",
+                              },
+                          },
+                          {
+                              "secretKey": "AWS_SECRET_ACCESS_KEY",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_SECRET_ACCESS_KEY",
+                              },
+                          },
+                      ],
+                  },
+              }
+```
+
+- [ ] **Step 4: Update `make_deployment` signature + body**
+
+Find the `def make_deployment(...)` line. Current signature (post-revert) is:
+
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, health_path, annotations):
+```
+
+Change to:
+
+```python
+          def make_deployment(name, namespace, image, port, replicas, env_list, db_secret, aws_secret, health_path, annotations):
+```
+
+(Replaces `env_from_secret` with two separate `db_secret`, `aws_secret` params.)
+
+Inside the function body, find where `envFrom` is set. Replace the env-construction logic with:
+
+```python
+              # Build envFrom dynamically based on what the app needs
+              env_from_blocks = []
+              if db_secret:
+                  env_from_blocks.append({"secretRef": {"name": db_secret}})
+              if aws_secret:
+                  env_from_blocks.append({"secretRef": {"name": aws_secret}})
+
+              # DATABASE_URL env var via secretKeyRef (preserve v1.2 behavior)
+              db_env = []
+              if db_secret:
+                  db_env.append({
+                      "name": "DATABASE_URL",
+                      "valueFrom": {"secretKeyRef": {"name": db_secret, "key": "uri"}},
+                  })
+
+              # Inject AWS configuration as static env vars
+              aws_env = []
+              if aws_secret:
+                  aws_env.extend([
+                      {"name": "AWS_REGION", "value": AWS_REGION},
+                      {"name": "BUCKET_NAME", "value": f"{AWS_ACCOUNT_ID}-{name}"},
+                  ])
+
+              container_env = list(env_list) + db_env + aws_env
+```
+
+Then in the container spec dict, set:
+```python
+              "envFrom": env_from_blocks,
+              "env": container_env,
+```
+
+- [ ] **Step 5: Update `compose()` — generalize SecretStore + add s3Needed branch + update make_deployment call**
+
+Find the existing `if spec.get("dbNeeded"):` block in `compose()`. The first resource emitted inside is currently the SecretStore. Generalize: move SecretStore emission OUTSIDE the dbNeeded block, emit if EITHER dbNeeded or s3Needed is true.
+
+```python
+              # SecretStore is shared between db and aws paths — emit once if EITHER is needed
+              needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+              if needs_secret_store:
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+
+              if spec.get("dbNeeded"):
+                  resource.update(
+                      rsp.desired.resources["dbcluster"],
+                      make_cnpg_cluster(...),
+                  )
+                  # NOTE: SecretStore emission moved out — handled by the shared
+                  # `needs_secret_store` block above
+                  resource.update(
+                      rsp.desired.resources["pushsecret"],
+                      make_push_secret(...),
+                  )
+                  resource.update(
+                      rsp.desired.resources["externalsecret"],
+                      make_external_secret(...),
+                  )
+
+              if spec.get("s3Needed"):
+                  resource.update(
+                      rsp.desired.resources["awspushsecret"],
+                      make_aws_push_secret(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "awspushsecret")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awsexternalsecret"],
+                      make_aws_external_secret(name, namespace,
+                                               annotations=std_annotations(xr_annotations, "awsexternalsecret")),
+                  )
+                  # NOTE: NO Bucket/User/Policy/UserPolicyAttachment/AccessKey emission here.
+                  # Those are scaffolder-emitted raw manifests in
+                  # base-apps/<name>/aws-resources.yaml. v1.3.1 architecture (Option B).
+```
+
+- [ ] **Step 6: Update `make_deployment` call site in compose()**
+
+Find the current call. Change to pass `db_secret` and `aws_secret` separately:
+
+```python
+              db_secret = f"{name}-db" if spec.get("dbNeeded") else None
+              aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
+              resource.update(
+                  rsp.desired.resources["deployment"],
+                  make_deployment(name, namespace, spec["image"], port,
+                                  replicas, spec.get("env", []),
+                                  db_secret, aws_secret,
+                                  health_path=spec.get("healthCheckPath", "/"),
+                                  annotations=std_annotations(xr_annotations, "deployment")),
+              )
+```
+
+- [ ] **Step 7: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/composition-application.yaml > /dev/null && echo "Composition YAML valid"
+```
+
+---
+
+### Task 1.6: Run all render tests → expect PASS
+
+**Files:** none
+
+- [ ] **Step 1: Run xr-with-s3 (should now PASS)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+**Expected: exit 0, no diff.**
+
+If FAIL: read the diff. Common causes:
+- Indent drift in Python (literal block in YAML)
+- Helper signature mismatch
+- AWS env var injection missing in make_deployment
+
+- [ ] **Step 2: Run xr-minimal (regression check)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+```
+
+**Expected: exit 0, no diff.** Proves `s3Needed:false` path is unchanged.
+
+- [ ] **Step 3: Run xr-with-db (regression check)**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+**Expected: exit 0, no diff.** Proves the v1.2 db path still works after SecretStore generalization (Task 1.5 Step 5).
+
+---
+
+### Task 1.7: Commit Phase 1
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+git add base-apps/crossplane-compositions/composition-application.yaml \
+        tests/composition/xr-with-s3.yaml \
+        tests/composition/expected-xr-with-s3.yaml
+
+git status --short   # expect: 3 files (1 modified, 2 created)
+
+git commit -m "$(cat <<'EOF'
+feat(composition): v1.3.1 AWS Vault round-trip via Option B (raw manifests)
+
+Re-adds the Composition Python code reverted in PR #234, adapted for
+Option B architecture: Composition handles ONLY the namespaced ESO
+config (SecretStore + PushSecret + ExternalSecret) + workload-side
+envFrom + AWS env var injection. The cluster-scoped AWS resources
+(Bucket, User, Policy, UserPolicyAttachment, AccessKey) are
+scaffolder-emitted as raw manifests in base-apps/<name>/aws-resources.yaml
+(matches existing loki-aws-infrastructure / argo-workflows-aws-
+infrastructure patterns proven on this cluster).
+
+What's added:
+  - AWS_ACCOUNT_ID + AWS_REGION constants (only used by Deployment
+    env-var injection now; no longer used to construct AWS resources)
+  - make_aws_push_secret + make_aws_external_secret helpers
+  - SecretStore generalization (emit-once if dbNeeded OR s3Needed)
+  - make_deployment: aws_secret param + AWS env var injection
+  - compose() s3Needed branch (ESO ONLY, NO AWS resources)
+  - xr-with-s3 test fixture + golden (7 docs, NOT 11 — reduced
+    scope reflects Option B architecture)
+
+What's NOT added (v1.3 mistake; ditched in v1.3.1):
+  - make_s3_bucket, make_iam_user, make_iam_user_policy,
+    make_iam_access_key helpers
+  - Crossplane RBAC for s3.aws.upbound.io / iam.aws.upbound.io
+  - compose() AWS resource emission
+
+XRD apiVersion stays v1alpha1 (s3Needed field already present
+post-revert; this PR makes it functional).
+
+Spec: docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git log -1 --stat
+```
+
+---
+
+### Task 1.8: Push branch + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/idp-v1.3.1-aws-eso-config
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main --head feat/idp-v1.3.1-aws-eso-config \
+  --title "feat(composition): v1.3.1 AWS Vault round-trip via Option B (raw manifests)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements v1.3.1 — re-attempts v1.3's AWS S3+IAM provisioning with **Option B architecture** (raw manifests via Backstage scaffolder) after v1.3 was paused due to Crossplane v2's namespaced-XR-cannot-compose-cluster-scoped-resources enforcement.
+
+## What this PR contains (Composition side ONLY)
+
+| Change | File | Impact |
+|---|---|---|
+| Re-add `AWS_ACCOUNT_ID` + `AWS_REGION` constants | `base-apps/crossplane-compositions/composition-application.yaml` | Used by Deployment AWS env var injection |
+| Re-add `make_aws_push_secret` + `make_aws_external_secret` helpers | (same file) | Re-introduces ESO Vault round-trip for AWS creds |
+| SecretStore generalization | (same file) | Emit-once if `dbNeeded` OR `s3Needed` is true |
+| `make_deployment` envFrom + AWS env vars | (same file) | When `aws_secret` is set, injects `<name>-aws` envFrom + `AWS_REGION`/`BUCKET_NAME` static env vars |
+| `compose()` s3Needed branch | (same file) | ESO ONLY — NO Bucket/User/Policy/UserPolicyAttachment/AccessKey emission |
+| Re-create test fixture + golden | `tests/composition/xr-with-s3.yaml` + `expected-xr-with-s3.yaml` | TDD — 7 documents (NOT 11 like v1.3 attempted; reflects Option B scope) |
+
+## What this PR does NOT contain (Option B = scaffolder side)
+
+The cluster-scoped AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey) are emitted by the Backstage scaffolder as raw manifests in `base-apps/<name>/aws-resources.yaml`. See companion arigsela/backstage PR.
+
+Reason: Crossplane v2 enforces a strict scope-mismatch check — namespaced XR cannot compose cluster-scoped resources. Option B respects this by having Composition NOT emit AWS resources; instead the scaffolder emits them as raw manifests (matches existing `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` patterns proven on this cluster).
+
+## Test plan
+
+- [x] `./tests/composition/render.sh xr-with-s3` PASS (Composition emits SecretStore + PushSecret + ExternalSecret + Deployment with envFrom; NOT AWS resources)
+- [x] `./tests/composition/render.sh xr-minimal` PASS (s3Needed:false unchanged)
+- [x] `./tests/composition/render.sh xr-with-db` PASS (db path still works after SecretStore generalization)
+- [ ] Companion arigsela/backstage PR for new aws-resources.yaml content-k8s file
+- [ ] User rebuilds Backstage image
+- [ ] User pre-creates Vault role for smoke-v131 namespace (re-uses v1.2's app-namespace-rw)
+- [ ] Smoke validation: scaffold smoke-v131 with `s3Needed:true` (image=amazon/aws-cli:latest); verify scaffold PR has 3 files (incl. aws-resources.yaml); merge → Pod gets envFrom + can `aws s3 cp`
+
+## Things explicitly NOT in v1.3.1 (per spec §10)
+
+- Composition-emitted AWS resources (the v1.3 mistake; rejected)
+- Custom IAM policies (single templated S3-RW)
+- Multiple buckets, versioning, CORS, lifecycle
+- SQS, SNS, RDS (v1.4+)
+- IRSA / Pod Identity (v2)
+- Vault dynamic credentials (v2)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 2 — Backstage scaffolder (single PR)
+
+This phase touches the `arigsela/backstage` repo (separate from kubernetes). Local clone at `~/git/backstage` per v1.1+ precedent.
+
+### Task 2.1: Set up branch in arigsela/backstage
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Switch to backstage repo + branch**
+
+```bash
+cd ~/git/backstage
+git fetch origin main
+git checkout -b feat/idp-v1.3.1-aws-resources origin/main
+git branch --show-current
+# Expected: feat/idp-v1.3.1-aws-resources
+```
+
+---
+
+### Task 2.2: Add `bucketName` to fetch.values mapping
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+The new `aws-resources.yaml` content-k8s file needs `bucketName` (computed as `<account-id>-<name>`) in its template values.
+
+- [ ] **Step 1: Edit fetch.values**
+
+Find the `steps[id=fetch].input.values` block. Add `bucketName:` line at the end:
+
+Current shape (post-v1.3 backstage PR #11):
+```yaml
+        values:
+          name: ${{ parameters.name | trim }}
+          namespace: ${{ parameters.name | trim }}
+          owner: ${{ parameters.owner | trim }}
+          image: ${{ parameters.image | trim }}
+          host: ${{ parameters.host | trim }}
+          healthCheckPath: ${{ parameters.healthCheckPath | trim }}
+          port: ${{ parameters.port }}
+          replicas: ${{ parameters.replicas }}
+          dbNeeded: ${{ parameters.dbNeeded }}
+          dbStorage: ${{ parameters.dbStorage | trim }}
+          s3Needed: ${{ parameters.s3Needed }}
+```
+
+Add at the end:
+```yaml
+          bucketName: 852893458518-${{ parameters.name | trim }}
+```
+
+(Hardcoded account ID matches the spec's account-prefix bucket naming convention.)
+
+---
+
+### Task 2.3: Create new content-k8s file aws-resources.yaml
+
+**Files:**
+- Create: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml`
+
+This is the NEW v1.3.1 file. Conditional on `s3Needed:true`. When false, file is empty (Backstage skips empty files).
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+{%- if values.s3Needed %}
+# AWS resources for ${{ values.name }} — provisioned via Crossplane provider-aws-s3
+# and provider-aws-iam (cluster-scoped resources, applied by ArgoCD).
+#
+# WARNING: bucket has forceDestroy:true — contents are permanently deleted on
+# teardown. The IAM user + access key are dedicated per-app (not shared).
+#
+# Cross-resource references via Crossplane label selectors (resolved at apply time
+# by the Crossplane controllers; no sync waves needed). Matches the existing
+# loki-aws-infrastructure / argo-workflows-aws-infrastructure pattern.
+
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: ${{ values.bucketName }}
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    forceDestroy: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: ${{ values.name }}-app
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-user
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    tags:
+      ManagedBy: crossplane
+      App: ${{ values.name }}
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: ${{ values.name }}-s3-policy
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    description: "S3 RW on ${{ values.name }}'s own bucket"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+          "Resource": [
+            "arn:aws:s3:::${{ values.bucketName }}",
+            "arn:aws:s3:::${{ values.bucketName }}/*"
+          ]
+        }]
+      }
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: ${{ values.name }}-s3-attachment
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy-attachment
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-policy
+    userRef:
+      name: ${{ values.name }}-app
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: ${{ values.name }}-app-key
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: access-key
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-user
+  # Connection secret keys: attribute.id, attribute.secret, username
+  writeConnectionSecretToRef:
+    name: ${{ values.name }}-aws-key
+    namespace: ${{ values.name }}
+  providerConfigRef:
+    name: default
+{%- endif %}
+```
+
+Note: when `values.s3Needed` is false, the Nunjucks renders this as an empty file. Backstage's scaffolder skips empty files.
+
+---
+
+### Task 2.4: Commit Phase 2 + push + open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+cd ~/git/backstage
+
+git add examples/templates/application/template.yaml \
+        "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/aws-resources.yaml"
+
+git status --short   # expect: 1 modified + 1 created
+
+git commit -m "$(cat <<'EOF'
+feat(scaffolder): v1.3.1 emit AWS resources as raw manifests (Option B)
+
+Companion to arigsela/kubernetes v1.3.1 PR. Adds the scaffolder side
+of the v1.3 re-attempt with Option B architecture: scaffolder emits
+cluster-scoped AWS resources (Bucket + User + Policy +
+UserPolicyAttachment + AccessKey) as raw manifests in
+base-apps/<name>/aws-resources.yaml.
+
+Matches the existing loki-aws-infrastructure / argo-workflows-aws-
+infrastructure pattern proven on this cluster. Cross-resource
+references via Crossplane label selectors (resolved at apply time;
+no sync waves).
+
+All 5 AWS resources carry TeraSky annotations + selector labels —
+visible in Backstage's Crossplane tab on the entity page (UX
+consistency with v1.1+).
+
+When s3Needed:false, the file renders empty (Backstage skips
+empty files). Existing apps without s3Needed unaffected.
+
+Spec: docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
+(in arigsela/kubernetes repo)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feat/idp-v1.3.1-aws-resources
+
+gh pr create --base main --head feat/idp-v1.3.1-aws-resources \
+  --title "feat(scaffolder): v1.3.1 emit AWS resources as raw manifests (Option B)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Companion to arigsela/kubernetes v1.3.1 PR. Adds the scaffolder side: when developer scaffolds with \`s3Needed:true\`, the scaffolder emits a NEW \`aws-resources.yaml\` file containing 5 cluster-scoped AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey).
+
+## Why this approach (Option B)
+
+v1.3 attempted to have the Crossplane Composition emit cluster-scoped AWS resources directly. Crossplane v2 enforces a strict scope-mismatch check — namespaced XApplication XR cannot compose cluster-scoped resources. v1.3.1 pivots to **raw manifests via the scaffolder**, matching the existing \`loki-aws-infrastructure/\` and \`argo-workflows-aws-infrastructure/\` patterns proven on this cluster.
+
+## Changes
+
+| Change | File | Why |
+|---|---|---|
+| Add \`bucketName\` to \`fetch.values\` mapping | \`examples/templates/application/template.yaml\` | Computed value used by aws-resources.yaml for both bucket name and IAM Policy ARNs |
+| Create new content-k8s file with 5 AWS resources | \`examples/templates/application/content-k8s/base-apps/\${{ values.name }}/aws-resources.yaml\` | Nunjucks-conditional on s3Needed:true; multi-doc YAML; each resource has TeraSky annotations + selector labels |
+
+## Cross-resource references
+
+UserPolicyAttachment uses \`policyArnSelector.matchLabels\` (resolves Policy by labels) + \`userRef.name\` (resolves User by name). AccessKey uses \`userSelector.matchLabels\`. Crossplane resolves these at apply time — no hard ARN references; no sync waves needed.
+
+## Test plan
+
+- [ ] After Backstage image rebuild, scaffold an app with \`s3Needed:true\` — verify PR has 3 files (smoke-v131.yaml, application-xr.yaml, **aws-resources.yaml** with 5 AWS resources)
+- [ ] Default behavior (\`s3Needed:false\`): scaffold PR has 2 files (no aws-resources.yaml; Backstage skips empty file)
+
+## Image rebuild needed?
+
+Yes. After this merges, the Backstage image needs to be rebuilt and \`base-apps/backstage/deployments.yaml\` tag bumped (or tag reused + pod relaunched, like v1.2.1 / v1.3).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 3 — USER GATE: Merge PRs + image rebuild + Vault role binding
+
+> **Subagent-driven-development pause point.** All Phase 3 actions require user-controlled steps.
+
+### Task 3.1: USER reviews + merges Phase 1 PR (kubernetes)
+
+- [ ] User merges PR opened by Task 1.8
+- [ ] Verify ArgoCD sync (~30s):
+
+```bash
+kubectl -n argo-cd get application crossplane-compositions \
+  -o jsonpath='{.status.sync.status}: revision={.status.sync.revision}{"\n"}'
+# Expected: Synced; revision matches merge commit
+
+# Verify v1.3.1 marker is live
+kubectl get composition application -o yaml 2>&1 | grep -c "make_aws_push_secret"
+# Expected: ≥1
+```
+
+---
+
+### Task 3.2: USER reviews + merges Phase 2 PR (backstage)
+
+- [ ] User merges PR opened by Task 2.4
+- [ ] Note: merge alone doesn't change cluster behavior — image rebuild needed
+
+---
+
+### Task 3.3: USER rebuilds Backstage image (or reuses tag like v1.2.1 / v1.3)
+
+- [ ] User builds image (standard local docker buildx + push to ECR flow)
+- [ ] Either bump tag OR reuse same tag and relaunch pod
+
+If reusing tag (faster):
+```bash
+kubectl -n backstage rollout restart deployment/backstage
+kubectl -n backstage rollout status deployment/backstage --timeout=2m
+```
+
+- [ ] Verify the new template is live on the Pod's filesystem:
+
+```bash
+BACKSTAGE_POD=$(kubectl -n backstage get pods -o name | head -1)
+kubectl -n backstage exec $BACKSTAGE_POD -- ls /app/examples/templates/application/content-k8s/base-apps/ 2>&1
+# Expected: shows the directory containing aws-resources.yaml template
+
+# Sanity check that the bucketName line is in the template
+kubectl -n backstage exec $BACKSTAGE_POD -- grep "bucketName" /app/examples/templates/application/template.yaml
+# Expected: shows the new line
+```
+
+---
+
+### Task 3.4: USER pre-creates Vault role for smoke-v131 namespace
+
+The Vault role binds the existing `app-namespace-rw` policy from v1.2 (no new policy needed; the templated path `k8s-secrets/<ns>/*` covers `aws-creds` sub-path automatically).
+
+- [ ] **Step 1: Create the role**
+
+(Assistant can run this via the same kubectl-exec + stored root token pattern from v1.2 / v1.3.)
+
+```bash
+NAMESPACE=smoke-v131
+
+# (with VAULT_TOKEN exported)
+vault write auth/kubernetes/role/${NAMESPACE} \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=${NAMESPACE} \
+  policies="default,app-namespace-rw" \
+  ttl=1h
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+vault read auth/kubernetes/role/smoke-v131
+# Expected: policies=[default app-namespace-rw], bound_service_account_namespaces=[smoke-v131]
+```
+
+---
+
+## Phase 4 — Smoke validation (smoke-v131)
+
+> **Subagent-driven-development pause point.** Phase 4 requires Backstage UI form submission + scaffold PR review/merge.
+
+### Task 4.1: Scaffold smoke-v131 via Backstage
+
+- [ ] **Step 1: Open Backstage**
+
+https://backstage.arigsela.com/create
+
+- [ ] **Step 2: Submit form**
+
+| Field | Value |
+|---|---|
+| Application name | `smoke-v131` |
+| Owner | `group:default/platform-engineering` |
+| Container image | `amazon/aws-cli:latest` |
+| Public hostname | `smoke-v131.arigsela.com` |
+| Container port | `8080` |
+| Replicas | `1` |
+| Health check path (optional) | `/` (default) |
+| Provision a Postgres database | **NO** |
+| Provision an AWS S3 bucket | **YES** ← v1.3.1 path under test |
+
+(image is `amazon/aws-cli:latest` so we can `kubectl exec aws s3 cp` from inside the Pod to validate AC-8. Pod will be Running but not Ready=True since aws-cli doesn't serve HTTP — expected; not a failure.)
+
+---
+
+### Task 4.2: Verify scaffold PR has 3 files (incl. aws-resources.yaml)
+
+- [ ] **Step 1: Inspect the resulting scaffold PR**
+
+```bash
+SCAFFOLD_PR=$(gh pr list --state open --search "smoke-v131 in:title" --json number --jq '.[0].number')
+echo "Scaffold PR: #$SCAFFOLD_PR"
+
+gh pr view $SCAFFOLD_PR --json files --jq '.files[] | "\(.path) (+\(.additions)/-\(.deletions))"'
+# Expected: 3 files
+#   base-apps/smoke-v131.yaml
+#   base-apps/smoke-v131/application-xr.yaml
+#   base-apps/smoke-v131/aws-resources.yaml
+```
+
+If only 2 files appear (no aws-resources.yaml): Backstage scaffolder template's Nunjucks conditional may have fallen through. Check Phase 2 Task 2.3 implementation; rebuild image if needed.
+
+- [ ] **Step 2: Inspect aws-resources.yaml content for the 5 expected resources**
+
+```bash
+gh pr diff $SCAFFOLD_PR | grep -E "^kind:" | sort -u
+# Expected: 5 lines — Bucket, User, Policy, UserPolicyAttachment, AccessKey, plus XApplication + Application from other files
+```
+
+- [ ] **Step 3: USER merges scaffold PR**
+
+---
+
+### Task 4.3: Verify ArgoCD sync + AWS resources composition
+
+```bash
+sleep 60  # let ArgoCD pick up + Crossplane providers reconcile
+
+kubectl -n argo-cd get application smoke-v131 \
+  -o jsonpath='{.status.sync.status}/{.status.health.status}{"\n"}'
+# Expected: Synced (Health may be Degraded since aws-cli doesn't serve HTTP — that's OK)
+
+# Cluster-scoped AWS resources (managed by ArgoCD via raw manifests)
+kubectl get bucket.s3.aws.upbound.io 2>&1 | grep smoke-v131
+kubectl get user.iam.aws.upbound.io 2>&1 | grep smoke-v131
+kubectl get policy.iam.aws.upbound.io 2>&1 | grep smoke-v131
+kubectl get userpolicyattachment.iam.aws.upbound.io 2>&1 | grep smoke-v131
+kubectl get accesskey.iam.aws.upbound.io 2>&1 | grep smoke-v131
+
+# Namespaced ESO resources (Composition-emitted)
+kubectl -n smoke-v131 get xapplications,secretstores,pushsecrets,externalsecrets,deployments,services,ingresses,pods,secrets 2>&1
+```
+
+---
+
+### Task 4.4: AC-5 verify bucket created in AWS
+
+```bash
+# (with local AWS CLI configured for account 852893458518)
+aws s3 ls s3://852893458518-smoke-v131/ 2>&1
+# Expected: empty bucket; "TotalObjects: 0" or no error
+```
+
+---
+
+### Task 4.5: AC-6 verify Vault path populated
+
+```bash
+kubectl -n vault get secret vault-unseal-keys -o jsonpath='{.data.root-token}' | base64 -d | kubectl -n vault exec -i vault-0 -- sh -c '
+  VAULT_TOKEN=$(cat); export VAULT_TOKEN
+  vault kv list -format=json k8s-secrets/smoke-v131 2>&1 | head
+'
+# Expected: shows ["aws-creds"]
+```
+
+For values inspection (be careful — credentials in tool output):
+```bash
+# Skip value inspection for security; trust the keys-only check
+```
+
+---
+
+### Task 4.6: AC-7 verify Deployment envFrom + AWS env vars
+
+```bash
+kubectl -n smoke-v131 get deployment smoke-v131 -o json 2>&1 | jq -c '.spec.template.spec.containers[0] | {envFrom, env}'
+# Expected:
+#   envFrom: [{ secretRef: { name: smoke-v131-aws } }]
+#   env: [{ name: AWS_REGION, value: us-east-2 }, { name: BUCKET_NAME, value: 852893458518-smoke-v131 }]
+```
+
+---
+
+### Task 4.7: AC-8 verify workload can write to bucket
+
+Wait until ESO has projected the Secret (`<smoke-v131-aws>`); then exec into the Pod:
+
+```bash
+# Wait for projected Secret
+until kubectl -n smoke-v131 get secret smoke-v131-aws >/dev/null 2>&1; do sleep 5; done
+echo "Projected Secret exists"
+
+# Find the running pod
+POD=$(kubectl -n smoke-v131 get pod -l app.kubernetes.io/name=smoke-v131 -o name | head -1)
+echo "Pod: $POD"
+
+# Test S3 write
+kubectl -n smoke-v131 exec $POD -- sh -c 'echo "v1.3.1 smoke test from $HOSTNAME at $(date)" > /tmp/test.txt && aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v131-test.txt'
+# Expected: "upload: ../tmp/test.txt to s3://852893458518-smoke-v131/v131-test.txt"
+
+# Verify object in bucket
+aws s3 ls s3://852893458518-smoke-v131/
+# Expected: shows v131-test.txt
+```
+
+If the `aws s3 cp` returns `InvalidAccessKeyId`: AWS IAM eventual consistency (5-10s) — wait + retry.
+
+---
+
+### Task 4.8: Tear down smoke-v131
+
+(Same v1 spec §8 corrected order — PR-delete first, then `kubectl delete xapplication`.)
+
+- [ ] **Step 1: Open teardown PR**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b chore/teardown-smoke-v131
+git rm base-apps/smoke-v131.yaml
+git rm -r base-apps/smoke-v131
+git commit -m "chore: tear down v1.3.1 smoke validation app
+
+Tests: bucket forceDestroy:true (data loss expected by design),
+IAM cleanup, Vault entry GC."
+git push -u origin chore/teardown-smoke-v131
+gh pr create --base main --head chore/teardown-smoke-v131 \
+  --title "chore: tear down v1.3.1 smoke-v131 validation app" \
+  --body "Removes manifests for the smoke-v131 v1.3.1 validation app per v1 spec §8 corrected decommission order."
+```
+
+- [ ] **Step 2: USER merges teardown PR**
+
+```bash
+sleep 30
+kubectl -n argo-cd get application smoke-v131 2>&1
+# Expected: NotFound
+```
+
+- [ ] **Step 3: Delete orphaned XR + namespace**
+
+(Crossplane's per-app Application is gone; namespaced resources are pruned by ArgoCD. AWS resources should be pruned by ArgoCD via per-app Application's prune behavior. Verify.)
+
+```bash
+kubectl -n smoke-v131 delete xapplication smoke-v131 2>&1 || echo "(XR already gone via ArgoCD prune)"
+kubectl delete namespace smoke-v131
+```
+
+- [ ] **Step 4: AC-10 verify teardown removes everything**
+
+```bash
+# Bucket should be gone (forceDestroy emptied + deleted)
+aws s3 ls s3://852893458518-smoke-v131/ 2>&1
+# Expected: "NoSuchBucket"
+
+# IAM resources should be gone
+aws iam get-user --user-name smoke-v131-app 2>&1 | head -3
+# Expected: "NoSuchEntity"
+
+# Vault entry should be gone (deletionPolicy:Delete on PushSecret)
+kubectl -n vault get secret vault-unseal-keys -o jsonpath='{.data.root-token}' | base64 -d | kubectl -n vault exec -i vault-0 -- sh -c '
+  VAULT_TOKEN=$(cat); export VAULT_TOKEN
+  vault kv list k8s-secrets/smoke-v131 2>&1
+'
+# Expected: "No value found"
+```
+
+---
+
+## Phase 5 — Close-out
+
+### Task 5.1: Append Run Notes to this plan
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md` (this file)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b docs/v1.3.1-close-out
+```
+
+- [ ] **Step 2: Append `## Run Notes` to end of file**
+
+Use the same template as v1.2 / v1.2.1 close-out PRs:
+
+```markdown
+
+## Run Notes (YYYY-MM-DD)
+
+**Outcome:** v1.3.1 of the IDP shipped. `s3Needed:true` triggers Backstage scaffolder to emit `aws-resources.yaml` containing 5 cluster-scoped AWS resources; Composition handles workload-side ESO config + envFrom + AWS env var injection. Workloads receive AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, BUCKET_NAME env vars automatically. AWS SDK auto-detects creds — zero workload code changes for S3 access.
+
+**E2E validation** (`smoke-v131`, s3Needed:true, dbNeeded:false):
+
+- ✅ Scaffold PR had 3 files (incl. aws-resources.yaml with 5 resources)
+- ✅ Bucket created at `s3://852893458518-smoke-v131/`
+- ✅ Vault path populated at `k8s-secrets/smoke-v131/aws-creds`
+- ✅ Deployment envFrom: smoke-v131-aws + AWS_REGION + BUCKET_NAME env vars
+- ✅ Workload exec'd `aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v131-test.txt` — succeeded
+- ✅ Backstage Crossplane tab showed all 5 AWS resources alongside Deployment/Service/Ingress
+- ✅ Teardown: bucket emptied + deleted (forceDestroy), IAM resources cleaned up, Vault entry GC'd
+- ✅ Goldens still PASS for xr-minimal + xr-with-db (regression check)
+
+**Bugs caught during execution** (delete subsection if none):
+
+| # | Bug | Fix PR |
+|---|---|---|
+| 1 | <one-line description> | arigsela/kubernetes#<num> |
+
+**v1.4 / v2 follow-up candidates:**
+- v1.4 — Additional AWS resources (SQS, SNS) via same Option B pattern; bucket sub-fields (versioning, lifecycle); custom IAM policy override
+- v2 — Vault dynamic credentials (CNPG + AWS); IRSA / Pod Identity exploration
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| docs/idp-v1.3.1-spec | docs: v1.3.1 design spec + plan |
+| feat/idp-v1.3.1-aws-eso-config (kubernetes) | feat(composition): v1.3.1 AWS Vault round-trip via Option B |
+| feat/idp-v1.3.1-aws-resources (backstage) | feat(scaffolder): v1.3.1 emit AWS resources as raw manifests |
+| chore/bump-backstage-v1.3.1 (or tag-reuse skipped) | chore(backstage): bump image tag |
+| chore/teardown-smoke-v131 | chore: tear down smoke validation app |
+| docs/v1.3.1-close-out (this branch) | docs: v1.3.1 run notes |
+
+**v1.3.1 status: shipped.**
+```
+
+- [ ] **Step 3: Commit + push + open PR**
+
+```bash
+git add docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md
+git commit -m "docs(idp): v1.3.1 close-out run notes"
+git push -u origin docs/v1.3.1-close-out
+gh pr create --base main --title "docs(idp): v1.3.1 close-out run notes" \
+  --body "Captures v1.3.1 outcome, smoke-v131 e2e validation, bug-fix PRs (if any), and v1.4/v2 follow-up candidates."
+```
+
+---
+
+## Plan execution mode
+
+**Recommended:** subagent-driven-development per v1.2 / v1.2.1 / v1.3 precedent.
+
+Phase boundaries:
+- **Phase 1 (Tasks 1.1–1.8)** — single subagent: TDD on goldens + Composition Python re-add + commit + open PR
+- **Phase 2 (Tasks 2.1–2.4)** — separate subagent (different repo): scaffolder template + new content-k8s file + commit + open PR
+- **Phase 3** — **HARD PAUSE** for subagent execution (user-merge gates + image rebuild + Vault role binding)
+- **Phase 4** — user-driven smoke validation (form submission, PR review, AWS verification, S3 write test)
+- **Phase 5** — final close-out subagent
+
+Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents (or sequentially per v1.3 / v1.2.1 precedent).

--- a/docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
+++ b/docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
@@ -1,0 +1,430 @@
+# IDP v1.3.1 — AWS S3 + IAM via Raw Manifests (Option B) — Design
+
+**Date:** 2026-05-02
+**Author:** Ari Sela (with Claude)
+**Status:** Approved for plan
+**Iteration:** v1.3.1 (re-attempt of v1.3 with Option B architecture after v1.3 hit a Crossplane v2 architectural blocker)
+**Prerequisite:** [IDP v1.2.1](./2026-05-01-idp-v1.2.1-ergonomic-fixes-design.md) shipped + [v1.3 paused notes](../plans/2026-05-01-idp-v1.3-aws-resources.md) understood
+
+## 1. Goal
+
+Same end-state as v1.3: developer scaffolds an app via Backstage with `s3Needed:true`; platform provisions a dedicated S3 bucket, IAM user, S3-RW policy, and access key; AWS credentials are routed through Vault; workload receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BUCKET_NAME` env vars automatically. AWS SDK auto-detects credentials. Zero application code changes.
+
+**Different architecture:** v1.3 attempted to have the Crossplane Composition emit cluster-scoped AWS resources directly. Crossplane v2 enforces a strict scope-mismatch check (namespaced XR cannot compose cluster-scoped resources), which invalidated that approach. v1.3.1 pivots to **raw manifests via the Backstage scaffolder** (matching the existing `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` patterns proven on this cluster). Composition stays out of AWS resource emission entirely; only handles workload-side envFrom + AWS env var injection + the namespaced ESO config.
+
+## 2. Current state (post-v1.3 revert)
+
+| Component | Shape today |
+|---|---|
+| `s3Needed: bool` XRD field | Present (kept post-v1.3 revert as no-op) |
+| Composition Python | At v1.2.1 baseline state (PR #234 reverted v1.3's Composition additions) |
+| Crossplane RBAC | At v1.2.1 baseline (no AWS API groups granted) |
+| Backstage scaffolder | `s3Needed` form input + content-k8s XR rendering merged via [arigsela/backstage#11](https://github.com/arigsela/backstage/pull/11) — currently no-op since Composition ignores the flag |
+| Backstage image | Currently has the v1.3 scaffolder template (s3Needed form + XR rendering) but no aws-resources.yaml content-k8s file |
+| AWS providers | provider-aws-s3 v2.5.3 + provider-aws-iam v2.5.3 + upbound-provider-family-aws v2.5.3 — all installed, healthy |
+| Reference patterns | `base-apps/loki-aws-infrastructure/` + `base-apps/argo-workflows-aws-infrastructure/` use raw manifests with selector-based cross-references; proven on cluster |
+| Vault `app-namespace-rw` policy | Live; reusable for v1.3.1 namespace bindings |
+
+## 3. Target state — the wire
+
+```
+  XApplication <name>            ┌─── Backstage scaffolder emits ────────────────┐
+  ──────────────────             │  base-apps/<name>/aws-resources.yaml          │
+  spec.s3Needed: true            │  (conditional on s3Needed:true; multi-doc)    │
+       │                         │                                                │
+       │                         │  Cluster-scoped (managed by ArgoCD):          │
+       │                         │   • Bucket <account-id>-<name>                │
+       │                         │     forceDestroy: true                        │
+       │                         │   • User <name>-app                            │
+       │                         │   • Policy <name>-s3-policy (S3 RW)           │
+       │                         │   • UserPolicyAttachment (Policy → User)      │
+       │                         │   • AccessKey <name>-app-key                  │
+       │                         │     writes K8s Secret <name>-aws-key          │
+       │                         │   All carry TeraSky annotations →             │
+       │                         │     visible in Backstage Crossplane tab       │
+       │                         └────────────────────────────────────────────────┘
+       │
+       │  Composition reads s3Needed flag, emits:
+       ▼
+  ┌──── Composition emits (namespaced, all in app's ns) ──────────┐
+  │  • SecretStore vault-backend     (shared with db path; emit-once if either flag true) │
+  │  • PushSecret <name>-aws-push    (selects <name>-aws-key, pushes to k8s-secrets/<name>/aws-creds) │
+  │  • ExternalSecret <name>-aws     (reads from Vault, projects K8s Secret <name>-aws) │
+  │  • Deployment <name>             (envFrom <name>-aws + AWS_REGION/BUCKET_NAME env vars) │
+  │  • Service, Ingress              (unchanged from v1.x baseline) │
+  └────────────────────────────────────────────────────────────────┘
+```
+
+**Vault path layout** (when both `dbNeeded` and `s3Needed` are true):
+
+```
+k8s-secrets/<name>/
+  ├── db                 (8 keys; from CNPG via PushSecret, v1.2)
+  └── aws-creds          (2 keys: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY; v1.3.1)
+```
+
+**Workload's effective env vars** (when `s3Needed:true`):
+
+```
+AWS_ACCESS_KEY_ID       (envFrom <name>-aws — Vault round-trip)
+AWS_SECRET_ACCESS_KEY   (envFrom <name>-aws — Vault round-trip)
+AWS_REGION              (direct env var: us-east-2)
+BUCKET_NAME             (direct env var: <account-id>-<name>)
+```
+
+AWS SDK auto-detects credentials. Zero application code changes.
+
+**Invariants preserved:**
+- v1, v1.1, v1.2, v1.2.1 patterns — all unchanged
+- chores-tracker untouched
+- `s3Needed:false` apps render byte-identical to today
+- Apps with both `dbNeeded` AND `s3Needed` set get BOTH cred paths (v1.2 db + v1.3.1 AWS)
+- XApplication XRD apiVersion stays `v1alpha1`
+- Crossplane AWS providers unchanged (no version bump)
+- ESO operator unchanged
+- The `app-namespace-rw` Vault policy from v1.2 already covers `k8s-secrets/<ns>/aws-creds` (sub-path of `<ns>/*`)
+
+## 4. Components
+
+| # | Artifact | Repo | Path | Action |
+|---|---|---|---|---|
+| 1 | Composition Python: SecretStore generalization | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-application.yaml` | Re-add `needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))` (reverted in PR #234) |
+| 2 | Composition Python: 2 ESO helpers | (same file) | Re-add `make_aws_push_secret` + `make_aws_external_secret` (reverted in PR #234, restored verbatim) |
+| 3 | Composition Python: AWS constants | (same file) | Re-add `AWS_ACCOUNT_ID = "852893458518"` + `AWS_REGION = "us-east-2"` |
+| 4 | Composition Python: `make_deployment` updates | (same file) | Re-add `aws_secret` parameter + envFrom dynamic build + `AWS_REGION`/`BUCKET_NAME` static env injection (reverted in PR #234) |
+| 5 | `compose()` wiring | (same file) | When `s3Needed:true`, emit SecretStore + PushSecret + ExternalSecret + pass `aws_secret` to `make_deployment`. **NO AWS resources emitted** (those are scaffolder-emitted) |
+| 6 | Crossplane RBAC | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-rbac.yaml` | **No change** — Crossplane SA does NOT manage AWS resources in Option B; ArgoCD applies them, provider-aws-* managers handle them with their own RBAC |
+| 7 | Test fixture (re-create) | `arigsela/kubernetes` | `tests/composition/xr-with-s3.yaml` | Re-create (deleted in PR #234) |
+| 8 | Test golden (re-create, **REDUCED scope**) | `arigsela/kubernetes` | `tests/composition/expected-xr-with-s3.yaml` | Re-create with **7 documents** (XR + Deployment + Service + Ingress + SecretStore + PushSecret + ExternalSecret). NO Bucket/User/Policy/UserPolicyAttachment/AccessKey (those are scaffolder-emitted) |
+| 9 | Existing test goldens unchanged | `arigsela/kubernetes` | `tests/composition/expected-xr-{minimal,with-db}.yaml` | **No change** |
+| 10 | Backstage scaffolder: NEW aws-resources.yaml content-k8s file | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml` | NEW file with Nunjucks-conditional 5 AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey) carrying TeraSky annotations + cross-resource selector labels |
+| 11 | Backstage scaffolder: bucketName in fetch.values | `arigsela/backstage` | `examples/templates/application/template.yaml` | Add `bucketName: 852893458518-${{ parameters.name | trim }}` to `steps.fetch.input.values` mapping |
+| 12 | Backstage scaffolder: form input | `arigsela/backstage` | `examples/templates/application/template.yaml` | **No change** — `s3Needed` form field already merged in arigsela/backstage#11 |
+| 13 | Backstage image | `arigsela/backstage` | n/a | Image rebuild needed (new content-k8s file + bucketName in fetch.values) |
+| 14 | XApplication XRD | `arigsela/kubernetes` | `base-apps/crossplane-compositions/xrd-application.yaml` | **No change** — `s3Needed` field already present (kept post-revert) |
+| 15 | Crossplane AWS providers | n/a | n/a | **No change** — already installed |
+
+**Things explicitly NOT in v1.3.1:**
+- ❌ Composition-emitted AWS resources (the v1.3 architectural mistake; rejected at design time)
+- ❌ Custom IAM policies (single templated S3-RW; v1.4+ as opt-in override)
+- ❌ Multiple buckets per app
+- ❌ Bucket versioning, CORS, lifecycle rules
+- ❌ SQS, SNS, RDS, etc. (v1.4+; same Option B pattern would apply)
+- ❌ Cross-account access, multi-region buckets
+- ❌ IRSA / Pod Identity (v2)
+- ❌ Vault dynamic credentials (v2)
+- ❌ Migration of existing apps (none have `s3Needed:true`)
+- ❌ ArgoCD sync wave annotations on AWS resources (matches loki/argo-workflows existing pattern; not needed)
+- ❌ Bucket retention opt-out (`s3.preserveBucket:true`) — v1.4+ if requested
+
+## 5. Composition Python additions (re-add from v1.3 attempt)
+
+Most code is verbatim from the reverted PR #231; the ONLY removed parts are the 4 AWS resource helpers (`make_s3_bucket`, `make_iam_user`, `make_iam_user_policy`, `make_iam_access_key`) and the AWS resource emission in `compose()`. Everything else returns.
+
+### 5.1 Constants (re-add)
+
+```python
+AWS_ACCOUNT_ID = "852893458518"
+AWS_REGION = "us-east-2"
+```
+
+### 5.2 ESO helpers (re-add verbatim)
+
+`make_aws_push_secret` and `make_aws_external_secret` — see [v1.3 spec §6.2 + §6.3](./2026-05-01-idp-v1.3-aws-resources-design.md) for full code. They:
+- PushSecret reads `<name>-aws-key` (created by scaffolder's AccessKey resource), pushes to Vault path `k8s-secrets/<namespace>/aws-creds` with key remap (`attribute.id` → `AWS_ACCESS_KEY_ID`, `attribute.secret` → `AWS_SECRET_ACCESS_KEY`)
+- ExternalSecret reads from Vault, projects to K8s Secret `<name>-aws`
+
+### 5.3 `make_deployment` updates (re-add)
+
+Signature: `def make_deployment(..., db_secret, aws_secret, health_path, annotations)` (replaces v1.2.1's `env_from_secret` with two separate params).
+
+Body: dynamic envFrom build + AWS env var injection — see [v1.3 spec §7.3](./2026-05-01-idp-v1.3-aws-resources-design.md) for full code.
+
+### 5.4 `compose()` additions
+
+```python
+needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+if needs_secret_store:
+    resource.update(rsp.desired.resources["secretstore"], make_secret_store(...))
+
+if spec.get("dbNeeded"):
+    # ... existing v1.2 dbcluster + pushsecret + externalsecret unchanged ...
+
+if spec.get("s3Needed"):
+    resource.update(
+        rsp.desired.resources["awspushsecret"],
+        make_aws_push_secret(name, namespace,
+                             annotations=std_annotations(xr_annotations, "awspushsecret")),
+    )
+    resource.update(
+        rsp.desired.resources["awsexternalsecret"],
+        make_aws_external_secret(name, namespace,
+                                 annotations=std_annotations(xr_annotations, "awsexternalsecret")),
+    )
+    # NOTE: NO Bucket/User/Policy/UserPolicyAttachment/AccessKey emission here.
+    # Those are scaffolder-emitted raw manifests in base-apps/<name>/aws-resources.yaml.
+```
+
+```python
+# Inside compose() — make_deployment call:
+db_secret = f"{name}-db" if spec.get("dbNeeded") else None
+aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
+resource.update(
+    rsp.desired.resources["deployment"],
+    make_deployment(name, namespace, spec["image"], port, replicas,
+                    spec.get("env", []), db_secret, aws_secret,
+                    health_path=spec.get("healthCheckPath", "/"),
+                    annotations=std_annotations(xr_annotations, "deployment")),
+)
+```
+
+## 6. New scaffolder file: `aws-resources.yaml`
+
+Path: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml`
+
+Conditional Nunjucks wrapper (`{%- if values.s3Needed %}...{%- endif %}`) means the file is empty when `s3Needed:false`. Backstage's scaffolder skips empty files.
+
+When `s3Needed:true`, emit 5 cluster-scoped AWS resources, each with:
+- TeraSky annotations: `add-to-catalog: "true"`, `owner`, `component-type: service`, `lifecycle: experimental`, `system: platform`, `backstage.io/source-location` — same set as v1.1 Composition-emitted resources, ensures AWS resources appear in Backstage's Crossplane tab
+- Cross-resource selector labels: `app.kubernetes.io/name: <name>`, `app.kubernetes.io/component: <kind>`, `app.kubernetes.io/managed-by: crossplane`
+
+### 6.1 Resource shapes
+
+**Bucket** (named `<account-id>-<name>` for global uniqueness; `forceDestroy: true` for clean teardown):
+```yaml
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: ${{ values.bucketName }}
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket
+    app.kubernetes.io/managed-by: crossplane
+  annotations: # ... TeraSky set ...
+spec:
+  forProvider:
+    region: us-east-2
+    forceDestroy: true
+  providerConfigRef:
+    name: default
+```
+
+**User** (per-app dedicated IAM user named `<name>-app`):
+```yaml
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: ${{ values.name }}-app
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-user
+    app.kubernetes.io/managed-by: crossplane
+spec:
+  forProvider:
+    tags:
+      ManagedBy: crossplane
+      App: ${{ values.name }}
+  providerConfigRef:
+    name: default
+```
+
+**Policy** (standalone Policy with templated S3-RW-on-own-bucket; NOT inline UserPolicy which doesn't exist):
+```yaml
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: ${{ values.name }}-s3-policy
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy
+    app.kubernetes.io/managed-by: crossplane
+spec:
+  forProvider:
+    description: "S3 RW on ${{ values.name }}'s own bucket"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+          "Resource": [
+            "arn:aws:s3:::${{ values.bucketName }}",
+            "arn:aws:s3:::${{ values.bucketName }}/*"
+          ]
+        }]
+      }
+  providerConfigRef:
+    name: default
+```
+
+**UserPolicyAttachment** (binds Policy to User via selector labels):
+```yaml
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: ${{ values.name }}-s3-attachment
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy-attachment
+    app.kubernetes.io/managed-by: crossplane
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-policy
+    userRef:
+      name: ${{ values.name }}-app
+  providerConfigRef:
+    name: default
+```
+
+**AccessKey** (creates K8s Secret in app's namespace with `attribute.id` + `attribute.secret`):
+```yaml
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: ${{ values.name }}-app-key
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: access-key
+    app.kubernetes.io/managed-by: crossplane
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-user
+  writeConnectionSecretToRef:
+    name: ${{ values.name }}-aws-key
+    namespace: ${{ values.name }}
+  providerConfigRef:
+    name: default
+```
+
+### 6.2 Cross-resource selector strategy
+
+UserPolicyAttachment uses `policyArnSelector.matchLabels` (resolves Policy by labels) + `userRef.name` (resolves User by name). AccessKey uses `userSelector.matchLabels` (resolves User by labels). **Crossplane resolves these at apply time** — no hard ARN references; no sync waves needed. This matches `loki-aws-infrastructure/iam-policy-attachment.yaml` and `argo-workflows-aws-infrastructure/access-key.yaml` patterns proven on this cluster.
+
+### 6.3 Scaffolder template change: add `bucketName` to fetch.values
+
+In `examples/templates/application/template.yaml`, the `steps.fetch.input.values` block needs a new computed value:
+
+```yaml
+values:
+  # ... existing values (name, namespace, owner, image, host, etc.) ...
+  bucketName: 852893458518-${{ parameters.name | trim }}
+```
+
+This value is used by `aws-resources.yaml` for both the Bucket name and the IAM Policy's bucket ARN.
+
+## 7. Failure modes
+
+| # | Failure | Symptom | Diagnosis | Fix |
+|---|---|---|---|---|
+| 1 | Bucket name collision | Bucket stuck in `Creating` with AWS error | `kubectl describe bucket <account>-<name>` shows `BucketAlreadyExists` | Choose different `name` for the XR; re-scaffold |
+| 2 | AccessKey Secret keys differ from assumed `attribute.id/attribute.secret` | PushSecret 404 on `secretKey: attribute.id` | Inspect existing AccessKey Secret on cluster (e.g., argo-workflows-s3-creds) | Update `make_aws_push_secret` data mapping; argo-workflows pattern confirms |
+| 3 | Bootstrap chain stuck | `secret <name>-aws not found` for ~60-120s | Bucket → User → AccessKey → ESO PushSecret → Vault → ESO ExternalSecret → Secret takes time | **Expected** during first deploy; documented; Pod CrashLoopBackOff resolves once chain completes |
+| 4 | Bucket force-destroy data loss | After teardown, bucket contents gone | `forceDestroy: true` is by design | **Documented prominently** in scaffolder form description + spec §7 |
+| 5 | Vault role binding missing | PushSecret 403 on first sync | Same as v1.2 issue | User must create per-namespace Vault role binding the existing `app-namespace-rw` policy BEFORE merging onboarding PR |
+| 6 | Crossplane selector resolution timing | UserPolicyAttachment / AccessKey stuck `Pending` for ~10-30s | Crossplane controllers wait until label-matched References resolve | Self-healing — Crossplane retries automatically |
+| 7 | IAM eventual consistency on first AWS API call | Workload's `aws s3 ls` returns `InvalidAccessKeyId` for ~5-10s | AWS IAM propagation latency | Self-healing |
+| 8 | Teardown order issues | After PR-delete, AccessKey/User refuses to delete | Crossplane providers retry deletion | Self-healing via Crossplane controller cooperation; takes 30-60s |
+| 9 | Pre-flight CRD verification skipped | First v1.3.1 app fails because UserPolicyAttachment kind missing | Unverified CRD availability | Phase 0 P.3 is **HARD GATE** — verify ALL 5 AWS CRDs by name |
+
+## 8. Acceptance criteria
+
+| AC | Check | How to verify |
+|---|---|---|
+| 1 — Pre-flight | All 5 AWS CRDs present; provider-aws healthy | `kubectl get crd ...` + `kubectl get providers` |
+| 2 — Composition goldens pass | xr-with-s3 (7 docs), xr-minimal, xr-with-db all PASS | `./tests/composition/render.sh xr-with-s3 / xr-minimal / xr-with-db` exit 0 |
+| 3 — Scaffolder emits aws-resources.yaml | `s3Needed:true` form → PR with 3 files (incl. aws-resources.yaml with 5 AWS resources) | Inspect PR diff |
+| 4 — Scaffolder skips aws-resources.yaml | `s3Needed:false` form → PR with 2 files (no aws-resources.yaml) | Inspect PR diff |
+| 5 — Bucket created in AWS | `aws s3 ls s3://852893458518-smoke-v131/` returns OK | AWS CLI |
+| 6 — Vault path populated | `vault kv get -mount=k8s-secrets smoke-v131/aws-creds` returns 2 keys | Vault CLI |
+| 7 — envFrom + env vars correct | Deployment has `envFrom: <name>-aws` + `AWS_REGION` + `BUCKET_NAME` env vars | `kubectl get deployment ... -o yaml` |
+| 8 — Workload writes to bucket | `kubectl exec -- aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v131-test.txt` succeeds | Manual exec test |
+| 9 — Backstage Crossplane tab shows AWS resources | smoke-v131 entity's Crossplane tab includes Bucket, User, Policy, UserPolicyAttachment, AccessKey | Visual check |
+| 10 — Teardown removes everything | After PR-delete + master-app prune: bucket gone, IAM resources gone, Vault entry gone | AWS CLI + `vault kv get` returns NotFound |
+| 11 — `s3Needed:false` apps unaffected | xr-minimal goldens PASS | Goldens check |
+| 12 — chores-tracker untouched | Existing apps still healthy | Spot-check |
+
+## 9. Sequencing
+
+```
+Phase 0 — Pre-flight
+   • Render harness baseline (xr-minimal + xr-with-db PASS)
+   • Verify v1.3 revert (PR #234) merged on main
+   • Verify all 5 AWS CRDs exist by NAME (lesson from v1.3):
+     buckets.s3.aws.upbound.io, users.iam.aws.upbound.io,
+     policies.iam.aws.upbound.io, userpolicyattachments.iam.aws.upbound.io,
+     accesskeys.iam.aws.upbound.io
+   • Verify provider-aws + ProviderConfig healthy
+       │
+       ▼
+Phase 1 (arigsela/kubernetes — single PR) ━━━━━━ Phase 2 (arigsela/backstage — single PR)
+   • Re-add Composition AWS code:               • Add NEW content-k8s file:
+     - SecretStore generalization                 aws-resources.yaml
+     - AWS_ACCOUNT_ID/AWS_REGION                  (Nunjucks-conditional;
+     - make_aws_push_secret + external_secret    5 AWS resources with TeraSky
+     - make_deployment aws_secret + AWS env vars  annotations + selector labels)
+     - compose() s3Needed branch (ESO ONLY)      • Add bucketName to fetch.values
+   • Re-create xr-with-s3 fixture                  in template.yaml
+   • Re-create expected-xr-with-s3 (7 docs)
+   • → Subagent-friendly, full TDD              • → Subagent-friendly
+        │                                                      │
+        └────────────────┬─────────────────────────────────────┘
+                         ▼
+                Phase 3 — USER GATE
+   • User merges both PRs
+   • User rebuilds Backstage image
+   • User pre-creates Vault role for smoke-v131 namespace
+                         │
+                         ▼
+Phase 4 — Smoke validation (smoke-v131)
+   • Scaffold via Backstage with s3Needed:true (no DB)
+     image: amazon/aws-cli:latest (so we can exec aws s3 cp inside Pod)
+   • Verify scaffold PR has 3 files (incl. aws-resources.yaml)
+   • Merge → AWS resources created, ESO bootstrap chain unwinds
+   • Verify ACs 5-9 (bucket, Vault, envFrom, exec, Backstage UI)
+   • Tear down per v1 corrected §8 order
+   • Verify AC-10 (everything GC'd)
+                         │
+                         ▼
+Phase 5 — Close-out
+   • Run notes appended
+```
+
+**Estimated time:** ~75 min including image rebuild gate.
+
+## 10. Decision rationale
+
+The 4 v1.3.1-specific decisions, captured for plan + future re-execution:
+
+| Q | Decision | Why |
+|---|---|---|
+| Q1 — SecretStore ownership | **Composition** (A) | SecretStore is per-namespace ESO config (not AWS resource); avoids dbNeeded+s3Needed conflict on shared resource name; pattern symmetry with v1.2 |
+| Q2 — ESO Push/External Secret ownership | **Composition** (A) | Pattern symmetry with v1.2 (Composition handles all per-namespace ESO config); cross-flow dependency exists either way; cleaner scaffolder template |
+| Q3 — Teardown order | **No sync waves; rely on ArgoCD prune + Crossplane controllers** (A) | Matches loki + argo-workflows existing patterns proven on cluster; Crossplane provider controllers handle AWS-side dependency ordering (UserPolicyAttachment → User succeeds; etc.); v1 §8 corrected order ensures atomic per-app Application prune |
+| Q4 — File structure | **Single multi-doc `aws-resources.yaml` with TeraSky annotations** (A) | UX consistency with v1.1+ (AWS resources in Backstage's Crossplane tab); cleanest scaffolder template; multi-doc YAML is standard |
+
+Plus 7 decisions inherited verbatim from v1.3 brainstorming (Q1-Q7 of the v1.3 spec): scope (S3+IAM only), XRD shape (s3Needed:bool extension), workload AWS auth (IAM user + access key + Vault round-trip), key naming (AWS SDK env-var convention), IAM permission model (single templated S3-RW), teardown semantic (forceDestroy:true), bucket naming (account-prefix).
+
+## 11. v1.x roadmap
+
+| Iteration | Goal | Status |
+|---|---|---|
+| v1 | Scaffolder → XR → Composition → app live | Shipped (2026-04-28) |
+| v1.1 | Auto-ingestion via TeraSky plugins | Shipped (2026-04-29) |
+| v1.2 | Vault round-trip for DB credentials | Shipped (2026-05-01) |
+| v1.2.1 | Ergonomic close-out | Shipped (2026-05-01) |
+| v1.3 | AWS S3+IAM via Composition (Option A) | **PAUSED** (2026-05-02) — architectural blocker |
+| **v1.3.1** | **AWS S3+IAM via raw manifests (Option B; this spec)** | **In progress (2026-05-02)** |
+| v1.4 | Additional AWS resources (SQS, SNS) via same Option B pattern; bucket sub-fields (versioning, lifecycle); custom IAM policy override | Future |
+| v2 | Vault dynamic creds (CNPG + AWS); IRSA / Pod Identity | Future |
+
+## 12. Lessons applied from v1.3
+
+- **CRDs verified by name, not just shape.** v1.3 spec assumed inline `UserPolicy` CRD existed; it doesn't. v1.3.1 Phase 0 P.3 enumerates all 5 expected CRDs by name and verifies each.
+- **Architecture proven on cluster before TDD.** v1.3 passed `crossplane render` goldens but failed at `kubectl apply` time due to scope-mismatch. v1.3.1 mirrors the proven loki/argo-workflows raw-manifest pattern; no risk of similar surprises.
+- **Smaller blast radius.** v1.3.1 reuses the v1.3 attempt's already-written and reviewed Composition code (just re-added post-revert), focusing implementation effort on the new aws-resources.yaml content-k8s file.


### PR DESCRIPTION
## Summary

Brings v1.3.1 brainstorming + planning out of conversation context into the repo. Spec captures the 4 v1.3.1-specific decisions (Q1-Q4) plus 7 carried over from v1.3 brainstorming. Plan turns them into bite-sized executable tasks ready for subagent-driven-development.

No code changes — pure docs.

## What's in this PR

| File | Lines | Purpose |
|---|---|---|
| docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md | 430 | Approved design spec |
| docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md | 1500+ | 5-phase implementation plan |

## v1.3.1 in one paragraph

Re-attempts v1.3's AWS S3+IAM provisioning with **Option B architecture**: Backstage scaffolder emits cluster-scoped AWS resources as raw manifests in `base-apps/<name>/aws-resources.yaml` (matches existing `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` patterns). Composition stays out of AWS resource emission entirely; only handles workload-side envFrom + AWS env var injection + the namespaced ESO config (SecretStore + PushSecret + ExternalSecret). Workload receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (via Vault), `AWS_REGION`, `BUCKET_NAME` (direct env vars) — zero application code changes; AWS SDK auto-detects.

## Decisions captured

**4 v1.3.1-specific decisions (Q1-Q4):**

| Q | Decision |
|---|---|
| SecretStore ownership | Composition (avoids name conflicts; pattern symmetry with v1.2) |
| ESO Push/External Secret ownership | Composition (pattern symmetry; cross-flow dependency exists either way) |
| Teardown order | No sync waves; ArgoCD prune + Crossplane controllers (matches loki/argo-workflows) |
| File structure | Single multi-doc `aws-resources.yaml` with TeraSky annotations |

**7 decisions inherited from v1.3 brainstorming** (scope, XRD shape, workload AWS auth, key naming, IAM permission model, teardown semantic, bucket naming).

## Why Option B (vs v1.3's Option A)

v1.3 attempted Composition-managed AWS resources but Crossplane v2 enforces a strict scope-mismatch check — namespaced XApplication XR cannot compose cluster-scoped resources. v1.3.1 sidesteps this by having scaffolder emit AWS resources as raw manifests (proven pattern on this cluster).

## Implementation scope

- ~75 min implementation budget
- Two PRs: arigsela/kubernetes (re-add Composition AWS code + tests) and arigsela/backstage (new content-k8s aws-resources.yaml + bucketName in fetch.values)
- Phase 3 USER GATE: image rebuild + Vault role binding
- Phase 4 smoke validation: scaffold smoke-v131 with `amazon/aws-cli` image; exec `aws s3 cp` inside Pod to validate AWS access end-to-end

## Lessons applied from v1.3

- Phase 0 P.3 verifies CRDs by NAME (not just shape) — the v1.3 lesson
- Architecture proven on cluster before TDD — v1.3.1 mirrors loki/argo-workflows patterns

## Test plan

- [x] Spec brainstorming complete (Q1-Q4 approved)
- [x] Spec self-reviewed for placeholders + ambiguity
- [x] Plan self-reviewed against spec coverage + type consistency
- [ ] User reviews this PR
- [ ] User merges → execution begins per chosen mode (subagent-driven recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)