### PR TITLE
chore(ingress): allow internal 10.0.0.0/8 on whitelisted ingresses

### DIFF
--- a/base-apps/agent-ui-frontend/ingress.yaml
+++ b/base-apps/agent-ui-frontend/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
     # IP Whitelist
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 spec:
   ingressClassName: nginx
   tls:

--- a/base-apps/argo-cd/ingress.yaml
+++ b/base-apps/argo-cd/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-connections: "50"
 
     # IP Whitelist
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"

--- a/base-apps/argo-rollouts/nginx-ingress.yaml
+++ b/base-apps/argo-rollouts/nginx-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-connections: "50"
 
     # IP Whitelist
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"

--- a/base-apps/argo-workflows/nginx-ingress.yaml
+++ b/base-apps/argo-workflows/nginx-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-connections: "50"
 
     # IP Whitelist (UI has no auth in POC --auth-mode=server)
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"

--- a/base-apps/atlantis/nginx-ingress.yaml
+++ b/base-apps/atlantis/nginx-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     # Your IPs + GitHub webhook delivery IPs (from https://api.github.com/meta hooks)
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,192.30.252.0/22,185.199.108.0/22,140.82.112.0/20,143.55.64.0/20,2a0a:a440::/29,2606:50c0::/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8,192.30.252.0/22,185.199.108.0/22,140.82.112.0/20,143.55.64.0/20,2a0a:a440::/29,2606:50c0::/32"
 spec:
   ingressClassName: nginx
   tls:

--- a/base-apps/backstage/nginx-ingress.yaml
+++ b/base-apps/backstage/nginx-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 spec:
   ingressClassName: nginx
   tls:

--- a/base-apps/coroot/ingress.yaml
+++ b/base-apps/coroot/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
 
     # IP Whitelist - Only allow home IP
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts (longer for dashboard loading)
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"

--- a/base-apps/n8n/nginx-ingress-admin.yaml
+++ b/base-apps/n8n/nginx-ingress-admin.yaml
@@ -19,7 +19,7 @@ metadata:
 
     # 🔒 IP WHITELIST - Admin UI Only
     # Only these IPs can access the n8n admin interface
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"

--- a/base-apps/oncall-crewai/frontend-ingress.yaml
+++ b/base-apps/oncall-crewai/frontend-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-connections: "20"
 
     # IP Whitelist — only reachable from your IP
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 
     # Timeouts (agent queries can take a while)
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"

--- a/base-apps/weather-kitchen-backend/nginx-ingress.yaml
+++ b/base-apps/weather-kitchen-backend/nginx-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /api/$1
     nginx.ingress.kubernetes.io/priority: "100"
     # IP Whitelist - restrict access to known IPs
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 spec:
   ingressClassName: nginx
   tls:

--- a/base-apps/weather-kitchen-frontend/nginx-ingress.yaml
+++ b/base-apps/weather-kitchen-frontend/nginx-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
     nginx.ingress.kubernetes.io/priority: "50"
     # IP Whitelist - restrict access to known IPs
-    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary

- Adds `10.0.0.0/8` to `nginx.ingress.kubernetes.io/whitelist-source-range` on the **11 ingresses** that currently restrict access by source IP.
- Fixes 403 Forbidden when reaching admin/internal UIs over WireGuard (or any in-tunnel / LAN path) — the existing allowlist only contained home/work public IPs (`73.7.190.154/32`, `170.85.56.189/32`, `170.85.130.202/32`).
- Public posture is unchanged for the wider internet; this only **adds** RFC1918 10/8 to the existing list.

## Why

When connected via WireGuard, traffic to ingress arrives with an internal `10.x.x.x` source IP, which nginx-ingress evaluates against `whitelist-source-range`. Since the allowlist only had three `/32` public IPs, the controller rejected the request with **403 Forbidden** before it ever reached the upstream service. Allowlisting `10.0.0.0/8` lets the WireGuard client subnet (and any other in-cluster/LAN paths) through.

## Files changed (11)

| App | File |
|---|---|
| argo-cd | `base-apps/argo-cd/ingress.yaml` |
| weather-kitchen-backend | `base-apps/weather-kitchen-backend/nginx-ingress.yaml` |
| weather-kitchen-frontend | `base-apps/weather-kitchen-frontend/nginx-ingress.yaml` |
| oncall-crewai | `base-apps/oncall-crewai/frontend-ingress.yaml` |
| n8n (admin) | `base-apps/n8n/nginx-ingress-admin.yaml` |
| argo-rollouts | `base-apps/argo-rollouts/nginx-ingress.yaml` |
| argo-workflows | `base-apps/argo-workflows/nginx-ingress.yaml` |
| atlantis | `base-apps/atlantis/nginx-ingress.yaml` (kept GH webhook ranges; 10/8 inserted before them) |
| backstage | `base-apps/backstage/nginx-ingress.yaml` |
| coroot | `base-apps/coroot/ingress.yaml` |
| agent-ui-frontend | `base-apps/agent-ui-frontend/ingress.yaml` |

Each file: a single annotation line changes from
```
"73.7.190.154/32,170.85.56.189/32,170.85.130.202/32"
```
to
```
"73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
```
(atlantis preserves its trailing GitHub webhook ranges and IPv6 entries).

## Out of scope

8 ingresses have **no** `whitelist-source-range` and are already publicly reachable, so they need no change for this issue: `chores-tracker*`, `oncall-agent`, `n8n` webhook, `whoami-test`, `grafana`, `vault`.

## Test plan

- [ ] After ArgoCD syncs, hit one of the gated hosts (e.g. `https://argocd.arigsela.com`) over WireGuard — should now load instead of returning 403.
- [ ] Confirm the same host still loads from a public-IP path that was previously working.
- [ ] Spot-check `kubectl describe ingress -n argo-cd argocd-server` (or any other touched app) and confirm the annotation contains `10.0.0.0/8`.
- [ ] Tail nginx-ingress controller logs while reproducing — no 403s for previously-blocked WG client IP.

## Notes / risks

- `10.0.0.0/8` is broad. It covers any RFC1918 10/8 source — not just WireGuard peers — which is fine here because the cluster's internal LAN is already trusted (see `nginx-ingress-controller.yaml` `trusted-proxies` list and `atlantis/network-policy.yaml`).
- Pod-to-ingress traffic that gets SNAT'd to a node's 10/8 IP would also be allowed. Today no pod relies on this, but worth flagging for future reviews.
- If a tighter scope is desired later, swap `10.0.0.0/8` for the specific WireGuard subnet (e.g. `10.13.13.0/24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)