### PR TITLE
feat(smoke-v131): onboard via Crossplane Application

### DIFF
--- a/base-apps/smoke-v131.yaml
+++ b/base-apps/smoke-v131.yaml
@@ -1,0 +1,24 @@
+# ArgoCD Application for smoke-v131
+# Sync wave 10 ensures XRD/Composition land before this app's XR.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: smoke-v131
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/smoke-v131
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: smoke-v131
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/smoke-v131/application-xr.yaml
+++ b/base-apps/smoke-v131/application-xr.yaml
@@ -1,0 +1,24 @@
+# XApplication (Crossplane) for smoke-v131
+# metadata.annotations are read by TeraSky's kubernetes-ingestor and copied
+# onto every composed child by the cluster-side Composition (see
+# arigsela/kubernetes:base-apps/crossplane-compositions/composition-application.yaml).
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XApplication
+metadata:
+  name: smoke-v131
+  namespace: smoke-v131
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  image: amazon/aws-cli:latest
+  host: smoke-v131.arigsela.com
+  port: 8080
+  replicas: 1
+  dbNeeded: false
+  dbStorage: 1Gi
+  s3Needed: true

--- a/base-apps/smoke-v131/aws-resources.yaml
+++ b/base-apps/smoke-v131/aws-resources.yaml
@@ -1,0 +1,142 @@
+
+# AWS resources for smoke-v131 — provisioned via Crossplane provider-aws-s3
+# and provider-aws-iam (cluster-scoped resources, applied by ArgoCD).
+#
+# WARNING: bucket has forceDestroy:true — contents are permanently deleted on
+# teardown. The IAM user + access key are dedicated per-app (not shared).
+#
+# Cross-resource references via Crossplane label selectors (resolved at apply time
+# by the Crossplane controllers; no sync waves needed). Matches the existing
+# loki-aws-infrastructure / argo-workflows-aws-infrastructure pattern.
+
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: 852893458518-smoke-v131
+  labels:
+    app.kubernetes.io/name: smoke-v131
+    app.kubernetes.io/component: bucket
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  forProvider:
+    region: us-east-2
+    forceDestroy: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: smoke-v131-app
+  labels:
+    app.kubernetes.io/name: smoke-v131
+    app.kubernetes.io/component: iam-user
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  forProvider:
+    tags:
+      ManagedBy: crossplane
+      App: smoke-v131
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: smoke-v131-s3-policy
+  labels:
+    app.kubernetes.io/name: smoke-v131
+    app.kubernetes.io/component: iam-policy
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  forProvider:
+    description: "S3 RW on smoke-v131's own bucket"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+          "Resource": [
+            "arn:aws:s3:::852893458518-smoke-v131",
+            "arn:aws:s3:::852893458518-smoke-v131/*"
+          ]
+        }]
+      }
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: smoke-v131-s3-attachment
+  labels:
+    app.kubernetes.io/name: smoke-v131
+    app.kubernetes.io/component: iam-policy-attachment
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        app.kubernetes.io/name: smoke-v131
+        app.kubernetes.io/component: iam-policy
+    userRef:
+      name: smoke-v131-app
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: smoke-v131-app-key
+  labels:
+    app.kubernetes.io/name: smoke-v131
+    app.kubernetes.io/component: access-key
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: group:default/platform-engineering
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/smoke-v131
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        app.kubernetes.io/name: smoke-v131
+        app.kubernetes.io/component: iam-user
+  # Connection secret keys: attribute.id, attribute.secret, username
+  writeConnectionSecretToRef:
+    name: smoke-v131-aws-key
+    namespace: smoke-v131
+  providerConfigRef:
+    name: default


### PR DESCRIPTION
Generated by Backstage `application-template`.
Owner: group:default/platform-engineering
Database: false
