### PR TITLE
Golden AI Platform POC: design + implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-0-foundation.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-0-foundation.md
@@ -1,0 +1,1419 @@
+# Golden POC — Phase 0: Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the platform infrastructure for the Golden AI Platform POC: install agentregistry + agentgateway + Langfuse as base-apps, reconfigure kagent to route LLM traffic through agentgateway and emit OTLP to Langfuse, set up the GitHub App for the PR Review Agent, and resolve the two preflight unknowns from the design doc.
+
+**Architecture:** Three new ArgoCD `Application` manifests (under `base-apps/`), each pointing at an upstream Helm chart with inline values. Vault holds platform secrets (Anthropic key, Langfuse keys, GitHub App private key, agentregistry admin token); ExternalSecret resources sync them per-namespace. kagent reconfig is a single PR to its existing `base-apps/kagent.yaml`.
+
+**Tech Stack:** ArgoCD, Helm (kagent v0.8.6 already installed), Crossplane v2 (already installed), Vault + External Secrets (already running per-namespace), CNPG (already running), agentregistry v0.3.x (Solo.io, pre-1.0), agentgateway (Solo.io, donated to LF), Langfuse self-hosted.
+
+**Reference design:** `docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md`
+
+**Branching reminder:** This plan operates on a worktree branch. Each commit lands on the worktree branch; all changes ship via the PR opened at the end of plan execution (handled by the wrapping plan, not by this plan's individual tasks).
+
+---
+
+## Task 0.1: Preflight check — kagent ToolServer CRD shape
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`
+
+The design doc has an open question (Section 11): does kagent's `ToolServer` CRD natively accept agentregistry OCI refs, or do we need a shim? Phase 1's Composition design depends on this answer.
+
+- [ ] **Step 1: Clone or browse the kagent project to find the ToolServer CRD source**
+
+Run: `gh repo clone kagent-dev/kagent /tmp/kagent && cd /tmp/kagent && grep -r "kind: ToolServer" --include="*.go" --include="*.yaml" | head -20`
+Expected: paths to the CRD definition (likely under `api/v1alpha1/` or similar).
+
+- [ ] **Step 2: Read the ToolServer CRD spec schema**
+
+Open the source file from Step 1. Identify the fields under `spec.config` or equivalent. Specifically check for: `image:`, `oci:`, `chart:`, `url:`, `command:`, `transport:`, `stdio:`, `sse:`, `streamableHttp:`.
+
+- [ ] **Step 3: Determine the OCI integration pattern**
+
+Based on Step 2's findings, classify into one of three buckets:
+- **Bucket A** — ToolServer accepts an OCI image directly (e.g., `spec.config.image: ghcr.io/...`). Phase 1 Composition just templates the URI. Easiest.
+- **Bucket B** — ToolServer accepts an HTTP/SSE/streamable URL pointing to a running MCP server, but does NOT pull from OCI. We need a controller or sidecar that runs the MCP server image and exposes it. Phase 1 needs a per-skill Deployment template.
+- **Bucket C** — ToolServer accepts something else (kagent-specific format, registry refs, etc.). Document the actual shape.
+
+- [ ] **Step 4: Record findings**
+
+Create file `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` with:
+
+```markdown
+# Phase 0 Preflight Results
+
+## Preflight 1 — kagent ToolServer CRD shape
+
+**kagent version inspected:** v0.8.6 (matches `base-apps/kagent.yaml` `targetRevision: 0.8.6`)
+**Source path:** [paste path from Step 1]
+**Bucket determined:** [A | B | C]
+**Schema excerpt:**
+
+\```yaml
+[paste relevant schema portion from CRD]
+\```
+
+**Phase 1 Composition implication:**
+[1-2 sentences describing what the Composition will render based on the bucket]
+
+---
+
+## Preflight 2 — agentregistry HTTP API
+
+[filled in by Task 0.2]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): record Phase 0 preflight 1 — kagent ToolServer shape"
+```
+
+---
+
+## Task 0.2: Preflight check — agentregistry HTTP API
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`
+
+Phase 3's Backstage embedded skill catalog plugin queries agentregistry's HTTP API. We need the endpoint paths to write the plugin.
+
+- [ ] **Step 1: Clone agentregistry source**
+
+Run: `gh repo clone agentregistry-dev/agentregistry /tmp/agentregistry && cd /tmp/agentregistry`
+
+- [ ] **Step 2: Find the HTTP API surface**
+
+Run: `grep -r "func.*Handler\|http.HandleFunc\|router.HandleFunc\|app.Get\|app.Post" --include="*.go" cmd/ pkg/ internal/ 2>/dev/null | head -40`
+
+Or look for OpenAPI/Swagger generation: `find . -name "*.yaml" -path "*/api/*" -o -name "openapi*.json" 2>/dev/null`.
+
+- [ ] **Step 3: Identify the four key endpoints we need for the Backstage plugin**
+
+For the Skill catalog plugin (design Section 5) we need:
+1. **List artifacts** — paginated list of all artifacts, filterable by type and tag.
+2. **Get artifact details** — single artifact by name + version.
+3. **List artifact versions** — version history for an artifact.
+4. **List tags** — distinct tag values across artifacts (for filter UI).
+
+Document the actual paths, request/response shapes, and auth requirements. If only some endpoints exist, document workarounds (e.g., "no `/tags` endpoint; client computes tag set from `/artifacts` response").
+
+- [ ] **Step 4: Record findings**
+
+Append to `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` under the "Preflight 2" header:
+
+```markdown
+## Preflight 2 — agentregistry HTTP API
+
+**agentregistry version inspected:** [version from go.mod or git tag]
+**Source path:** [paste path]
+**Base URL pattern:** `https://agentregistry.<base-domain>/api/v1` (or actual)
+
+### Endpoints
+
+| Need | Method + Path | Response shape (relevant fields) | Auth |
+|---|---|---|---|
+| List artifacts | [paste] | [paste] | [paste] |
+| Get artifact | [paste] | [paste] | [paste] |
+| List versions | [paste] | [paste] | [paste] |
+| List tags | [paste or "compute client-side"] | n/a | n/a |
+
+### Phase 3 plugin implication
+
+[1-2 sentences describing what the Backstage plugin will fetch and how]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): record Phase 0 preflight 2 — agentregistry HTTP API"
+```
+
+---
+
+## Task 0.3: Set up GitHub App for PR Review Agent
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` (record App ID + install ID)
+
+The PR Review Agent (Phase 2) needs a GitHub App with PR-read + PR-comment-write permissions. This is one-time admin work in the GitHub UI; capture results so Phase 2 can wire them up.
+
+- [ ] **Step 1: Create the GitHub App**
+
+Go to https://github.com/settings/apps/new (personal) or https://github.com/organizations/<org>/settings/apps/new (org).
+
+Fill in:
+- **GitHub App name:** `golden-poc-pr-reviewer`
+- **Homepage URL:** `https://github.com/arigsela/kubernetes`
+- **Webhook URL:** `https://github-webhook.<base-domain>/webhook` (placeholder; the adapter is built in Phase 2 — webhook deliveries will fail until then, that's fine)
+- **Webhook secret:** generate with `openssl rand -hex 32`. Save the secret to a scratchpad — going into Vault in Step 4.
+- **Repository permissions:**
+  - Contents: Read-only
+  - Pull requests: Read and write
+  - Metadata: Read-only (mandatory)
+- **Subscribe to events:** Pull request
+- **Where can this GitHub App be installed:** Only on this account
+
+Click "Create GitHub App". Note the **App ID** (top of the App's settings page after creation).
+
+- [ ] **Step 2: Generate a private key**
+
+In the App settings, scroll to "Private keys" → "Generate a private key". A `.pem` file downloads. Open it; you'll need its contents in Step 4.
+
+- [ ] **Step 3: Install the App on `arigsela/kubernetes`**
+
+In the App settings, click "Install App" in the left sidebar. Choose the account, select "Only select repositories" → check `arigsela/kubernetes`. Install.
+
+After install, the URL contains the **Installation ID** (the number after `/installations/`). Record it.
+
+- [ ] **Step 4: Store credentials in Vault**
+
+Run (from a host with `vault` CLI authenticated):
+
+```bash
+vault kv put k8s-secrets/github-webhook-adapter \
+  app_id=<App ID from Step 1> \
+  installation_id=<Installation ID from Step 3> \
+  webhook_secret=<webhook secret from Step 1> \
+  private_key=@/path/to/downloaded/pem-file.pem
+```
+
+- [ ] **Step 5: Record App identifiers in preflight-results doc**
+
+Append to `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`:
+
+```markdown
+## GitHub App: golden-poc-pr-reviewer
+
+- **App ID:** [number]
+- **Installation ID:** [number]
+- **Vault path:** `k8s-secrets/github-webhook-adapter`
+- **Repo scope:** arigsela/kubernetes
+- **Permissions:** Contents:read, Pull requests:read+write, Metadata:read
+- **Subscribed events:** Pull request
+- **Webhook URL (Phase 2 will wire this up):** `https://github-webhook.<base-domain>/webhook`
+- **Webhook secret:** stored in Vault (NOT recorded here)
+- **Private key:** stored in Vault (NOT recorded here)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): record GitHub App identifiers (creds in Vault)"
+```
+
+---
+
+## Task 0.4: Stage Anthropic API key for agentgateway in Vault
+
+**Files:** None (Vault-only operation; no repo changes)
+
+kagent already has its own Anthropic key at the path it uses (`kagent-anthropic` Secret in `kagent` namespace). agentgateway will hold the platform-wide key under its own Vault path so kagent can be reconfigured to route through it (Task 0.10).
+
+- [ ] **Step 1: Verify the key exists in Vault**
+
+Run:
+```bash
+vault kv get k8s-secrets/agentgateway 2>/dev/null || echo "Path does not exist yet"
+```
+
+- [ ] **Step 2: If missing, write the Anthropic API key**
+
+If the path does not exist or lacks the key:
+```bash
+vault kv put k8s-secrets/agentgateway ANTHROPIC_API_KEY=<your-key>
+```
+
+If you need a new key, create one at https://console.anthropic.com/settings/keys.
+
+- [ ] **Step 3: Verify**
+
+Run: `vault kv get k8s-secrets/agentgateway`
+Expected: shows the key path with `ANTHROPIC_API_KEY` listed (value masked).
+
+No commit — this task only stages a secret in Vault. The downstream task (0.9) creates the ExternalSecret manifest that pulls it.
+
+---
+
+## Task 0.5: Install Langfuse — namespace + database secret + ArgoCD app
+
+**Files:**
+- Create: `base-apps/langfuse.yaml`
+- Create: `base-apps/langfuse/namespace.yaml`
+- Create: `base-apps/langfuse/secret-store.yaml`
+- Create: `base-apps/langfuse/external-secret-db.yaml`
+- Create: `base-apps/langfuse/cnpg-cluster.yaml`
+
+Langfuse uses Postgres. Reuse the existing CNPG pattern so the database lives in the cluster like other CNPG-backed apps.
+
+- [ ] **Step 1: Create the namespace manifest**
+
+Create `base-apps/langfuse/namespace.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: langfuse
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+```
+
+- [ ] **Step 2: Create the namespace's SecretStore**
+
+Create `base-apps/langfuse/secret-store.yaml` mirroring the per-namespace pattern in `base-apps/n8n/secret-store.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: langfuse
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "langfuse"
+          serviceAccountRef:
+            name: "default"
+```
+
+- [ ] **Step 3: Add the Vault role for the langfuse namespace**
+
+This is a Vault-side operation, run from a host with `vault` CLI:
+
+```bash
+vault write auth/kubernetes/role/langfuse \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=langfuse \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 4: Create the CNPG Cluster manifest for Langfuse's Postgres**
+
+Create `base-apps/langfuse/cnpg-cluster.yaml`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: langfuse-db
+  namespace: langfuse
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: langfuse
+      owner: langfuse
+  storage:
+    size: 5Gi
+```
+
+- [ ] **Step 5: Create the ExternalSecret that exposes the CNPG-generated DB credentials**
+
+CNPG generates a Secret named `<cluster>-app` (here `langfuse-db-app`) with `uri`, `host`, `port`, `username`, `password`, `dbname`. Langfuse reads `DATABASE_URL`. Use a PushSecret pattern OR pass the CNPG secret directly.
+
+For simplicity, the Langfuse Helm values (Task 0.7) will reference `langfuse-db-app` directly. No ExternalSecret needed for the DB; only the Langfuse instance keys (next step) need ESO.
+
+Create `base-apps/langfuse/external-secret-db.yaml` as a NoOp placeholder marker so this step has an artifact:
+
+```yaml
+# CNPG generates langfuse-db-app Secret in this namespace automatically.
+# The Langfuse Helm chart references it via env vars.
+# This file is intentionally empty of resources — kept for documentation
+# alignment with other base-apps directories.
+```
+
+(If your linter rejects empty YAML, replace with a single-line comment in a `.md` file in the same dir, or skip this step.)
+
+- [ ] **Step 6: Create the ArgoCD Application for the namespace + db (Langfuse install itself comes in Task 0.6)**
+
+Create `base-apps/langfuse.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: langfuse
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/langfuse
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: langfuse
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 7: Commit and let ArgoCD sync the namespace + DB**
+
+```bash
+git add base-apps/langfuse.yaml base-apps/langfuse/
+git commit -m "feat(langfuse): namespace, SecretStore, CNPG cluster (Phase 0)"
+```
+
+After this commit lands on main (via the eventual PR), wait ~1 minute for ArgoCD sync.
+
+- [ ] **Step 8: Verify CNPG cluster is healthy**
+
+Run (after ArgoCD sync):
+```bash
+kubectl get cluster -n langfuse
+kubectl get secret langfuse-db-app -n langfuse
+```
+Expected: cluster status `Cluster in healthy state`; secret exists with keys uri/host/port/username/password/dbname.
+
+If the secret hasn't appeared, CNPG is still bootstrapping — wait another minute and recheck.
+
+---
+
+## Task 0.6: Install Langfuse application via Helm-as-ArgoCD-app
+
+**Files:**
+- Create: `base-apps/langfuse-app.yaml`
+
+Langfuse's official Helm chart deploys the web/worker/db. Since CNPG is the DB (Task 0.5), the Helm chart's bundled Postgres is disabled.
+
+- [ ] **Step 1: Determine pinned chart version**
+
+Run: `helm search repo langfuse 2>/dev/null || helm repo add langfuse https://langfuse.github.io/langfuse-k8s && helm search repo langfuse/langfuse --versions | head -5`
+
+Pick the latest stable (e.g., `0.x.x`). Record the version chosen.
+
+- [ ] **Step 2: Create the ArgoCD Application for the Helm chart**
+
+Create `base-apps/langfuse-app.yaml`. Replace `<CHART_VERSION>` with the pinned version from Step 1:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: langfuse-app
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"  # after langfuse namespace + db (sync-wave 0)
+spec:
+  project: default
+  source:
+    chart: langfuse
+    repoURL: https://langfuse.github.io/langfuse-k8s
+    targetRevision: <CHART_VERSION>
+    helm:
+      valuesObject:
+        # Disable bundled Postgres; use CNPG cluster from Task 0.5
+        postgresql:
+          deploy: false
+        langfuse:
+          # CNPG generates a "uri" key in langfuse-db-app secret
+          additionalEnv:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: langfuse-db-app
+                  key: uri
+          nextauth:
+            url: https://langfuse.<base-domain>
+            secret:
+              # Generated at install; rotation requires re-deploy
+              valueFrom:
+                secretKeyRef:
+                  name: langfuse-instance
+                  key: nextauth-secret
+          salt:
+            valueFrom:
+              secretKeyRef:
+                name: langfuse-instance
+                key: salt
+        # Ingress
+        ingress:
+          enabled: true
+          className: nginx
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-prod
+            nginx.ingress.kubernetes.io/ssl-redirect: "true"
+          hosts:
+            - host: langfuse.<base-domain>
+              paths:
+                - path: /
+                  pathType: Prefix
+          tls:
+            - hosts:
+                - langfuse.<base-domain>
+              secretName: langfuse-tls
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: langfuse
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+```
+
+**Important:** replace `<base-domain>` with your actual base domain (whatever pattern the existing nginx ingresses use — check `base-apps/backstage/nginx-ingress.yaml` for the pattern).
+
+- [ ] **Step 3: Stage the `langfuse-instance` Secret in Vault**
+
+Generate two random strings:
+```bash
+NEXTAUTH=$(openssl rand -hex 32)
+SALT=$(openssl rand -hex 32)
+vault kv put k8s-secrets/langfuse \
+  nextauth-secret="$NEXTAUTH" \
+  salt="$SALT"
+```
+
+- [ ] **Step 4: Add an ExternalSecret to expose `langfuse-instance` into the namespace**
+
+Create `base-apps/langfuse/external-secret-instance.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: langfuse-instance
+  namespace: langfuse
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: langfuse-instance
+    creationPolicy: Owner
+  data:
+    - secretKey: nextauth-secret
+      remoteRef:
+        key: langfuse
+        property: nextauth-secret
+    - secretKey: salt
+      remoteRef:
+        key: langfuse
+        property: salt
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/langfuse-app.yaml base-apps/langfuse/external-secret-instance.yaml
+git commit -m "feat(langfuse): install via Helm + instance secrets (Phase 0)"
+```
+
+- [ ] **Step 6: After ArgoCD sync, smoke-test Langfuse**
+
+Wait for ArgoCD sync (~2 minutes for the chart to install). Then:
+
+```bash
+kubectl get pods -n langfuse
+# Expected: langfuse-web, langfuse-worker pods Running
+curl -fsS https://langfuse.<base-domain>/api/public/health
+# Expected: {"status":"OK"}
+```
+
+Open `https://langfuse.<base-domain>` in a browser. Sign up (Langfuse self-host requires creating a user account on first visit). Create a project named **`golden-poc`**. Note the Public Key (starts with `pk-lf-...`) and Secret Key (starts with `sk-lf-...`) — these go into Vault next.
+
+- [ ] **Step 7: Stage Langfuse project keys in Vault**
+
+```bash
+vault kv put k8s-secrets/langfuse-project \
+  public_key="<pk-lf-... from Step 6>" \
+  secret_key="<sk-lf-... from Step 6>" \
+  project_id=golden-poc
+```
+
+These keys are consumed by kagent (Task 0.10) and Backstage (Phase 3).
+
+---
+
+## Task 0.7: Install agentgateway — namespace + ArgoCD app
+
+**Files:**
+- Create: `base-apps/agentgateway.yaml`
+- Create: `base-apps/agentgateway/namespace.yaml`
+- Create: `base-apps/agentgateway/secret-store.yaml`
+- Create: `base-apps/agentgateway/external-secret.yaml`
+
+agentgateway is Solo.io's HTTP/gRPC proxy for AI traffic. We deploy it as a transparent proxy fronting the Anthropic API.
+
+- [ ] **Step 1: Find the Helm chart**
+
+Visit https://agentgateway.dev/docs/install or run:
+```bash
+helm repo add agentgateway https://agentgateway.dev/charts 2>/dev/null
+helm search repo agentgateway --versions | head -5
+```
+
+If the chart URL has changed, browse https://github.com/agentgateway and find the actual chart location. Record the resolved repoURL and version.
+
+- [ ] **Step 2: Create namespace manifest**
+
+`base-apps/agentgateway/namespace.yaml`:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentgateway
+```
+
+- [ ] **Step 3: Create namespace SecretStore**
+
+`base-apps/agentgateway/secret-store.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: agentgateway
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "agentgateway"
+          serviceAccountRef:
+            name: "default"
+```
+
+- [ ] **Step 4: Create the Vault role**
+
+```bash
+vault write auth/kubernetes/role/agentgateway \
+  bound_service_account_names=default,agentgateway \
+  bound_service_account_namespaces=agentgateway \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 5: Create the ExternalSecret for the Anthropic key**
+
+`base-apps/agentgateway/external-secret.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: agentgateway-anthropic
+  namespace: agentgateway
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: agentgateway-anthropic
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: agentgateway
+        property: ANTHROPIC_API_KEY
+```
+
+- [ ] **Step 6: Create the ArgoCD app for the namespace resources (sync-wave 0)**
+
+`base-apps/agentgateway.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agentgateway
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/agentgateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agentgateway
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add base-apps/agentgateway.yaml base-apps/agentgateway/
+git commit -m "feat(agentgateway): namespace, SecretStore, Anthropic ExternalSecret (Phase 0)"
+```
+
+- [ ] **Step 8: Verify**
+
+After ArgoCD sync:
+```bash
+kubectl get secret agentgateway-anthropic -n agentgateway
+# Expected: secret exists with ANTHROPIC_API_KEY key
+```
+
+---
+
+## Task 0.8: Install agentgateway Helm chart
+
+**Files:**
+- Create: `base-apps/agentgateway-app.yaml`
+
+- [ ] **Step 1: Create the ArgoCD Application for the Helm chart**
+
+Replace `<REPO_URL>` and `<CHART_VERSION>` with the values resolved in Task 0.7 Step 1:
+
+`base-apps/agentgateway-app.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agentgateway-app
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    chart: agentgateway
+    repoURL: <REPO_URL>
+    targetRevision: <CHART_VERSION>
+    helm:
+      valuesObject:
+        # Anthropic upstream config — exact values keys depend on the chart's
+        # schema. Adjust based on the chart's values.yaml after Step 2 review.
+        upstreams:
+          anthropic:
+            type: anthropic
+            baseURL: https://api.anthropic.com
+            apiKeySecret:
+              name: agentgateway-anthropic
+              key: ANTHROPIC_API_KEY
+        # Cluster-internal Service for kagent to call
+        service:
+          type: ClusterIP
+          port: 80
+          targetPort: 8080
+        # Rate limiting (POC level)
+        rateLimit:
+          enabled: true
+          requestsPerSecond: 10
+        # Logging
+        logging:
+          level: info
+          format: json
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agentgateway
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+```
+
+- [ ] **Step 2: Inspect the chart's actual values schema before merging**
+
+Run:
+```bash
+helm show values <REPO_URL>/agentgateway --version <CHART_VERSION> > /tmp/agentgateway-values.yaml
+less /tmp/agentgateway-values.yaml
+```
+
+Compare against the keys used in Step 1's `valuesObject`. If keys differ (e.g., `upstreams` is actually called `providers` or `backends`), update `base-apps/agentgateway-app.yaml` accordingly. **Do not commit the updated file until the keys match the chart's schema.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add base-apps/agentgateway-app.yaml
+git commit -m "feat(agentgateway): install via Helm with Anthropic upstream (Phase 0)"
+```
+
+- [ ] **Step 4: After ArgoCD sync, smoke-test agentgateway**
+
+```bash
+kubectl get pods -n agentgateway
+# Expected: agentgateway pod Running
+
+# From any other namespace, send a Claude request through the gateway:
+kubectl run curl-test --rm -i --image=curlimages/curl --restart=Never -- \
+  curl -sS -X POST http://agentgateway.agentgateway.svc.cluster.local/v1/messages \
+  -H "anthropic-version: 2023-06-01" \
+  -H "x-api-key: dummy-internal-token" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-haiku-4-5-20251001",
+    "max_tokens": 64,
+    "messages": [{"role":"user","content":"Say PONG."}]
+  }'
+```
+
+Expected: a JSON response containing `"content":[{"type":"text","text":"PONG..."}]`.
+
+If the gateway returns 401/403, the upstream key wiring needs adjustment — review the chart values' actual auth-injection mechanism and update `base-apps/agentgateway-app.yaml` accordingly. Iterate until the smoke test passes before proceeding.
+
+---
+
+## Task 0.9: Install agentregistry — namespace + ArgoCD app
+
+**Files:**
+- Create: `base-apps/agentregistry.yaml`
+- Create: `base-apps/agentregistry/namespace.yaml`
+- Create: `base-apps/agentregistry/secret-store.yaml`
+- Create: `base-apps/agentregistry/external-secret.yaml`
+- Create: `base-apps/agentregistry/ingress.yaml`
+
+- [ ] **Step 1: Create namespace manifest**
+
+`base-apps/agentregistry/namespace.yaml`:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentregistry
+```
+
+- [ ] **Step 2: Stage admin token in Vault**
+
+```bash
+vault kv put k8s-secrets/agentregistry \
+  admin_token="$(openssl rand -hex 32)"
+```
+
+- [ ] **Step 3: Create namespace SecretStore**
+
+`base-apps/agentregistry/secret-store.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: agentregistry
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "agentregistry"
+          serviceAccountRef:
+            name: "default"
+```
+
+- [ ] **Step 4: Create the Vault role**
+
+```bash
+vault write auth/kubernetes/role/agentregistry \
+  bound_service_account_names=default,agentregistry \
+  bound_service_account_namespaces=agentregistry \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 5: Create the ExternalSecret**
+
+`base-apps/agentregistry/external-secret.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: agentregistry-admin
+  namespace: agentregistry
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: agentregistry-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: admin_token
+      remoteRef:
+        key: agentregistry
+        property: admin_token
+```
+
+- [ ] **Step 6: Create the Ingress for external UI access**
+
+`base-apps/agentregistry/ingress.yaml`:
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agentregistry
+  namespace: agentregistry
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - agentregistry.<base-domain>
+      secretName: agentregistry-tls
+  rules:
+    - host: agentregistry.<base-domain>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Service name comes from the agentregistry chart; verify in Task 0.10 Step 2
+                name: agentregistry
+                port:
+                  number: 12121
+```
+
+(Replace `<base-domain>` with your actual base domain.)
+
+- [ ] **Step 7: Create the ArgoCD app**
+
+`base-apps/agentregistry.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agentregistry
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/agentregistry
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agentregistry
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add base-apps/agentregistry.yaml base-apps/agentregistry/
+git commit -m "feat(agentregistry): namespace, SecretStore, ExternalSecret, Ingress (Phase 0)"
+```
+
+---
+
+## Task 0.10: Install agentregistry Helm chart
+
+**Files:**
+- Create: `base-apps/agentregistry-app.yaml`
+
+- [ ] **Step 1: Find the Helm chart**
+
+The agentregistry repo's README documents the Helm install. Run:
+```bash
+git clone https://github.com/agentregistry-dev/agentregistry /tmp/ar-chart 2>/dev/null
+ls /tmp/ar-chart/charts/ /tmp/ar-chart/deploy/ /tmp/ar-chart/helm/ 2>/dev/null
+```
+
+Find the `Chart.yaml`. The chart may be hosted at `oci://ghcr.io/agentregistry-dev/agentregistry` or as a packaged tarball. Record the actual location.
+
+If only a local chart exists, fork the chart into `base-apps/agentregistry/chart/` and use `path:` instead of `chart:` in the ArgoCD Application.
+
+- [ ] **Step 2: Create the ArgoCD Application for agentregistry**
+
+Replace `<REPO_URL>` and `<CHART_VERSION>` with the values from Step 1.
+
+`base-apps/agentregistry-app.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agentregistry-app
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    chart: agentregistry
+    repoURL: <REPO_URL>
+    targetRevision: <CHART_VERSION>
+    helm:
+      valuesObject:
+        # Persistent storage for OCI artifacts
+        persistence:
+          enabled: true
+          size: 10Gi
+          storageClass: ""  # default
+        # Web UI on port 12121 (per project docs)
+        service:
+          type: ClusterIP
+          port: 12121
+        # Admin token from ExternalSecret (Task 0.9)
+        auth:
+          adminTokenSecret:
+            name: agentregistry-admin
+            key: admin_token
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agentregistry
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+```
+
+- [ ] **Step 3: Inspect the chart's actual values schema**
+
+Same approach as Task 0.8 Step 2. Run `helm show values <REPO_URL>/agentregistry --version <CHART_VERSION>` and reconcile. Update before commit if keys differ.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/agentregistry-app.yaml
+git commit -m "feat(agentregistry): install via Helm with persistent storage (Phase 0)"
+```
+
+- [ ] **Step 5: After ArgoCD sync, smoke-test agentregistry**
+
+```bash
+kubectl get pods -n agentregistry
+# Expected: agentregistry pod Running
+
+curl -fsS https://agentregistry.<base-domain>/api/v1/health 2>/dev/null \
+  || curl -fsS https://agentregistry.<base-domain>/healthz
+# Expected: 200 OK with health body
+```
+
+Open `https://agentregistry.<base-domain>` in a browser — should see the agentregistry UI.
+
+- [ ] **Step 6: Install `arctl` CLI locally for skill seeding (Task 0.11)**
+
+Per the agentregistry docs:
+```bash
+curl -fsSL https://raw.githubusercontent.com/agentregistry-dev/agentregistry/main/scripts/get-arctl | bash
+arctl --version
+```
+
+Configure `arctl` to point at the registry:
+```bash
+arctl login https://agentregistry.<base-domain> --token <admin_token from Vault>
+```
+
+---
+
+## Task 0.11: Seed agentregistry with the four POC skills
+
+**Files:**
+- Create: `scripts/seed-agentregistry.sh`
+
+The four POC skills are pushed via `arctl`. This is one-time work; the script lives in the repo so it's reproducible (e.g., re-seeding after a registry rebuild).
+
+- [ ] **Step 1: Write the seed script**
+
+Create `scripts/seed-agentregistry.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Seed agentregistry with the four POC skills.
+# Idempotent: re-running pushes new versions but doesn't fail if already present.
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-https://agentregistry.<base-domain>}"
+ADMIN_TOKEN="${ADMIN_TOKEN:?must be set; vault kv get -field=admin_token k8s-secrets/agentregistry}"
+
+arctl login "$REGISTRY_URL" --token "$ADMIN_TOKEN"
+
+# Skill 1: kubernetes-mcp
+arctl push skill \
+  --name kubernetes-mcp \
+  --version v1 \
+  --type mcp-server \
+  --image ghcr.io/manusa/kubernetes-mcp-server:latest \
+  --tags k8s,read-only,observability \
+  --description "Read-only Kubernetes API access via MCP."
+
+# Skill 2: prometheus-mcp (Coroot equivalent OK)
+arctl push skill \
+  --name prometheus-mcp \
+  --version v1 \
+  --type mcp-server \
+  --image ghcr.io/pab1it0/prometheus-mcp-server:latest \
+  --tags metrics,read-only,observability \
+  --description "PromQL queries via MCP. POC accepts Coroot proxy."
+
+# Skill 3: github-mcp (Anthropic's official server)
+arctl push skill \
+  --name github-mcp \
+  --version v1 \
+  --type mcp-server \
+  --image ghcr.io/github/github-mcp-server:latest \
+  --tags github,review \
+  --description "GitHub Pull Request and Issue tools via MCP."
+
+# Skill 4: k8s-yaml-lint (custom; published in Phase 2 of the POC)
+# In Phase 0 we register the placeholder; Phase 2 builds and pushes the actual image.
+arctl push skill \
+  --name k8s-yaml-lint \
+  --version v0-placeholder \
+  --type mcp-server \
+  --image ghcr.io/arigsela/k8s-yaml-lint:placeholder \
+  --tags k8s,lint,custom \
+  --description "Structural YAML/Kustomize linting via kube-linter. Placeholder until Phase 2 builds the real image."
+
+echo "Seed complete. Verify in UI: $REGISTRY_URL"
+arctl list skills
+```
+
+(Replace `<base-domain>` and verify exact `arctl push` flag names against `arctl push --help`. The flag set may differ if agentregistry has evolved; adjust accordingly.)
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x scripts/seed-agentregistry.sh
+```
+
+- [ ] **Step 3: Run the seed script**
+
+```bash
+ADMIN_TOKEN=$(vault kv get -field=admin_token k8s-secrets/agentregistry) \
+  REGISTRY_URL=https://agentregistry.<base-domain> \
+  ./scripts/seed-agentregistry.sh
+```
+
+Expected output: four "pushed" lines and a final `arctl list skills` showing all four entries.
+
+- [ ] **Step 4: Verify in the UI**
+
+Open `https://agentregistry.<base-domain>`. The four skills should appear in the catalog.
+
+- [ ] **Step 5: Commit the script**
+
+```bash
+git add scripts/seed-agentregistry.sh
+git commit -m "feat(agentregistry): seed script for the four POC skills (Phase 0)"
+```
+
+---
+
+## Task 0.12: Reconfigure kagent to route LLM calls through agentgateway
+
+**Files:**
+- Modify: `base-apps/kagent.yaml`
+
+kagent currently calls Anthropic directly using the `kagent-anthropic` Secret. We point kagent at agentgateway's internal endpoint instead. agentgateway holds the real Anthropic key and forwards.
+
+- [ ] **Step 1: Determine kagent's mechanism for overriding the Anthropic base URL**
+
+Two possibilities depending on kagent's chart values:
+- **Option A:** kagent's `providers.anthropic` section accepts a `baseURL` or `endpoint` field. Look in the kagent Helm chart values.yaml.
+- **Option B:** kagent uses the upstream Anthropic SDK and respects the `ANTHROPIC_BASE_URL` env var. Inject it via `controller.env` in the Helm values.
+
+Run:
+```bash
+helm show values ghcr.io/kagent-dev/kagent/helm/kagent --version 0.8.6 \
+  | grep -i -A3 "baseurl\|endpoint\|anthropic" | head -50
+```
+
+Choose the option that matches the chart and update `base-apps/kagent.yaml` accordingly.
+
+- [ ] **Step 2: Update `base-apps/kagent.yaml`**
+
+If Option A (chart-native field): under `providers.anthropic`, add:
+```yaml
+        providers:
+          default: anthropic
+          anthropic:
+            provider: Anthropic
+            model: claude-haiku-4-5-20251001
+            apiKeySecretRef: kagent-anthropic
+            apiKeySecretKey: ANTHROPIC_API_KEY
+            baseURL: http://agentgateway.agentgateway.svc.cluster.local/v1
+```
+
+If Option B (env var): under `controller.env`, append:
+```yaml
+        controller:
+          # ... (preserve existing volumes/volumeMounts)
+          env:
+            - name: ANTHROPIC_BASE_URL
+              value: http://agentgateway.agentgateway.svc.cluster.local/v1
+```
+
+The exact YAML location depends on the chart's structure observed in Step 1.
+
+- [ ] **Step 3: Note the implication for kagent's `kagent-anthropic` Secret**
+
+When kagent talks to agentgateway instead of Anthropic, the value of `ANTHROPIC_API_KEY` it sends becomes a token that agentgateway can choose to validate or ignore. For POC simplicity:
+- Keep the `kagent-anthropic` Secret in the `kagent` namespace as-is.
+- agentgateway is configured (Task 0.8) to ignore inbound auth and inject its own Anthropic key on the upstream call.
+
+If agentgateway is configured to validate inbound tokens (a Phase-1.5 hardening), update both kagent's Secret and agentgateway's allowlist together.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/kagent.yaml
+git commit -m "feat(kagent): route LLM calls through agentgateway (Phase 0)"
+```
+
+- [ ] **Step 5: After ArgoCD sync, smoke-test the new path**
+
+Wait for the kagent controller pod to roll out (~1 minute):
+```bash
+kubectl rollout status deployment/kagent-controller -n kagent
+```
+
+Invoke any existing kagent Agent that's enabled (e.g., `k8s-agent` per `base-apps/kagent.yaml`):
+```bash
+# Adjust this curl to whatever your existing pattern is for kagent agent invocation;
+# the goal is just to make ONE LLM call go through.
+kubectl exec -n kagent deploy/kagent-controller -- /usr/local/bin/kagent-cli \
+  invoke --agent k8s-agent --input "list namespaces" 2>&1 | head -20
+```
+
+Then check agentgateway logs for the request:
+```bash
+kubectl logs -n agentgateway -l app=agentgateway --tail=20
+# Expected: a log line showing POST /v1/messages with model=claude-haiku-4-5-20251001
+```
+
+If agentgateway received nothing, the kagent reconfig is still pointing at Anthropic directly — re-check Step 2.
+
+---
+
+## Task 0.13: Configure kagent to emit OTLP traces to Langfuse (in addition to Coroot)
+
+**Files:**
+- Modify: `base-apps/kagent.yaml`
+- Create: `base-apps/kagent/external-secret-langfuse.yaml`
+
+Currently kagent emits OTLP to Coroot at `coroot-coroot.coroot.svc.cluster.local:4317` (per existing `base-apps/kagent.yaml` lines 121-135). We add a second OTLP exporter targeting Langfuse so traces appear in both UIs (no impact on existing Coroot flow).
+
+- [ ] **Step 1: Identify Langfuse's OTLP ingest endpoint**
+
+Langfuse self-host typically exposes OTLP at `/api/public/otel/v1/traces` (HTTP) on the main web service. Verify by:
+```bash
+curl -fsS https://langfuse.<base-domain>/api/public/otel/v1/traces -X POST -i 2>&1 | head -5
+# Expected: 401 (auth required) or 415 (unsupported media type for empty body) — proves the endpoint exists.
+```
+
+- [ ] **Step 2: Stage Langfuse OTLP auth in Vault**
+
+Langfuse OTLP requires Basic Auth with `<public_key>:<secret_key>` (set in Task 0.6 Step 7). Encode the auth header value:
+
+```bash
+PK=$(vault kv get -field=public_key k8s-secrets/langfuse-project)
+SK=$(vault kv get -field=secret_key k8s-secrets/langfuse-project)
+AUTH=$(echo -n "$PK:$SK" | base64 -w 0)
+vault kv put k8s-secrets/kagent-langfuse otlp_auth_header="Basic $AUTH"
+```
+
+- [ ] **Step 3: Add the Vault role for kagent (if not already present)**
+
+```bash
+vault read auth/kubernetes/role/kagent 2>/dev/null \
+  || vault write auth/kubernetes/role/kagent \
+       bound_service_account_names=default,kagent \
+       bound_service_account_namespaces=kagent \
+       policies=k8s-secrets-read \
+       ttl=24h
+```
+
+- [ ] **Step 4: Create the namespace SecretStore (if missing) and ExternalSecret**
+
+Check if `base-apps/kagent/secret-store.yaml` exists. If yes, just add the ExternalSecret. If no, create both.
+
+`base-apps/kagent/external-secret-langfuse.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-langfuse
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: kagent-langfuse
+    creationPolicy: Owner
+  data:
+    - secretKey: OTLP_AUTH_HEADER
+      remoteRef:
+        key: kagent-langfuse
+        property: otlp_auth_header
+```
+
+- [ ] **Step 5: Update `base-apps/kagent.yaml` to add the second OTLP exporter**
+
+Modify the `otel.tracing` block. The kagent chart's exact schema for multiple exporters depends on its OpenTelemetry Collector configuration. Two patterns are common:
+
+**Pattern X — chart supports `otel.tracing.exporters` list:**
+```yaml
+        otel:
+          tracing:
+            enabled: true
+            exporters:
+              - name: coroot
+                otlp:
+                  endpoint: "coroot-coroot.coroot.svc.cluster.local:4317"
+                  protocol: "grpc"
+                  insecure: true
+              - name: langfuse
+                otlp:
+                  endpoint: "https://langfuse.<base-domain>/api/public/otel/v1/traces"
+                  protocol: "http/protobuf"
+                  headers:
+                    authorization: ${OTLP_AUTH_HEADER}
+```
+
+**Pattern Y — chart only supports a single exporter:**
+Leave the existing Coroot exporter, AND deploy a small `otel-collector` Deployment in the `kagent` namespace that fans out (one input from kagent, two outputs to Coroot and Langfuse). This is more work and shifts to a new sub-task — recommend doing Pattern X first if the chart supports it.
+
+Inspect the chart values to determine which pattern applies:
+```bash
+helm show values ghcr.io/kagent-dev/kagent/helm/kagent --version 0.8.6 \
+  | yq '.otel' 2>/dev/null
+```
+
+- [ ] **Step 6: Mount the OTLP_AUTH_HEADER env var**
+
+If Pattern X with `${OTLP_AUTH_HEADER}` interpolation requires the env var on the controller pod, also add to `controller.envFrom` in `base-apps/kagent.yaml`:
+```yaml
+        controller:
+          # ...
+          envFrom:
+            - secretRef:
+                name: kagent-langfuse
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add base-apps/kagent.yaml base-apps/kagent/external-secret-langfuse.yaml
+git commit -m "feat(kagent): emit OTLP traces to Langfuse (Phase 0)"
+```
+
+- [ ] **Step 8: After ArgoCD sync, smoke-test the trace flow end to end**
+
+```bash
+# Trigger a kagent invocation (any agent works)
+# (substitute your actual invocation command from Task 0.12 Step 5)
+
+# Then check Langfuse:
+# Open https://langfuse.<base-domain> → project "golden-poc" → Traces tab
+# Expected: at least one trace appears within ~30 seconds
+```
+
+If no trace appears: check `kubectl logs -n kagent deploy/kagent-controller --tail=50 | grep -i otlp` for export errors. Common causes: OTLP_AUTH_HEADER format mismatch (must include the literal word "Basic "), wrong endpoint protocol (HTTP vs gRPC).
+
+---
+
+## Task 0.14: End-to-end Phase 0 verification
+
+**Files:** None (verification-only task)
+
+This task confirms all Phase 0 components are working together before we proceed to Phase 1.
+
+- [ ] **Step 1: All ArgoCD applications healthy**
+
+```bash
+argocd app list 2>/dev/null \
+  | grep -E "langfuse|langfuse-app|agentgateway|agentgateway-app|agentregistry|agentregistry-app|kagent" \
+  | awk '{print $1, $2, $6, $7}' \
+  | column -t
+```
+
+Expected: all rows show `Synced` and `Healthy`.
+
+- [ ] **Step 2: All four skills in agentregistry**
+
+```bash
+curl -fsS -H "Authorization: Bearer $(vault kv get -field=admin_token k8s-secrets/agentregistry)" \
+  https://agentregistry.<base-domain>/api/v1/skills | jq '.[] | .name'
+```
+
+Expected: `kubernetes-mcp`, `prometheus-mcp`, `github-mcp`, `k8s-yaml-lint` (the placeholder version is acceptable).
+
+- [ ] **Step 3: Anthropic call traverses the gateway**
+
+Run any kagent agent invocation, then immediately:
+```bash
+kubectl logs -n agentgateway -l app=agentgateway --tail=10 \
+  | grep -E "POST /v1/messages|claude-"
+```
+
+Expected: at least one log line within the last 30 seconds matches.
+
+- [ ] **Step 4: Trace appears in Langfuse**
+
+Open `https://langfuse.<base-domain>`, navigate to project `golden-poc` → Traces. Expected: trace count > 0.
+
+- [ ] **Step 5: GitHub App can be reached**
+
+```bash
+gh api /apps/golden-poc-pr-reviewer 2>&1 \
+  || echo "App settings (private endpoint): https://github.com/settings/apps/golden-poc-pr-reviewer"
+```
+
+Visit the URL. Verify the App is installed on `arigsela/kubernetes` (Installation ID matches what's in Vault).
+
+- [ ] **Step 6: Update preflight-results doc with end-to-end status**
+
+Append a final section to `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`:
+
+```markdown
+## Phase 0 — End-to-end status
+
+- [x] Langfuse running, project `golden-poc` created, OTLP ingest verified.
+- [x] agentgateway running, anthropic upstream verified end-to-end.
+- [x] agentregistry running, four skills seeded (k8s-yaml-lint is placeholder).
+- [x] kagent reconfigured to route through agentgateway and emit OTLP to Langfuse.
+- [x] GitHub App `golden-poc-pr-reviewer` installed on arigsela/kubernetes.
+
+**Phase 1 ready to start.**
+```
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): Phase 0 end-to-end verification complete"
+```
+
+Phase 0 complete. Phase 1 plan can now be executed; it has unambiguous answers for both preflight checks and a working platform to deploy onto.

--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-1-xagent.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-1-xagent.md
@@ -1,0 +1,838 @@
+# Golden POC — Phase 1: XAgent + Composition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the XAgent v1alpha1 Crossplane v2 namespaced XR, write its Composition (function-python script), pre-create the per-skill RBAC, hand-write the Cluster Health XAgent, and verify it works end-to-end via its HTTP endpoint with curl. No Backstage, no surface adapters yet — just the spine.
+
+**Architecture:** XAgent is a Crossplane v2 namespaced XR that mirrors the existing XApplication pattern. Its Composition is a single-step `function-python` pipeline that renders a kagent Agent CR, ToolServer CR(s), ExternalSecret (when surface needs creds), Service, Ingress, and TeraSky/Backstage labels. RBAC for skills is pre-created at install time per the design doc — the Composition wires the agent's ServiceAccount to existing RoleBindings by name.
+
+**Tech Stack:** Crossplane v2 (apiextensions.crossplane.io/v2), function-python, kagent.dev/v1alpha1 CRDs (Agent, ToolServer), External Secrets, nginx-ingress, cert-manager.
+
+**Reference design:** `docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md` Section 4 (XAgent + Composition), Section 7 (Cluster Health Agent).
+
+**Dependency:** Phase 0 must be complete. Read `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` first — its "Bucket A/B/C" determination for kagent ToolServer shape changes Task 1.4.
+
+---
+
+## Task 1.1: Create the agents namespace + SecretStore
+
+**Files:**
+- Create: `base-apps/agents.yaml`
+- Create: `base-apps/agents/namespace.yaml`
+- Create: `base-apps/agents/secret-store.yaml`
+
+The `agents` namespace is the home for XAgent CRs and the kagent Agent CRs they render.
+
+- [ ] **Step 1: Create namespace manifest**
+
+`base-apps/agents/namespace.yaml`:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents
+  labels:
+    app.kubernetes.io/managed-by: gitops
+```
+
+- [ ] **Step 2: Create SecretStore for the agents namespace**
+
+`base-apps/agents/secret-store.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: agents
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "agents"
+          serviceAccountRef:
+            name: "default"
+```
+
+- [ ] **Step 3: Create the Vault role**
+
+```bash
+vault write auth/kubernetes/role/agents \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=agents \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 4: Create the ArgoCD Application**
+
+`base-apps/agents.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agents
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/agents
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agents
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/agents.yaml base-apps/agents/
+git commit -m "feat(agents): namespace + SecretStore for XAgent CRs (Phase 1)"
+```
+
+After ArgoCD sync: verify `kubectl get ns agents` and `kubectl get secretstore vault-backend -n agents`.
+
+---
+
+## Task 1.2: Pre-create per-skill RBAC
+
+**Files:**
+- Create: `base-apps/agents/rbac-skills.yaml`
+
+Per design doc Section 4: "RBAC is pre-created at install time per skill; the Composition wires the agent's ServiceAccount to the appropriate existing RoleBinding by name." We define ClusterRoles per skill once; agents that use that skill get bound to it.
+
+- [ ] **Step 1: Define ClusterRoles for each skill type**
+
+`base-apps/agents/rbac-skills.yaml`:
+```yaml
+# Cluster-wide read-only Role for any agent using the kubernetes-mcp skill.
+# Naming convention: agent-skill-<skill-name>
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-skill-kubernetes-mcp
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "events", "namespaces", "nodes", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+---
+# Read-only HTTP access to Coroot (which exposes a Prometheus-compatible API).
+# This skill makes outbound HTTP calls; no Kubernetes API perms required, but
+# we keep the ClusterRole defined for symmetry and future-proofing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-skill-prometheus-mcp
+rules: []  # placeholder; this skill needs network policy, not RBAC
+---
+# github-mcp talks to GitHub API only — no cluster permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-skill-github-mcp
+rules: []
+---
+# k8s-yaml-lint runs offline — no permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-skill-k8s-yaml-lint
+rules: []
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add base-apps/agents/rbac-skills.yaml
+git commit -m "feat(agents): per-skill ClusterRoles for XAgent SAs to bind (Phase 1)"
+```
+
+After ArgoCD sync: `kubectl get clusterrole | grep agent-skill-` should show all four.
+
+---
+
+## Task 1.3: Define the XAgent XRD
+
+**Files:**
+- Create: `base-apps/crossplane-compositions/xrd-agent.yaml`
+
+Mirrors the existing `xrd-application.yaml` shape: `apiextensions.crossplane.io/v2`, namespaced, single version v1alpha1.
+
+- [ ] **Step 1: Write the XRD**
+
+`base-apps/crossplane-compositions/xrd-agent.yaml`:
+```yaml
+# base-apps/crossplane-compositions/xrd-agent.yaml
+# XAgent — engineer-facing API for declaring an AI agent.
+# Namespaced (Crossplane v2 default). Schema is v1alpha1; iterate freely.
+# Model selection, gateway routing, observability, RBAC binding are all
+# platform defaults set by the Composition, not XR fields.
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xagents.platform.arigsela.com
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  scope: Namespaced
+  group: platform.arigsela.com
+  names:
+    kind: XAgent
+    plural: xagents
+  defaultCompositionRef:
+    name: agent
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [description, systemPrompt, skills, surface]
+              properties:
+                description:
+                  type: string
+                  description: |
+                    Human-readable purpose of the agent. Shown in Backstage
+                    catalog. One sentence; this is not the system prompt.
+                  minLength: 10
+                  maxLength: 500
+                systemPrompt:
+                  type: string
+                  description: "The agent's system prompt — what to do, how to behave, what to avoid."
+                  minLength: 20
+                skills:
+                  type: array
+                  description: "agentregistry skill references."
+                  minItems: 1
+                  items:
+                    type: object
+                    required: [ref]
+                    properties:
+                      ref:
+                        type: string
+                        pattern: "^oci://.+:.+$"
+                        description: "OCI URI, e.g. oci://agentregistry.agentregistry.svc/skills/kubernetes-mcp:v1"
+                      alias:
+                        type: string
+                        description: "Optional short name for this skill in the agent's prompt context."
+                surface:
+                  type: string
+                  enum: [slack, http, mcp, github-webhook]
+                  description: "How humans/systems reach this agent."
+                model:
+                  type: string
+                  default: "platform-default"
+                  description: |
+                    Override the platform default model. POC accepts this field
+                    but uses kagent's configured default regardless. Multi-model
+                    support is deferred to v1.1.
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add base-apps/crossplane-compositions/xrd-agent.yaml
+git commit -m "feat(xrd): XAgent v1alpha1 namespaced XR (Phase 1)"
+```
+
+After ArgoCD sync: `kubectl get xrd xagents.platform.arigsela.com` should show as established.
+
+---
+
+## Task 1.4: Write the Composition function-python script
+
+**Files:**
+- Create: `base-apps/crossplane-compositions/composition-agent.yaml`
+
+The Composition's Python script renders the child resources. The structure mirrors the existing XApplication composition (`composition-application.yaml`).
+
+**ADAPTATION NOTE:** Read Phase 0's preflight-results doc Bucket determination for kagent ToolServer shape **before** writing Step 1. This task is written assuming **Bucket A** (kagent ToolServer accepts an OCI image directly). If Phase 0 found Bucket B (need a per-skill MCP server Deployment), insert that rendering logic in `make_tool_server_resources()`. If Bucket C (something else), adapt the `make_tool_server()` function to that shape.
+
+- [ ] **Step 1: Write the composition manifest**
+
+`base-apps/crossplane-compositions/composition-agent.yaml`:
+````yaml
+# base-apps/crossplane-compositions/composition-agent.yaml
+# Composition for XAgent. Single function-python step. Renders:
+#   - kagent Agent CR (model points at agentgateway endpoint)
+#   - kagent ToolServer CR(s) — one per unique skill ref
+#   - ExternalSecret (only when surface needs creds)
+#   - Service + Ingress (always — supports HTTP fallback and "Try it" button)
+#   - ServiceAccount + RoleBinding(s) wiring the agent's SA to per-skill ClusterRoles
+#   - TeraSky/Backstage labels and annotations on every rendered resource
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: agent
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  compositeTypeRef:
+    apiVersion: platform.arigsela.com/v1alpha1
+    kind: XAgent
+  mode: Pipeline
+  pipeline:
+    - step: render-resources
+      functionRef:
+        name: function-python
+      input:
+        apiVersion: python.fn.crossplane.io/v1beta1
+        kind: Script
+        script: |
+          from crossplane.function import resource
+
+          STD_LABELS_TEMPLATE = {
+              "app.kubernetes.io/name": None,
+              "app.kubernetes.io/managed-by": "crossplane",
+              "app.kubernetes.io/component": "agent",
+              "backstage.io/kubernetes-id": None,
+          }
+
+          TERASKY_ANNOTATION_PREFIXES = ("terasky.backstage.io/", "backstage.io/", "platform.arigsela.com/")
+
+          # Skill name -> agentregistry path mapping. Used to extract a short
+          # skill name from the OCI ref so we can name resources predictably
+          # and bind ClusterRoles by `agent-skill-<name>`.
+          # OCI ref format: oci://agentregistry.agentregistry.svc/skills/<name>:<version>
+          def parse_skill_name(ref: str) -> str:
+              # ref like "oci://.../skills/kubernetes-mcp:v1"
+              after_skills = ref.split("/skills/", 1)[-1]
+              return after_skills.split(":", 1)[0]
+
+          def std_labels(name):
+              labels = dict(STD_LABELS_TEMPLATE)
+              labels["app.kubernetes.io/name"] = name
+              labels["backstage.io/kubernetes-id"] = name
+              return labels
+
+          def std_annotations(xr_annotations, resource_name):
+              copied = {
+                  k: v for k, v in (xr_annotations or {}).items()
+                  if k.startswith(TERASKY_ANNOTATION_PREFIXES)
+              }
+              copied["crossplane.io/composition-resource-name"] = resource_name
+              return copied
+
+          # ---- kagent Agent CR ----
+          # ADAPTATION: the exact spec shape depends on kagent v0.8.6's Agent CRD.
+          # Verify field names against the CRD before relying on this in production.
+          # The shape below is a reasonable default; adjust if the CRD differs.
+          def make_kagent_agent(name, namespace, system_prompt, skill_names, annotations):
+              return {
+                  "apiVersion": "kagent.dev/v1alpha1",
+                  "kind": "Agent",
+                  "metadata": {
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "description": "Managed by XAgent Composition",
+                      "systemMessage": system_prompt,
+                      "modelConfig": "anthropic",  # references the kagent provider config
+                      "tools": [
+                          {"toolServer": tname}
+                          for tname in skill_names
+                      ],
+                      "serviceAccount": f"agent-{name}",
+                  },
+              }
+
+          # ---- kagent ToolServer CR ----
+          # ADAPTATION: per Phase 0 preflight Bucket. Below assumes Bucket A
+          # (ToolServer accepts an OCI image directly via spec.config.image).
+          # For Bucket B, this would render a Deployment + Service per skill
+          # and the ToolServer would point to the Service URL via spec.config.url.
+          def make_tool_server(skill_name, oci_ref, namespace, annotations):
+              return {
+                  "apiVersion": "kagent.dev/v1alpha1",
+                  "kind": "ToolServer",
+                  "metadata": {
+                      "name": skill_name,
+                      "namespace": namespace,
+                      "labels": std_labels(skill_name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "description": f"Skill {skill_name} from agentregistry",
+                      "config": {
+                          # Strip the "oci://" prefix; kagent expects an image ref.
+                          "image": oci_ref.replace("oci://", ""),
+                      },
+                  },
+              }
+
+          # ---- Service + Ingress (always rendered) ----
+          def make_service(name, namespace, annotations):
+              return {
+                  "apiVersion": "v1",
+                  "kind": "Service",
+                  "metadata": {
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "type": "ClusterIP",
+                      "selector": {"app.kubernetes.io/name": name},
+                      "ports": [{"name": "http", "port": 80, "targetPort": 8080}],
+                  },
+              }
+
+          # AGENTS_BASE_DOMAIN is set in the Composition's input below; falls
+          # back to "agents.cluster.local" if missing. Replace with your real
+          # domain at composition time (or override via XR annotation).
+          DEFAULT_BASE_DOMAIN = "agents.cluster.local"
+
+          def make_ingress(name, namespace, annotations, base_domain):
+              host = f"{name}.{base_domain}"
+              base_annotations = {
+                  "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+                  "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                  # POC: source-IP allowlist to cluster pod CIDR + Backstage pod IP.
+                  # Replace with your actual ranges.
+                  "nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/8,192.168.0.0/16",
+              }
+              merged_annotations = {**base_annotations, **annotations}
+              return {
+                  "apiVersion": "networking.k8s.io/v1",
+                  "kind": "Ingress",
+                  "metadata": {
+                      "name": name,
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": merged_annotations,
+                  },
+                  "spec": {
+                      "ingressClassName": "nginx",
+                      "tls": [{"hosts": [host], "secretName": f"{name}-tls"}],
+                      "rules": [{
+                          "host": host,
+                          "http": {"paths": [{
+                              "path": "/", "pathType": "Prefix",
+                              "backend": {"service": {"name": name, "port": {"number": 80}}},
+                          }]},
+                      }],
+                  },
+              }
+
+          # ---- ServiceAccount + RoleBindings ----
+          def make_service_account(name, namespace, annotations):
+              return {
+                  "apiVersion": "v1",
+                  "kind": "ServiceAccount",
+                  "metadata": {
+                      "name": f"agent-{name}",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+              }
+
+          def make_cluster_role_binding(agent_name, namespace, skill_name, annotations):
+              return {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "ClusterRoleBinding",
+                  "metadata": {
+                      "name": f"agent-{agent_name}-skill-{skill_name}",
+                      "labels": std_labels(agent_name),
+                      "annotations": annotations,
+                  },
+                  "subjects": [{
+                      "kind": "ServiceAccount",
+                      "name": f"agent-{agent_name}",
+                      "namespace": namespace,
+                  }],
+                  "roleRef": {
+                      "kind": "ClusterRole",
+                      "name": f"agent-skill-{skill_name}",
+                      "apiGroup": "rbac.authorization.k8s.io",
+                  },
+              }
+
+          # ---- ExternalSecret (only when surface needs creds) ----
+          def make_external_secret_for_surface(agent_name, namespace, surface, annotations):
+              if surface == "slack":
+                  return {
+                      "apiVersion": "external-secrets.io/v1beta1",
+                      "kind": "ExternalSecret",
+                      "metadata": {
+                          "name": f"{agent_name}-slack",
+                          "namespace": namespace,
+                          "labels": std_labels(agent_name),
+                          "annotations": annotations,
+                      },
+                      "spec": {
+                          "refreshInterval": "1h",
+                          "secretStoreRef": {"name": "vault-backend", "kind": "SecretStore"},
+                          "target": {"name": f"{agent_name}-slack", "creationPolicy": "Owner"},
+                          "data": [{
+                              "secretKey": "slack_bot_token",
+                              "remoteRef": {
+                                  "key": f"agents/{agent_name}",
+                                  "property": "slack_bot_token",
+                              },
+                          }],
+                      },
+                  }
+              if surface == "github-webhook":
+                  return {
+                      "apiVersion": "external-secrets.io/v1beta1",
+                      "kind": "ExternalSecret",
+                      "metadata": {
+                          "name": f"{agent_name}-github",
+                          "namespace": namespace,
+                          "labels": std_labels(agent_name),
+                          "annotations": annotations,
+                      },
+                      "spec": {
+                          "refreshInterval": "1h",
+                          "secretStoreRef": {"name": "vault-backend", "kind": "SecretStore"},
+                          "target": {"name": f"{agent_name}-github", "creationPolicy": "Owner"},
+                          "data": [
+                              {"secretKey": "github_app_id",       "remoteRef": {"key": f"agents/{agent_name}", "property": "github_app_id"}},
+                              {"secretKey": "github_installation_id", "remoteRef": {"key": f"agents/{agent_name}", "property": "github_installation_id"}},
+                              {"secretKey": "github_private_key",  "remoteRef": {"key": f"agents/{agent_name}", "property": "github_private_key"}},
+                          ],
+                      },
+                  }
+              return None  # http, mcp — no per-agent secret
+
+          # ---- compose() entry point ----
+          def compose(req, rsp):
+              xr = resource.struct_to_dict(req.observed.composite.resource)
+              spec = xr["spec"]
+              meta = xr["metadata"]
+              name = meta["name"]
+              namespace = meta["namespace"]
+              xr_annotations = meta.get("annotations", {})
+              base_domain = xr_annotations.get(
+                  "platform.arigsela.com/base-domain",
+                  DEFAULT_BASE_DOMAIN,
+              )
+
+              skills = spec["skills"]
+              skill_names = [parse_skill_name(s["ref"]) for s in skills]
+              # de-dup while preserving order
+              seen = set()
+              unique_skill_names = []
+              for sn in skill_names:
+                  if sn not in seen:
+                      seen.add(sn)
+                      unique_skill_names.append(sn)
+              skill_ref_by_name = {parse_skill_name(s["ref"]): s["ref"] for s in skills}
+
+              # 1) ServiceAccount
+              resource.update(
+                  rsp.desired.resources["serviceaccount"],
+                  make_service_account(name, namespace,
+                                       std_annotations(xr_annotations, "serviceaccount")),
+              )
+
+              # 2) ClusterRoleBindings (one per unique skill)
+              for sn in unique_skill_names:
+                  resource.update(
+                      rsp.desired.resources[f"crb-{sn}"],
+                      make_cluster_role_binding(name, namespace, sn,
+                                                std_annotations(xr_annotations, f"crb-{sn}")),
+                  )
+
+              # 3) ToolServers (one per unique skill)
+              for sn in unique_skill_names:
+                  resource.update(
+                      rsp.desired.resources[f"toolserver-{sn}"],
+                      make_tool_server(sn, skill_ref_by_name[sn], namespace,
+                                       std_annotations(xr_annotations, f"toolserver-{sn}")),
+                  )
+
+              # 4) kagent Agent CR
+              resource.update(
+                  rsp.desired.resources["agent"],
+                  make_kagent_agent(name, namespace, spec["systemPrompt"],
+                                    unique_skill_names,
+                                    std_annotations(xr_annotations, "agent")),
+              )
+
+              # 5) Service (always)
+              resource.update(
+                  rsp.desired.resources["service"],
+                  make_service(name, namespace,
+                               std_annotations(xr_annotations, "service")),
+              )
+
+              # 6) Ingress (always)
+              resource.update(
+                  rsp.desired.resources["ingress"],
+                  make_ingress(name, namespace,
+                               std_annotations(xr_annotations, "ingress"),
+                               base_domain),
+              )
+
+              # 7) ExternalSecret (only when surface needs creds)
+              es = make_external_secret_for_surface(
+                  name, namespace, spec["surface"],
+                  std_annotations(xr_annotations, "externalsecret"),
+              )
+              if es is not None:
+                  resource.update(
+                      rsp.desired.resources["externalsecret"],
+                      es,
+                  )
+````
+
+- [ ] **Step 2: Validate the Composition renders correctly with `crossplane render`**
+
+Create a fixture XAgent and a stub functions.yaml:
+
+```bash
+mkdir -p /tmp/xagent-render
+cat > /tmp/xagent-render/xr.yaml <<'EOF'
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: cluster-health
+  namespace: agents
+spec:
+  description: "Reports cluster status"
+  systemPrompt: "You are the Cluster Health Agent."
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/kubernetes-mcp:v1
+    - ref: oci://agentregistry.agentregistry.svc/skills/prometheus-mcp:v1
+  surface: slack
+EOF
+
+cat > /tmp/xagent-render/functions.yaml <<'EOF'
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-python
+spec:
+  package: ghcr.io/crossplane-contrib/function-python:v0.x.x  # match your installed version
+EOF
+
+crossplane render \
+  /tmp/xagent-render/xr.yaml \
+  base-apps/crossplane-compositions/composition-agent.yaml \
+  /tmp/xagent-render/functions.yaml
+```
+
+Expected: rendered output containing ServiceAccount, two ClusterRoleBindings (kubernetes-mcp, prometheus-mcp), two ToolServers, one Agent, one Service, one Ingress, and one ExternalSecret (slack flavor).
+
+If `crossplane render` errors on schema, fix the script and retry until clean output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add base-apps/crossplane-compositions/composition-agent.yaml
+git commit -m "feat(crossplane): Composition for XAgent (function-python) (Phase 1)"
+```
+
+After ArgoCD sync: `kubectl get composition agent` should show as established.
+
+---
+
+## Task 1.5: Hand-write the Cluster Health XAgent
+
+**Files:**
+- Create: `base-apps/agents/cluster-health/agent.yaml`
+- Create: `base-apps/agents/cluster-health/catalog-info.yaml`
+
+The Cluster Health Agent is the first XAgent. Hand-written for Phase 1 (Backstage's Software Template that scaffolds these comes in Phase 3).
+
+- [ ] **Step 1: Write the XAgent**
+
+`base-apps/agents/cluster-health/agent.yaml`:
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: cluster-health
+  namespace: agents
+  annotations:
+    platform.arigsela.com/base-domain: "<base-domain>"  # replace
+spec:
+  description: "Reports cluster/namespace status: pod readiness, events, recent deploys, top noisy pods. Read-only."
+  systemPrompt: |
+    You are the Cluster Health Agent. On request, gather for the named namespace
+    (or cluster-wide if none specified):
+      - Pod readiness counts
+      - Events in the last hour, grouped by reason
+      - Deployments in the last 24h
+      - Top 5 pods by CPU and by memory
+    Respond with brief, skimmable Markdown. Lead with anything actionable
+    (CrashLoopBackOff, OOMKilled, ImagePullBackOff). If everything is normal,
+    say so plainly. You are read-only — do not take any action.
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/kubernetes-mcp:v1
+      alias: k8s
+    - ref: oci://agentregistry.agentregistry.svc/skills/prometheus-mcp:v1
+      alias: prom
+  surface: slack
+```
+
+(Phase 1 sets `surface: slack` so the right ExternalSecret is rendered, but the Slack adapter itself doesn't exist yet — Phase 2 wires that. The agent is invokable via curl in the meantime.)
+
+- [ ] **Step 2: Pre-stage the (unused-yet) Slack bot token in Vault**
+
+```bash
+vault kv put k8s-secrets/agents/cluster-health \
+  slack_bot_token="placeholder-set-in-phase-2"
+```
+
+(Phase 2 replaces the placeholder with the real token after the Slack app is configured.)
+
+- [ ] **Step 3: Write the Backstage Component manifest (anticipates Phase 3)**
+
+`base-apps/agents/cluster-health/catalog-info.yaml`:
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cluster-health-agent
+  description: "Reports cluster/namespace status — read-only."
+  annotations:
+    backstage.io/kubernetes-id: cluster-health
+    kagent.dev/agent-name: cluster-health
+    langfuse.platform.arigsela.com/project: golden-poc
+    agent.platform.arigsela.com/try-url: https://cluster-health.<base-domain>/v1/messages
+spec:
+  type: agent
+  lifecycle: experimental
+  owner: platform-team
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/agents/cluster-health/
+git commit -m "feat(agent): cluster-health XAgent — first agent end-to-end (Phase 1)"
+```
+
+After ArgoCD sync: `kubectl get xagent cluster-health -n agents` should show as Synced/Ready.
+
+- [ ] **Step 5: Verify all child resources rendered**
+
+```bash
+kubectl get sa,toolserver,agent,service,ingress,externalsecret,clusterrolebinding -n agents \
+  -l app.kubernetes.io/name=cluster-health
+```
+
+Expected: `agent-cluster-health` ServiceAccount; two ToolServers (kubernetes-mcp, prometheus-mcp); kagent Agent named `cluster-health`; Service `cluster-health`; Ingress `cluster-health`; ExternalSecret `cluster-health-slack`.
+
+For ClusterRoleBindings (cluster-scoped, no namespace flag):
+```bash
+kubectl get clusterrolebinding | grep "agent-cluster-health-skill-"
+# Expected: two bindings (kubernetes-mcp, prometheus-mcp)
+```
+
+---
+
+## Task 1.6: Smoke-test the Cluster Health Agent via HTTP
+
+**Files:** None (verification-only)
+
+- [ ] **Step 1: Wait for the kagent Agent pod to be running**
+
+```bash
+kubectl get pods -n agents -l kagent.dev/agent-name=cluster-health
+# Expected: pod Running and Ready
+```
+
+If the pod is not running: `kubectl describe pod -n agents -l kagent.dev/agent-name=cluster-health` and look for image pull errors (likely an issue with the ToolServer OCI ref → adjust per Phase 0 preflight bucket).
+
+- [ ] **Step 2: Invoke via the agent's Service (in-cluster)**
+
+```bash
+kubectl run curl-test --rm -i --image=curlimages/curl --restart=Never --quiet -- \
+  curl -sS -X POST http://cluster-health.agents.svc.cluster.local/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":"What is the status of the agents namespace?"}]
+  }' | head -100
+```
+
+Expected: a JSON response with the agent's structured Markdown analysis of the `agents` namespace (running pods, events, etc.).
+
+If the request times out: kagent runtime probably can't reach the ToolServers. Check kagent controller logs: `kubectl logs -n kagent deploy/kagent-controller --tail=100 | grep -i toolserver`.
+
+- [ ] **Step 3: Verify the LLM call traversed agentgateway**
+
+```bash
+kubectl logs -n agentgateway -l app=agentgateway --tail=10 | grep -E "claude-|messages"
+# Expected: a recent log line for the message we just sent
+```
+
+- [ ] **Step 4: Verify the trace appears in Langfuse**
+
+Open `https://langfuse.<base-domain>` → project `golden-poc` → Traces. Expected: a new trace within 30 seconds, tagged with `cluster-health` (or with the agent name visible in the trace metadata).
+
+If no trace: check kagent controller logs for OTLP export errors; revisit Phase 0 Task 0.13.
+
+---
+
+## Task 1.7: Phase 1 acceptance + handoff to Phase 2
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` (append Phase 1 status)
+
+- [ ] **Step 1: Run all Phase 1 verification one more time**
+
+```bash
+kubectl get xagent cluster-health -n agents -o jsonpath='{.status.conditions}' | jq
+# Expected: Ready=True, Synced=True
+```
+
+Plus: invoke the agent via curl one more time and confirm a clean Markdown response.
+
+- [ ] **Step 2: Append status to preflight-results.md**
+
+```markdown
+## Phase 1 — Status
+
+- [x] `agents` namespace + SecretStore created.
+- [x] Per-skill ClusterRoles defined (`agent-skill-kubernetes-mcp`, `agent-skill-prometheus-mcp`, `agent-skill-github-mcp`, `agent-skill-k8s-yaml-lint`).
+- [x] XAgent XRD established (`xagents.platform.arigsela.com`).
+- [x] Composition `agent` established. Renders 7 resource types; verified via `crossplane render`.
+- [x] Cluster Health XAgent reconciles all 7 child resources.
+- [x] curl smoke test against `https://cluster-health.<base-domain>` returns LLM response.
+- [x] Trace visible in Langfuse for the smoke test.
+
+**Phase 2 ready to start.**
+```
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): Phase 1 verification complete"
+```
+
+Phase 1 complete. The platform spine works end-to-end without Backstage or surface adapters. Phase 2 layers on Slack and GitHub webhook adapters plus the PR Review agent.

--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-2-adapters.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-2-adapters.md
@@ -1,0 +1,1555 @@
+# Golden POC — Phase 2: Surface Adapters + PR Review Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the two shared surface adapters (Slack and GitHub webhook), build the custom k8s-yaml-lint skill (replacing Phase 0's placeholder in agentregistry), hand-write the PR Review XAgent, and demonstrate both agents end-to-end on their real surfaces.
+
+**Architecture:** Both adapters are small Go services that watch XAgent resources via Kubernetes informers and route surface-specific traffic to per-agent HTTP endpoints (rendered by the XAgent Composition in Phase 1). slack-adapter subscribes to Slack Events API; github-webhook-adapter receives GitHub webhook deliveries. The k8s-yaml-lint skill is a small Python MCP server wrapping kube-linter, packaged as an OCI image and republished into agentregistry.
+
+**Tech Stack:** Go 1.22 (adapters), client-go (informers), Slack Bolt SDK or slack-go, go-github, Python 3.12 + the official MCP Python SDK (k8s-yaml-lint), kube-linter, Docker for image builds, ECR (existing) for image hosting.
+
+**Reference design:** `docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md` Section 6 (Slack/GitHub adapters), Section 7 (PR Review Agent).
+
+**Dependencies:**
+- Phase 0 complete (agentgateway, agentregistry, GitHub App credentials in Vault).
+- Phase 1 complete (XAgent XRD + Composition + cluster-health agent running).
+
+---
+
+## Task 2.1: Build the slack-adapter service
+
+**Files:**
+- Create: `services/slack-adapter/Dockerfile`
+- Create: `services/slack-adapter/go.mod`
+- Create: `services/slack-adapter/main.go`
+- Create: `services/slack-adapter/internal/informer/informer.go`
+- Create: `services/slack-adapter/internal/router/router.go`
+- Create: `services/slack-adapter/internal/slack/handler.go`
+- Create: `services/slack-adapter/README.md`
+
+The slack-adapter watches `XAgent` resources with `surface: slack`, builds a routing table from XAgent annotations (e.g., `platform.arigsela.com/slack-command: cluster-health`), and dispatches Slack `app_mention` events to the matching agent's HTTP endpoint.
+
+- [ ] **Step 1: Initialize the Go module + dependencies**
+
+```bash
+mkdir -p services/slack-adapter/internal/{informer,router,slack}
+cd services/slack-adapter
+go mod init github.com/arigsela/kubernetes/services/slack-adapter
+go get k8s.io/client-go@latest k8s.io/apimachinery@latest k8s.io/apiextensions-apiserver@latest \
+       github.com/slack-go/slack@latest \
+       github.com/go-logr/logr@latest go.uber.org/zap@latest
+```
+
+- [ ] **Step 2: Write `main.go`**
+
+`services/slack-adapter/main.go`:
+```go
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/arigsela/kubernetes/services/slack-adapter/internal/informer"
+	"github.com/arigsela/kubernetes/services/slack-adapter/internal/router"
+	slackh "github.com/arigsela/kubernetes/services/slack-adapter/internal/slack"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	defer logger.Sync()
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Fatal("rest.InClusterConfig", zap.Error(err))
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		logger.Fatal("dynamic.NewForConfig", zap.Error(err))
+	}
+
+	rt := router.New()
+	inf := informer.New(dyn, rt, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go inf.Run(ctx)
+
+	bot := slackh.New(
+		os.Getenv("SLACK_BOT_TOKEN"),
+		os.Getenv("SLACK_SIGNING_SECRET"),
+		rt,
+		logger,
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slack/events", bot.HandleEvents)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Addr:              ":8080",
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		logger.Info("slack-adapter listening on :8080")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("http.ListenAndServe", zap.Error(err))
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+	logger.Info("shutting down")
+	cancel()
+	shutdownCtx, c := context.WithTimeout(context.Background(), 10*time.Second)
+	defer c()
+	_ = srv.Shutdown(shutdownCtx)
+}
+```
+
+- [ ] **Step 3: Write the XAgent informer**
+
+`services/slack-adapter/internal/informer/informer.go`:
+```go
+package informer
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/arigsela/kubernetes/services/slack-adapter/internal/router"
+)
+
+var xagentGVR = schema.GroupVersionResource{
+	Group:    "platform.arigsela.com",
+	Version:  "v1alpha1",
+	Resource: "xagents",
+}
+
+type Informer struct {
+	dyn    dynamic.Interface
+	router *router.Router
+	log    *zap.Logger
+}
+
+func New(dyn dynamic.Interface, r *router.Router, log *zap.Logger) *Informer {
+	return &Informer{dyn: dyn, router: r, log: log}
+}
+
+func (i *Informer) Run(ctx context.Context) {
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(i.dyn, 30*time.Second)
+	gen := factory.ForResource(xagentGVR).Informer()
+
+	_, _ = gen.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    i.upsert,
+		UpdateFunc: func(_, obj interface{}) { i.upsert(obj) },
+		DeleteFunc: i.delete,
+	})
+
+	factory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), gen.HasSynced) {
+		i.log.Error("informer cache failed to sync")
+		return
+	}
+	<-ctx.Done()
+}
+
+func (i *Informer) upsert(obj interface{}) {
+	m, ok := obj.(*metav1Lite)
+	if !ok {
+		return
+	}
+	if m.Spec.Surface != "slack" {
+		return
+	}
+	cmd, ok := m.Metadata.Annotations["platform.arigsela.com/slack-command"]
+	if !ok {
+		return
+	}
+	i.router.Set(cmd, router.Target{
+		Namespace: m.Metadata.Namespace,
+		Name:      m.Metadata.Name,
+		Endpoint:  endpointFor(m.Metadata.Namespace, m.Metadata.Name),
+	})
+	i.log.Info("registered", zap.String("cmd", cmd), zap.String("agent", m.Metadata.Name))
+}
+
+func (i *Informer) delete(obj interface{}) {
+	m, ok := obj.(*metav1Lite)
+	if !ok {
+		return
+	}
+	if cmd, ok := m.Metadata.Annotations["platform.arigsela.com/slack-command"]; ok {
+		i.router.Delete(cmd)
+	}
+}
+
+func endpointFor(ns, name string) string {
+	return "http://" + name + "." + ns + ".svc.cluster.local/v1/messages"
+}
+
+// metav1Lite is a minimal projection used by the dynamic informer.
+// (For brevity here; in real code, use unstructured.Unstructured + helpers.)
+type metav1Lite struct {
+	Metadata metav1.ObjectMeta `json:"metadata"`
+	Spec     struct {
+		Surface string `json:"surface"`
+	} `json:"spec"`
+}
+```
+
+(For brevity this uses a typed projection; in production code, use `unstructured.Unstructured` and `metav1.ObjectMetaAccessor` helpers — fix this if your linter complains during build.)
+
+- [ ] **Step 4: Write the router**
+
+`services/slack-adapter/internal/router/router.go`:
+```go
+package router
+
+import "sync"
+
+type Target struct {
+	Namespace string
+	Name      string
+	Endpoint  string
+}
+
+type Router struct {
+	mu    sync.RWMutex
+	byCmd map[string]Target
+}
+
+func New() *Router { return &Router{byCmd: make(map[string]Target)} }
+
+func (r *Router) Set(cmd string, t Target) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byCmd[cmd] = t
+}
+
+func (r *Router) Delete(cmd string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.byCmd, cmd)
+}
+
+func (r *Router) Lookup(cmd string) (Target, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.byCmd[cmd]
+	return t, ok
+}
+```
+
+- [ ] **Step 5: Write the Slack handler**
+
+`services/slack-adapter/internal/slack/handler.go`:
+```go
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	slackgo "github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/arigsela/kubernetes/services/slack-adapter/internal/router"
+)
+
+type Handler struct {
+	api    *slackgo.Client
+	signSecret string
+	router *router.Router
+	log    *zap.Logger
+	httpc  *http.Client
+}
+
+func New(token, signSecret string, r *router.Router, log *zap.Logger) *Handler {
+	return &Handler{
+		api: slackgo.New(token),
+		signSecret: signSecret,
+		router: r,
+		log: log,
+		httpc: &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (h *Handler) HandleEvents(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	sv, err := slackgo.NewSecretsVerifier(r.Header, h.signSecret)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if _, err := sv.Write(body); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if err := sv.Ensure(); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	ev, err := slackevents.ParseEvent(body, slackevents.OptionNoVerifyToken())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch ev.Type {
+	case slackevents.URLVerification:
+		var rc *slackevents.ChallengeResponse
+		if err := json.Unmarshal(body, &rc); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(rc.Challenge))
+	case slackevents.CallbackEvent:
+		switch e := ev.InnerEvent.Data.(type) {
+		case *slackevents.AppMentionEvent:
+			h.handleMention(e)
+		}
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (h *Handler) handleMention(e *slackevents.AppMentionEvent) {
+	// Strip the bot mention prefix and split into command + rest of message.
+	text := strings.TrimSpace(e.Text)
+	if i := strings.Index(text, ">"); i > -1 {
+		text = strings.TrimSpace(text[i+1:])
+	}
+	parts := strings.SplitN(text, " ", 2)
+	if len(parts) == 0 {
+		return
+	}
+	cmd := parts[0]
+	userMsg := ""
+	if len(parts) > 1 {
+		userMsg = parts[1]
+	}
+
+	target, ok := h.router.Lookup(cmd)
+	if !ok {
+		_, _, _ = h.api.PostMessage(e.Channel, slackgo.MsgOptionText(
+			"No agent registered for `"+cmd+"`. Available agents are routed via the `platform.arigsela.com/slack-command` annotation.",
+			false,
+		))
+		return
+	}
+
+	body := map[string]any{
+		"messages": []map[string]string{{"role": "user", "content": userMsg}},
+	}
+	bb, _ := json.Marshal(body)
+	resp, err := h.httpc.Post(target.Endpoint, "application/json", bytes.NewReader(bb))
+	if err != nil {
+		h.log.Error("agent call failed", zap.Error(err), zap.String("agent", target.Name))
+		_, _, _ = h.api.PostMessage(e.Channel, slackgo.MsgOptionText("Agent unreachable: "+err.Error(), false), slackgo.MsgOptionTS(e.TimeStamp))
+		return
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	// Expect kagent's response format: { "content": [{"type":"text","text":"..."}] }
+	var parsed struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	_ = json.Unmarshal(respBody, &parsed)
+	out := ""
+	for _, c := range parsed.Content {
+		out += c.Text + "\n"
+	}
+	if out == "" {
+		out = string(respBody)
+	}
+
+	_, _, _ = h.api.PostMessage(e.Channel, slackgo.MsgOptionText(out, false), slackgo.MsgOptionTS(e.TimeStamp))
+}
+```
+
+- [ ] **Step 6: Write the Dockerfile**
+
+`services/slack-adapter/Dockerfile`:
+```dockerfile
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/slack-adapter ./
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/slack-adapter /slack-adapter
+USER 65532:65532
+ENTRYPOINT ["/slack-adapter"]
+```
+
+- [ ] **Step 7: Build, test locally, and push the image**
+
+```bash
+cd services/slack-adapter
+go build ./...      # compile check
+go vet ./...
+
+# Build and push to ECR (existing ecr-auth pattern is configured cluster-side)
+IMG=<your-ecr-repo>/slack-adapter:v0.1.0
+docker build -t "$IMG" .
+docker push "$IMG"
+```
+
+Record the resolved image reference for use in Task 2.2.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/slack-adapter/
+git commit -m "feat(slack-adapter): Go service watching XAgents and routing Slack mentions (Phase 2)"
+```
+
+---
+
+## Task 2.2: Deploy slack-adapter as a base-app
+
+**Files:**
+- Create: `base-apps/slack-adapter.yaml`
+- Create: `base-apps/slack-adapter/namespace.yaml`
+- Create: `base-apps/slack-adapter/secret-store.yaml`
+- Create: `base-apps/slack-adapter/external-secret.yaml`
+- Create: `base-apps/slack-adapter/rbac.yaml`
+- Create: `base-apps/slack-adapter/deployment.yaml`
+- Create: `base-apps/slack-adapter/service.yaml`
+- Create: `base-apps/slack-adapter/ingress.yaml`
+
+- [ ] **Step 1: Stage Slack credentials in Vault**
+
+(After completing Task 2.3 Step 1 — creating the Slack app — return here.)
+
+```bash
+vault kv put k8s-secrets/slack-adapter \
+  bot_token=<xoxb-... from Slack app config> \
+  signing_secret=<from Slack app config>
+```
+
+- [ ] **Step 2: Create namespace and SecretStore**
+
+`base-apps/slack-adapter/namespace.yaml`:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: slack-adapter
+```
+
+`base-apps/slack-adapter/secret-store.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: slack-adapter
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "slack-adapter"
+          serviceAccountRef:
+            name: "default"
+```
+
+```bash
+vault write auth/kubernetes/role/slack-adapter \
+  bound_service_account_names=default,slack-adapter \
+  bound_service_account_namespaces=slack-adapter \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 3: ExternalSecret**
+
+`base-apps/slack-adapter/external-secret.yaml`:
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-adapter
+  namespace: slack-adapter
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: slack-adapter
+    creationPolicy: Owner
+  data:
+    - {secretKey: SLACK_BOT_TOKEN,      remoteRef: {key: slack-adapter, property: bot_token}}
+    - {secretKey: SLACK_SIGNING_SECRET, remoteRef: {key: slack-adapter, property: signing_secret}}
+```
+
+- [ ] **Step 4: RBAC for the XAgent informer**
+
+`base-apps/slack-adapter/rbac.yaml`:
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: slack-adapter
+  namespace: slack-adapter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: slack-adapter-xagent-watch
+rules:
+  - apiGroups: ["platform.arigsela.com"]
+    resources: ["xagents"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: slack-adapter-xagent-watch
+subjects:
+  - kind: ServiceAccount
+    name: slack-adapter
+    namespace: slack-adapter
+roleRef:
+  kind: ClusterRole
+  name: slack-adapter-xagent-watch
+  apiGroup: rbac.authorization.k8s.io
+```
+
+- [ ] **Step 5: Deployment + Service + Ingress**
+
+`base-apps/slack-adapter/deployment.yaml`:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-adapter
+  namespace: slack-adapter
+  labels:
+    app.kubernetes.io/name: slack-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: slack-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: slack-adapter
+    spec:
+      serviceAccountName: slack-adapter
+      imagePullSecrets:
+        - name: ecr-auth
+      containers:
+        - name: app
+          image: <your-ecr-repo>/slack-adapter:v0.1.0  # from Task 2.1 Step 7
+          ports:
+            - {containerPort: 8080, name: http}
+          envFrom:
+            - secretRef:
+                name: slack-adapter
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits:   {cpu: 500m, memory: 256Mi}
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            initialDelaySeconds: 3
+```
+
+`base-apps/slack-adapter/service.yaml`:
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: slack-adapter
+  namespace: slack-adapter
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: slack-adapter
+  ports:
+    - {name: http, port: 80, targetPort: 8080}
+```
+
+`base-apps/slack-adapter/ingress.yaml`:
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: slack-adapter
+  namespace: slack-adapter
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [slack.<base-domain>]
+      secretName: slack-adapter-tls
+  rules:
+    - host: slack.<base-domain>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: slack-adapter
+                port: {number: 80}
+```
+
+- [ ] **Step 6: ArgoCD application**
+
+`base-apps/slack-adapter.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: slack-adapter
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/slack-adapter
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: slack-adapter
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add base-apps/slack-adapter.yaml base-apps/slack-adapter/
+git commit -m "feat(slack-adapter): deploy as base-app (Phase 2)"
+```
+
+After ArgoCD sync: `kubectl get pods -n slack-adapter` shows the pod Running and `kubectl logs` shows informer cache synced.
+
+---
+
+## Task 2.3: Set up Slack app + wire to cluster-health agent
+
+**Files:**
+- Modify: `base-apps/agents/cluster-health/agent.yaml` (add slack-command annotation)
+
+- [ ] **Step 1: Create the Slack app**
+
+Go to https://api.slack.com/apps → "Create New App" → "From scratch":
+- App name: `golden-poc-bot`
+- Workspace: your workspace
+
+In the new app:
+- **OAuth & Permissions** → Bot Token Scopes: `app_mentions:read`, `chat:write`, `chat:write.public`. Install the app to the workspace. Copy the **Bot User OAuth Token** (starts with `xoxb-`).
+- **Basic Information** → App Credentials → copy the **Signing Secret**.
+- **Event Subscriptions** → Enable Events.
+  - Request URL: `https://slack.<base-domain>/slack/events`
+  - Subscribe to bot events: `app_mention`
+  - Save Changes (Slack will verify the URL — needs Task 2.2 deployed and reachable; iterate if needed).
+
+- [ ] **Step 2: Push tokens to Vault**
+
+```bash
+vault kv put k8s-secrets/slack-adapter \
+  bot_token=<xoxb-...> \
+  signing_secret=<...>
+```
+
+Restart the slack-adapter pod to pick up new envs:
+```bash
+kubectl rollout restart deployment/slack-adapter -n slack-adapter
+```
+
+- [ ] **Step 3: Tag cluster-health XAgent with the slash command**
+
+Modify `base-apps/agents/cluster-health/agent.yaml` to add the annotation:
+
+```yaml
+metadata:
+  name: cluster-health
+  namespace: agents
+  annotations:
+    platform.arigsela.com/base-domain: "<base-domain>"
+    platform.arigsela.com/slack-command: "cluster-health"  # new
+```
+
+- [ ] **Step 4: Update the Vault placeholder with a real bot token (from Step 1)**
+
+Phase 1 staged a placeholder under `k8s-secrets/agents/cluster-health` for `slack_bot_token`. The agent itself doesn't actually need a Slack token (the adapter handles all Slack I/O), but the ExternalSecret rendered by the Composition exists. Either:
+
+**Option A:** Leave the placeholder; the secret is unused by the agent.
+**Option B:** Remove the slack-token requirement from the Composition for `surface: slack` (since the adapter holds it). Cleaner long term but requires re-running `crossplane render` to verify.
+
+For Phase 2, **Option A** is fine. Mark this for cleanup in Phase 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/agents/cluster-health/agent.yaml
+git commit -m "feat(agent): wire cluster-health to slack-command 'cluster-health' (Phase 2)"
+```
+
+- [ ] **Step 6: End-to-end Slack test**
+
+In Slack, in any channel where the bot is invited:
+```
+@golden-poc-bot cluster-health agents
+```
+
+Expected: a thread reply with the agent's Markdown analysis of the `agents` namespace.
+
+If the bot doesn't respond:
+- Check `kubectl logs -n slack-adapter -l app.kubernetes.io/name=slack-adapter --tail=50` for routing or HTTP errors.
+- Verify the Slack Events Request URL was successfully verified (Slack app config page).
+
+---
+
+## Task 2.4: Build the github-webhook-adapter service
+
+**Files:**
+- Create: `services/github-webhook-adapter/Dockerfile`
+- Create: `services/github-webhook-adapter/go.mod`
+- Create: `services/github-webhook-adapter/main.go`
+- Create: `services/github-webhook-adapter/internal/informer/informer.go`
+- Create: `services/github-webhook-adapter/internal/router/router.go`
+- Create: `services/github-webhook-adapter/internal/github/handler.go`
+- Create: `services/github-webhook-adapter/internal/github/app_auth.go`
+- Create: `services/github-webhook-adapter/README.md`
+
+This adapter receives GitHub webhook deliveries, looks up the matching agent (by `platform.arigsela.com/github-repo` annotation), invokes the agent with the PR diff + context, parses the response into line-anchored review comments, and posts them via the GitHub API using a GitHub App-authenticated client.
+
+- [ ] **Step 1: Initialize and write `main.go`**
+
+```bash
+mkdir -p services/github-webhook-adapter/internal/{informer,router,github}
+cd services/github-webhook-adapter
+go mod init github.com/arigsela/kubernetes/services/github-webhook-adapter
+go get k8s.io/client-go@latest k8s.io/apimachinery@latest \
+       github.com/google/go-github/v66@latest \
+       github.com/bradleyfalzon/ghinstallation/v2@latest \
+       github.com/golang-jwt/jwt/v5@latest \
+       go.uber.org/zap@latest
+```
+
+`services/github-webhook-adapter/main.go`:
+```go
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/arigsela/kubernetes/services/github-webhook-adapter/internal/github"
+	"github.com/arigsela/kubernetes/services/github-webhook-adapter/internal/informer"
+	"github.com/arigsela/kubernetes/services/github-webhook-adapter/internal/router"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	defer logger.Sync()
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil { logger.Fatal("rest", zap.Error(err)) }
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil { logger.Fatal("dynamic", zap.Error(err)) }
+
+	rt := router.New()
+	go informer.New(dyn, rt, logger).Run(context.Background())
+
+	h := github.NewHandler(
+		os.Getenv("GITHUB_APP_ID"),
+		os.Getenv("GITHUB_INSTALLATION_ID"),
+		[]byte(os.Getenv("GITHUB_PRIVATE_KEY")),
+		os.Getenv("GITHUB_WEBHOOK_SECRET"),
+		rt,
+		logger,
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook", h.HandleWebhook)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	srv := &http.Server{Addr: ":8080", Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	go func() {
+		logger.Info("github-webhook-adapter listening on :8080")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("listen", zap.Error(err))
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+	c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(c)
+}
+```
+
+- [ ] **Step 2: Write the informer**
+
+`services/github-webhook-adapter/internal/informer/informer.go`:
+```go
+package informer
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/arigsela/kubernetes/services/github-webhook-adapter/internal/router"
+)
+
+var xagentGVR = schema.GroupVersionResource{
+	Group: "platform.arigsela.com", Version: "v1alpha1", Resource: "xagents",
+}
+
+type Informer struct {
+	dyn    dynamic.Interface
+	router *router.Router
+	log    *zap.Logger
+}
+
+func New(dyn dynamic.Interface, r *router.Router, l *zap.Logger) *Informer {
+	return &Informer{dyn: dyn, router: r, log: l}
+}
+
+func (i *Informer) Run(ctx context.Context) {
+	f := dynamicinformer.NewDynamicSharedInformerFactory(i.dyn, 30*time.Second)
+	gen := f.ForResource(xagentGVR).Informer()
+	_, _ = gen.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    i.upsert,
+		UpdateFunc: func(_, obj interface{}) { i.upsert(obj) },
+		DeleteFunc: i.delete,
+	})
+	f.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), gen.HasSynced) {
+		i.log.Error("cache sync failed")
+		return
+	}
+	<-ctx.Done()
+}
+
+func (i *Informer) upsert(obj interface{}) {
+	// (Use unstructured.Unstructured + accessor helpers; abbreviated here.)
+	// Filter: spec.surface == "github-webhook" AND
+	// metadata.annotations["platform.arigsela.com/github-repo"] is set.
+	// Register: repo -> Target{Namespace, Name, Endpoint}
+}
+func (i *Informer) delete(obj interface{}) {
+	// Inverse of upsert.
+}
+```
+
+(The skeleton above is incomplete by design — fill in the unstructured-access boilerplate during implementation. The pattern matches `slack-adapter/internal/informer/informer.go` closely.)
+
+- [ ] **Step 3: Write the router**
+
+`services/github-webhook-adapter/internal/router/router.go`:
+```go
+package router
+
+import "sync"
+
+type Target struct {
+	Namespace string
+	Name      string
+	Endpoint  string  // http://<name>.<ns>.svc.cluster.local/v1/messages
+}
+
+type Router struct {
+	mu     sync.RWMutex
+	byRepo map[string]Target  // key: "owner/repo"
+}
+
+func New() *Router { return &Router{byRepo: map[string]Target{}} }
+
+func (r *Router) Set(repo string, t Target) {
+	r.mu.Lock(); defer r.mu.Unlock()
+	r.byRepo[repo] = t
+}
+func (r *Router) Delete(repo string) {
+	r.mu.Lock(); defer r.mu.Unlock()
+	delete(r.byRepo, repo)
+}
+func (r *Router) Lookup(repo string) (Target, bool) {
+	r.mu.RLock(); defer r.mu.RUnlock()
+	t, ok := r.byRepo[repo]
+	return t, ok
+}
+```
+
+- [ ] **Step 4: Write the GitHub App auth helper**
+
+`services/github-webhook-adapter/internal/github/app_auth.go`:
+```go
+package github
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	gh "github.com/google/go-github/v66/github"
+)
+
+// NewClient returns a github client authenticated as the App's installation.
+func NewClient(appID, installationID string, privateKeyPEM []byte) (*gh.Client, error) {
+	aid, err := strconv.ParseInt(appID, 10, 64)
+	if err != nil { return nil, err }
+	iid, err := strconv.ParseInt(installationID, 10, 64)
+	if err != nil { return nil, err }
+	tr, err := ghinstallation.New(http.DefaultTransport, aid, iid, privateKeyPEM)
+	if err != nil { return nil, err }
+	return gh.NewClient(&http.Client{Transport: tr}), nil
+}
+```
+
+- [ ] **Step 5: Write the webhook handler**
+
+`services/github-webhook-adapter/internal/github/handler.go`:
+```go
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	gh "github.com/google/go-github/v66/github"
+
+	"github.com/arigsela/kubernetes/services/github-webhook-adapter/internal/router"
+)
+
+type Handler struct {
+	client *gh.Client
+	secret []byte
+	router *router.Router
+	log    *zap.Logger
+	httpc  *http.Client
+}
+
+func NewHandler(appID, instID string, key []byte, secret string, r *router.Router, l *zap.Logger) *Handler {
+	c, err := NewClient(appID, instID, key)
+	if err != nil { l.Fatal("github auth", zap.Error(err)) }
+	return &Handler{
+		client: c,
+		secret: []byte(secret),
+		router: r,
+		log: l,
+		httpc: &http.Client{Timeout: 90 * time.Second},
+	}
+}
+
+func (h *Handler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	payload, err := gh.ValidatePayload(r, h.secret)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized); return
+	}
+	event, err := gh.ParseWebHook(gh.WebHookType(r), payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest); return
+	}
+
+	switch e := event.(type) {
+	case *gh.PullRequestEvent:
+		if e.GetAction() != "opened" && e.GetAction() != "synchronize" {
+			w.WriteHeader(http.StatusOK); return
+		}
+		go h.processPR(context.Background(), e)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+type ReviewComment struct {
+	Path     string `json:"path"`
+	Line     int    `json:"line"`
+	Severity string `json:"severity"`  // CRITICAL | HIGH | MEDIUM | LOW
+	Message  string `json:"message"`
+	Suggestion string `json:"suggestion"`
+}
+
+type AgentResponse struct {
+	Comments []ReviewComment `json:"comments"`
+	OverallNote string `json:"overall_note,omitempty"`  // when no risks
+}
+
+func (h *Handler) processPR(ctx context.Context, e *gh.PullRequestEvent) {
+	owner := e.GetRepo().GetOwner().GetLogin()
+	repo := e.GetRepo().GetName()
+	num := e.GetPullRequest().GetNumber()
+	full := owner + "/" + repo
+
+	target, ok := h.router.Lookup(full)
+	if !ok {
+		h.log.Info("no agent for repo", zap.String("repo", full))
+		return
+	}
+
+	// Fetch the full diff via the github-mcp tool by way of the agent itself.
+	// We pass minimal context; the agent uses its github-mcp skill to fetch detail.
+	prompt := map[string]any{
+		"messages": []map[string]string{{
+			"role": "user",
+			"content": "Review PR #" + itoa(num) + " in " + full + ". Return JSON matching the shape: " +
+				`{"comments":[{"path":"...","line":N,"severity":"HIGH","message":"...","suggestion":"..."}],"overall_note":"..."}`,
+		}},
+	}
+	bb, _ := json.Marshal(prompt)
+	resp, err := h.httpc.Post(target.Endpoint, "application/json", bytes.NewReader(bb))
+	if err != nil { h.log.Error("agent call", zap.Error(err)); return }
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// kagent wraps response: {content: [{type:"text", text: "..."}]}.
+	// Extract the text and parse as AgentResponse.
+	var k struct {
+		Content []struct{ Text string `json:"text"` } `json:"content"`
+	}
+	_ = json.Unmarshal(body, &k)
+	textBody := ""
+	for _, c := range k.Content { textBody += c.Text }
+
+	// Extract the JSON block from the LLM's reply.
+	textBody = strings.TrimSpace(textBody)
+	if i := strings.Index(textBody, "{"); i > 0 { textBody = textBody[i:] }
+	if i := strings.LastIndex(textBody, "}"); i > 0 { textBody = textBody[:i+1] }
+
+	var ar AgentResponse
+	if err := json.Unmarshal([]byte(textBody), &ar); err != nil {
+		h.log.Error("agent response parse", zap.Error(err), zap.String("body", textBody))
+		// Fallback: post the raw text as an issue comment.
+		_, _, _ = h.client.Issues.CreateComment(ctx, owner, repo, num, &gh.IssueComment{Body: gh.String(textBody)})
+		return
+	}
+
+	// Build a single GitHub review with all comments.
+	if len(ar.Comments) == 0 {
+		body := ar.OverallNote
+		if body == "" { body = "No risks identified." }
+		_, _, _ = h.client.PullRequests.CreateReview(ctx, owner, repo, num, &gh.PullRequestReviewRequest{
+			Body: gh.String(body),
+			Event: gh.String("COMMENT"),
+		})
+		return
+	}
+
+	commits, _, err := h.client.PullRequests.ListCommits(ctx, owner, repo, num, &gh.ListOptions{PerPage: 100})
+	if err != nil || len(commits) == 0 { h.log.Error("list commits", zap.Error(err)); return }
+	headSHA := commits[len(commits)-1].GetSHA()
+
+	draft := []*gh.DraftReviewComment{}
+	for _, c := range ar.Comments {
+		body := "[" + c.Severity + "] " + c.Message
+		if c.Suggestion != "" { body += "\n\n_Suggestion:_ " + c.Suggestion }
+		draft = append(draft, &gh.DraftReviewComment{
+			Path: gh.String(c.Path),
+			Line: gh.Int(c.Line),
+			Body: gh.String(body),
+		})
+	}
+	_, _, _ = h.client.PullRequests.CreateReview(ctx, owner, repo, num, &gh.PullRequestReviewRequest{
+		CommitID: gh.String(headSHA),
+		Body: gh.String("Automated review from PR Review Agent"),
+		Event: gh.String("COMMENT"),
+		Comments: draft,
+	})
+}
+
+func itoa(n int) string { return strings.TrimSpace(strings.Repeat(" ", 0)) + fmtInt(n) }
+func fmtInt(n int) string {
+	if n == 0 { return "0" }
+	neg := n < 0
+	if neg { n = -n }
+	b := []byte{}
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg { b = append([]byte{'-'}, b...) }
+	return string(b)
+}
+```
+
+(Several helpers above are intentionally minimalist — replace `itoa` with `strconv.Itoa(num)` in production. Kept here to avoid extra imports in the plan.)
+
+- [ ] **Step 6: Dockerfile + build + push**
+
+`services/github-webhook-adapter/Dockerfile`:
+```dockerfile
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/github-webhook-adapter ./
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/github-webhook-adapter /github-webhook-adapter
+USER 65532:65532
+ENTRYPOINT ["/github-webhook-adapter"]
+```
+
+```bash
+cd services/github-webhook-adapter
+go build ./... && go vet ./...
+IMG=<your-ecr-repo>/github-webhook-adapter:v0.1.0
+docker build -t "$IMG" .
+docker push "$IMG"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/github-webhook-adapter/
+git commit -m "feat(github-webhook-adapter): Go service for PR webhook routing (Phase 2)"
+```
+
+---
+
+## Task 2.5: Deploy github-webhook-adapter as a base-app
+
+**Files:**
+- Create: `base-apps/github-webhook-adapter.yaml`
+- Create: `base-apps/github-webhook-adapter/{namespace,secret-store,external-secret,rbac,deployment,service,ingress}.yaml`
+
+Same shape as the slack-adapter base-app structure (Task 2.2). Differences:
+- ExternalSecret pulls `app_id`, `installation_id`, `webhook_secret`, `private_key` from `k8s-secrets/github-webhook-adapter` (staged in Phase 0 Task 0.3).
+- Ingress hostname: `github-webhook.<base-domain>` (matches the GitHub App's webhook URL).
+- ClusterRole grants watch on `xagents` (same as slack-adapter).
+
+- [ ] **Step 1: Create the namespace + SecretStore + ExternalSecret**
+
+(Mirror slack-adapter Task 2.2 Steps 2–3; substitute `slack-adapter` → `github-webhook-adapter`. The ExternalSecret data block:)
+
+```yaml
+data:
+  - {secretKey: GITHUB_APP_ID,          remoteRef: {key: github-webhook-adapter, property: app_id}}
+  - {secretKey: GITHUB_INSTALLATION_ID, remoteRef: {key: github-webhook-adapter, property: installation_id}}
+  - {secretKey: GITHUB_WEBHOOK_SECRET,  remoteRef: {key: github-webhook-adapter, property: webhook_secret}}
+  - {secretKey: GITHUB_PRIVATE_KEY,     remoteRef: {key: github-webhook-adapter, property: private_key}}
+```
+
+- [ ] **Step 2: Vault role**
+
+```bash
+vault write auth/kubernetes/role/github-webhook-adapter \
+  bound_service_account_names=default,github-webhook-adapter \
+  bound_service_account_namespaces=github-webhook-adapter \
+  policies=k8s-secrets-read \
+  ttl=24h
+```
+
+- [ ] **Step 3: RBAC, Deployment, Service, Ingress**
+
+Identical structure to slack-adapter except:
+- Ingress host: `github-webhook.<base-domain>`
+- Image: `<your-ecr-repo>/github-webhook-adapter:v0.1.0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/github-webhook-adapter.yaml base-apps/github-webhook-adapter/
+git commit -m "feat(github-webhook-adapter): deploy as base-app (Phase 2)"
+```
+
+After ArgoCD sync: `kubectl get pods -n github-webhook-adapter` shows Running.
+
+- [ ] **Step 5: Verify webhook endpoint reachable from GitHub**
+
+```bash
+curl -fsS -X POST https://github-webhook.<base-domain>/webhook \
+  -H "X-GitHub-Event: ping" \
+  -d '{}' \
+  -i 2>&1 | head -5
+# Expected: HTTP 401 (signature missing) — proves the endpoint is reachable.
+```
+
+If the URL isn't reachable from the public internet (homelab NAT issues), set up a Cloudflare Tunnel or smee.io proxy now. The GitHub App's webhook URL must be publicly reachable.
+
+---
+
+## Task 2.6: Build the custom k8s-yaml-lint skill (MCP server)
+
+**Files:**
+- Create: `services/k8s-yaml-lint/Dockerfile`
+- Create: `services/k8s-yaml-lint/pyproject.toml`
+- Create: `services/k8s-yaml-lint/server.py`
+- Create: `services/k8s-yaml-lint/README.md`
+
+A small MCP server that wraps `kube-linter` and exposes a `lint_yaml` tool.
+
+- [ ] **Step 1: Write the MCP server**
+
+`services/k8s-yaml-lint/server.py`:
+```python
+"""k8s-yaml-lint MCP server: wraps kube-linter as an MCP tool."""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+server = Server("k8s-yaml-lint")
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="lint_yaml",
+            description=(
+                "Run kube-linter against the provided Kubernetes YAML. "
+                "Returns structured findings with severity, file, line, check name, and message."
+            ),
+            inputSchema={
+                "type": "object",
+                "required": ["yaml"],
+                "properties": {
+                    "yaml": {
+                        "type": "string",
+                        "description": "Multi-document YAML containing one or more Kubernetes resources.",
+                    },
+                    "checks": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional kube-linter check names to enable; defaults to all built-in checks.",
+                    },
+                },
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name != "lint_yaml":
+        raise ValueError(f"unknown tool: {name}")
+    yaml_text = arguments["yaml"]
+    checks = arguments.get("checks") or []
+
+    with tempfile.TemporaryDirectory() as td:
+        yaml_path = Path(td) / "input.yaml"
+        yaml_path.write_text(yaml_text)
+        cmd = ["kube-linter", "lint", "--format", "json", str(yaml_path)]
+        if checks:
+            cmd += ["--include", ",".join(checks)]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        # kube-linter exits non-zero on findings; that's fine.
+        try:
+            payload = json.loads(proc.stdout) if proc.stdout else {"Reports": []}
+        except json.JSONDecodeError:
+            payload = {"raw_stdout": proc.stdout, "raw_stderr": proc.stderr}
+
+    return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+
+def main():
+    import asyncio
+    asyncio.run(_run())
+
+
+async def _run():
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: pyproject.toml + Dockerfile**
+
+`services/k8s-yaml-lint/pyproject.toml`:
+```toml
+[project]
+name = "k8s-yaml-lint"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = ["mcp>=1.0.0"]
+
+[project.scripts]
+k8s-yaml-lint = "server:main"
+```
+
+`services/k8s-yaml-lint/Dockerfile`:
+```dockerfile
+FROM python:3.12-slim AS base
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL -o /usr/local/bin/kube-linter https://github.com/stackrox/kube-linter/releases/latest/download/kube-linter-linux \
+    && chmod +x /usr/local/bin/kube-linter \
+    && apt-get purge -y curl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml server.py ./
+RUN pip install --no-cache-dir -e .
+
+USER 65532:65532
+ENTRYPOINT ["python", "server.py"]
+```
+
+- [ ] **Step 3: Build and push the image**
+
+```bash
+cd services/k8s-yaml-lint
+IMG=<your-ecr-repo>/k8s-yaml-lint:v1
+docker build -t "$IMG" .
+docker push "$IMG"
+```
+
+- [ ] **Step 4: Republish into agentregistry (replaces Phase 0 placeholder)**
+
+```bash
+arctl push skill \
+  --name k8s-yaml-lint \
+  --version v1 \
+  --type mcp-server \
+  --image <your-ecr-repo>/k8s-yaml-lint:v1 \
+  --tags k8s,lint,custom \
+  --description "Structural YAML/Kustomize linting via kube-linter."
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/k8s-yaml-lint/
+git commit -m "feat(k8s-yaml-lint): custom MCP skill wrapping kube-linter (Phase 2)"
+```
+
+---
+
+## Task 2.7: Hand-write the PR Review XAgent
+
+**Files:**
+- Create: `base-apps/agents/pr-review/agent.yaml`
+- Create: `base-apps/agents/pr-review/catalog-info.yaml`
+- Modify: Vault entry `k8s-secrets/agents/pr-review` to mirror Phase 0's GitHub App creds (so the per-agent ExternalSecret can resolve)
+
+- [ ] **Step 1: Stage GitHub App creds under the per-agent Vault path**
+
+The Composition's per-agent ExternalSecret reads from `k8s-secrets/agents/<name>` for `github-webhook` surface. Either:
+- **Option A:** Copy the App credentials from `k8s-secrets/github-webhook-adapter` to `k8s-secrets/agents/pr-review`.
+- **Option B:** Adjust the Composition to read from a shared path for `github-webhook` surface (cleaner; do this in Phase 4 cleanup).
+
+For Phase 2, Option A:
+```bash
+APP_ID=$(vault kv get -field=app_id k8s-secrets/github-webhook-adapter)
+INSTALL_ID=$(vault kv get -field=installation_id k8s-secrets/github-webhook-adapter)
+PRIV_KEY=$(vault kv get -field=private_key k8s-secrets/github-webhook-adapter)
+vault kv put k8s-secrets/agents/pr-review \
+  github_app_id="$APP_ID" \
+  github_installation_id="$INSTALL_ID" \
+  github_private_key="$PRIV_KEY"
+```
+
+- [ ] **Step 2: Write the XAgent**
+
+`base-apps/agents/pr-review/agent.yaml`:
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: pr-review
+  namespace: agents
+  annotations:
+    platform.arigsela.com/base-domain: "<base-domain>"
+    platform.arigsela.com/github-repo: arigsela/kubernetes
+spec:
+  description: "Posts inline review comments on opened PRs with risk callouts."
+  systemPrompt: |
+    You are the PR Review Agent for arigsela/kubernetes. For each PR diff:
+
+    Categorize risks as:
+      CRITICAL — secret exposure, mass deletion, prod-affecting RBAC widening
+      HIGH     — CRD removals, broad RBAC changes, removed health checks,
+                 image:latest, forceDestroy on persistent storage
+      MEDIUM   — replicas reduced below 2, removed resource limits, namespace changes
+      LOW      — style, comments, cosmetic
+
+    Use github-mcp to fetch the diff. Use lint to run structural checks.
+
+    Respond ONLY with valid JSON matching this schema:
+      {
+        "comments": [
+          {"path":"...","line":N,"severity":"HIGH","message":"one-line explanation",
+           "suggestion":"one-line fix"}
+        ],
+        "overall_note": "string, used only when comments=[]"
+      }
+
+    Do NOT approve or merge. You are advisory only.
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/github-mcp:v1
+      alias: github
+    - ref: oci://agentregistry.agentregistry.svc/skills/k8s-yaml-lint:v1
+      alias: lint
+  surface: github-webhook
+```
+
+- [ ] **Step 3: Backstage Component**
+
+`base-apps/agents/pr-review/catalog-info.yaml`:
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pr-review-agent
+  description: "Posts inline review comments on opened PRs."
+  annotations:
+    backstage.io/kubernetes-id: pr-review
+    kagent.dev/agent-name: pr-review
+    langfuse.platform.arigsela.com/project: golden-poc
+    agent.platform.arigsela.com/try-url: https://pr-review.<base-domain>/v1/messages
+spec:
+  type: agent
+  lifecycle: experimental
+  owner: platform-team
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/agents/pr-review/
+git commit -m "feat(agent): pr-review XAgent + Backstage Component (Phase 2)"
+```
+
+After ArgoCD sync: `kubectl get xagent pr-review -n agents` shows Synced/Ready and all child resources exist.
+
+---
+
+## Task 2.8: End-to-end test on a real PR
+
+**Files:** None (verification-only)
+
+- [ ] **Step 1: Open a deliberately-risky PR against arigsela/kubernetes**
+
+Create a feature branch and a PR that includes one of:
+- A Deployment with `replicas: 1` and a removed `livenessProbe`
+- A `forceDestroy: true` on an S3 bucket Composition output
+- A new ClusterRole with `verbs: ["*"]` on `secrets`
+
+Push and open the PR via GitHub UI or `gh pr create`.
+
+- [ ] **Step 2: Watch the github-webhook-adapter logs**
+
+```bash
+kubectl logs -n github-webhook-adapter -l app.kubernetes.io/name=github-webhook-adapter -f
+# Expected: "PR opened" log within ~5s of pushing the PR; agent call; then "review created"
+```
+
+- [ ] **Step 3: Verify review comments appear on the PR**
+
+Refresh the PR page in GitHub. Expected: a review with inline comments at the lines containing the risky changes, with severity prefixes.
+
+If the review fails to post but the agent was called: check `kubectl logs -n agents -l kagent.dev/agent-name=pr-review` for the LLM's actual response — it may not have produced valid JSON. Iterate on the system prompt.
+
+- [ ] **Step 4: Verify trace in Langfuse**
+
+Open Langfuse → project `golden-poc` → Traces → filter by `pr-review`. Expected: one trace per PR event with the full conversation.
+
+---
+
+## Task 2.9: Phase 2 acceptance + handoff to Phase 3
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`
+
+- [ ] **Step 1: Append Phase 2 status**
+
+```markdown
+## Phase 2 — Status
+
+- [x] slack-adapter built, deployed, watching XAgents.
+- [x] cluster-health agent reachable via `@golden-poc-bot cluster-health <ns>` in Slack.
+- [x] github-webhook-adapter built, deployed, watching XAgents.
+- [x] Custom k8s-yaml-lint skill v1 built and pushed to agentregistry (replaces Phase 0 placeholder).
+- [x] pr-review XAgent live; reviews real PRs on arigsela/kubernetes with inline comments.
+- [x] Both agents observable in Langfuse.
+
+**Phase 3 ready to start.**
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): Phase 2 verification complete"
+```
+
+Phase 2 complete. Both demo agents work end-to-end on their real surfaces. Phase 3 layers on Backstage's Software Template + per-agent UX so engineers can self-serve future agents instead of hand-writing YAML.

--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-3-backstage.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-3-backstage.md
@@ -1,0 +1,916 @@
+# Golden POC — Phase 3: Backstage Template + Plugins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the "Create New Agent" Software Template to Backstage so engineers self-serve new agents through a form (5 fields → PR), and ship the per-agent page polish (Try-it card with chat sidecar + Langfuse invocations link) and the embedded skill catalog plugin (top-level `/skills` route).
+
+**Architecture:** The Software Template is a `scaffolder.backstage.io/v1beta3` Template manifest under `base-apps/backstage/templates/create-agent/`, with a Jinja skeleton that renders two files per agent: `agent.yaml` (the XAgent CR) and `catalog-info.yaml` (the Backstage Component). Two custom frontend plugins extend the Backstage app: `plugin-agent-tryit` (per-agent card) and `plugin-skill-catalog` (top-level page). Both fetch from existing services (Langfuse REST API, agentregistry HTTP API).
+
+**Tech Stack:** Backstage (existing), `@backstage/plugin-scaffolder` (existing), Jinja templating in scaffolder skeleton, React + TypeScript for plugins, `@backstage/core-plugin-api`, Backstage CLI for plugin scaffolding.
+
+**Reference design:** `docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md` Section 5 (Backstage UX), Section 7 (per-agent specifics).
+
+**Dependencies:**
+- Phase 0 complete (agentregistry HTTP API surface documented in preflight-results).
+- Phase 1 complete (XAgent XRD live; the Template scaffolds CRs of this kind).
+- Phase 2 complete (two agents reachable via real surfaces; the Try-it card needs a working agent endpoint to demo).
+
+---
+
+## Task 3.1: Create the "Create New Agent" Software Template
+
+**Files:**
+- Create: `base-apps/backstage/templates/create-agent/template.yaml`
+- Create: `base-apps/backstage/templates/create-agent/skeleton/agent.yaml`
+- Create: `base-apps/backstage/templates/create-agent/skeleton/catalog-info.yaml`
+- Modify: `base-apps/backstage/configmaps.yaml` (add the Template to the Backstage catalog locations)
+
+- [ ] **Step 1: Write the Template manifest**
+
+`base-apps/backstage/templates/create-agent/template.yaml`:
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-agent
+  title: Create New Agent
+  description: |
+    Ship a new AI agent through the platform: Backstage form -> PR -> ArgoCD ->
+    Crossplane Composition -> kagent runtime. Skills come from agentregistry.
+  tags: [ai, agent, golden-poc]
+spec:
+  owner: platform-team
+  type: agent
+
+  parameters:
+    - title: Identity
+      required: [name, namespace, owner]
+      properties:
+        name:
+          type: string
+          title: Agent name
+          description: Lowercase letters, numbers, hyphens. Used everywhere — choose carefully.
+          pattern: "^[a-z][a-z0-9-]{2,30}$"
+        namespace:
+          type: string
+          title: Namespace
+          enum: [agents]
+          default: agents
+        owner:
+          type: string
+          title: Owner
+          ui:field: OwnerPicker
+          ui:options:
+            allowedKinds: [Group, User]
+
+    - title: Behavior
+      required: [description, systemPrompt]
+      properties:
+        description:
+          type: string
+          title: Description
+          description: One sentence shown in the Backstage catalog.
+          minLength: 10
+          maxLength: 200
+        systemPrompt:
+          type: string
+          title: System prompt
+          description: What the agent should do, how to behave, what to avoid.
+          ui:widget: textarea
+          ui:options: {rows: 12}
+
+    - title: Skills + Surface
+      required: [skills, surface]
+      properties:
+        skills:
+          type: array
+          title: Skills
+          description: agentregistry skill OCI references. Browse the Skills tab to pick.
+          minItems: 1
+          items:
+            type: object
+            required: [ref]
+            properties:
+              ref:
+                type: string
+                title: OCI ref
+                pattern: "^oci://.+:.+$"
+              alias:
+                type: string
+                title: Alias (optional)
+        surface:
+          type: string
+          title: Surface
+          enum: [slack, http, mcp, github-webhook]
+          enumNames:
+            - "Slack (chat command)"
+            - "HTTP only (Try-it button)"
+            - "MCP (IDE integration)"
+            - "GitHub webhook (PR review)"
+
+    - title: Surface configuration
+      properties:
+        slackCommand:
+          type: string
+          title: Slack command (only for surface=slack)
+          description: The word that follows the bot mention. e.g. 'cluster-health' for '@bot cluster-health <args>'
+          pattern: "^[a-z][a-z0-9-]*$"
+        githubRepo:
+          type: string
+          title: GitHub repo (only for surface=github-webhook)
+          description: e.g. arigsela/kubernetes
+          pattern: "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$"
+
+  steps:
+    - id: render
+      name: Render agent + catalog manifests
+      action: fetch:template
+      input:
+        url: ./skeleton
+        targetPath: base-apps/agents/${{ parameters.name }}
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          owner: ${{ parameters.owner }}
+          description: ${{ parameters.description }}
+          systemPrompt: ${{ parameters.systemPrompt }}
+          skills: ${{ parameters.skills }}
+          surface: ${{ parameters.surface }}
+          slackCommand: ${{ parameters.slackCommand }}
+          githubRepo: ${{ parameters.githubRepo }}
+
+    - id: publish
+      name: Open Pull Request
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=kubernetes&owner=arigsela
+        branchName: agent/${{ parameters.name }}
+        title: "Add agent: ${{ parameters.name }}"
+        description: |
+          Adds the `${{ parameters.name }}` agent to the platform.
+
+          - **Surface:** ${{ parameters.surface }}
+          - **Skills:** ${{ parameters.skills.length }}
+          - **Owner:** ${{ parameters.owner }}
+
+          Generated by the Backstage "Create New Agent" template.
+        targetPath: base-apps/agents/${{ parameters.name }}
+
+  output:
+    links:
+      - title: Pull Request
+        url: ${{ steps.publish.output.remoteUrl }}
+        icon: github
+```
+
+- [ ] **Step 2: Write the skeleton — `agent.yaml`**
+
+`base-apps/backstage/templates/create-agent/skeleton/agent.yaml`:
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    platform.arigsela.com/base-domain: "<base-domain>"  # platform-managed; replace at scaffold time if templated dynamically
+{%- if values.surface == "slack" and values.slackCommand %}
+    platform.arigsela.com/slack-command: ${{ values.slackCommand }}
+{%- endif %}
+{%- if values.surface == "github-webhook" and values.githubRepo %}
+    platform.arigsela.com/github-repo: ${{ values.githubRepo }}
+{%- endif %}
+spec:
+  description: ${{ values.description | dump }}
+  systemPrompt: |
+    ${{ values.systemPrompt | indent(4) }}
+  skills:
+{%- for s in values.skills %}
+    - ref: ${{ s.ref }}
+{%- if s.alias %}
+      alias: ${{ s.alias }}
+{%- endif %}
+{%- endfor %}
+  surface: ${{ values.surface }}
+```
+
+- [ ] **Step 3: Write the skeleton — `catalog-info.yaml`**
+
+`base-apps/backstage/templates/create-agent/skeleton/catalog-info.yaml`:
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}-agent
+  description: ${{ values.description | dump }}
+  annotations:
+    backstage.io/kubernetes-id: ${{ values.name }}
+    kagent.dev/agent-name: ${{ values.name }}
+    langfuse.platform.arigsela.com/project: golden-poc
+    agent.platform.arigsela.com/try-url: https://${{ values.name }}.<base-domain>/v1/messages
+spec:
+  type: agent
+  lifecycle: experimental
+  owner: ${{ values.owner }}
+```
+
+- [ ] **Step 4: Register the Template in Backstage's catalog locations**
+
+Edit `base-apps/backstage/configmaps.yaml`. Find the `app-config.yaml` section (or whichever ConfigMap holds Backstage's app-config). Add to `catalog.locations`:
+
+```yaml
+catalog:
+  locations:
+    # ... existing locations ...
+    - type: url
+      target: https://github.com/arigsela/kubernetes/blob/main/base-apps/backstage/templates/create-agent/template.yaml
+      rules:
+        - allow: [Template]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/backstage/templates/create-agent/ base-apps/backstage/configmaps.yaml
+git commit -m "feat(backstage): Software Template 'Create New Agent' (Phase 3)"
+```
+
+After ArgoCD sync (or Backstage's catalog refresh interval — usually 5min): Template appears in Backstage at "Create" → "Create New Agent".
+
+---
+
+## Task 3.2: End-to-end test: scaffold a third agent through the template
+
+**Files:** None (verification-only); produces a PR and a third agent in `base-apps/agents/`
+
+- [ ] **Step 1: Open Backstage in a browser**
+
+Navigate to `https://backstage.<base-domain>` → "Create" → "Create New Agent".
+
+- [ ] **Step 2: Fill out the form for a test agent**
+
+- Name: `echo-test`
+- Namespace: `agents`
+- Owner: pick yourself or platform-team
+- Description: "Test agent that echoes input back. Used to verify the Software Template scaffolds correctly."
+- System prompt: "You are a simple echo agent. Reply with exactly: '[ECHO] ' followed by the user's last message."
+- Skills: 1 entry — `oci://agentregistry.agentregistry.svc/skills/kubernetes-mcp:v1` (you don't actually need it; just satisfies the minItems: 1 requirement). Alias `k8s`.
+- Surface: `http` (no Slack or GitHub wiring needed — minimal smoke test)
+
+Click Create.
+
+- [ ] **Step 3: Verify the PR opens with the right contents**
+
+Backstage redirects to a PR URL. Confirm:
+- Branch: `agent/echo-test`
+- Files added: `base-apps/agents/echo-test/agent.yaml` and `base-apps/agents/echo-test/catalog-info.yaml`
+- Contents match the values you submitted
+
+- [ ] **Step 4: Merge the PR**
+
+Merge to main. ArgoCD syncs; Crossplane Composition reconciles; the kagent Agent comes up.
+
+- [ ] **Step 5: Verify the agent appears in the Backstage catalog**
+
+Wait ~2 minutes (Backstage catalog refresh + Kubernetes plugin discovery).
+
+In Backstage, navigate to Catalog → filter by Type: agent. Expected: `echo-test-agent` appears alongside `cluster-health-agent` and `pr-review-agent`.
+
+- [ ] **Step 6: Smoke-test the rendered agent**
+
+```bash
+kubectl run curl-test --rm -i --image=curlimages/curl --restart=Never --quiet -- \
+  curl -sS -X POST http://echo-test.agents.svc.cluster.local/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"hello world"}]}'
+```
+
+Expected: response containing "[ECHO] hello world".
+
+If everything works: the template is functional. Don't delete `echo-test` yet — Phase 3 Task 3.3's Try-it card uses it as a demo target.
+
+---
+
+## Task 3.3: Build the per-agent Try-it card plugin
+
+**Files:**
+- Create: `services/backstage-plugin-agent-tryit/package.json`
+- Create: `services/backstage-plugin-agent-tryit/src/plugin.ts`
+- Create: `services/backstage-plugin-agent-tryit/src/components/TryItCard/TryItCard.tsx`
+- Create: `services/backstage-plugin-agent-tryit/src/components/TryItCard/index.ts`
+- Create: `services/backstage-plugin-agent-tryit/src/api/AgentApi.ts`
+- Create: `services/backstage-plugin-agent-tryit/src/api/LangfuseApi.ts`
+- Create: `services/backstage-plugin-agent-tryit/src/index.ts`
+- Modify: Backstage app `packages/app/src/App.tsx` (register plugin) — done via the Backstage app build, not in this repo
+
+Backstage frontend plugin architecture: the plugin code lives outside this repo (in the Backstage app's `plugins/` directory). For GitOps, the *configuration* and the *plugin source* both go into the repo as scaffolding — the actual `yarn build` happens in the Backstage Docker image build, which is out of scope for this plan.
+
+For Phase 3, we ship the plugin source as a scaffold under `services/` so it lives in this repo for review, with a README documenting how to wire it into the Backstage app build.
+
+- [ ] **Step 1: Scaffold the plugin via Backstage CLI (one-time, requires Node)**
+
+Locally (not in cluster):
+```bash
+cd services/
+npx @backstage/cli new --select frontend-plugin --option id=agent-tryit
+```
+
+This generates `services/backstage-plugin-agent-tryit/` with the standard structure. Move/rename if needed to match the file paths above.
+
+- [ ] **Step 2: Implement the AgentApi (proxy through Backstage backend)**
+
+The Try-it button POSTs to the agent's Service. Direct browser → cluster Service is blocked (ingress allowlists). Route via Backstage's backend proxy.
+
+`services/backstage-plugin-agent-tryit/src/api/AgentApi.ts`:
+```typescript
+import { createApiRef, DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+
+export interface AgentMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AgentApi {
+  invoke(tryUrl: string, messages: AgentMessage[]): Promise<string>;
+}
+
+export const agentApiRef = createApiRef<AgentApi>({
+  id: 'plugin.agent-tryit.agent',
+});
+
+export class AgentApiClient implements AgentApi {
+  constructor(
+    private readonly discovery: DiscoveryApi,
+    private readonly fetch: FetchApi,
+  ) {}
+
+  async invoke(tryUrl: string, messages: AgentMessage[]): Promise<string> {
+    // Backstage backend proxy must be configured to forward
+    // /api/proxy/agents/<host> -> https://<host>/. See README for proxy config.
+    const u = new URL(tryUrl);
+    const proxyPath = await this.discovery.getBaseUrl('proxy');
+    const url = `${proxyPath}/agents/${u.hostname}${u.pathname}`;
+    const res = await this.fetch.fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages }),
+    });
+    if (!res.ok) {
+      throw new Error(`Agent returned ${res.status}: ${await res.text()}`);
+    }
+    const body = await res.json();
+    // kagent shape: { content: [{ type: 'text', text: '...' }] }
+    return (body.content ?? [])
+      .filter((c: any) => c.type === 'text')
+      .map((c: any) => c.text)
+      .join('\n');
+  }
+}
+```
+
+- [ ] **Step 3: Implement the LangfuseApi (recent invocations)**
+
+`services/backstage-plugin-agent-tryit/src/api/LangfuseApi.ts`:
+```typescript
+import { createApiRef, DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+
+export interface LangfuseTrace {
+  id: string;
+  name: string;
+  timestamp: string;
+  latencyMs: number;
+  totalTokens?: number;
+  url: string;
+}
+
+export interface LangfuseApi {
+  recentTraces(agentName: string, limit?: number): Promise<LangfuseTrace[]>;
+}
+
+export const langfuseApiRef = createApiRef<LangfuseApi>({
+  id: 'plugin.agent-tryit.langfuse',
+});
+
+export class LangfuseApiClient implements LangfuseApi {
+  constructor(
+    private readonly discovery: DiscoveryApi,
+    private readonly fetch: FetchApi,
+    private readonly project: string = 'golden-poc',
+  ) {}
+
+  async recentTraces(agentName: string, limit = 10): Promise<LangfuseTrace[]> {
+    // Proxy: /api/proxy/langfuse/api/public/traces?tags=<agent>&limit=10
+    const proxyBase = await this.discovery.getBaseUrl('proxy');
+    const url = `${proxyBase}/langfuse/api/public/traces?tags=${encodeURIComponent(agentName)}&limit=${limit}`;
+    const res = await this.fetch.fetch(url);
+    if (!res.ok) throw new Error(`Langfuse returned ${res.status}`);
+    const body = await res.json();
+    return (body.data ?? []).map((t: any) => ({
+      id: t.id,
+      name: t.name ?? '(unnamed)',
+      timestamp: t.timestamp,
+      latencyMs: t.latency ?? 0,
+      totalTokens: t.totalTokens,
+      url: `${t.htmlPath ?? '/trace/' + t.id}`,
+    }));
+  }
+}
+```
+
+- [ ] **Step 4: Implement the TryItCard component**
+
+`services/backstage-plugin-agent-tryit/src/components/TryItCard/TryItCard.tsx`:
+```tsx
+import React, { useEffect, useState } from 'react';
+import {
+  Card, CardContent, CardHeader, TextField, Button,
+  Typography, CircularProgress, Box, Link, Divider,
+} from '@material-ui/core';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { useApi } from '@backstage/core-plugin-api';
+import { agentApiRef } from '../../api/AgentApi';
+import { langfuseApiRef, LangfuseTrace } from '../../api/LangfuseApi';
+
+const TRY_URL_ANNOTATION = 'agent.platform.arigsela.com/try-url';
+const KAGENT_NAME_ANNOTATION = 'kagent.dev/agent-name';
+
+export const TryItCard: React.FC = () => {
+  const { entity } = useEntity();
+  const agentApi = useApi(agentApiRef);
+  const langfuseApi = useApi(langfuseApiRef);
+
+  const tryUrl = entity.metadata.annotations?.[TRY_URL_ANNOTATION];
+  const agentName = entity.metadata.annotations?.[KAGENT_NAME_ANNOTATION];
+
+  const [input, setInput] = useState('');
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [traces, setTraces] = useState<LangfuseTrace[]>([]);
+
+  useEffect(() => {
+    if (!agentName) return;
+    langfuseApi.recentTraces(agentName, 5).then(setTraces).catch(() => {});
+  }, [agentName, langfuseApi]);
+
+  if (!tryUrl) {
+    return (
+      <Card>
+        <CardHeader title="Try this agent" />
+        <CardContent>
+          <Typography color="textSecondary">
+            No <code>{TRY_URL_ANNOTATION}</code> annotation found on this Component.
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const onSend = async () => {
+    setLoading(true);
+    setResponse('');
+    try {
+      const out = await agentApi.invoke(tryUrl, [{ role: 'user', content: input }]);
+      setResponse(out);
+    } catch (e: any) {
+      setResponse(`Error: ${e.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader title="Try this agent" subheader={tryUrl} />
+      <CardContent>
+        <TextField
+          fullWidth
+          multiline
+          minRows={3}
+          variant="outlined"
+          label="Your message"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          disabled={loading}
+        />
+        <Box mt={2}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={onSend}
+            disabled={loading || !input}
+            startIcon={loading ? <CircularProgress size={16} /> : null}
+          >
+            {loading ? 'Calling agent...' : 'Send'}
+          </Button>
+        </Box>
+        {response && (
+          <Box mt={3}>
+            <Typography variant="subtitle2">Response</Typography>
+            <Box mt={1} p={2} bgcolor="grey.100" borderRadius={4}>
+              <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{response}</pre>
+            </Box>
+          </Box>
+        )}
+        <Divider style={{ margin: '24px 0' }} />
+        <Typography variant="subtitle2">Recent traces (Langfuse)</Typography>
+        {traces.length === 0 ? (
+          <Typography color="textSecondary" variant="body2">No recent traces.</Typography>
+        ) : (
+          <ul>
+            {traces.map(t => (
+              <li key={t.id}>
+                <Link href={t.url} target="_blank" rel="noopener">
+                  {new Date(t.timestamp).toLocaleString()} — {t.latencyMs}ms{t.totalTokens ? `, ${t.totalTokens} tokens` : ''}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+```
+
+- [ ] **Step 5: Wire the API factories + plugin entry point**
+
+`services/backstage-plugin-agent-tryit/src/plugin.ts`:
+```typescript
+import {
+  createPlugin,
+  createApiFactory,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import { agentApiRef, AgentApiClient } from './api/AgentApi';
+import { langfuseApiRef, LangfuseApiClient } from './api/LangfuseApi';
+
+export const agentTryitPlugin = createPlugin({
+  id: 'agent-tryit',
+  apis: [
+    createApiFactory({
+      api: agentApiRef,
+      deps: { discovery: discoveryApiRef, fetch: fetchApiRef },
+      factory: ({ discovery, fetch }) => new AgentApiClient(discovery, fetch),
+    }),
+    createApiFactory({
+      api: langfuseApiRef,
+      deps: { discovery: discoveryApiRef, fetch: fetchApiRef },
+      factory: ({ discovery, fetch }) => new LangfuseApiClient(discovery, fetch),
+    }),
+  ],
+});
+```
+
+`services/backstage-plugin-agent-tryit/src/index.ts`:
+```typescript
+export { agentTryitPlugin } from './plugin';
+export { TryItCard } from './components/TryItCard';
+```
+
+- [ ] **Step 6: Document the Backstage app integration in README**
+
+`services/backstage-plugin-agent-tryit/README.md`:
+````markdown
+# @internal/plugin-agent-tryit
+
+Backstage frontend plugin for the Golden POC. Adds a "Try this agent" card
+on Component pages where the Component has type=agent.
+
+## Wiring into the Backstage app
+
+In your Backstage app repo:
+
+1. Add this plugin as a workspace dependency:
+   ```
+   yarn workspace app add @internal/plugin-agent-tryit
+   ```
+
+2. Register the card on Components of type=agent in `packages/app/src/components/catalog/EntityPage.tsx`:
+   ```tsx
+   import { TryItCard } from '@internal/plugin-agent-tryit';
+
+   const agentEntityPage = (
+     <EntityLayout>
+       <EntityLayout.Route path="/" title="Overview">
+         <Grid container spacing={3}>
+           <Grid item md={6}><TryItCard /></Grid>
+           <Grid item md={6}><EntityAboutCard /></Grid>
+           <Grid item md={12}><EntityKubernetesContent /></Grid>
+         </Grid>
+       </EntityLayout.Route>
+     </EntityLayout>
+   );
+
+   // Add to entityPage:
+   // {entity.spec?.type === 'agent' ? agentEntityPage : ...}
+   ```
+
+3. Configure the proxy in `app-config.yaml`:
+   ```yaml
+   proxy:
+     endpoints:
+       '/agents':
+         target: 'http://internal-agents-router.agents.svc.cluster.local'
+         changeOrigin: true
+       '/langfuse':
+         target: 'https://langfuse.<base-domain>'
+         headers:
+           Authorization: "Basic ${LANGFUSE_AUTH_HEADER}"
+   ```
+
+   `LANGFUSE_AUTH_HEADER` is the base64 of `<public_key>:<secret_key>` (staged
+   in Vault as `k8s-secrets/langfuse-project`).
+
+4. Rebuild and redeploy the Backstage container image.
+````
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/backstage-plugin-agent-tryit/
+git commit -m "feat(backstage-plugin-agent-tryit): per-agent Try-it card + Langfuse traces (Phase 3)"
+```
+
+- [ ] **Step 8: Rebuild Backstage image (out-of-this-repo)**
+
+In your Backstage app repo (not this repo):
+1. Add the workspace dep, register the card, configure the proxy per the README.
+2. Rebuild + push the Backstage Docker image.
+3. Bump the image tag in `base-apps/backstage/deployments.yaml`.
+4. Commit + ArgoCD picks up.
+
+Verify in browser: navigate to `https://backstage.<base-domain>` → Catalog → `cluster-health-agent` → expected: "Try this agent" card visible. Type a message, click Send. Response from the agent appears.
+
+---
+
+## Task 3.4: Build the embedded skill catalog plugin
+
+**Files:**
+- Create: `services/backstage-plugin-skill-catalog/package.json`
+- Create: `services/backstage-plugin-skill-catalog/src/plugin.ts`
+- Create: `services/backstage-plugin-skill-catalog/src/api/AgentRegistryApi.ts`
+- Create: `services/backstage-plugin-skill-catalog/src/components/SkillCatalogPage/SkillCatalogPage.tsx`
+- Create: `services/backstage-plugin-skill-catalog/src/index.ts`
+- Create: `services/backstage-plugin-skill-catalog/README.md`
+
+**ADAPTATION NOTE:** The actual API paths and response shapes for agentregistry come from Phase 0 Preflight 2. Open `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md` and use the documented endpoints in `AgentRegistryApi.ts`. The code below assumes a standard REST pattern — update field names if Preflight 2 found different.
+
+- [ ] **Step 1: Scaffold the plugin**
+
+```bash
+cd services/
+npx @backstage/cli new --select frontend-plugin --option id=skill-catalog
+```
+
+- [ ] **Step 2: Implement the AgentRegistryApi**
+
+`services/backstage-plugin-skill-catalog/src/api/AgentRegistryApi.ts`:
+```typescript
+import { createApiRef, DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+
+export interface Skill {
+  name: string;
+  type: 'mcp-server' | 'skill' | 'agent' | 'prompt';
+  version: string;
+  description: string;
+  tags: string[];
+  ociRef: string;
+}
+
+export interface AgentRegistryApi {
+  list(filters?: { type?: string; tag?: string }): Promise<Skill[]>;
+}
+
+export const agentRegistryApiRef = createApiRef<AgentRegistryApi>({
+  id: 'plugin.skill-catalog.agentregistry',
+});
+
+export class AgentRegistryApiClient implements AgentRegistryApi {
+  constructor(
+    private readonly discovery: DiscoveryApi,
+    private readonly fetch: FetchApi,
+  ) {}
+
+  async list(filters: { type?: string; tag?: string } = {}): Promise<Skill[]> {
+    const proxyBase = await this.discovery.getBaseUrl('proxy');
+    const params = new URLSearchParams();
+    if (filters.type) params.set('type', filters.type);
+    if (filters.tag) params.set('tag', filters.tag);
+    // ADAPT: replace /api/v1/skills with the actual endpoint from Preflight 2.
+    const res = await this.fetch.fetch(`${proxyBase}/agentregistry/api/v1/skills?${params}`);
+    if (!res.ok) throw new Error(`agentregistry returned ${res.status}`);
+    const body = await res.json();
+    // ADAPT: shape per Preflight 2.
+    return (body.items ?? body.data ?? []).map((s: any) => ({
+      name: s.name,
+      type: s.type ?? 'mcp-server',
+      version: s.latestVersion ?? s.version ?? 'unknown',
+      description: s.description ?? '',
+      tags: s.tags ?? [],
+      ociRef: `oci://agentregistry.agentregistry.svc/skills/${s.name}:${s.latestVersion ?? s.version}`,
+    }));
+  }
+}
+```
+
+- [ ] **Step 3: Implement the catalog page**
+
+`services/backstage-plugin-skill-catalog/src/components/SkillCatalogPage/SkillCatalogPage.tsx`:
+```tsx
+import React, { useEffect, useState } from 'react';
+import {
+  Page, Header, Content, ContentHeader,
+  InfoCard, Table, TableColumn,
+} from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+import { Chip, IconButton, Tooltip } from '@material-ui/core';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+import { agentRegistryApiRef, Skill } from '../../api/AgentRegistryApi';
+
+const columns = (): TableColumn<Skill>[] => [
+  { title: 'Name',        field: 'name',        defaultSort: 'asc' },
+  { title: 'Type',        field: 'type',
+    render: (s) => <Chip label={s.type} size="small" /> },
+  { title: 'Version',     field: 'version' },
+  { title: 'Description', field: 'description' },
+  { title: 'Tags',
+    render: (s) => s.tags.map(t => <Chip key={t} label={t} size="small" />) },
+  { title: 'OCI ref',
+    render: (s) => (
+      <span style={{ fontFamily: 'monospace', fontSize: 12 }}>
+        {s.ociRef}
+        <Tooltip title="Copy">
+          <IconButton size="small" onClick={() => navigator.clipboard.writeText(s.ociRef)}>
+            <FileCopyIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </span>
+    ),
+  },
+];
+
+export const SkillCatalogPage: React.FC = () => {
+  const api = useApi(agentRegistryApiRef);
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.list().then(setSkills).catch(e => setErr(e.message)).finally(() => setLoading(false));
+  }, [api]);
+
+  return (
+    <Page themeId="tool">
+      <Header title="Skill Catalog" subtitle="agentregistry-backed catalog of skills, MCP servers, agents, prompts" />
+      <Content>
+        <ContentHeader title="All artifacts" />
+        {err ? (
+          <InfoCard title="Failed to load">
+            <pre>{err}</pre>
+          </InfoCard>
+        ) : (
+          <Table
+            columns={columns()}
+            data={skills}
+            options={{ search: true, paging: true, pageSize: 20 }}
+            isLoading={loading}
+          />
+        )}
+      </Content>
+    </Page>
+  );
+};
+```
+
+- [ ] **Step 4: Plugin entry + route**
+
+`services/backstage-plugin-skill-catalog/src/plugin.ts`:
+```typescript
+import {
+  createPlugin,
+  createApiFactory,
+  discoveryApiRef,
+  fetchApiRef,
+  createRouteRef,
+} from '@backstage/core-plugin-api';
+import { createRoutableExtension } from '@backstage/core-plugin-api';
+import { agentRegistryApiRef, AgentRegistryApiClient } from './api/AgentRegistryApi';
+
+export const rootRouteRef = createRouteRef({ id: 'skill-catalog' });
+
+export const skillCatalogPlugin = createPlugin({
+  id: 'skill-catalog',
+  apis: [
+    createApiFactory({
+      api: agentRegistryApiRef,
+      deps: { discovery: discoveryApiRef, fetch: fetchApiRef },
+      factory: ({ discovery, fetch }) => new AgentRegistryApiClient(discovery, fetch),
+    }),
+  ],
+  routes: { root: rootRouteRef },
+});
+
+export const SkillCatalogIndexPage = skillCatalogPlugin.provide(
+  createRoutableExtension({
+    name: 'SkillCatalogIndexPage',
+    component: () => import('./components/SkillCatalogPage/SkillCatalogPage').then(m => m.SkillCatalogPage),
+    mountPoint: rootRouteRef,
+  }),
+);
+```
+
+`services/backstage-plugin-skill-catalog/src/index.ts`:
+```typescript
+export { skillCatalogPlugin, SkillCatalogIndexPage } from './plugin';
+```
+
+- [ ] **Step 5: README — wiring into Backstage app**
+
+`services/backstage-plugin-skill-catalog/README.md`:
+````markdown
+# @internal/plugin-skill-catalog
+
+Top-level page at `/skills` showing artifacts from the in-cluster
+agentregistry instance.
+
+## Wiring
+
+1. `yarn workspace app add @internal/plugin-skill-catalog`
+2. In `packages/app/src/App.tsx`:
+   ```tsx
+   import { SkillCatalogIndexPage } from '@internal/plugin-skill-catalog';
+   // inside <FlatRoutes>:
+   <Route path="/skills" element={<SkillCatalogIndexPage />} />
+   ```
+3. Add a sidebar item in `packages/app/src/components/Root/Root.tsx`:
+   ```tsx
+   <SidebarItem icon={ExtensionIcon} to="skills" text="Skills" />
+   ```
+4. Configure the proxy in `app-config.yaml` (already added in agent-tryit Task 3.3 README):
+   ```yaml
+   proxy:
+     endpoints:
+       '/agentregistry':
+         target: 'http://agentregistry.agentregistry.svc.cluster.local:12121'
+         changeOrigin: true
+   ```
+5. Rebuild Backstage image, bump `base-apps/backstage/deployments.yaml`.
+````
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/backstage-plugin-skill-catalog/
+git commit -m "feat(backstage-plugin-skill-catalog): /skills page backed by agentregistry (Phase 3)"
+```
+
+- [ ] **Step 7: Rebuild Backstage image; verify in browser**
+
+(Same out-of-repo Backstage rebuild as Task 3.3 Step 8.)
+
+After deploy: open `https://backstage.<base-domain>/skills`. Expected: a table with the four POC skills (kubernetes-mcp, prometheus-mcp, github-mcp, k8s-yaml-lint), search and tag filtering work, "Copy OCI ref" buttons work.
+
+---
+
+## Task 3.5: End-to-end Phase 3 verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`
+
+- [ ] **Step 1: Verify the full Backstage agent journey**
+
+In Backstage:
+1. Open `/skills`. Find a skill, copy its OCI ref.
+2. Click Create → "Create New Agent". Fill the form, paste the OCI ref into Skills.
+3. Submit. PR opens.
+4. Merge the PR.
+5. After ~2 min, the agent appears in the Catalog.
+6. Open the agent's page. The "Try this agent" card is visible.
+7. Type a message, click Send. Response appears.
+8. Recent traces section shows at least one trace.
+
+If all eight steps work: Phase 3 is complete.
+
+- [ ] **Step 2: Append Phase 3 status to preflight-results.md**
+
+```markdown
+## Phase 3 — Status
+
+- [x] "Create New Agent" Software Template scaffolds two-file PRs.
+- [x] echo-test agent created end-to-end via the template.
+- [x] backstage-plugin-agent-tryit deployed; Try-it card works on agent pages.
+- [x] backstage-plugin-skill-catalog deployed; /skills page lists agentregistry artifacts.
+- [x] Backstage proxy configured for /agents and /langfuse and /agentregistry.
+
+**Phase 4 ready to start.**
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): Phase 3 verification complete"
+```
+
+Phase 3 complete. Engineers self-serve agents through Backstage; the demo's "front door" is real. Phase 4 is demo polish.

--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-4-polish.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-4-polish.md
@@ -1,0 +1,572 @@
+# Golden POC — Phase 4: Demo Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pre-bake the Cluster Health agent for >=1 week so Langfuse accumulates real history; rehearse the 30-minute demo narrative end to end; record a backup video; assemble a demo-day operational checklist; capture cleanup items deferred from earlier phases.
+
+**Architecture:** No new code. This phase is operational rigor. Outputs are documents, scripts, and recordings — no new ArgoCD applications.
+
+**Tech Stack:** None new. Uses what's already running.
+
+**Reference design:** `docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md` Section 2 (Demo narrative), Section 9 (Cuttable scope), Section 10 (Risks).
+
+**Dependencies:** Phases 0, 1, 2, 3 complete and verified.
+
+---
+
+## Task 4.1: Pre-bake Cluster Health Agent (start as early as possible)
+
+**Files:**
+- Create: `scripts/heartbeat-cluster-health.sh`
+- Create: `base-apps/cronjobs/cluster-health-heartbeat.yaml`
+
+The demo's first beat shows Langfuse with real historical traces. We need at least a week of invocations accumulated by demo day.
+
+- [ ] **Step 1: Write a heartbeat script that exercises the agent**
+
+`scripts/heartbeat-cluster-health.sh`:
+```bash
+#!/usr/bin/env bash
+# Invokes cluster-health agent with rotating inputs so Langfuse accumulates
+# realistic-looking historical traces. Designed to run as a Kubernetes CronJob
+# every 15 minutes.
+set -euo pipefail
+
+AGENT_URL="${AGENT_URL:-http://cluster-health.agents.svc.cluster.local/v1/messages}"
+
+# Rotate the input each invocation so traces show varied prompts.
+NAMESPACES=(agents kagent agentregistry langfuse argo-cd default monitoring vault)
+NS="${NAMESPACES[$(( RANDOM % ${#NAMESPACES[@]} ))]}"
+
+PAYLOAD=$(cat <<EOF
+{"messages":[{"role":"user","content":"Status of namespace ${NS}?"}]}
+EOF
+)
+
+curl -fsS -X POST "$AGENT_URL" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  -o /dev/null -w "%{http_code} ${NS} %{time_total}s\n"
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x scripts/heartbeat-cluster-health.sh
+```
+
+- [ ] **Step 3: Wrap as a CronJob**
+
+`base-apps/cronjobs/cluster-health-heartbeat.yaml`:
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cluster-health-heartbeat
+  namespace: agents
+  labels:
+    app.kubernetes.io/name: cluster-health-heartbeat
+    app.kubernetes.io/component: demo-prebake
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: heartbeat
+              image: curlimages/curl:8.10.1
+              env:
+                - name: AGENT_URL
+                  value: "http://cluster-health.agents.svc.cluster.local/v1/messages"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  NAMESPACES="agents kagent agentregistry langfuse argo-cd default monitoring vault"
+                  arr=($NAMESPACES)
+                  NS=${arr[$(($RANDOM % ${#arr[@]}))]}
+                  curl -fsS -X POST "$AGENT_URL" \
+                    -H "Content-Type: application/json" \
+                    -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Status of namespace ${NS}?\"}]}" \
+                    -o /dev/null -w "%{http_code} ${NS} %{time_total}s\n"
+              resources:
+                requests: {cpu: 10m, memory: 16Mi}
+                limits:   {cpu: 100m, memory: 64Mi}
+```
+
+- [ ] **Step 4: Add to the agents directory and commit**
+
+```bash
+mkdir -p base-apps/cronjobs
+mv base-apps/cronjobs/cluster-health-heartbeat.yaml base-apps/agents/cluster-health/heartbeat-cronjob.yaml
+git add base-apps/agents/cluster-health/heartbeat-cronjob.yaml scripts/heartbeat-cluster-health.sh
+git commit -m "feat(demo-prebake): hourly heartbeat against cluster-health for Langfuse history (Phase 4)"
+```
+
+**Important:** start this CronJob ASAP — at least 7 days before demo day. ~96 invocations/day; should yield ~700 historical traces in a week, which looks credible during the demo.
+
+- [ ] **Step 5: Verify**
+
+After ~30 minutes:
+```bash
+kubectl get jobs -n agents -l app.kubernetes.io/name=cluster-health-heartbeat
+# Expected: 2 completed jobs
+```
+
+Open Langfuse → project `golden-poc` → Traces. Trace count should be growing.
+
+---
+
+## Task 4.2: Pre-stage the deliberately-risky PR for the live demo
+
+**Files:**
+- Create: `scripts/demo/queued-pr-changes.patch`
+- Create: `scripts/demo/open-demo-pr.sh`
+
+The demo's "watch the PR Review Agent fire" beat needs a real PR. Don't make it on stage — pre-stage the changes so a single command opens the PR with the risky content.
+
+- [ ] **Step 1: Capture the demo's risky changes as a diff**
+
+The risky changes (per design Section 7):
+- A Deployment with `replicas: 1` (down from 2)
+- Removed `livenessProbe` block
+
+Pick a real Deployment in the repo to modify. Suggestion: a non-critical sample app like `weather-kitchen-backend.yaml`.
+
+`scripts/demo/queued-pr-changes.patch` — capture by running locally:
+```bash
+# In the worktree, manually edit the chosen file to add the risks.
+# Then capture:
+git diff > scripts/demo/queued-pr-changes.patch
+git checkout -- .  # discard the local edits; the patch is the source of truth
+```
+
+The patch contents will look something like:
+```diff
+--- a/base-apps/weather-kitchen-backend/deployments.yaml
++++ b/base-apps/weather-kitchen-backend/deployments.yaml
+@@ -10,7 +10,7 @@ spec:
+-  replicas: 2
++  replicas: 1
+@@ -28,11 +28,6 @@ spec:
+-          livenessProbe:
+-            httpGet:
+-              path: /healthz
+-              port: 8080
+-            initialDelaySeconds: 30
+-            periodSeconds: 30
+```
+
+Commit the patch file (NOT the live edits):
+```bash
+git add scripts/demo/queued-pr-changes.patch
+git commit -m "feat(demo): pre-staged PR diff with intentional risks for PR Review Agent demo (Phase 4)"
+```
+
+- [ ] **Step 2: Write the script that opens the demo PR on demand**
+
+`scripts/demo/open-demo-pr.sh`:
+```bash
+#!/usr/bin/env bash
+# Opens the demo PR. Run this during the live demo to fire the PR Review Agent.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+BRANCH="demo/pr-review-$(date +%Y%m%d-%H%M)"
+
+git checkout main
+git pull origin main
+git checkout -b "$BRANCH"
+git apply scripts/demo/queued-pr-changes.patch
+git add -u
+git commit -m "demo: scale weather-kitchen-backend down + remove livenessProbe (intentional)"
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "[DEMO] scale down + remove probe" \
+  --body "Demo PR. The PR Review Agent should comment with severity-tagged inline review."
+```
+
+```bash
+chmod +x scripts/demo/open-demo-pr.sh
+git add scripts/demo/open-demo-pr.sh
+git commit -m "feat(demo): one-shot script to open the demo PR (Phase 4)"
+```
+
+---
+
+## Task 4.3: Rehearsal script — the 30-minute demo narrative
+
+**Files:**
+- Create: `docs/golden-demo-rehearsal.md`
+
+Write the demo as an annotated walk-through with timing. Rehearse twice: once solo, once with someone else watching.
+
+- [ ] **Step 1: Write the rehearsal doc**
+
+`docs/golden-demo-rehearsal.md`:
+````markdown
+# Golden POC Demo Rehearsal — 30 minutes
+
+**Audience:** Mixed exec + engineering leadership at Golden.
+**Goal:** Land the "engineer journey" — Backstage form to running agent in minutes.
+**Tone:** Confident, technically grounded. Treat the audience as smart adults.
+
+## Pre-flight (T-1 hour)
+
+- [ ] Cluster reachable from demo laptop. VPN connected and tested.
+- [ ] All ArgoCD apps healthy (`argocd app list`). Anything red — fix or excuse from demo.
+- [ ] `gh` CLI authenticated. `kubectl` context correct.
+- [ ] Browser tabs prepared (in this order):
+  1. Backstage catalog filtered to `Type: agent`
+  2. Backstage `cluster-health-agent` page (Try-it card visible)
+  3. Langfuse project `golden-poc` Traces tab
+  4. Backstage `/skills` page
+  5. GitHub repo `arigsela/kubernetes` (PRs tab)
+- [ ] Slack workspace open in a separate window with a #demo channel; bot invited.
+- [ ] Recording started in the background (Task 4.4 — backup).
+- [ ] Demo PR script in a terminal (not opened — only run if live build succeeds).
+
+## The walkthrough
+
+### Beat 1 — "Here's the platform" (T+0:00, 3 min)
+
+Open Backstage catalog (Tab 1). Two agents visible: cluster-health and pr-review.
+
+Talk track:
+> "This is our internal AI platform. Two agents are live today. Both follow the same shape: they're declared as YAML, shipped through ArgoCD, run on kagent. Engineers don't write Kubernetes — they fill out a form."
+
+### Beat 2 — "Let's use one" (T+3:00, 4 min)
+
+Switch to Tab 2 (cluster-health page). Point out:
+- Status (running)
+- Recent traces (the heartbeat-driven history)
+- Try-it card
+
+Click the Recent Traces section, click into a trace. Switches to Langfuse (Tab 3). Show one trace with full LLM call detail.
+
+Back to Backstage. Type into the Try-it box: `What's the status of the agentregistry namespace?`. Click Send. Response appears (~10s).
+
+Talk track:
+> "Same agent reachable in Slack, in Backstage, and via curl. We built this *once* and made it usable everywhere people already work."
+
+### Beat 3 — "Let's build a new one" (T+7:00, 8 min)
+
+Click "Create" → "Create New Agent".
+
+Fill the form for a real-feeling new agent. Suggested:
+- Name: `release-notes`
+- Description: "Drafts release notes from merged PRs in the last week"
+- System prompt: (have this pre-typed in your notes; paste it)
+- Skills: github-mcp (paste OCI ref from Tab 4)
+- Surface: HTTP only
+- (Skip the slackCommand / githubRepo fields for HTTP surface)
+
+Click Create. Backstage opens the PR.
+
+> "That's the entire engineer experience for a new agent. Twenty lines of YAML — none of it Kubernetes."
+
+Switch to GitHub (Tab 5). Walk through the PR's two files. Highlight that there's no Deployment, no Service, no Ingress, no Secret — Crossplane handles all of that.
+
+Merge the PR.
+
+Switch to a terminal, watch ArgoCD reconcile and Crossplane render:
+```bash
+watch -n 2 'kubectl get xagent release-notes -n agents -o jsonpath="{.status.conditions[*].type}={.status.conditions[*].status}"'
+```
+
+After ~90 seconds, the agent is Synced=True, Ready=True. Back to Backstage Catalog — refresh — the new agent is listed.
+
+Click into the agent. Try-it card already works. Type "Draft notes for the last week of merged PRs." Send. Response appears.
+
+> "Three minutes ago this didn't exist. Now it's a first-class agent — observable, reusable, owned by a team."
+
+### Beat 4 — "Live, on a real PR" (T+15:00, 8 min)
+
+Switch to Tab 5 (GitHub PRs). Open a terminal. Run:
+```bash
+./scripts/demo/open-demo-pr.sh
+```
+
+The PR opens. Refresh the GitHub tab; PR is visible. Wait ~15s.
+
+Inline review comments appear on the affected lines, severity-tagged.
+
+> "The PR Review Agent uses the same platform. New surface — GitHub webhooks instead of Slack — but same XAgent CR shape, same Composition, same observability."
+
+Click into one of the comments. Switch to Langfuse (Tab 3). Find the trace for this PR review (filter by `pr-review` tag). Show the full agent reasoning.
+
+### Beat 5 — "Where the next agent's skills come from" (T+23:00, 4 min)
+
+Switch to Tab 4 (`/skills` page). Show the four skills.
+
+Talk track:
+> "agentregistry — the OCI-backed registry that ships skills as artifacts. Three of these came from upstream open source. One we built ourselves. Engineers browse this, copy a ref, paste it into the form. Same supply chain as containers."
+
+Click into k8s-yaml-lint. Show the version, the OCI ref, the description.
+
+### Beat 6 — Close (T+27:00, 3 min)
+
+> "Every piece of what we just saw runs on commodity infra: ArgoCD, Crossplane, Vault, kagent, agentgateway, agentregistry, Langfuse. Nothing bespoke at the layer that matters. The differentiator is the *opinionated assembly* — the XAgent abstraction, the Backstage template, the per-agent observability defaults."
+>
+> "This is what 'AI platform' means in practice. Not chatbots — infrastructure."
+
+Pause for questions.
+
+## Fallbacks (use if something breaks)
+
+| What broke | Fallback |
+|---|---|
+| Slack adapter down during Beat 2 | Use the Try-it card instead of Slack |
+| ArgoCD sync slow during Beat 3 | Show a previously-created agent; pre-record this beat as backup |
+| Webhook to homelab failing during Beat 4 | Skip the live build; show recorded video of a prior PR Review Agent firing |
+| Langfuse UI down | `kubectl logs` showing the trace export, plus a screenshot of a prior trace |
+| Anthropic API down | Skip Beat 4; extend Beat 5 with deeper agentregistry walkthrough |
+| Cluster down entirely | Play the full backup video from Task 4.4 |
+
+## Rehearsal log
+
+- Rehearsal 1 (date): completed in __ min. Issues: __. Fixes: __.
+- Rehearsal 2 (date): completed in __ min. Issues: __. Fixes: __.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/golden-demo-rehearsal.md
+git commit -m "docs(demo): 30-minute rehearsal script + fallbacks (Phase 4)"
+```
+
+- [ ] **Step 3: Run the rehearsal twice**
+
+The first rehearsal uncovers timing and prop issues. The second confirms the fixes. Update the doc's "Rehearsal log" section after each run.
+
+---
+
+## Task 4.4: Record backup video
+
+**Files:**
+- Create: `docs/golden-demo-recording-checklist.md`
+
+The backup video runs ~30 minutes; if the live demo fails irrecoverably, switch to it.
+
+- [ ] **Step 1: Pick a screen recorder**
+
+macOS: QuickTime (built-in), or OBS Studio for higher quality.
+Linux: SimpleScreenRecorder, OBS.
+
+Settings: 1920x1080 minimum, 30fps, system audio + microphone.
+
+- [ ] **Step 2: Record the rehearsed walkthrough**
+
+Run through the rehearsal script once, recording start to finish. Don't pause; if you mess up a beat, keep going — it's the backup, not the polished cut.
+
+- [ ] **Step 3: Trim and export**
+
+Trim the start (pre-recording fumbling) and end. Export as MP4 H.264, no compression artifacts.
+
+Filename: `golden-poc-demo-backup-YYYY-MM-DD.mp4`. Keep on the demo laptop AND a USB stick AND uploaded somewhere private (e.g., a private Drive folder).
+
+- [ ] **Step 4: Document the backup playback path**
+
+`docs/golden-demo-recording-checklist.md`:
+````markdown
+# Demo Recording — Locations + Playback
+
+- **Primary:** demo laptop, `~/Movies/golden-poc-demo-backup-YYYY-MM-DD.mp4`
+- **Backup 1:** USB stick (label: "GOLDEN POC DEMO")
+- **Backup 2:** [private link]
+
+## Playback fallback path
+
+If the live demo fails irrecoverably:
+1. Pause, acknowledge the issue ("homelab connectivity is being uncooperative — let me show you the recording instead").
+2. Open the backup video. Play full screen.
+3. Pause at natural breakpoints to handle questions.
+
+## Don't
+
+- Don't pretend the recording is live.
+- Don't apologize repeatedly. One acknowledgment, then continue confidently.
+- Don't rely on the recording so early in the demo that the audience never sees the live system. If you can land Beat 1 + Beat 2 live, the credibility is established — the recording covers Beats 3-6 if needed.
+````
+
+```bash
+git add docs/golden-demo-recording-checklist.md
+git commit -m "docs(demo): backup video recording + playback checklist (Phase 4)"
+```
+
+(The video file itself is NOT committed — too large. Stays on the laptop / USB / private storage.)
+
+---
+
+## Task 4.5: Demo-day operational checklist
+
+**Files:**
+- Create: `docs/golden-demo-day-checklist.md`
+
+- [ ] **Step 1: Write the checklist**
+
+`docs/golden-demo-day-checklist.md`:
+````markdown
+# Demo Day Checklist
+
+## T-2 hours
+
+- [ ] Eat lunch / coffee. Don't demo hungry or jittery.
+- [ ] Review rehearsal doc one more time.
+
+## T-1 hour
+
+- [ ] VPN connected to homelab. Test:
+  ```bash
+  kubectl get nodes
+  argocd app list | head
+  ```
+- [ ] All ArgoCD apps Synced + Healthy.
+- [ ] Backup video on demo laptop, opened in a media player ready to fullscreen.
+- [ ] Slack open, bot invited to #demo channel.
+- [ ] Browser tabs in correct order (per rehearsal doc Pre-flight).
+- [ ] Terminal windows ready:
+  - One for `watch` commands during Beat 3
+  - One for `./scripts/demo/open-demo-pr.sh` during Beat 4
+
+## T-15 min
+
+- [ ] Smoke test: invoke cluster-health from Slack. Confirm response.
+- [ ] Smoke test: open the Try-it card in Backstage. Send a test message. Confirm response.
+- [ ] Smoke test: open Langfuse, confirm recent traces visible.
+- [ ] Notifications off (Slack, Mail, system).
+- [ ] Charger plugged in.
+- [ ] Phone on silent.
+
+## T-0
+
+- [ ] Start screen recording (in case audience asks for the recording later).
+- [ ] Begin Beat 1.
+
+## Post-demo
+
+- [ ] Stop recording. Save with date.
+- [ ] Note questions asked + your answers.
+- [ ] Note anything that broke + the fallback used.
+- [ ] Send a thank-you note within 24 hours.
+
+## DO NOT
+
+- Apologize for the platform's youth or feature gaps.
+- Promise specific features without checking with the team first.
+- Compare unfavorably to anything Golden currently uses.
+- Show the system prompt of an agent in detail unless asked.
+
+## DO
+
+- Pause after each beat. Take a breath. Look up.
+- Invite questions during natural breakpoints.
+- If a question is hard, "let me come back to that" is fine.
+````
+
+```bash
+git add docs/golden-demo-day-checklist.md
+git commit -m "docs(demo): demo-day operational checklist (Phase 4)"
+```
+
+---
+
+## Task 4.6: Cleanup items deferred from earlier phases
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-agent.yaml` (Composition cleanup)
+
+Phase 2 and Phase 3 left a few items marked for cleanup. Address them now.
+
+- [ ] **Step 1: Drop unused per-agent slack-token ExternalSecret**
+
+Phase 2 Task 2.3 noted: the per-agent `slack_bot_token` Secret rendered for `surface: slack` is unused (the slack-adapter holds the token). Either remove it or repurpose.
+
+For Phase 4, **remove it** — clean Composition output is worth the small refactor.
+
+In `base-apps/crossplane-compositions/composition-agent.yaml`, modify `make_external_secret_for_surface()`:
+
+```python
+          def make_external_secret_for_surface(agent_name, namespace, surface, annotations):
+              # Slack: the slack-adapter holds the bot token; agents don't need
+              # per-agent secrets for slack surface.
+              if surface == "github-webhook":
+                  # ... (unchanged)
+                  return { ... }
+              return None
+```
+
+After commit + ArgoCD sync, the existing `cluster-health-slack` ExternalSecret is pruned by Crossplane.
+
+- [ ] **Step 2: Move PR Review's GitHub creds out of per-agent Vault path**
+
+Phase 2 Task 2.7 noted: per-agent ExternalSecret reads from `k8s-secrets/agents/<name>` for `github-webhook` surface, but creds are duplicated from the adapter's path. Cleaner: have the Composition reference the shared `k8s-secrets/github-webhook-adapter` path instead, since GitHub App credentials are platform-shared, not per-agent.
+
+In `make_external_secret_for_surface()`, change `github-webhook` branch's `remoteRef.key` from `f"agents/{agent_name}"` to `"github-webhook-adapter"`.
+
+Then delete the duplicate Vault entry:
+```bash
+vault kv delete k8s-secrets/agents/pr-review
+```
+
+- [ ] **Step 3: Test the Composition still works**
+
+```bash
+crossplane render \
+  /tmp/xagent-render/xr.yaml \
+  base-apps/crossplane-compositions/composition-agent.yaml \
+  /tmp/xagent-render/functions.yaml | head -100
+```
+
+Verify rendered output excludes the slack ExternalSecret and includes the github-webhook ExternalSecret pointing at the shared Vault path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add base-apps/crossplane-compositions/composition-agent.yaml
+git commit -m "refactor(composition-agent): drop unused per-agent slack secret; share GH App creds (Phase 4 cleanup)"
+```
+
+---
+
+## Task 4.7: Final acceptance + handoff to demo day
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md`
+
+- [ ] **Step 1: Final pre-demo verification**
+
+Run through the full demo rehearsal one more time. All beats land cleanly.
+
+- [ ] **Step 2: Append final status**
+
+```markdown
+## Phase 4 — Status
+
+- [x] Cluster Health heartbeat CronJob running every 15min — Langfuse has [N] historical traces.
+- [x] Demo PR script tested.
+- [x] Rehearsal completed twice. Time: __ min. Notes: __.
+- [x] Backup video recorded and stored on demo laptop + USB + private storage.
+- [x] Demo-day checklist documented.
+- [x] Composition cleanup applied (slack secret dropped; GH creds shared path).
+
+**POC complete. Ready for Golden demo on [date].**
+```
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-phase-0-preflight-results.md
+git commit -m "docs(golden-poc): Phase 4 complete — POC ready for Golden demo"
+```
+
+POC complete. Demo it.

--- a/docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md
+++ b/docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md
@@ -1,0 +1,485 @@
+# Golden AI Platform POC — Design
+
+**Date:** 2026-05-02
+**Status:** Draft, pending user review
+**Audience for the demo:** Mixed exec + engineering leadership at Golden
+**Source presentation:** `/Users/arisela/Designing AI platform/golden-ai-platform-presentation-source.md` (28 slides + 4 appendix)
+
+## 1. Overview
+
+This document specifies a Proof of Concept (POC) demonstrating the AI platform pitched in the Golden source presentation. The POC is designed to be a credible, demo-able artifact running on the existing arigsela homelab k3s cluster, exercising the engineer-facing journey: from Backstage Software Template through Crossplane Composition through kagent runtime, with skills served from an in-cluster solo.io agentregistry, LLM traffic flowing through agentgateway, and traces captured in Langfuse.
+
+The POC is not the full 18-month roadmap from the deck. It is a tight 30-minute demo narrative built from the deck's slide 12 ("Backstage as front door"), slide 14 (kagent), slide 16 (skills distribution), slide 17 (Runbook Agent as the day-1 agent), and slide 25 (the platform flywheel).
+
+### Goals
+
+- Land the **engineer journey** end to end: form fill in Backstage → PR → ArgoCD → Crossplane → kagent runtime → Slack response and inline GitHub PR review.
+- Demonstrate the **complete solo.io agentic stack** (kagent + agentregistry + agentgateway) in one cluster.
+- Ship two visible agents: **Cluster Health Agent** (pre-baked, mirrors slide 17 Runbook Agent) and **PR Review Agent** (live-built during the demo to prove the platform leverage from slide 25).
+- Use Crossplane v2 namespaced XRs as the abstraction layer, mirroring the existing `XApplication` pattern.
+
+### Non-goals
+
+- Customer-facing AI surfaces (deck Phase 4+).
+- Full Bedrock integration with HIPAA path (deck slide 13). Anthropic API direct is used for the demo; production routing is a design-doc note.
+- Multi-tenant isolation patterns at full deck-fidelity (deck slide 13). Single-namespace POC is sufficient.
+- Per-agent cost dashboards, eval harnesses, governance routing in Backstage (deck Level 3 polish).
+
+## 2. Demo narrative (30 minutes)
+
+The demo walks through one storyline: an engineer ships a new agent through the platform, while another agent is already running.
+
+1. **Open Backstage.** Show the Catalog with the Agents tab. Cluster Health Agent already lives there — running, with recent invocations visible, a "Try it" button, and a link to its Langfuse traces.
+2. **Click "Try it" on Cluster Health Agent.** Live response in a chat sidecar. Open Langfuse, show the trace.
+3. **Build agent #2 live.** Backstage → "Create New Agent" template → fill the form (~7 fields) for the PR Review Agent. Click Create.
+4. **Show the PR.** Backstage opened a PR against `arigsela/kubernetes` adding `base-apps/agents/pr-review/agent.yaml` and `catalog-info.yaml`. Walk through the agent.yaml: ~25 lines, no Kubernetes machinery exposed.
+5. **Merge the PR.** ArgoCD picks up within ~30s. Agent appears in the Backstage catalog. Show Crossplane reconciling the Composition (kagent Agent CR, ToolServer CRs, ExternalSecret, Service, Ingress).
+6. **Open a real GitHub PR** on `arigsela/kubernetes` (queued ahead of time, contains an intentionally risky change). Webhook fires. PR Review Agent posts inline review comments. Pull the trace up in Langfuse.
+7. **Close with the "Browse Skills" tab in Backstage** — embedded agentregistry catalog. "This is where the next agent's skills come from."
+
+### Demo-risk fallbacks
+
+- If GitHub webhook breaks: invoke PR Review Agent via curl against its HTTP endpoint, show the same output.
+- If Slack breaks for Cluster Health: fall through to the "Try it" button or curl.
+- If agentregistry's UI breaks: fall through to `arctl list` in a terminal.
+- The "Try it" button is the load-bearing demo moment; it does not depend on Slack or GitHub, only on the cluster being up.
+
+## 3. Reference architecture
+
+```
+Engineer
+  |
+  v
+Backstage (existing)
+  +-- Software Template "Create New Agent"  --> PR to arigsela/kubernetes
+  +-- Catalog: Agents (auto-discovered via TeraSky annotations)
+  +-- Per-agent page: status, Try-it card, Langfuse link
+  +-- Skills tab (embedded agentregistry plugin)
+                            |
+                            v
+                        ArgoCD (existing)
+                            | syncs base-apps/agents/<name>/*.yaml
+                            v
+                        XAgent CR (Crossplane v2 namespaced XR, new)
+                            |
+                            v
+                Crossplane Composition (function-python, new)
+                    renders:
+                        +-- kagent Agent CR
+                        +-- kagent ToolServer CR(s)
+                        +-- ExternalSecret (surface-specific creds, when needed)
+                        +-- Service + Ingress (always)
+                        +-- TeraSky/Backstage labels and annotations
+                            |
+                            v
+                kagent (existing) runs the Agent
+                            |
+              +-------------+--------------+
+              v                            v
+        agentgateway (new)            Langfuse (new)
+        all LLM traffic               OTLP trace ingest
+              |
+              v
+        Anthropic API
+        (production: Bedrock)
+
+
+agentregistry (new) <-- kagent pulls skill artifacts (OCI)
+   | (in-cluster Helm release; UI on 12121)
+   v
+   Skill artifacts (kubernetes-mcp, prometheus-mcp, github-mcp, k8s-yaml-lint)
+
+
+slack-adapter (new shared service)            github-webhook-adapter (new shared service)
+   watches XAgents with surface: slack            watches XAgents with surface: github-webhook
+   --> agent HTTP endpoints                       --> agent HTTP endpoints
+```
+
+### What's new vs. reused
+
+**New:**
+- `XAgent` XRD + Composition + function-python script
+- `base-apps/agentregistry/`, `base-apps/agentgateway/`, `base-apps/langfuse/` Helm releases
+- `base-apps/slack-adapter/` and `base-apps/github-webhook-adapter/` shared services
+- Backstage Software Template and per-agent page custom plugin (Try-it card)
+- Backstage embedded skill catalog plugin
+- Two demo agents (`cluster-health`, `pr-review`)
+- One custom skill (`k8s-yaml-lint`)
+
+**Reused:**
+- Backstage (existing deployment)
+- ArgoCD (existing master-app pattern)
+- Crossplane v2 with function-python (existing setup)
+- Vault + External Secrets (existing per-namespace SecretStore pattern)
+- kagent (existing install)
+- TeraSky annotation pattern (`backstage.io/kubernetes-id`, `terasky.backstage.io/*`)
+- nginx-ingress, cert-manager, Coroot
+
+## 4. XAgent XR and Composition
+
+### XAgent — engineer-facing API
+
+The XAgent XR follows the same intent-only philosophy as the existing `XApplication`: the engineer specifies *what* the agent should do, not *how*. The Composition picks the model, gateway, observability, secrets, and RBAC.
+
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: pr-review
+  namespace: agents
+  annotations:
+    platform.arigsela.com/github-repo: arigsela/kubernetes
+spec:
+  description: "Posts inline review comments on opened PRs with risk callouts"
+  systemPrompt: |
+    You are a PR Review Agent for arigsela/kubernetes...
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/github-mcp:v1
+      alias: github
+    - ref: oci://agentregistry.agentregistry.svc/skills/k8s-yaml-lint:v1
+      alias: lint
+  surface: github-webhook
+  # model: claude-sonnet  # platform default; override only when needed
+```
+
+### XRD definition
+
+Lives at `base-apps/crossplane-compositions/xrd-agent.yaml`. Mirrors `xrd-application.yaml`:
+
+- `apiVersion: apiextensions.crossplane.io/v2`
+- `scope: Namespaced`
+- `group: platform.arigsela.com`
+- `kind: XAgent`, `plural: xagents`
+- `defaultCompositionRef: { name: agent }`
+- `versions: [{ name: v1alpha1, served: true, referenceable: true }]`
+
+Required fields: `description`, `systemPrompt`, `skills` (array, minItems: 1), `surface` (enum: `slack | http | mcp | github-webhook`).
+
+Optional fields: `model` (default `claude-sonnet`).
+
+`skills[].ref` validation pattern: must start with `oci://`.
+
+### Composition
+
+Single-step pipeline at `base-apps/crossplane-compositions/composition-agent.yaml`, using `function-python` (same function used by the XApplication Composition).
+
+Per `XAgent`, the Composition renders:
+
+1. **`kagent.dev/v1alpha1` Agent CR** — name, system prompt, model endpoint pointing at `https://gateway.agentgateway.svc/v1/messages` (NOT a direct Anthropic key), and skill ToolServer references.
+2. **`kagent.dev/v1alpha1` ToolServer CR(s)** — one per unique skill `ref`. Each points at an agentregistry OCI URI. (See open question 1 in Section 11 about whether kagent's ToolServer CRD natively accepts OCI refs or needs a shim.)
+3. **`ExternalSecret`** — only when the surface requires surface-specific credentials:
+   - `surface: slack` → Slack bot token (read from `<namespace>/agents/<name>` in Vault)
+   - `surface: github-webhook` → GitHub App private key + app ID
+   - `surface: http` or `mcp` → no per-agent secret rendered
+4. **`Service` + `Ingress`** — always rendered. Provides the HTTP endpoint for the "Try it" button and the curl fallback for any surface.
+5. **TeraSky/Backstage labels and annotations** — same pattern as XApplication: `app.kubernetes.io/name`, `app.kubernetes.io/managed-by: crossplane`, `backstage.io/kubernetes-id`, plus carried-through `terasky.backstage.io/*` annotations.
+
+### What the Composition does NOT render
+
+- The Slack adapter or GitHub webhook adapter. These are shared cluster services that watch XAgent resources via the Kubernetes API and route accordingly.
+- LLM credentials. agentgateway holds the Anthropic API key.
+- Langfuse trace configuration. kagent emits OTLP at install-time configuration; per-agent setup is not required.
+- Skill ServiceAccount RBAC. RBAC is pre-created at install time per skill; the Composition wires the agent's ServiceAccount to the appropriate existing RoleBinding by name.
+
+## 5. Backstage UX (Level 2 polish)
+
+### Software Template
+
+`base-apps/backstage/templates/create-agent/`. A standard `scaffolder.backstage.io/v1beta3` Template, three-step form:
+
+- **Identity:** `name` (kebab-case validated), `namespace` (dropdown of agent namespaces), `owner` (`OwnerPicker` widget).
+- **Behavior:** `description` (single line), `systemPrompt` (textarea).
+- **Skills + Surface:** `skills` (array, `SkillPicker` custom widget hitting agentregistry's HTTP API; falls back to plain text inputs), `surface` (radio: `slack | http | mcp | github-webhook`).
+
+Two scaffolder steps:
+1. `fetch:template` against a Jinja skeleton that renders **two files**: `base-apps/agents/<name>/agent.yaml` (the XAgent) and `base-apps/agents/<name>/catalog-info.yaml` (the Backstage Component definition).
+2. `publish:github:pull-request` → opens a PR against `arigsela/kubernetes` on branch `agent/<name>`.
+
+Output gives the engineer a link to the PR. End-to-end "Create" click to PR-open ~5 seconds.
+
+### Catalog auto-discovery
+
+The `catalog-info.yaml` rendered by the template registers the agent as a Backstage Component of type `agent`. The Kubernetes plugin (already configured) auto-discovers the rendered child resources via the TeraSky `backstage.io/kubernetes-id` label and links them to the Component.
+
+The agent appears in the catalog approximately one minute after PR merge (ArgoCD sync + Crossplane reconcile + Backstage Kubernetes plugin refresh).
+
+### Per-agent page (Level 2 polish)
+
+`catalog-info.yaml` template renders these annotations:
+
+```yaml
+annotations:
+  kagent.dev/agent-name: <name>
+  langfuse.platform.arigsela.com/project: golden-poc
+  agent.platform.arigsela.com/try-url: https://<name>.agents.<base-domain>/v1/messages
+```
+
+A small custom Backstage frontend plugin reads these annotations and renders a card on the agent's page with:
+
+- **Status** — from the Kubernetes plugin (running / failed / progressing).
+- **Recent Invocations** — queries Langfuse REST API filtered by `tags: [<name>]`. Last 10 invocations: timestamp, duration, token count, click-through to full trace.
+- **"Try it" chat sidecar** — small React component that POSTs to the `try-url`, streams the response. The demo's most reliable visual moment.
+- **Quick links** — kagent UI for this agent, ArgoCD app, Langfuse project filter.
+
+### Authentication on the agent's HTTP endpoint
+
+For the POC, the agent Ingress restricts source-IP to the cluster network and the Backstage pod IP. The "Try it" button proxies through Backstage's backend, which holds a shared bearer token. Production needs proper auth (per-user OIDC, agent-scoped tokens) — this is explicitly POC-deferred.
+
+### Embedded skill catalog (`/skills` route)
+
+A second small Backstage frontend plugin: a top-level page at `/skills` that:
+
+- Fetches `https://agentregistry.<base-domain>/api/v1/artifacts` (exact endpoint pending agentregistry code-read, see open question 2 in Section 11).
+- Filters by type (skill, MCP server, agent, prompt — agentregistry's four artifact types) and tags.
+- Per-skill detail view: description, latest version, dependencies, copy-pasteable `oci://` ref.
+- Linked from the Software Template's SkillPicker so engineers can browse → pick → fill.
+
+## 6. Platform infrastructure
+
+### `base-apps/agentregistry/`
+
+- Helm chart from solo.io's `agentregistry-dev/agentregistry`. Pin v0.3.x exact version (pre-1.0).
+- Namespace: `agentregistry`.
+- Components: server (REST API + web UI on port 12121), OCI proxy, persistent volume for artifact storage.
+- Auth: internal-only for POC. Admin token in Vault → ExternalSecret.
+- Seed via one-shot Job that runs `arctl push` for the four POC skills.
+- UI exposed via Ingress at `agentregistry.<base-domain>` so the embedded Backstage plugin can reach it through Backstage's backend, and so the demo fallback ("open agentregistry's UI in a browser tab") works.
+
+### `base-apps/agentgateway/`
+
+- Helm chart from solo.io's [agentgateway](https://agentgateway.dev) project.
+- Namespace: `agentgateway`.
+- Configuration:
+  - Upstream: `api.anthropic.com`. (Production routes to Bedrock for HIPAA paths — design-doc note, not POC scope.)
+  - Auth: `ANTHROPIC_API_KEY` in Vault → ExternalSecret. Agents never see the key.
+  - Internal endpoint: `https://gateway.agentgateway.svc/v1/messages`.
+  - Rate limit policy: 10 req/s/agent (POC; demonstrates the cost-control story).
+  - Request/response logging to stdout.
+
+### `base-apps/langfuse/`
+
+- Langfuse self-host Helm chart.
+- Namespace: `langfuse`.
+- Backend: CNPG-managed Postgres (reuse existing CNPG pattern from XApplication's `dbNeeded: true`). Single Cluster instance.
+- Single Langfuse project: `golden-poc`. Public + secret keys generated at install, stored in Vault.
+- Web UI exposed via Ingress at `langfuse.<base-domain>`.
+
+### kagent reconfiguration
+
+Update existing `base-apps/kagent` configmap/values:
+
+- Default LLM endpoint → `https://gateway.agentgateway.svc/v1/messages`.
+- OTLP trace export → Langfuse OTLP ingest endpoint, with project keys via ExternalSecret.
+
+Single PR, then every kagent agent inherits both behaviors.
+
+### `base-apps/slack-adapter/`
+
+Small Go service (~250 lines):
+
+- Watches XAgent resources with `surface: slack` via Kubernetes informer.
+- Builds `<slash-command, agent-namespace/name>` map on startup and on XAgent changes.
+- Subscribes to Slack Events API for `app_mention` events.
+- On message: parses the command, POSTs message to that agent's HTTP endpoint, posts the response back to the Slack thread.
+- Needs `SLACK_BOT_TOKEN` from Vault.
+- Single Deployment, 1 replica.
+
+### `base-apps/github-webhook-adapter/`
+
+Small Go service (~300 lines):
+
+- Watches XAgent resources with `surface: github-webhook` via Kubernetes informer.
+- Each XAgent has annotation `platform.arigsela.com/github-repo: arigsela/<repo>` indicating which repo it serves.
+- HTTP endpoint receives GitHub webhook deliveries (PR opened/synchronize). Verifies signature, looks up the matching agent, POSTs PR diff + context to it, parses response, posts inline review comments via GitHub API.
+- Auth: GitHub App credentials (`APP_ID`, `PRIVATE_KEY`) from Vault.
+- GitHub App setup is the most admin-heavy single piece of the POC (~30 minutes of GitHub UI work). Done once during Phase 0.
+
+## 7. Demo agents
+
+### Agent 1: Cluster Health Agent (pre-baked)
+
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: cluster-health
+  namespace: agents
+spec:
+  description: "Reports cluster/namespace status: pod readiness, events, recent deploys, top noisy pods. Read-only."
+  systemPrompt: |
+    You are the Cluster Health Agent. On request, gather for the named namespace
+    (or cluster-wide if none specified):
+      - Pod readiness counts
+      - Events in the last hour, grouped by reason
+      - Deployments in the last 24h
+      - Top 5 pods by CPU and by memory
+    Respond with brief, skimmable Markdown. Lead with anything actionable
+    (CrashLoopBackOff, OOMKilled, ImagePullBackOff). If everything is normal, say so plainly.
+    You are read-only — do not take any action.
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/kubernetes-mcp:v1
+      alias: k8s
+    - ref: oci://agentregistry.agentregistry.svc/skills/prometheus-mcp:v1
+      alias: prom
+  surface: slack
+```
+
+**Invocation flow:**
+1. `@goldenai cluster-health agents` in Slack
+2. slack-adapter routes to the agent's HTTP endpoint
+3. Agent calls `kubernetes-mcp` (kubectl-style reads) and `prometheus-mcp` (or Coroot equivalent)
+4. LLM synthesizes Markdown, slack-adapter posts to thread
+
+**Sample output (demo target):**
+
+```
+**Namespace `agents`** — 5 pods running
+
+- Ready: 5/5  - Events (1h): none  - Recent deploys (24h): pr-review-agent (just now!)
+Top by CPU: cluster-health-agent (8m), pr-review-agent (5m), ...
+Cluster looks healthy.
+```
+
+The "pr-review-agent (just now!)" line is a designed-in callback to the live-build moment from the demo narrative.
+
+**RBAC:** ServiceAccount with cluster-wide read-only Role (get/list on pods, events, deployments, namespaces). Pre-created at install time. Composition wires the agent's SA to the existing RoleBinding by name.
+
+### Agent 2: PR Review Agent (live-built during the demo)
+
+```yaml
+apiVersion: platform.arigsela.com/v1alpha1
+kind: XAgent
+metadata:
+  name: pr-review
+  namespace: agents
+  annotations:
+    platform.arigsela.com/github-repo: arigsela/kubernetes
+spec:
+  description: "Posts inline review comments on opened PRs with risk callouts."
+  systemPrompt: |
+    You are the PR Review Agent for arigsela/kubernetes. For each PR diff:
+
+    Categorize risks as:
+      CRITICAL — secret exposure, mass deletion, prod-affecting RBAC widening
+      HIGH     — CRD removals, broad RBAC changes, removed health checks,
+                 image:latest, forceDestroy on persistent storage
+      MEDIUM   — replicas reduced below 2, removed resource limits, namespace changes
+      LOW      — style, comments, cosmetic
+
+    For each risk, post an inline review comment on the affected lines with severity
+    prefix, one-line explanation, and one-line suggested fix. If no risks, post a
+    single approving overall comment. Do NOT approve or merge — you are advisory only.
+  skills:
+    - ref: oci://agentregistry.agentregistry.svc/skills/github-mcp:v1
+      alias: github
+    - ref: oci://agentregistry.agentregistry.svc/skills/k8s-yaml-lint:v1
+      alias: lint
+  surface: github-webhook
+```
+
+**Invocation flow:**
+
+1. Engineer opens a PR on `arigsela/kubernetes` (the demo has a queued PR with intentional risks: `replicas: 1`, removed `livenessProbe`)
+2. GitHub fires webhook → github-webhook-adapter
+3. Adapter looks up `pr-review` agent (annotation matches repo), POSTs PR context
+4. Agent calls `github-mcp` to fetch the full diff, then `k8s-yaml-lint` for structural checks
+5. LLM returns line-anchored severity-tagged comments
+6. Adapter posts inline review comments via GitHub API
+
+**Demo target output (visible on the PR in GitHub):**
+
+- Line `replicas: 1`: `[MEDIUM] Replicas reduced below 2 — risks downtime during pod replacement. Consider keeping >=2.`
+- Removed `livenessProbe` block: `[HIGH] livenessProbe removed — silently broken pods won't be restarted. Restore or justify in PR description.`
+
+**RBAC:** GitHub App permissions (read PRs, write PR comments — no merge, no approve). `k8s-yaml-lint` runs offline.
+
+### Skills seeded into agentregistry for the POC
+
+| Skill | Source | Notes |
+|---|---|---|
+| `kubernetes-mcp` | upstream (`mcp-server-kubernetes` or similar) | Pulled into agentregistry once at install |
+| `prometheus-mcp` | upstream (`mcp-prometheus`) | Coroot equivalent acceptable |
+| `github-mcp` | Anthropic's official github MCP server | Standard distribution |
+| `k8s-yaml-lint` | **Custom** — ~50 lines Python wrapping `kube-linter` as MCP | The "we built this skill ourselves" callout |
+
+## 8. Phasing
+
+POC build is approximately 7–8 weeks of focused work for one engineer.
+
+| Phase | Weeks | Scope |
+|---|---|---|
+| **0 — Foundation** | 1 | Install agentregistry + agentgateway + Langfuse. Reconfigure kagent to route through gateway and emit OTLP. Smoke test each in isolation. Set up GitHub App. Resolve the two preflight checks (Section 11). |
+| **1 — XAgent + Composition** | 2–3 | XRD + Composition + function-python script. Hand-write a `cluster-health` XAgent YAML, watch it reconcile, hit its HTTP endpoint with curl. End-to-end working *without* Backstage. |
+| **2 — Surface adapters** | 4–5 | Slack adapter and GitHub webhook adapter. Cluster Health works in Slack. PR Review works via webhook on a test repo. |
+| **3 — Backstage** | 6–7 | Software Template + auto-discovery + per-agent Try-it card. Embedded skill catalog if time permits. By end of Phase 3, the Cluster Health agent must be running continuously so Langfuse accumulates a week of historical traces in time for the demo. |
+| **4 — Demo polish** | 8 | Cluster Health agent has now been running for ~1 week and Langfuse shows real history. Rehearse the live build of PR Review. Record a backup video covering the entire 30-minute narrative. |
+
+The first end-to-end agent runs by week 3, *without* Backstage. This derisks the spine of the platform — every later phase layers on a working core.
+
+## 9. Cuttable scope
+
+Drop in this order if timeline tightens:
+
+1. **Embedded skill catalog plugin** (Section 5) — fall back to "open agentregistry's UI in a separate browser tab" during the demo.
+2. **Custom `k8s-yaml-lint` skill** (Section 7) — PR Review Agent works with `github-mcp` alone; you lose only the "we built this skill ourselves" callout.
+3. **PR Review Agent live-build** (steps 3–6 of the demo narrative) — if webhook plumbing won't cooperate, demo only Cluster Health. Platform story still lands.
+4. **Per-agent invocations card** in Backstage — replace with a single "Recent traces in Langfuse" link.
+
+Not cuttable: the XAgent + Composition + "Try it" button. Without those three, this isn't a platform demo.
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| agentregistry pre-1.0 instability | Pin a specific version; fallback path is hand-written kagent ToolServer CRs that inline MCP server image refs (skipping the registry for that agent). |
+| kagent OTLP → Langfuse format mismatch | Verify during Phase 0; if mismatch, drop a small OTel collector in between. |
+| GitHub webhook delivery to homelab cluster | Cloudflare Tunnel or smee.io for the demo. Test in Phase 2. |
+| Slack Events API setup | Standard pattern but requires public-facing endpoint; reuse existing nginx-ingress + cert-manager. |
+| Composition function-python protobuf edge cases (the float-vs-int issue your existing XApplication script flagged) | Copy the casting pattern from your existing compose function. |
+| Demo flakiness | Cluster Health pre-baked for >=1 week; curl fallback for every surface; backup recorded video. |
+| agentregistry HTTP API surface for the Backstage skill catalog | Start with a hard-coded skill list; only hit the API once it's been verified stable. |
+| Live demo connectivity to homelab from the Golden meeting room | Pre-establish VPN; backup is the recorded video. |
+
+## 11. Open questions and preflight checks
+
+These are unknowns that should be resolved during implementation-plan writing, not during build:
+
+1. **kagent's ToolServer CRD shape** — does it natively accept agentregistry OCI refs, or do we need a shim controller that pulls the artifact and feeds kagent a local path? Resolution: ~half-day code-read of the kagent project.
+2. **agentregistry's HTTP API** — what endpoints exist for the Skill catalog plugin to consume? Resolution: ~half-day code-read of the agentregistry project.
+
+Both are flagged as Phase 0 prerequisite tasks in the implementation plan.
+
+## 12. Production extensions (deliberately deferred)
+
+These are explicitly documented as POC-deferred, with the framing "in production this would be...":
+
+- **Bedrock for the HIPAA path** (deck slide 13). agentgateway upstream switches from `api.anthropic.com` to a Bedrock endpoint; per-tenant data flows route through this path while non-PHI metadata flows can route to Anthropic.
+- **Multi-tenant isolation** (deck slide 13). Namespace-per-tenant patterns; tenant-scoped tool servers; logical scoping enforced in agentgateway middleware.
+- **Per-user OIDC auth** on agent HTTP endpoints (Section 5).
+- **Per-agent cost dashboards and eval harnesses in Backstage** (deck slide 12 Level 3 polish).
+- **Customer-facing AI surfaces** (deck Phase 4+) — the Volunteer Matching Assistant (slide 19) is the canonical example.
+- **Production scale-out of agentregistry** beyond the in-cluster Helm release.
+
+## 13. Glossary
+
+- **Agent**: a software component that reasons and takes actions using an LLM and a set of tools.
+- **MCP (Model Context Protocol)**: the emerging standard for how agents access tools. Skills in this design are MCP servers.
+- **kagent**: Kubernetes-native open-source framework (CNCF) for declaring and running agents as custom resources. Existing in the cluster.
+- **agentregistry**: solo.io's sister project to kagent — a registry for the four artifact types (skills, MCP servers, agents, prompts). Pre-1.0 as of this design.
+- **agentgateway**: solo.io's HTTP/gRPC proxy for A2A and MCP traffic. Donated to Linux Foundation.
+- **Langfuse**: open-source LLM observability with trace UI, eval support, and OTLP ingest.
+- **XAgent**: the new Crossplane v2 namespaced XR introduced by this POC.
+- **Surface**: the channel by which humans or systems reach an agent (Slack, HTTP, MCP, GitHub webhook).
+- **TeraSky annotations**: the existing pattern (`backstage.io/kubernetes-id` and `terasky.backstage.io/*`) for Backstage Kubernetes plugin discovery.
+
+## 14. References
+
+- Source presentation: `/Users/arisela/Designing AI platform/golden-ai-platform-presentation-source.md`
+- kagent: https://github.com/kagent-dev/kagent
+- agentregistry: https://github.com/agentregistry-dev/agentregistry
+- agentgateway: https://agentgateway.dev
+- Solo.io press release on Agent Skills: https://www.solo.io/press-releases/agent-skills-kubernetes-ecosystem
+- Langfuse: https://langfuse.com
+- Backstage Software Templates: https://backstage.io/docs/features/software-templates
+- Existing XApplication design: `docs/superpowers/specs/2026-04-28-backstage-crossplane-idp-design.md`
+- Existing v1.3 AWS resources design (paused, architectural blocker): `docs/superpowers/specs/2026-05-01-idp-v1.3-aws-resources-design.md`


### PR DESCRIPTION
## Summary

This PR adds the **design spec** and **five phase-by-phase implementation plans** for a Proof of Concept demo of the Golden AI Platform. The POC is designed to run on this homelab cluster and exercise the engineer journey from Backstage form -> PR -> ArgoCD -> Crossplane -> kagent runtime, with skills served from in-cluster solo.io agentregistry, LLM traffic via agentgateway, and traces in Langfuse.

**No infrastructure changes in this PR — docs only.** Everything is reviewable; nothing deploys until the plans are executed in follow-up PRs.

## Design

`docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md` — the full design (14 sections + glossary). Distills the 28-slide Golden source presentation into a tight 30-minute demo narrative built from slides 12, 14, 16, 17, 25.

Key decisions:
- **Demo storyline:** engineer journey, with two agents — Cluster Health (pre-baked, mirrors slide 17 Runbook Agent) and PR Review (live-built during the demo to prove platform leverage from slide 25).
- **Engineer-facing API:** Crossplane v2 namespaced ``XAgent`` XR. Intent-only (description, systemPrompt, skills, surface) — Composition handles all Kubernetes machinery.
- **Skill distribution:** in-cluster solo.io agentregistry; kagent pulls OCI artifacts at runtime.
- **LLM gateway:** solo.io agentgateway as transparent proxy in front of Anthropic API (production = Bedrock for HIPAA paths).
- **Observability:** Langfuse self-hosted; OTLP from kagent.
- **Surfaces:** shared slack-adapter and github-webhook-adapter watching XAgent resources via Kubernetes informers.

## Implementation plans

Five plans, one per phase, each independently executable and producing a working artifact:

| Plan | Scope | Outcome |
|---|---|---|
| `2026-05-03-golden-poc-phase-0-foundation.md` | Install agentregistry, agentgateway, Langfuse. Reconfigure kagent (route via gateway, OTLP to Langfuse). Set up GitHub App. Resolve two preflight code-reads. | Three platform services smoke-tested in isolation. |
| `2026-05-03-golden-poc-phase-1-xagent.md` | XAgent XRD + Composition (function-python) + per-skill RBAC + first agent (cluster-health). | cluster-health agent reachable via curl. End-to-end without Backstage. |
| `2026-05-03-golden-poc-phase-2-adapters.md` | Slack adapter, GitHub webhook adapter (Go). Custom k8s-yaml-lint MCP skill (Python). PR Review agent. | cluster-health works in Slack. PR Review posts inline review comments on real PRs. |
| `2026-05-03-golden-poc-phase-3-backstage.md` | "Create New Agent" Software Template + skeleton. Per-agent Try-it card plugin. Embedded /skills catalog plugin. | Engineers self-serve agents through Backstage form -> PR -> running agent. |
| `2026-05-03-golden-poc-phase-4-polish.md` | Heartbeat CronJob (pre-bake Langfuse history). Demo PR script. Rehearsal doc. Backup video. Demo-day checklist. | POC ready for Golden demo. |

Phase 1 has explicit ADAPTATION branches keyed to Phase 0's preflight results (kagent ToolServer CRD shape, agentregistry HTTP API surface). Plans for Phases 1-4 don't bake guesses — they branch on documented findings.

Total estimated build effort: 7-8 weeks of focused work for one engineer.

## Test plan

This PR is docs-only — no functional tests. Reviewing means:

- [ ] Spec reads cleanly start-to-finish (~15 min)
- [ ] Phase 0 plan has no missing setup (Vault, ECR, GitHub App, etc.)
- [ ] Phase 1 Composition design matches the existing XApplication pattern (`base-apps/crossplane-compositions/composition-application.yaml`)
- [ ] Phase 2 Go services structure looks sane (informer + router + handler split)
- [ ] Phase 3 Backstage template + plugin scaffolds align with existing Backstage app build process
- [ ] Phase 4 demo narrative + fallbacks are credible

## What's deferred (in spec Section 12)

- Bedrock for HIPAA path (production extension; POC uses Anthropic direct)
- Multi-tenant isolation at full deck-fidelity
- Per-user OIDC auth on agent endpoints
- Per-agent cost dashboards and eval harnesses
- Customer-facing AI surfaces (Phase 4+ in the deck)