### PR TITLE
feat(composition): v1.3.1 AWS Vault round-trip via Option B (raw manifests)

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -53,6 +53,12 @@ spec:
           DB_SECRET_KEYS = ["dbname", "host", "jdbc-uri", "password",
                             "pgpass", "port", "uri", "username"]
 
+          # AWS account + region constants. Confirmed from existing default
+          # ProviderConfig (status shows 10 resources using it) + chores-tracker-backend
+          # ECR image refs. Single account for all v1.x infra.
+          AWS_ACCOUNT_ID = "852893458518"
+          AWS_REGION = "us-east-2"
+
           def make_secret_store(name, namespace, annotations):
               return {
                   "apiVersion": "external-secrets.io/v1beta1",
@@ -148,7 +154,92 @@ spec:
                   },
               }
 
-          def make_deployment(name, namespace, image, port, replicas, env_list, env_from_secret, annotations, health_path):
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+                      "secretStoreRefs": [
+                          {"name": "vault-backend", "kind": "SecretStore"},
+                      ],
+                      "selector": {
+                          "secret": {"name": f"{name}-aws-key"},
+                      },
+                      "data": [
+                          {
+                              "match": {
+                                  "secretKey": "attribute.id",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_ACCESS_KEY_ID",
+                                  },
+                              },
+                          },
+                          {
+                              "match": {
+                                  "secretKey": "attribute.secret",
+                                  "remoteRef": {
+                                      "remoteKey": f"{namespace}/aws-creds",
+                                      "property": "AWS_SECRET_ACCESS_KEY",
+                                  },
+                              },
+                          },
+                      ],
+                  },
+              }
+
+          def make_aws_external_secret(name, namespace, annotations):
+              """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
+              return {
+                  "apiVersion": "external-secrets.io/v1beta1",
+                  "kind": "ExternalSecret",
+                  "metadata": {
+                      "name": f"{name}-aws",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "15s",
+                      "secretStoreRef": {
+                          "name": "vault-backend",
+                          "kind": "SecretStore",
+                      },
+                      "target": {
+                          "name": f"{name}-aws",
+                          "creationPolicy": "Owner",
+                      },
+                      "data": [
+                          {
+                              "secretKey": "AWS_ACCESS_KEY_ID",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_ACCESS_KEY_ID",
+                              },
+                          },
+                          {
+                              "secretKey": "AWS_SECRET_ACCESS_KEY",
+                              "remoteRef": {
+                                  "key": f"{namespace}/aws-creds",
+                                  "property": "AWS_SECRET_ACCESS_KEY",
+                              },
+                          },
+                      ],
+                  },
+              }
+
+          def make_deployment(name, namespace, image, port, replicas, env_list, db_secret, aws_secret, health_path, annotations):
               container = {
                   "name": "app",
                   "image": image,
@@ -166,14 +257,34 @@ spec:
                       "initialDelaySeconds": 5, "periodSeconds": 10,
                   },
               }
-              if env_list:
-                  container["env"] = [{"name": e["name"], "value": e["value"]} for e in env_list]
-              if env_from_secret:
-                  container.setdefault("env", []).append({
+              # Build envFrom dynamically based on what the app needs
+              env_from_blocks = []
+              if db_secret:
+                  env_from_blocks.append({"secretRef": {"name": db_secret}})
+              if aws_secret:
+                  env_from_blocks.append({"secretRef": {"name": aws_secret}})
+
+              # DATABASE_URL env var via secretKeyRef (preserve v1.2 behavior)
+              db_env = []
+              if db_secret:
+                  db_env.append({
                       "name": "DATABASE_URL",
-                      "valueFrom": {"secretKeyRef": {"name": env_from_secret, "key": "uri"}},
+                      "valueFrom": {"secretKeyRef": {"name": db_secret, "key": "uri"}},
                   })
-                  container["envFrom"] = [{"secretRef": {"name": env_from_secret}}]
+
+              # Inject AWS configuration as static env vars
+              aws_env = []
+              if aws_secret:
+                  aws_env.extend([
+                      {"name": "AWS_REGION", "value": AWS_REGION},
+                      {"name": "BUCKET_NAME", "value": f"{AWS_ACCOUNT_ID}-{name}"},
+                  ])
+
+              container_env = list(env_list) + db_env + aws_env
+              if container_env:
+                  container["env"] = container_env
+              if env_from_blocks:
+                  container["envFrom"] = env_from_blocks
               return {
                   "apiVersion": "apps/v1",
                   "kind": "Deployment",
@@ -275,14 +386,15 @@ spec:
               replicas = int(spec.get("replicas", 2))
 
               db_secret = f"{name}-db" if spec.get("dbNeeded") else None
-              env_from  = db_secret
+              aws_secret = f"{name}-aws" if spec.get("s3Needed") else None
 
               resource.update(
                   rsp.desired.resources["deployment"],
                   make_deployment(name, namespace, spec["image"], port,
-                                  replicas, spec.get("env", []), env_from,
-                                  annotations=std_annotations(xr_annotations, "deployment"),
-                                  health_path=spec.get("healthCheckPath", "/")),
+                                  replicas, spec.get("env", []),
+                                  db_secret, aws_secret,
+                                  health_path=spec.get("healthCheckPath", "/"),
+                                  annotations=std_annotations(xr_annotations, "deployment")),
               )
               resource.update(
                   rsp.desired.resources["service"],
@@ -295,6 +407,15 @@ spec:
                                annotations=std_annotations(xr_annotations, "ingress")),
               )
 
+              # SecretStore is shared between db and aws paths — emit once if EITHER is needed
+              needs_secret_store = bool(spec.get("dbNeeded") or spec.get("s3Needed"))
+              if needs_secret_store:
+                  resource.update(
+                      rsp.desired.resources["secretstore"],
+                      make_secret_store(name, namespace,
+                                        annotations=std_annotations(xr_annotations, "secretstore")),
+                  )
+
               if spec.get("dbNeeded"):
                   resource.update(
                       rsp.desired.resources["dbcluster"],
@@ -302,11 +423,8 @@ spec:
                                         instances=1, storage=spec.get("dbStorage", "1Gi"),
                                         annotations=std_annotations(xr_annotations, "dbcluster")),
                   )
-                  resource.update(
-                      rsp.desired.resources["secretstore"],
-                      make_secret_store(name, namespace,
-                                        annotations=std_annotations(xr_annotations, "secretstore")),
-                  )
+                  # NOTE: SecretStore emission moved out — handled by the shared
+                  # `needs_secret_store` block above
                   resource.update(
                       rsp.desired.resources["pushsecret"],
                       make_push_secret(name, namespace,
@@ -317,3 +435,18 @@ spec:
                       make_external_secret(name, namespace,
                                            annotations=std_annotations(xr_annotations, "externalsecret")),
                   )
+
+              if spec.get("s3Needed"):
+                  resource.update(
+                      rsp.desired.resources["awspushsecret"],
+                      make_aws_push_secret(name, namespace,
+                                           annotations=std_annotations(xr_annotations, "awspushsecret")),
+                  )
+                  resource.update(
+                      rsp.desired.resources["awsexternalsecret"],
+                      make_aws_external_secret(name, namespace,
+                                               annotations=std_annotations(xr_annotations, "awsexternalsecret")),
+                  )
+                  # NOTE: NO Bucket/User/Policy/UserPolicyAttachment/AccessKey emission here.
+                  # Those are scaffolder-emitted raw manifests in
+                  # base-apps/<name>/aws-resources.yaml. v1.3.1 architecture (Option B).

--- a/tests/composition/expected-xr-with-s3.yaml
+++ b/tests/composition/expected-xr-with-s3.yaml
@@ -1,0 +1,253 @@
+# tests/composition/expected-xr-with-s3.yaml
+# Sorted by yq -P 'sort_keys(..)'. Keep alphabetic key order.
+---
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  host: smoke-s3-app.arigsela.com
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  port: 8080
+  replicas: 1
+  s3Needed: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: deployment
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-s3-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: crossplane
+        app.kubernetes.io/name: smoke-s3-app
+        backstage.io/kubernetes-id: smoke-s3-app
+    spec:
+      containers:
+        - env:
+            - name: AWS_REGION
+              value: us-east-2
+            - name: BUCKET_NAME
+              value: 852893458518-smoke-s3-app
+          envFrom:
+            - secretRef:
+                name: smoke-s3-app-aws
+          image: nginxinc/nginx-unprivileged:1.25-alpine
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          name: app
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      imagePullSecrets:
+        - name: ecr-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: service
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: smoke-s3-app
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    crossplane.io/composition-resource-name: ingress
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app
+  namespace: platform-smoke
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: smoke-s3-app.arigsela.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: smoke-s3-app
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - smoke-s3-app.arigsela.com
+      secretName: smoke-s3-app-tls
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awsexternalsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws
+  namespace: platform-smoke
+spec:
+  data:
+    - remoteRef:
+        key: platform-smoke/aws-creds
+        property: AWS_ACCESS_KEY_ID
+      secretKey: AWS_ACCESS_KEY_ID
+    - remoteRef:
+        key: platform-smoke/aws-creds
+        property: AWS_SECRET_ACCESS_KEY
+      secretKey: AWS_SECRET_ACCESS_KEY
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    name: smoke-s3-app-aws
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: awspushsecret
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: smoke-s3-app-aws-push
+  namespace: platform-smoke
+spec:
+  data:
+    - match:
+        remoteRef:
+          property: AWS_ACCESS_KEY_ID
+          remoteKey: platform-smoke/aws-creds
+        secretKey: attribute.id
+    - match:
+        remoteRef:
+          property: AWS_SECRET_ACCESS_KEY
+          remoteKey: platform-smoke/aws-creds
+        secretKey: attribute.secret
+  deletionPolicy: Delete
+  refreshInterval: 5m
+  secretStoreRefs:
+    - kind: SecretStore
+      name: vault-backend
+  selector:
+    secret:
+      name: smoke-s3-app-aws-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+    crossplane.io/composition-resource-name: secretstore
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/system: platform
+  labels:
+    app.kubernetes.io/managed-by: crossplane
+    app.kubernetes.io/name: smoke-s3-app
+    backstage.io/kubernetes-id: smoke-s3-app
+  name: vault-backend
+  namespace: platform-smoke
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: platform-smoke
+          serviceAccountRef:
+            name: default
+      path: k8s-secrets
+      server: http://vault.vault.svc.cluster.local:8200
+      version: v2

--- a/tests/composition/xr-with-s3.yaml
+++ b/tests/composition/xr-with-s3.yaml
@@ -1,0 +1,20 @@
+# tests/composition/xr-with-s3.yaml
+# TDD input: XApplication with AWS S3 bucket enabled (no DB).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-s3-app
+  namespace: platform-smoke
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-s3-app
+spec:
+  image: nginxinc/nginx-unprivileged:1.25-alpine
+  host: smoke-s3-app.arigsela.com
+  port: 8080
+  replicas: 1
+  s3Needed: true


### PR DESCRIPTION
## Summary

Implements v1.3.1 — re-attempts v1.3's AWS S3+IAM provisioning with **Option B architecture** (raw manifests via Backstage scaffolder) after v1.3 was paused due to Crossplane v2's namespaced-XR-cannot-compose-cluster-scoped-resources enforcement.

## What this PR contains (Composition side ONLY)

| Change | File | Impact |
|---|---|---|
| Re-add `AWS_ACCOUNT_ID` + `AWS_REGION` constants | `base-apps/crossplane-compositions/composition-application.yaml` | Used by Deployment AWS env var injection |
| Re-add `make_aws_push_secret` + `make_aws_external_secret` helpers | (same file) | ESO Vault round-trip for AWS creds |
| SecretStore generalization | (same file) | Emit-once if `dbNeeded` OR `s3Needed` is true |
| `make_deployment` envFrom + AWS env vars | (same file) | When `aws_secret` is set, injects `<name>-aws` envFrom + `AWS_REGION`/`BUCKET_NAME` static env vars |
| `compose()` s3Needed branch | (same file) | ESO ONLY — NO Bucket/User/Policy/UserPolicyAttachment/AccessKey emission |
| Re-create test fixture + golden | `tests/composition/xr-with-s3.yaml` + `expected-xr-with-s3.yaml` | TDD — 7 documents (NOT 11 like v1.3 attempted; reflects Option B scope) |

## What this PR does NOT contain (Option B = scaffolder side)

The cluster-scoped AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey) are emitted by the Backstage scaffolder as raw manifests in `base-apps/<name>/aws-resources.yaml`. See companion arigsela/backstage PR.

## Test plan

- [x] `./tests/composition/render.sh xr-with-s3` PASS (7 docs: XR + Deployment + Service + Ingress + ExternalSecret + PushSecret + SecretStore)
- [x] `./tests/composition/render.sh xr-minimal` PASS (s3Needed:false unchanged)
- [x] `./tests/composition/render.sh xr-with-db` PASS (db path still works after SecretStore generalization)
- [ ] Companion arigsela/backstage PR for new aws-resources.yaml content-k8s file
- [ ] User rebuilds Backstage image
- [ ] User pre-creates Vault role for smoke-v131 namespace (re-uses v1.2's app-namespace-rw)
- [ ] Smoke validation: scaffold smoke-v131 with `s3Needed:true` (image=amazon/aws-cli:latest); verify scaffold PR has 3 files (incl. aws-resources.yaml); merge → Pod gets envFrom + can `aws s3 cp`

## Things explicitly NOT in v1.3.1 (per spec §10)

- Composition-emitted AWS resources (the v1.3 mistake; rejected)
- Custom IAM policies (single templated S3-RW)
- Multiple buckets, versioning, CORS, lifecycle
- SQS, SNS, RDS (v1.4+)
- IRSA / Pod Identity (v2)
- Vault dynamic credentials (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)