### PR TITLE
fix(composition): correct AWS PushSecret source keys (provider-aws-iam v2.5.3)

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -179,7 +179,7 @@ spec:
                       "data": [
                           {
                               "match": {
-                                  "secretKey": "attribute.id",
+                                  "secretKey": "username",
                                   "remoteRef": {
                                       "remoteKey": f"{namespace}/aws-creds",
                                       "property": "AWS_ACCESS_KEY_ID",
@@ -188,7 +188,7 @@ spec:
                           },
                           {
                               "match": {
-                                  "secretKey": "attribute.secret",
+                                  "secretKey": "password",
                                   "remoteRef": {
                                       "remoteKey": f"{namespace}/aws-creds",
                                       "property": "AWS_SECRET_ACCESS_KEY",

--- a/tests/composition/expected-xr-with-s3.yaml
+++ b/tests/composition/expected-xr-with-s3.yaml
@@ -207,12 +207,12 @@ spec:
         remoteRef:
           property: AWS_ACCESS_KEY_ID
           remoteKey: platform-smoke/aws-creds
-        secretKey: attribute.id
+        secretKey: username
     - match:
         remoteRef:
           property: AWS_SECRET_ACCESS_KEY
           remoteKey: platform-smoke/aws-creds
-        secretKey: attribute.secret
+        secretKey: password
   deletionPolicy: Delete
   refreshInterval: 5m
   secretStoreRefs:


### PR DESCRIPTION
## Summary

Hotfix for v1.3.1: PushSecret was reading from `attribute.id` / `attribute.secret` Secret keys (assumed from stale loki/argo-workflows comments), but upbound provider-aws-iam v2.5.3's AccessKey resource actually writes to `username` (AWS access key ID, 20 bytes) and `password` (secret access key, 40 bytes).

## How discovered

v1.3.1 smoke validation of smoke-v131 surfaced the issue: PushSecret stuck Errored with `set secret failed: secret key attribute.id does not exist`.

Inspected the live AccessKey Secret `smoke-v131-aws-key`:

| Key | Size | Meaning |
|---|---|---|
| username | 20 bytes (AKIA-prefixed) | AWS access key ID |
| password | 40 bytes | AWS secret access key |
| attribute.secret | 0 bytes | empty (deprecated) |
| attribute.ses_smtp_password_v4 | 0 bytes | empty (SES variant) |

Same pattern verified on the existing `argo-workflows-s3-creds` Secret. The provider's behavior changed (or always was this way) but the precedent comments in the cluster's existing AWS-app manifests had the wrong key names.

## What this PR fixes

- `base-apps/crossplane-compositions/composition-application.yaml`: `make_aws_push_secret` data mapping now reads `username` / `password` (was `attribute.id` / `attribute.secret`)
- `tests/composition/expected-xr-with-s3.yaml`: golden updated to match

## Test plan

- [x] `./tests/composition/render.sh xr-with-s3` PASS
- [x] `./tests/composition/render.sh xr-minimal` PASS (regression)
- [x] `./tests/composition/render.sh xr-with-db` PASS (regression)
- [ ] After merge: PushSecret on smoke-v131 retries on next refresh tick (or kick via annotation); Vault populates; ExternalSecret syncs; Pod becomes Ready

## Lesson for v1.3.2 / future

Phase 0 P.3 verified CRD existence by name. Should ALSO verify connection Secret KEY shapes against a live AccessKey resource on cluster (e.g., `kubectl -n argo-workflows get secret argo-workflows-s3-creds -o jsonpath='{.data}' | jq 'keys'`). The stale comments in loki/argo-workflows manifests misled v1.3 + v1.3.1 spec-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)