### PR TITLE
fix(backstage): grant ESO read RBAC so Crossplane tab shows ESO resources

### DIFF
--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -94,6 +94,14 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 
+  # External Secrets Operator (ESO) — v1.2 + v1.3.1 IDP apps emit SecretStore /
+  # PushSecret / ExternalSecret as part of their Vault round-trip flow.
+  # Without this, the Backstage Crossplane tab can't list these resources
+  # even though they're in the XR's resourceRefs.
+  - apiGroups: ["external-secrets.io"]
+    resources: ["secretstores", "pushsecrets", "externalsecrets"]
+    verbs: ["get", "list", "watch"]
+
   # Crossplane internal status resources used by the resources plugin's graph
   - apiGroups: ["protection.crossplane.io"]
     resources: ["*"]


### PR DESCRIPTION
## Summary

Hotfix surfaced during v1.3.1 smoke validation: the Backstage Crossplane tab on `smoke-v131`'s entity page only showed 4 resources (XR + Deployment + Service + Ingress) instead of the expected 7.

## Root cause

The XR's `resourceRefs` correctly lists all 6 composed kinds — Composition is emitting `SecretStore` + `PushSecret` + `ExternalSecret` properly. But the `backstage-crossplane-read` ClusterRole lacks `external-secrets.io` permission. So the Backstage SA can't list those resources, and the Crossplane tab silently omits them.

This is the same class of issue as:
- v1.1 PR #214 (added `apiextensions.k8s.io/customresourcedefinitions`)
- v1.2 RBAC additions (added `postgresql.cnpg.io`)
- v1.3.1 smoke validation (this PR)

Pattern: every time the Composition or scaffolder introduces a new resource type, this ClusterRole needs an additive update.

## What this PR does

Adds to `base-apps/backstage/rbac.yaml`:
```yaml
- apiGroups: ["external-secrets.io"]
  resources: ["secretstores", "pushsecrets", "externalsecrets"]
  verbs: ["get", "list", "watch"]
```

(Read-only; no `/status` subresources needed since this is just for listing in the UI, not for write operations.)

## Test plan

- [ ] Merge → ArgoCD reconciles ClusterRole (~30s)
- [ ] Backstage UI auto-refreshes
- [ ] Visit `backstage.arigsela.com/catalog/default/component/smoke-v131/crossplane`
- [ ] Confirm Crossplane tab shows 7 resources (was 4 before fix)

## Known unrelated limitation

The 5 cluster-scoped AWS resources (Bucket, User, Policy, UserPolicyAttachment, AccessKey) STILL won't appear in the Crossplane tab even after this fix. They're scaffolder-emitted raw manifests, not Composition-emitted, so they're not in the XR's `resourceRefs`. This is a fundamental limitation of v1.3.1's Option B architecture, documented for v1.4+ design work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)