### PR TITLE
docs(idp): v1.3.1 close-out — run notes + spec source-key backport

### DIFF
--- a/docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md
+++ b/docs/superpowers/plans/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests.md
@@ -1496,3 +1496,62 @@ Phase boundaries:
 - **Phase 5** — final close-out subagent
 
 Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents (or sequentially per v1.3 / v1.2.1 precedent).
+
+---
+
+## Run Notes (2026-05-03)
+
+**Outcome:** v1.3.1 of the IDP shipped. `s3Needed:true` triggers Backstage scaffolder to emit `aws-resources.yaml` containing 5 cluster-scoped AWS resources; Composition handles workload-side ESO config + envFrom + AWS env var injection. Workload receives `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BUCKET_NAME` env vars automatically. AWS SDK auto-detects credentials. `aws s3 cp` from inside the pod succeeded — full pipeline validated end-to-end.
+
+**E2E validation** (`smoke-v131`, s3Needed:true, dbNeeded:false):
+
+- ✅ Scaffold PR had **3 files** (smoke-v131.yaml + application-xr.yaml + aws-resources.yaml with 5 AWS resources) — proves v1.3.1's Option B scaffolder works
+- ✅ Bucket created at `s3://852893458518-smoke-v131/`
+- ✅ Vault path `k8s-secrets/smoke-v131/aws-creds` populated with 2 keys (after PushSecret hotfix in PR #239)
+- ✅ Deployment envFrom: `smoke-v131-aws` + AWS_REGION + BUCKET_NAME static env vars
+- ✅ Workload `aws s3 cp /tmp/test.txt s3://$BUCKET_NAME/v131-test.txt` succeeded — AC-8 passed end-to-end
+- ✅ Backstage Crossplane tab showed 7 resources (XR + Deployment + Service + Ingress + SecretStore + PushSecret + ExternalSecret) **after** the ESO RBAC fix in PR #240
+- ✅ Goldens still PASS for xr-minimal + xr-with-db (regression check)
+
+**Bugs caught during execution:**
+
+| # | Bug | Severity | Fix |
+|---|---|---|---|
+| 1 | PushSecret data mapping referenced non-existent Secret keys (`attribute.id` / `attribute.secret`); actual upbound provider-aws-iam v2.5.3 AccessKey Secret keys are `username` (20-byte AKIA-prefixed access key ID) + `password` (40-byte secret access key). Stale comments in `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` misled the original spec. | blocking (smoke-v131 stuck Errored) | [PR #239](https://github.com/arigsela/kubernetes/pull/239) — fixed source keys + updated test golden |
+| 2 | UserPolicyAttachment briefly stuck `cannot resolve references: PolicyArn empty` for ~30s after first apply (Crossplane label selector resolution lag while Policy `status.atProvider.arn` populated). | minor (transient) | Self-healed via Crossplane retries |
+| 3 | Backstage `backstage-crossplane-read` ClusterRole lacked `external-secrets.io/*` permission. Composition emitted SecretStore + PushSecret + ExternalSecret correctly (XR's resourceRefs included them) but Backstage SA couldn't list them, so Crossplane tab silently omitted them. | minor (UX) | [PR #240](https://github.com/arigsela/kubernetes/pull/240) — added external-secrets.io to ClusterRole. Same class as v1.1 PR #214 (CRD discovery permission). |
+| 4 | Per-app ArgoCD Application missing `resources-finalizer.argocd.argoproj.io` finalizer → cluster-scoped AWS resources orphaned on master-app prune (vs v1.2's namespaced resources which got cleaned up via `kubectl delete namespace`). | minor (teardown only) | Manual cleanup of orphaned AWS resources required (`kubectl delete bucket,user,...`). Documented as v1.4 candidate (scaffolder template should add finalizer). |
+
+**v1.4 / v2 follow-up candidates:**
+
+- **v1.4 — scaffolder template adds `resources-finalizer.argocd.argoproj.io`** to per-app Application so master-app prune cascades to cluster-scoped AWS resources (fix for bug #4)
+- **v1.4 — Backstage UX**: cluster-scoped AWS resources don't appear in Crossplane tab (architectural limitation of Option B; not in XR's resourceRefs). Options to investigate:
+  - TeraSky's `ingestAllXRDs:true` already auto-ingests them as Backstage components; relate them via `dependsOn` or label-based linking
+  - Custom Backstage relationship plugin
+  - Accept as documented limitation (kubectl + AWS console for visibility)
+- **v1.4 — Additional AWS resources** via same Option B pattern: SQS, SNS, RDS, DynamoDB
+- **v1.4 — Bucket sub-fields**: versioning, lifecycle rules, CORS — opt-in via XR fields
+- **v1.4 — Custom IAM policy override**: `s3.customPolicyJson` field for advanced use cases (default stays "S3 RW on own bucket")
+- **v2 — Vault dynamic credentials** (CNPG + AWS) via VSO + Vault AWS Secrets Engine
+- **v2 — IRSA / Pod Identity** alternative to long-lived access keys
+
+**Spec corrections applied in this close-out PR:**
+
+- §5.2: `make_aws_push_secret` source keys corrected from `attribute.id`/`attribute.secret` → `username`/`password` (with rationale referencing PR #239)
+- §6.1 AccessKey description: clarified that `username` and `password` are the actual populated keys; `attribute.secret` and `attribute.ses_smtp_password_v4` exist but are empty
+
+**Final PR sequence:**
+
+| PR | Status |
+|---|---|
+| [#236 spec/plan](https://github.com/arigsela/kubernetes/pull/236) | Merged |
+| [#237 v1.3.1 Composition Phase 1](https://github.com/arigsela/kubernetes/pull/237) | Merged |
+| [arigsela/backstage#12 v1.3.1 scaffolder Phase 2](https://github.com/arigsela/backstage/pull/12) | Merged |
+| (image rebuild — same tag, no manifest PR) | User reused tag + relaunched pod |
+| [#238 smoke-v131 scaffold](https://github.com/arigsela/kubernetes/pull/238) | Merged |
+| [#239 PushSecret source keys hotfix](https://github.com/arigsela/kubernetes/pull/239) | Merged |
+| [#240 ESO RBAC for Backstage](https://github.com/arigsela/kubernetes/pull/240) | Merged |
+| [#242 smoke-v131 teardown](https://github.com/arigsela/kubernetes/pull/242) | Merged |
+| (this PR) | docs: v1.3.1 close-out run notes + spec backport |
+
+**v1.3.1 status: shipped** (with manual AWS resource cleanup required during teardown — fix queued for v1.4 via scaffolder finalizer).

--- a/docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
+++ b/docs/superpowers/specs/2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md
@@ -131,7 +131,7 @@ AWS_REGION = "us-east-2"
 ### 5.2 ESO helpers (re-add verbatim)
 
 `make_aws_push_secret` and `make_aws_external_secret` — see [v1.3 spec §6.2 + §6.3](./2026-05-01-idp-v1.3-aws-resources-design.md) for full code. They:
-- PushSecret reads `<name>-aws-key` (created by scaffolder's AccessKey resource), pushes to Vault path `k8s-secrets/<namespace>/aws-creds` with key remap (`attribute.id` → `AWS_ACCESS_KEY_ID`, `attribute.secret` → `AWS_SECRET_ACCESS_KEY`)
+- PushSecret reads `<name>-aws-key` (created by scaffolder's AccessKey resource), pushes to Vault path `k8s-secrets/<namespace>/aws-creds` with key remap (`username` → `AWS_ACCESS_KEY_ID`, `password` → `AWS_SECRET_ACCESS_KEY`). **CORRECTION (post-shakeout, PR #239):** the source keys are `username` and `password`, NOT `attribute.id` and `attribute.secret` as v1.3 spec assumed. Stale comments in `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` misled the original spec; actual upbound provider-aws-iam v2.5.3 AccessKey connection Secret has 4 keys (`username`, `password`, `attribute.secret`, `attribute.ses_smtp_password_v4`) where `username` is 20 bytes (AKIA-prefixed AWS access key ID) and `password` is 40 bytes (secret access key). The other two are empty.
 - ExternalSecret reads from Vault, projects to K8s Secret `<name>-aws`
 
 ### 5.3 `make_deployment` updates (re-add)
@@ -279,7 +279,7 @@ spec:
     name: default
 ```
 
-**AccessKey** (creates K8s Secret in app's namespace with `attribute.id` + `attribute.secret`):
+**AccessKey** (creates K8s Secret in app's namespace with `username` (= AWS access key ID) + `password` (= secret access key); `attribute.secret` and `attribute.ses_smtp_password_v4` also exist but are empty in upbound provider-aws-iam v2.5.3):
 ```yaml
 apiVersion: iam.aws.upbound.io/v1beta1
 kind: AccessKey


### PR DESCRIPTION
Captures v1.3.1 outcome (shipped end-to-end), the 4 bugs caught during smoke validation, and v1.4/v2 follow-up candidates.

## Outcome

v1.3.1 shipped. Workload `aws s3 cp` from inside the Pod successfully wrote to the per-app S3 bucket using AWS credentials routed through Vault. AWS SDK auto-detects via the standard env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`); zero workload code changes for S3 access.

## Bugs caught (all fixed or documented)

1. **PushSecret source keys** — spec assumed `attribute.id`/`attribute.secret`; actual upbound provider-aws-iam v2.5.3 keys are `username`/`password`. Fixed in PR #239 (composition Python + golden); spec backported in this PR.
2. **UserPolicyAttachment selector resolution** — transient ~30s lag while Policy `status.atProvider.arn` populated. Self-healed.
3. **Missing ESO RBAC for Backstage** — `backstage-crossplane-read` ClusterRole lacked `external-secrets.io/*`, so SecretStore/PushSecret/ExternalSecret didn't render in Crossplane tab even though they were in XR resourceRefs. Fixed in PR #240.
4. **Missing ArgoCD finalizer on per-app Application** — cluster-scoped AWS resources orphaned on master-app prune; required manual `kubectl delete` cleanup. Documented for v1.4 (scaffolder template should add `resources-finalizer.argocd.argoproj.io`).

## Spec backport

- §5.2: `make_aws_push_secret` source keys corrected
- §6.1: AccessKey description clarified

## v1.4 candidates

- Scaffolder finalizer for proper cluster-scoped resource cleanup
- Backstage AWS-resource UX (Crossplane tab limitation of Option B)
- Additional AWS resources (SQS, SNS, RDS, DynamoDB)
- Bucket sub-fields (versioning, lifecycle, CORS)
- Custom IAM policy override

🤖 Generated with [Claude Code](https://claude.com/claude-code)