### PR TITLE
docs(idp): v1.4 design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md
+++ b/docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md
@@ -1,0 +1,1360 @@
+# IDP v1.4 — Scaffolder Finalizer + Bucket Sub-Fields + Decommission Template — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement IDP v1.4 — 5-item bundle that closes out v1.3.1's rough edges plus rounds out the AWS bucket story plus automates the manual teardown step.
+
+**Architecture:** Composition Python stays out of AWS resource emission (Option B preserved). XRD gains 3 new optional fields validated only at API-server level. Backstage scaffolder gains 4 new conditional bucket sub-resources, ArgoCD finalizer on the per-app Application template, and a NEW Decommission template that opens teardown PRs via `publish:github:pull-request` action's `gitDeletePaths` feature. Cross-resource references via Crossplane label selectors (matches v1.3.1 patterns).
+
+**Tech Stack:** Crossplane v2.2.1 + function-python (composition), Crossplane provider-aws-s3 v2.5.3 + provider-aws-iam v2.5.3 (already installed), External Secrets Operator (ESO), HashiCorp Vault, Backstage scaffolder (Nunjucks templating), `crossplane render` CLI + `yq` for goldens-based regression.
+
+**Spec:** [`docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md`](../specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md) (committed `b757870`)
+
+---
+
+## Pre-flight (run once before Phase 1 starts)
+
+### P.1 — Verify the Composition test harness still works (sanity baseline)
+
+```bash
+cd /Users/arisela/git/kubernetes
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+Expected: all three exit 0 with no diff output. If any fails, investigate before adding v1.4 changes.
+
+### P.2 — Confirm v1.3.1 close-out PR #243 merged on main
+
+```bash
+git fetch origin main
+git log origin/main --oneline | grep -E "v1.3.1 close-out|1df974a" | head -3
+```
+
+Expected: at least one commit referencing the v1.3.1 close-out. If not, merge PR #243 first.
+
+### P.3 — Verify all 4 Bucket sub-resource CRDs exist by NAME (HARD GATE)
+
+The v1.3 lesson: verify CRDs by name BEFORE writing code that depends on them.
+
+```bash
+for crd in \
+  bucketversionings.s3.aws.upbound.io \
+  bucketlifecycleconfigurations.s3.aws.upbound.io \
+  bucketcorsconfigurations.s3.aws.upbound.io \
+  bucketpublicaccessblocks.s3.aws.upbound.io; do
+  kubectl get crd $crd -o jsonpath='{.spec.scope}: {.metadata.name}{"\n"}' 2>&1 || echo "MISSING: $crd"
+done
+```
+
+**Expected output:** all 4 lines show `Cluster: <crd>`.
+
+**If any CRD is MISSING:** STOP. v1.4 depends on these specific kinds.
+
+### P.4 — Verify Backstage scaffolder version supports `gitDeletePaths`
+
+The decommission template uses `publish:github:pull-request` action's `gitDeletePaths` field. This feature was added in Backstage v1.20+ (`@backstage/plugin-scaffolder-backend-module-github` v0.5+).
+
+```bash
+cd ~/git/backstage
+grep '"@backstage/plugin-scaffolder-backend-module-github"' packages/backend/package.json
+```
+
+Expected: version `^0.9.6` or higher (current homelab is on `^0.9.6` per the reference clone — supports `gitDeletePaths`).
+
+**If version is older:** the decommission template will silently fail to delete files, opening empty PRs. Either upgrade the package or use a different scaffolder action (e.g., a custom action that writes empty files). For v1.4: trust the version is current; flag if smoke validation reveals the action doesn't work.
+
+### P.5 — Confirm the local backstage clone is current
+
+```bash
+cd ~/git/backstage
+git fetch origin main
+git status   # should be clean; main should be up to date
+```
+
+If branches are uncommitted or stale: clean up before starting.
+
+---
+
+## Phase 1 — Kubernetes repo (XRD-only PR)
+
+Branch: `feat/idp-v1.4-xrd-bucket-subfields` off `origin/main`. Trivially small (one file, additive).
+
+### Task 1.1: Set up the implementation branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main
+git checkout -b feat/idp-v1.4-xrd-bucket-subfields origin/main
+git branch --show-current
+# Expected: feat/idp-v1.4-xrd-bucket-subfields
+```
+
+---
+
+### Task 1.2: Add 3 new optional fields to XApplication XRD
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/xrd-application.yaml`
+
+The XRD's `spec.versions[0].schema.openAPIV3Schema.properties.spec.properties` block currently has fields up through `s3Needed`. Add 3 new optional fields immediately after `s3Needed`.
+
+- [ ] **Step 1: Locate `s3Needed` in the XRD**
+
+```bash
+grep -n "s3Needed:" base-apps/crossplane-compositions/xrd-application.yaml
+```
+
+Expected: shows the line where `s3Needed:` is defined. Note the line number — new fields go AFTER its block ends (after the `default: false` line).
+
+- [ ] **Step 2: Add `s3Versioning` field**
+
+Find the `s3Needed:` block. Immediately AFTER its complete definition (after the `default: false` line + any comment block that closes the field), insert:
+
+```yaml
+                s3Versioning:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true (and s3Needed:true), emits BucketVersioning resource enabling
+                    object versioning on the bucket. Useful for recovery from accidental
+                    deletes or overwrites.
+                    Note: AWS only supports `Suspended` (not full disable) once enabled —
+                    flipping back to false suspends versioning but doesn't delete history.
+```
+
+(Indentation: 16 spaces, matching surrounding properties.)
+
+- [ ] **Step 3: Add `s3LifecycleDays` field**
+
+Immediately after the `s3Versioning` block:
+
+```yaml
+                s3LifecycleDays:
+                  type: integer
+                  default: 0
+                  minimum: 0
+                  description: |
+                    When > 0 (and s3Needed:true), emits BucketLifecycleConfiguration with a
+                    single rule that expires all objects after N days. When 0, no lifecycle
+                    rule is created.
+                    Common values: 7 (transient logs), 30 (build artifacts), 365 (compliance
+                    retention).
+```
+
+- [ ] **Step 4: Add `s3CorsEnabled` field**
+
+Immediately after the `s3LifecycleDays` block:
+
+```yaml
+                s3CorsEnabled:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true (and s3Needed:true), emits BucketCorsConfiguration with
+                    permissive defaults: allow all origins, GET/PUT/POST/DELETE/HEAD methods,
+                    all headers, max-age 3600s. Useful for web apps that load assets directly
+                    from S3.
+                    For granular CORS configuration, see v1.5+ (deferred).
+```
+
+- [ ] **Step 5: Verify YAML still parses**
+
+```bash
+yq '.' base-apps/crossplane-compositions/xrd-application.yaml > /dev/null && echo "XRD valid"
+```
+
+If yq errors: indentation drifted. Each field block must be 16 spaces deep.
+
+---
+
+### Task 1.3: Run all 3 render tests → expect PASS (regression)
+
+**Files:** none (running tests)
+
+The Composition Python doesn't read these new fields, so output is unchanged. All existing goldens should still pass.
+
+- [ ] **Step 1: Run xr-minimal**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-minimal
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run xr-with-db**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-db
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run xr-with-s3**
+
+```bash
+DOCKER_HOST=unix:///Users/arisela/.colima/default/docker.sock ./tests/composition/render.sh xr-with-s3
+```
+
+Expected: PASS.
+
+If any test FAILS: the XRD edit corrupted the file structure. Diff against `git diff` and fix.
+
+---
+
+### Task 1.4: Commit + push + open Phase 1 PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Stage + commit**
+
+```bash
+git add base-apps/crossplane-compositions/xrd-application.yaml
+git status --short   # expect: 1 file modified
+
+git commit -m "$(cat <<'EOF'
+feat(xrd): v1.4 add s3Versioning + s3LifecycleDays + s3CorsEnabled fields
+
+XApplication XRD gains 3 new optional fields supporting v1.4's bucket
+sub-resources:
+
+  s3Versioning: bool (default false)
+    -> When true, scaffolder emits BucketVersioning resource
+
+  s3LifecycleDays: int (default 0; 0 means no rule)
+    -> When > 0, scaffolder emits BucketLifecycleConfiguration with
+       single expiration rule
+
+  s3CorsEnabled: bool (default false)
+    -> When true, scaffolder emits BucketCorsConfiguration with
+       permissive defaults
+
+Composition Python ignores these fields — they're for API-server
+validation only (so XRs containing them are accepted). All AWS
+resource emission happens via Backstage scaffolder per Option B
+architecture (v1.3.1).
+
+XRD apiVersion stays v1alpha1 (additive optional fields with
+defaults; backwards-compat per Crossplane v2 evolution rules).
+
+Existing test goldens unchanged; all three pass as regression check.
+
+Companion arigsela/backstage PR adds the scaffolder logic that
+reads these fields + emits the corresponding AWS sub-resources +
+decommission scaffolder template + finalizer fix.
+
+Spec: docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git log -1 --stat
+```
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/idp-v1.4-xrd-bucket-subfields
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --head feat/idp-v1.4-xrd-bucket-subfields \
+  --title "feat(xrd): v1.4 add s3Versioning + s3LifecycleDays + s3CorsEnabled fields" \
+  --body "$(cat <<'EOF'
+## Summary
+
+XApplication XRD gains 3 new optional fields supporting v1.4's bucket sub-resources. Composition Python ignores them — they're for API-server validation only (so XRs containing them are accepted). All AWS resource emission happens via the companion arigsela/backstage scaffolder PR per Option B architecture (v1.3.1).
+
+## Changes
+
+| Change | File | Impact |
+|---|---|---|
+| Add `s3Versioning: bool` (default false) | `base-apps/crossplane-compositions/xrd-application.yaml` | When true, scaffolder emits BucketVersioning |
+| Add `s3LifecycleDays: int` (default 0, min 0) | (same file) | When > 0, scaffolder emits BucketLifecycleConfiguration |
+| Add `s3CorsEnabled: bool` (default false) | (same file) | When true, scaffolder emits BucketCorsConfiguration |
+
+## Test plan
+
+- [x] `./tests/composition/render.sh xr-minimal` PASS (regression)
+- [x] `./tests/composition/render.sh xr-with-db` PASS (regression)
+- [x] `./tests/composition/render.sh xr-with-s3` PASS (regression)
+- [ ] Companion arigsela/backstage PR: scaffolder template + decommission template
+- [ ] User rebuilds Backstage image
+- [ ] Smoke validation: scaffold smoke-v14 with all 3 sub-fields enabled
+
+## Things explicitly NOT in this PR
+
+- Composition Python changes (Option B: AWS resources via scaffolder, not Composition)
+- Test golden updates (Composition output unchanged for these fields)
+- Scaffolder logic (companion arigsela/backstage PR)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 2 — Backstage repo (scaffolder + decommission template + app-config)
+
+Branch: `feat/idp-v1.4-bucket-subfields-finalizer-decommission` off `origin/main` in `arigsela/backstage`.
+
+This is the bigger PR — 5 distinct change groups:
+- 2.2: Finalizer on per-app App template
+- 2.3: 3 new form fields in Application template
+- 2.4: Conditional XR template emission for new fields
+- 2.5: Append 4 sub-resources to aws-resources.yaml
+- 2.6: NEW Decommission template
+- 2.7: Register Decommission template in app-config
+
+### Task 2.1: Set up branch in arigsela/backstage
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+cd ~/git/backstage
+git fetch origin main
+git checkout -b feat/idp-v1.4-bucket-subfields-finalizer-decommission origin/main
+git branch --show-current
+```
+
+---
+
+### Task 2.2: Add finalizer to per-app Application template (the v1.3.1 bug #4 fix)
+
+**Files:**
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml`
+
+Note the literal `${{ values.name }}` in the directory/file name — that's the existing Backstage scaffolder convention.
+
+- [ ] **Step 1: Locate the per-app Application template**
+
+```bash
+ls "examples/templates/application/content-k8s/base-apps/"
+# Expected: shows ${{ values.name }}.yaml file + ${{ values.name }}/ dir
+```
+
+- [ ] **Step 2: Add the finalizer to metadata**
+
+Open `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml`. Find the `metadata:` block. After `name:` and `namespace:` lines (and before `annotations:` if present), add:
+
+```yaml
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+```
+
+The full metadata block should now look like:
+```yaml
+metadata:
+  name: ${{ values.name }}
+  namespace: argo-cd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+```
+
+- [ ] **Step 3: Verify YAML still parses**
+
+```bash
+yq '.' "examples/templates/application/content-k8s/base-apps/\${{ values.name }}.yaml" > /dev/null && echo "valid"
+```
+
+If yq errors: literal `${{ }}` in the file confuses yq during parsing. That's normal for Backstage templates. The file is processed at scaffold-time by Nunjucks, not yq. Skip yq validation; trust the editor's YAML mode for this file.
+
+---
+
+### Task 2.3: Add 3 new optional form fields to Application template
+
+**Files:**
+- Modify: `examples/templates/application/template.yaml`
+
+- [ ] **Step 1: Find the "Resources (optional)" parameter group**
+
+```bash
+grep -n "Resources (optional)\|s3Needed:" examples/templates/application/template.yaml
+```
+
+Expected: shows the `- title: Resources (optional)` line followed by the existing `s3Needed: ...` field block.
+
+- [ ] **Step 2: Append 3 new optional fields after `s3Needed`**
+
+Find the `s3Needed:` field block in the "Resources (optional)" group. AFTER its complete definition (after the `default: false` line; preserve any descriptive `description: |` block), add:
+
+```yaml
+        s3Versioning:
+          type: boolean
+          title: Enable bucket versioning
+          description: |
+            When enabled, the bucket retains all versions of objects.
+            Useful for recovery from accidental deletes/overwrites.
+          default: false
+        s3LifecycleDays:
+          type: integer
+          title: Bucket lifecycle (days until objects expire)
+          description: |
+            When > 0, S3 automatically deletes objects older than N days.
+            Common values: 7 (logs), 30 (build artifacts), 365 (compliance).
+            Set to 0 to disable lifecycle.
+          default: 0
+          minimum: 0
+        s3CorsEnabled:
+          type: boolean
+          title: Enable CORS (web app pattern)
+          description: |
+            When enabled, the bucket allows cross-origin browser access
+            with permissive defaults (all origins, common methods).
+            Useful for web apps loading assets directly from S3.
+          default: false
+```
+
+(Indentation: 8 spaces matching surrounding fields.)
+
+- [ ] **Step 3: Find the `fetch.values` mapping**
+
+```bash
+grep -n "values:" examples/templates/application/template.yaml | head -5
+```
+
+Expected: shows the `values:` block under `steps[id=fetch].input.values`.
+
+- [ ] **Step 4: Add 3 new lines to the `fetch.values` mapping**
+
+In the `values:` block, find the existing `s3Needed: ${{ parameters.s3Needed }}` line. AFTER it (and before any other entries OR at the end of the values list), add:
+
+```yaml
+          s3Versioning: ${{ parameters.s3Versioning }}
+          s3LifecycleDays: ${{ parameters.s3LifecycleDays }}
+          s3CorsEnabled: ${{ parameters.s3CorsEnabled }}
+```
+
+(Indentation: 10 spaces matching surrounding values.)
+
+(No `| trim` filters — these are booleans + integer; trim only applies to strings and would error on non-strings.)
+
+---
+
+### Task 2.4: Conditionally emit new fields in XR template
+
+**Files:**
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml`
+
+The XR template currently emits `s3Needed: ${{ values.s3Needed }}` (and the existing v1.x fields). Add 3 conditional blocks for the new fields.
+
+- [ ] **Step 1: Locate the spec block in the XR template**
+
+```bash
+grep -n "spec:\|s3Needed:" "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/application-xr.yaml"
+```
+
+- [ ] **Step 2: Add 3 conditional emission blocks after `s3Needed`**
+
+In the `spec:` block, find the line `s3Needed: ${{ values.s3Needed }}`. AFTER it, add:
+
+```yaml
+  {%- if values.s3Versioning %}
+  s3Versioning: ${{ values.s3Versioning }}
+  {%- endif %}
+  {%- if values.s3LifecycleDays > 0 %}
+  s3LifecycleDays: ${{ values.s3LifecycleDays }}
+  {%- endif %}
+  {%- if values.s3CorsEnabled %}
+  s3CorsEnabled: ${{ values.s3CorsEnabled }}
+  {%- endif %}
+```
+
+(2-space indent inside `spec:`; Nunjucks `{%- %}` for whitespace stripping.)
+
+**Why conditional emission:** when the field is at default (false / 0), don't emit it in the rendered XR. Keeps the XR clean for the common case. The XRD's `default:` value handles missing fields server-side.
+
+---
+
+### Task 2.5: Append 4 new bucket sub-resources to aws-resources.yaml
+
+**Files:**
+- Modify: `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml`
+
+The current file has 5 AWS resources inside a `{%- if values.s3Needed %}...{%- endif %}` wrapper. Append 4 more resources INSIDE the same wrapper:
+- `BucketVersioning` (conditional on `s3Versioning:true`)
+- `BucketLifecycleConfiguration` (conditional on `s3LifecycleDays > 0`)
+- `BucketCorsConfiguration` (conditional on `s3CorsEnabled:true`)
+- `BucketPublicAccessBlock` (always emit when `s3Needed:true` — security default)
+
+- [ ] **Step 1: Locate the closing `{%- endif %}` of the existing `s3Needed` block**
+
+```bash
+grep -n "endif\|kind:" "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/aws-resources.yaml"
+```
+
+Expected: shows 5 `kind:` lines (Bucket, User, Policy, UserPolicyAttachment, AccessKey) and one `{%- endif %}` line at the bottom.
+
+- [ ] **Step 2: Append BucketVersioning (conditional on s3Versioning)**
+
+Just BEFORE the closing `{%- endif %}` line, insert:
+
+```yaml
+{%- if values.s3Versioning %}
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketVersioning
+metadata:
+  name: ${{ values.name }}-versioning
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-versioning
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    versioningConfiguration:
+      - status: Enabled
+  providerConfigRef:
+    name: default
+{%- endif %}
+```
+
+- [ ] **Step 3: Append BucketLifecycleConfiguration (conditional on s3LifecycleDays > 0)**
+
+After the BucketVersioning block (still inside the outer `{%- if values.s3Needed %}` wrapper), insert:
+
+```yaml
+{%- if values.s3LifecycleDays > 0 %}
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketLifecycleConfiguration
+metadata:
+  name: ${{ values.name }}-lifecycle
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-lifecycle
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    rule:
+      - id: expire-objects
+        status: Enabled
+        expiration:
+          - days: ${{ values.s3LifecycleDays }}
+  providerConfigRef:
+    name: default
+{%- endif %}
+```
+
+- [ ] **Step 4: Append BucketCorsConfiguration (conditional on s3CorsEnabled)**
+
+After the BucketLifecycleConfiguration block:
+
+```yaml
+{%- if values.s3CorsEnabled %}
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketCorsConfiguration
+metadata:
+  name: ${{ values.name }}-cors
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-cors
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    corsRule:
+      - allowedOrigins: ["*"]
+        allowedMethods: ["GET", "PUT", "POST", "DELETE", "HEAD"]
+        allowedHeaders: ["*"]
+        maxAgeSeconds: 3600
+  providerConfigRef:
+    name: default
+{%- endif %}
+```
+
+- [ ] **Step 5: Append BucketPublicAccessBlock (always-emitted; NO conditional wrapper inside the s3Needed block)**
+
+After the BucketCorsConfiguration block (and BEFORE the outer `{%- endif %}` that closes `{%- if values.s3Needed %}`), insert:
+
+```yaml
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketPublicAccessBlock
+metadata:
+  name: ${{ values.name }}-pab
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-public-access-block
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    blockPublicAcls: true
+    blockPublicPolicy: true
+    ignorePublicAcls: true
+    restrictPublicBuckets: true
+  providerConfigRef:
+    name: default
+```
+
+(NO `{%- if %}` wrapper — this resource is always emitted when `s3Needed:true`. Security default: all 4 blocks enabled.)
+
+---
+
+### Task 2.6: Create NEW Decommission scaffolder template
+
+**Files:**
+- Create: `examples/templates/decommission/template.yaml`
+
+This is a brand-new Backstage scaffolder template. Create the directory and file:
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p examples/templates/decommission
+```
+
+- [ ] **Step 2: Create `examples/templates/decommission/template.yaml`** with this exact content:
+
+```yaml
+# examples/templates/decommission/template.yaml
+# Decommission Application (Crossplane) — opens a teardown PR by removing
+# the app's manifests from arigsela/kubernetes. Master-app prunes the per-app
+# Application post-merge; v1.4's resources-finalizer.argocd.argoproj.io
+# cascades AWS resource deletion. User runs `kubectl delete namespace <name>`
+# manually as the last step.
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: decommission-application
+  title: Decommission Application (Crossplane)
+  description: >-
+    Tear down a Crossplane-provisioned application by opening a PR that removes
+    its manifests from arigsela/kubernetes. After merge, master-app prune
+    cascades to all managed resources via v1.4's ArgoCD finalizer.
+  tags:
+    - crossplane
+    - kubernetes
+    - decommission
+    - recommended
+spec:
+  owner: group:platform-engineering
+  type: service
+
+  parameters:
+    - title: Identity
+      required: [name]
+      properties:
+        name:
+          type: string
+          title: Application name to tear down
+          description: Must match an existing app under base-apps/ (e.g., smoke-v131)
+          pattern: "^[a-z][a-z0-9-]{2,38}[a-z0-9]$"
+
+  steps:
+    - id: publish
+      name: Open teardown PR
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=kubernetes&owner=arigsela
+        branchName: chore/teardown-${{ parameters.name | trim }}
+        title: "chore: tear down ${{ parameters.name | trim }} (decommission)"
+        description: |
+          Decommissioning ${{ parameters.name | trim }}. After merging:
+
+          1. master-app prunes the per-app Application within ~30s.
+          2. The v1.4 finalizer (resources-finalizer.argocd.argoproj.io) cascades
+             deletion of all managed resources (cluster-scoped AWS + namespaced
+             ESO config + composed app resources).
+          3. Run `kubectl delete namespace ${{ parameters.name | trim }}` to
+             clean up the namespace (the only manual step remaining).
+
+          Generated by Backstage `decommission-application` template.
+        targetPath: ""
+        gitDeletePaths:
+          - base-apps/${{ parameters.name | trim }}.yaml
+          - base-apps/${{ parameters.name | trim }}/
+
+  output:
+    links:
+      - title: Teardown PR
+        url: ${{ steps.publish.output.remoteUrl }}
+```
+
+The `gitDeletePaths` field tells `publish:github:pull-request` to delete those paths in the PR's commit. No `fetch:template` step is needed — we're not generating new content, just removing existing files.
+
+---
+
+### Task 2.7: Register Decommission template in app-config + production overlay
+
+**Files:**
+- Modify: `app-config.yaml`
+- Modify: `app-config.production.yaml`
+
+The Backstage catalog only loads templates that are explicitly registered under `catalog.locations`. Add the decommission template entry to BOTH files (per v1's "production overlay arrays don't merge" lesson — both files must list every entry).
+
+- [ ] **Step 1: Find catalog.locations in `app-config.yaml`**
+
+```bash
+grep -n "application/template.yaml\|catalog:\|locations:" app-config.yaml | head -10
+```
+
+Expected: shows the existing entry for `examples/templates/application/template.yaml`.
+
+- [ ] **Step 2: Add the new entry to `app-config.yaml`**
+
+Find the existing entry like:
+```yaml
+    # Application (Crossplane) — onboard a container image as a managed app.
+    # See: examples/templates/application/template.yaml
+    - type: file
+      target: ./examples/templates/application/template.yaml
+      rules:
+        - allow: [Template]
+```
+
+Immediately AFTER it, add:
+```yaml
+
+    # Decommission Application (Crossplane) — tear down a managed app.
+    # See: examples/templates/decommission/template.yaml
+    - type: file
+      target: ./examples/templates/decommission/template.yaml
+      rules:
+        - allow: [Template]
+```
+
+(Note: `target` path is relative to `/app` in the container, mirroring the existing entry.)
+
+- [ ] **Step 3: Add the same entry to `app-config.production.yaml`**
+
+Same addition, same shape. Find the production catalog.locations block (it should have the existing application/template.yaml entry — if not, the v1 production-overlay bug regressed). Add the decommission entry right after.
+
+- [ ] **Step 4: Verify both files parse**
+
+```bash
+yq '.' app-config.yaml > /dev/null && echo "app-config.yaml valid"
+yq '.' app-config.production.yaml > /dev/null && echo "app-config.production.yaml valid"
+```
+
+---
+
+### Task 2.8: Commit + push + open Phase 2 PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Stage all 5 modified/created files**
+
+```bash
+cd ~/git/backstage
+
+git add examples/templates/application/template.yaml \
+        "examples/templates/application/content-k8s/base-apps/\${{ values.name }}.yaml" \
+        "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/application-xr.yaml" \
+        "examples/templates/application/content-k8s/base-apps/\${{ values.name }}/aws-resources.yaml" \
+        examples/templates/decommission/template.yaml \
+        app-config.yaml \
+        app-config.production.yaml
+
+git status --short   # expect: 5 modified + 1 created
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(scaffolder): v1.4 finalizer + bucket sub-fields + decommission template
+
+5 v1.4 close-out items:
+
+1. Application scaffolder: add finalizer to per-app ArgoCD App template
+   (resources-finalizer.argocd.argoproj.io). Closes v1.3.1 bug #4 —
+   master-app prune now cascades to cluster-scoped AWS resources via
+   ArgoCD's normal cascade-delete behavior. Scaffolder-only fix —
+   existing infra apps (loki-aws-infrastructure, etc.) intentionally
+   NOT patched (safety; their resources should NOT cascade-delete).
+
+2. Application scaffolder: add 3 new optional form fields:
+   s3Versioning, s3LifecycleDays, s3CorsEnabled. Threaded through
+   fetch.values. XR template conditionally emits each.
+
+3. Application scaffolder aws-resources.yaml: append 4 new bucket
+   sub-resources:
+   - BucketVersioning (conditional on s3Versioning:true)
+   - BucketLifecycleConfiguration (conditional on s3LifecycleDays > 0)
+   - BucketCorsConfiguration (conditional on s3CorsEnabled:true)
+   - BucketPublicAccessBlock (ALWAYS emit when s3Needed:true; security
+     default — all 4 public-access blocks enabled)
+   All use bucketSelector.matchLabels for cross-resource references
+   (Crossplane resolves at apply time, no sync waves).
+
+4. NEW examples/templates/decommission/template.yaml: Backstage
+   scaffolder template "Decommission Application (Crossplane)". Single
+   form input (app name). Action: publish:github:pull-request with
+   gitDeletePaths to delete base-apps/<name>.yaml + base-apps/<name>/.
+   Eliminates the manual git rm + gh pr create flow.
+
+5. app-config.yaml + app-config.production.yaml: register the new
+   decommission template under catalog.locations (BOTH files per v1's
+   production-overlay-array-replace gotcha).
+
+Companion arigsela/kubernetes PR adds 3 XRD optional fields for
+API-server validation (Composition Python ignores them).
+
+After this merges + Backstage image rebuild:
+- New scaffolded apps get the finalizer (cascade-delete on teardown)
+- 9 AWS resources possible per bucket (5 base + 4 sub-resources, with
+  conditional emission of 3 of the sub-resources)
+- "Decommission Application (Crossplane)" template available at
+  /create — opens teardown PR via form
+
+Spec: docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
+(in arigsela/kubernetes repo)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/idp-v1.4-bucket-subfields-finalizer-decommission
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --base main --head feat/idp-v1.4-bucket-subfields-finalizer-decommission \
+  --title "feat(scaffolder): v1.4 finalizer + bucket sub-fields + decommission template" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Companion to arigsela/kubernetes v1.4 XRD PR. 5 close-out items for v1.3.1's rough edges, all on the Backstage scaffolder side.
+
+## Changes
+
+| # | Change | File |
+|---|---|---|
+| 1 | Application scaffolder per-app App template gains `resources-finalizer.argocd.argoproj.io` (closes v1.3.1 bug #4) | `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml` |
+| 2 | 3 new optional form fields (s3Versioning, s3LifecycleDays, s3CorsEnabled) + fetch.values threading + conditional XR emission | `examples/templates/application/template.yaml` + content-k8s XR template |
+| 3 | aws-resources.yaml appended with BucketVersioning + BucketLifecycleConfiguration + BucketCorsConfiguration (conditional) + BucketPublicAccessBlock (always) | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml` |
+| 4 | NEW Decommission scaffolder template using `publish:github:pull-request` with `gitDeletePaths` | `examples/templates/decommission/template.yaml` |
+| 5 | Register Decommission template in catalog | `app-config.yaml` + `app-config.production.yaml` |
+
+## Why scaffolder-only finalizer
+
+This finalizer makes Application deletion CASCADE-DELETE all managed resources. For IDP-scaffolded apps, that's correct. For permanent infra apps (loki-aws-infrastructure, crossplane-aws-provider, etc.), it would be DANGEROUS — accidentally deleting their Application would destroy production infrastructure. Forward-fix only.
+
+## Why BucketPublicAccessBlock always-on
+
+Security-by-default. All 4 public-access blocks enabled (block_public_acls + block_public_policy + ignore_public_acls + restrict_public_buckets) for every IDP bucket. No XR field exposes opt-out (rare use case; v1.5+ if needed).
+
+## Test plan
+
+- [ ] Merge after companion arigsela/kubernetes XRD PR merges
+- [ ] User rebuilds Backstage image
+- [ ] User pre-creates Vault role for smoke-v14 namespace
+- [ ] Smoke validation: scaffold smoke-v14 with all 4 sub-fields enabled (s3Needed:true, s3Versioning:true, s3LifecycleDays:7, s3CorsEnabled:true) — verify 9 AWS resources + finalizer in scaffold PR
+- [ ] After merge: bucket has versioning Enabled, lifecycle rule active, CORS active, PublicAccessBlock all 4 blocks True
+- [ ] Visit Backstage `/create` → confirm Decommission template visible
+- [ ] CRITICAL: use Decommission template to open teardown PR; merge; verify ALL AWS resources gone WITHOUT manual `kubectl delete bucket,user,...`
+
+## Things explicitly NOT in this PR
+
+- Source-code repo creation in scaffolder (deferred to v1.5)
+- Granular CORS configuration (v1.5+)
+- Multi-rule lifecycle (v1.5+)
+- Retroactive finalizer on existing per-app Applications (safety)
+- More AWS resource types (SQS, SNS, RDS) — separate iterations
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr view --json number,url -q '"PR #\(.number): \(.url)"'
+```
+
+---
+
+## Phase 3 — USER GATE: Merge PRs + image rebuild + Vault role binding
+
+> **Subagent-driven-development pause point.** All Phase 3 actions require user-controlled steps.
+
+### Task 3.1: USER reviews + merges Phase 1 PR (kubernetes)
+
+- [ ] User merges PR opened by Task 1.4
+- [ ] Verify ArgoCD sync (~30s):
+
+```bash
+sleep 30
+kubectl -n argo-cd get application crossplane-compositions \
+  -o jsonpath='{.status.sync.status}: revision={.status.sync.revision}{"\n"}'
+# Expected: Synced; revision matches merge commit
+
+# Verify XRD has the new fields
+kubectl get xrd xapplications.platform.arigsela.com \
+  -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}' | \
+  jq 'keys' 2>&1
+# Expected: array includes s3Versioning, s3LifecycleDays, s3CorsEnabled
+```
+
+---
+
+### Task 3.2: USER reviews + merges Phase 2 PR (backstage)
+
+- [ ] User merges PR opened by Task 2.8
+- [ ] Note: merge alone doesn't change cluster behavior — image rebuild needed
+
+---
+
+### Task 3.3: USER rebuilds Backstage image
+
+Same approach as v1.2.1 / v1.3.1 / v1.3 worked: rebuild image with same tag, then `kubectl -n backstage rollout restart deployment/backstage`.
+
+- [ ] User rebuilds image (standard local docker buildx + push to ECR flow)
+- [ ] Restart deployment:
+
+```bash
+kubectl -n backstage rollout restart deployment/backstage
+kubectl -n backstage rollout status deployment/backstage --timeout=2m
+```
+
+- [ ] Verify the new template is on the live Pod:
+
+```bash
+BACKSTAGE_POD=$(kubectl -n backstage get pods -o name | head -1)
+
+# Verify decommission template exists
+kubectl -n backstage exec $BACKSTAGE_POD -- ls /app/examples/templates/
+# Expected: shows 'application/' AND 'decommission/'
+
+# Verify finalizer is in the per-app App template
+kubectl -n backstage exec $BACKSTAGE_POD -- grep -A 1 "finalizers" \
+  '/app/examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml'
+# Expected: shows resources-finalizer.argocd.argoproj.io
+
+# Verify aws-resources.yaml has the 4 new sub-resource blocks
+kubectl -n backstage exec $BACKSTAGE_POD -- grep "kind:" \
+  '/app/examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml' | sort -u
+# Expected: 9 unique kinds (Bucket, User, Policy, UserPolicyAttachment, AccessKey,
+#   BucketVersioning, BucketLifecycleConfiguration, BucketCorsConfiguration,
+#   BucketPublicAccessBlock)
+```
+
+---
+
+### Task 3.4: USER pre-creates Vault role for smoke-v14 namespace
+
+The Vault role binds the existing `app-namespace-rw` policy from v1.2.
+
+- [ ] **Step 1: Create the role** (via assistant's kubectl-exec + stored root token pattern, or local authenticated CLI)
+
+```bash
+NAMESPACE=smoke-v14
+
+vault write auth/kubernetes/role/${NAMESPACE} \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=${NAMESPACE} \
+  policies="default,app-namespace-rw" \
+  ttl=1h
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+vault read auth/kubernetes/role/smoke-v14
+# Expected: policies=[default app-namespace-rw], bound_service_account_namespaces=[smoke-v14]
+```
+
+---
+
+## Phase 4 — Smoke validation (smoke-v14)
+
+> **Subagent-driven-development pause point.** Phase 4 requires Backstage UI form submission + scaffold PR review/merge + AWS verification + critical decommission-template test.
+
+### Task 4.1: Scaffold smoke-v14 via Backstage Application template
+
+- [ ] **Step 1: Open Backstage**
+
+https://backstage.arigsela.com/create
+
+- [ ] **Step 2: Submit Application (Crossplane) form**
+
+| Field | Value |
+|---|---|
+| Application name | `smoke-v14` |
+| Owner | `group:default/platform-engineering` |
+| Container image | `amazon/aws-cli:latest` |
+| Public hostname | `smoke-v14.arigsela.com` |
+| Container port | `8080` |
+| Replicas | `1` |
+| Health check path (optional) | `/` (default) |
+| Provision a Postgres database | **NO** |
+| Provision an AWS S3 bucket | **YES** ← v1.3.1 path |
+| Enable bucket versioning | **YES** ← v1.4 NEW |
+| Bucket lifecycle (days until objects expire) | **7** ← v1.4 NEW |
+| Enable CORS (web app pattern) | **YES** ← v1.4 NEW |
+
+(image is `amazon/aws-cli:latest` so we can `kubectl exec aws s3 cp` from inside the Pod — same as v1.3.1.)
+
+- [ ] **Step 3: Inspect resulting scaffold PR**
+
+```bash
+SCAFFOLD_PR=$(gh pr list --state open --search "smoke-v14 in:title" --json number --jq '.[0].number')
+echo "Scaffold PR: #$SCAFFOLD_PR"
+
+# Verify 3 files
+gh pr view $SCAFFOLD_PR --json files --jq '.files[] | "\(.path) (+\(.additions)/-\(.deletions))"'
+# Expected: 3 files
+#   base-apps/smoke-v14.yaml
+#   base-apps/smoke-v14/application-xr.yaml
+#   base-apps/smoke-v14/aws-resources.yaml
+
+# Verify finalizer is present in per-app Application
+gh pr view $SCAFFOLD_PR --json files --jq '.files[] | select(.path == "base-apps/smoke-v14.yaml") | .path' | xargs gh pr diff $SCAFFOLD_PR --output - | grep -A 2 "finalizers:"
+# Expected: shows resources-finalizer.argocd.argoproj.io
+
+# Verify 9 AWS resources in aws-resources.yaml
+gh pr diff $SCAFFOLD_PR | grep -E "^\+kind:" | sort | uniq -c
+# Expected: kind counts include Bucket=1, User=1, Policy=1, UserPolicyAttachment=1, AccessKey=1,
+#   BucketVersioning=1, BucketLifecycleConfiguration=1, BucketCorsConfiguration=1,
+#   BucketPublicAccessBlock=1 = 9 distinct resources (plus XApplication + Application from other files)
+```
+
+- [ ] **Step 4: USER merges scaffold PR**
+
+---
+
+### Task 4.2: Verify ArgoCD sync + AWS resources
+
+```bash
+sleep 60  # let ArgoCD pick up + Crossplane providers reconcile
+
+kubectl -n argo-cd get application smoke-v14 \
+  -o jsonpath='{.status.sync.status}/{.status.health.status}{"\n"}'
+# Expected: Synced (Health may be Degraded since aws-cli doesn't serve HTTP)
+
+# Verify finalizer ON the live Application (NOT just the manifest)
+kubectl -n argo-cd get application smoke-v14 -o jsonpath='{.metadata.finalizers}{"\n"}'
+# Expected: ["resources-finalizer.argocd.argoproj.io"]
+
+# Cluster-scoped AWS resources
+echo "--- All AWS resources for smoke-v14 ---"
+for kind in bucket.s3.aws.upbound.io user.iam.aws.upbound.io policy.iam.aws.upbound.io userpolicyattachment.iam.aws.upbound.io accesskey.iam.aws.upbound.io bucketversioning.s3.aws.upbound.io bucketlifecycleconfiguration.s3.aws.upbound.io bucketcorsconfiguration.s3.aws.upbound.io bucketpublicaccessblock.s3.aws.upbound.io; do
+  echo "$kind:"
+  kubectl get $kind 2>&1 | grep -i smoke-v14 || echo "  (not yet)"
+done
+```
+
+Wait until all 9 resources show as SYNCED (sub-resources may take 30-60s longer than the parent Bucket due to selector resolution).
+
+---
+
+### Task 4.3: AC-10 — Versioning Enabled in AWS
+
+```bash
+aws s3api get-bucket-versioning --bucket 852893458518-smoke-v14
+# Expected: { "Status": "Enabled" }
+```
+
+---
+
+### Task 4.4: AC-11 — Lifecycle rule active in AWS
+
+```bash
+aws s3api get-bucket-lifecycle-configuration --bucket 852893458518-smoke-v14
+# Expected: shows the rule with expiration: { Days: 7 }
+```
+
+---
+
+### Task 4.5: AC-12 — CORS active in AWS
+
+```bash
+aws s3api get-bucket-cors --bucket 852893458518-smoke-v14
+# Expected: shows CORSRules with AllowedOrigins=["*"], AllowedMethods=[GET,PUT,POST,DELETE,HEAD]
+```
+
+---
+
+### Task 4.6: AC-13 — PublicAccessBlock active in AWS
+
+```bash
+aws s3api get-public-access-block --bucket 852893458518-smoke-v14
+# Expected: all 4 blocks True (BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets)
+```
+
+---
+
+### Task 4.7: AC-8 — Decommission template visible in Backstage
+
+- [ ] **Step 1: Open Backstage**
+
+https://backstage.arigsela.com/create
+
+- [ ] **Step 2: Verify "Decommission Application (Crossplane)" template appears**
+
+Should be in the templates list with title "Decommission Application (Crossplane)" and tags including `decommission`.
+
+- [ ] **Step 3: Click into the template; confirm form has a single `name` input**
+
+---
+
+### Task 4.8: AC-9 + AC-7 — CRITICAL TEST: Decommission template opens teardown PR + cascade works
+
+This is the headline test for v1.4. The decommission template should open a teardown PR. Merging that PR should cascade-delete all AWS resources WITHOUT manual `kubectl delete bucket,user,...`.
+
+- [ ] **Step 1: Submit Decommission form**
+
+In Backstage, open the Decommission Application (Crossplane) template. Enter:
+- name: `smoke-v14`
+
+Submit.
+
+- [ ] **Step 2: Inspect the resulting teardown PR**
+
+```bash
+TEARDOWN_PR=$(gh pr list --state open --search "tear down smoke-v14 in:title" --json number --jq '.[0].number')
+echo "Teardown PR: #$TEARDOWN_PR"
+
+gh pr view $TEARDOWN_PR --json files --jq '.files[] | "\(.path) (+\(.additions)/-\(.deletions))"'
+# Expected: 3 files all DELETED (negative additions, positive deletions)
+#   base-apps/smoke-v14.yaml (-24)
+#   base-apps/smoke-v14/application-xr.yaml (-24)
+#   base-apps/smoke-v14/aws-resources.yaml (-130+ depending on sub-fields)
+```
+
+If PR has 0 files OR shows `gitDeletePaths` warnings: P.4 version assumption was wrong. Investigate Backstage scaffolder version + the `publish:github:pull-request` action's documentation for your version.
+
+- [ ] **Step 3: USER merges teardown PR**
+
+```bash
+sleep 30  # master-app prune
+kubectl -n argo-cd get application smoke-v14 2>&1 | head -3
+# Expected: NotFound (Application has been pruned by master-app)
+```
+
+- [ ] **Step 4: WAIT 90s for finalizer cascade to fully unwind AWS resources**
+
+```bash
+sleep 90
+```
+
+- [ ] **Step 5: Verify AC-7 — ALL AWS resources gone WITHOUT manual cleanup**
+
+```bash
+echo "--- Verifying all AWS resources are gone ---"
+for kind in bucket user policy userpolicyattachment accesskey bucketversioning bucketlifecycleconfiguration bucketcorsconfiguration bucketpublicaccessblock; do
+  RESULT=$(kubectl get ${kind}.s3.aws.upbound.io 2>&1 | grep -i smoke-v14 2>&1 || echo "✓ none")
+  RESULT2=$(kubectl get ${kind}.iam.aws.upbound.io 2>&1 | grep -i smoke-v14 2>&1 || echo "")
+  echo "$kind: ${RESULT:-$RESULT2}"
+done
+
+echo
+echo "--- AWS-side verification ---"
+aws s3 ls s3://852893458518-smoke-v14/ 2>&1 | head -3
+# Expected: NoSuchBucket
+
+aws iam get-user --user-name smoke-v14-app 2>&1 | head -3
+# Expected: NoSuchEntity
+```
+
+If ANY resource still exists after 90s: the finalizer didn't cascade. Investigate:
+```bash
+kubectl -n argo-cd get application smoke-v14 -o yaml 2>&1 | head -30
+# Look for finalizers blocking deletion
+```
+
+If cascade failed: this is bug #4 reproducing. Document, then admin-override:
+```bash
+kubectl -n argo-cd patch application smoke-v14 --type=merge -p '{"metadata":{"finalizers":[]}}'
+# Then manually delete the AWS resources as in v1.3.1 teardown
+```
+
+- [ ] **Step 6: Verify Vault entry GC'd** (same as v1.3.1)
+
+```bash
+kubectl -n vault get secret vault-unseal-keys -o jsonpath='{.data.root-token}' | base64 -d | kubectl -n vault exec -i vault-0 -- sh -c '
+  VAULT_TOKEN=$(cat); export VAULT_TOKEN
+  vault kv list k8s-secrets/smoke-v14 2>&1
+'
+# Expected: "No value found" (PushSecret deletionPolicy:Delete worked)
+```
+
+- [ ] **Step 7: Cleanup namespace** (manual last step per spec; not automated by decommission template)
+
+```bash
+kubectl delete namespace smoke-v14
+```
+
+- [ ] **Step 8: Optional cleanup of Vault role**
+
+```bash
+kubectl -n vault get secret vault-unseal-keys -o jsonpath='{.data.root-token}' | base64 -d | kubectl -n vault exec -i vault-0 -- sh -c '
+  VAULT_TOKEN=$(cat); export VAULT_TOKEN
+  vault delete auth/kubernetes/role/smoke-v14
+'
+```
+
+---
+
+### Task 4.9: AC-14 — chores-tracker still healthy
+
+```bash
+kubectl -n chores-tracker get externalsecret -o jsonpath='{range .items[*]}{.metadata.name}: Ready={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'
+# Expected: Ready=True
+
+kubectl -n chores-tracker get pods 2>&1 | head -5
+# Expected: pods running, no recent restart count spike
+```
+
+---
+
+## Phase 5 — Close-out
+
+### Task 5.1: Append Run Notes to this plan
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md` (this file)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b docs/v1.4-close-out
+```
+
+- [ ] **Step 2: Append `## Run Notes` section**
+
+Use the same template structure as v1.2.1 / v1.3.1 close-outs:
+
+```markdown
+
+## Run Notes (YYYY-MM-DD)
+
+**Outcome:** v1.4 of the IDP shipped. Per-app ArgoCD Applications now carry the resources-finalizer so master-app prune cascades to all managed resources (closes v1.3.1 bug #4 — no more manual `kubectl delete bucket,user,...`). Bucket has versioning + lifecycle + CORS + public-access-block sub-resources available via opt-in form fields (PAB always-on as security default). NEW Decommission template at /create lets developers open teardown PRs without `git rm` + `gh pr create`.
+
+**E2E validation** (`smoke-v14`, all sub-fields enabled):
+
+- ✅ Scaffold PR had 3 files (smoke-v14.yaml + application-xr.yaml + aws-resources.yaml)
+- ✅ aws-resources.yaml emitted 9 AWS resources (5 base + 4 sub-resources)
+- ✅ Per-app Application has resources-finalizer.argocd.argoproj.io
+- ✅ Bucket created at `s3://852893458518-smoke-v14/`
+- ✅ `aws s3api get-bucket-versioning` returns `Status: Enabled`
+- ✅ `aws s3api get-bucket-lifecycle-configuration` returns expiration rule (7 days)
+- ✅ `aws s3api get-bucket-cors` returns the rule
+- ✅ `aws s3api get-public-access-block` returns all 4 blocks True
+- ✅ Backstage `/create` shows Decommission Application (Crossplane) template
+- ✅ Decommission form opens teardown PR with 3 files DELETED (gitDeletePaths worked)
+- ✅ **AC-7 PASSED** — after teardown PR merge: all 9 AWS resources gone WITHOUT manual `kubectl delete` (finalizer cascade worked end-to-end)
+- ✅ Vault entry GC'd (PushSecret deletionPolicy:Delete worked)
+- ✅ chores-tracker untouched
+
+**Bugs caught during execution** (delete subsection if none):
+
+| # | Bug | Fix PR |
+|---|---|---|
+| 1 | <one-line description> | arigsela/kubernetes#<num> |
+
+**v1.5 / v2 follow-up candidates:**
+- v1.5 — Source-code repo creation in scaffolder (Dockerfile + GitHub Actions CI; the bigger feature deferred from v1.4)
+- v1.6 — More AWS resource types (SQS, SNS, RDS) via Option B pattern
+- v1.6 — Granular CORS configuration; multi-rule lifecycle
+- v1.6 — Custom IAM policy override
+- v1.6 — Backstage AWS-resource UX (cluster-scoped resources don't appear in Crossplane tab)
+- v2 — Vault dynamic credentials + IRSA / Pod Identity
+
+**Final PR sequence:**
+
+| PR | What |
+|---|---|
+| docs/idp-v1.4-spec | docs: v1.4 design spec + plan |
+| feat/idp-v1.4-xrd-bucket-subfields (kubernetes) | feat(xrd): 3 new optional fields |
+| feat/idp-v1.4-bucket-subfields-finalizer-decommission (backstage) | feat(scaffolder): finalizer + sub-fields + decommission |
+| (image rebuild — same tag, no manifest PR) | User rebuilt + relaunched pod |
+| <scaffold/smoke-v14 PR>  | feat(smoke-v14): onboard via Crossplane Application |
+| <chore/teardown-smoke-v14 PR> | chore: tear down smoke-v14 (decommission) |
+| docs/v1.4-close-out (this branch) | docs: v1.4 run notes |
+
+**v1.4 status: shipped.**
+```
+
+- [ ] **Step 3: Commit + push + open PR**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md
+git commit -m "docs(idp): v1.4 close-out run notes"
+git push -u origin docs/v1.4-close-out
+gh pr create --base main --title "docs(idp): v1.4 close-out run notes" \
+  --body "Captures v1.4 outcome, smoke-v14 e2e validation, bug-fix PRs (if any), and v1.5/v2 follow-up candidates."
+```
+
+---
+
+## Plan execution mode
+
+**Recommended:** subagent-driven-development per v1.2 / v1.2.1 / v1.3.1 precedent.
+
+Phase boundaries:
+- **Phase 1 (Tasks 1.1-1.4)** — single subagent: tiny XRD addition + commit + open PR
+- **Phase 2 (Tasks 2.1-2.8)** — separate subagent (different repo): finalizer + 3 form fields + 4 sub-resources + new decommission template + app-config + commit + open PR
+- **Phase 3** — **HARD PAUSE** for subagent execution (user-merge gates + image rebuild + Vault role binding)
+- **Phase 4** — user-driven smoke validation (form submission, PR review, AWS verification, decommission template test)
+- **Phase 5** — final close-out subagent
+
+Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents (or sequentially per v1.3.1 precedent).

--- a/docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
+++ b/docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
@@ -1,0 +1,543 @@
+# IDP v1.4 — Scaffolder Finalizer + Bucket Sub-Fields + Decommission Template — Design
+
+**Date:** 2026-05-03 (expanded 2026-05-09)
+**Author:** Ari Sela (with Claude)
+**Status:** Approved for plan
+**Iteration:** v1.4 (close-out polish for v1.3.1's rough edges; expanded-scope bundle of 5 items)
+**Prerequisite:** [IDP v1.3.1](./2026-05-02-idp-v1.3.1-aws-resources-raw-manifests-design.md) shipped + close-out PR #243 merged
+
+## 1. Goal
+
+Close out v1.3.1's rough edges + round out the AWS bucket story + automate the manual teardown step. Five items in scope:
+
+1. **Scaffolder finalizer fix** (closes v1.3.1 bug #4) — adds `resources-finalizer.argocd.argoproj.io` to the per-app ArgoCD Application template so master-app prune cascades to cluster-scoped AWS resources.
+
+2. **Bucket versioning** — optional `s3Versioning: bool` XR field; when true, emits `BucketVersioning` enabling object versioning on the bucket (recovery from accidental deletes/overwrites).
+
+3. **Bucket lifecycle** — optional `s3LifecycleDays: int` XR field; when > 0, emits `BucketLifecycleConfiguration` with one rule that expires all objects after N days (cost control).
+
+4. **Bucket CORS** — optional `s3CorsEnabled: bool` XR field; when true, emits `BucketCorsConfiguration` with permissive defaults (web app pattern). Plus **always-emitted `BucketPublicAccessBlock`** with all 4 blocks enabled (security default; no XR field).
+
+5. **Decommission scaffolder template** — new Backstage template ("Decommission Application (Crossplane)") that takes an app name and opens a teardown PR (`git rm base-apps/<name>*`). Eliminates the manual `git rm` + `gh pr create` we've been doing during smoke teardowns.
+
+Bundle is intentionally tight (~125 min implementation budget). Source-code repo creation in scaffolder explicitly out of scope — deferred to v1.5 with its own brainstorm (too many open design questions to bundle).
+
+## 2. Current state (post-v1.3.1)
+
+| Component | Shape today |
+|---|---|
+| Per-app ArgoCD Application template | No `resources-finalizer.argocd.argoproj.io`; cluster-scoped AWS resources orphan on teardown |
+| Bucket resource shape | Only `forceDestroy: true` + `region: us-east-2`; no versioning / lifecycle / CORS / public access block |
+| XApplication XRD spec.properties | Has `s3Needed`, `dbNeeded`, `dbStorage`, `image`, `host`, `port`, `replicas`, `env`, `healthCheckPath` — no S3 sub-fields |
+| Scaffolder form (single template) | "Application (Crossplane)" creates new apps; **no decommission/teardown template exists** |
+| Manual teardown workflow today | `git checkout main && git pull && git checkout -b chore/teardown-<name> && git rm base-apps/<name>.yaml && git rm -r base-apps/<name>/ && git commit && git push && gh pr create ...` (8+ commands) |
+| Bucket sub-resource CRDs | All 5 installed (`bucketversionings`, `bucketlifecycleconfigurations`, `bucketcorsconfigurations`, `bucketpublicaccessblocks`, `bucketownershipcontrols`); v1.4 uses 4 |
+
+## 3. Target state — the wire
+
+**Two scaffolder templates** (Application + Decommission) + **expanded XR fields** + **3 new bucket sub-resources** + **finalizer**.
+
+```
+─── Scaffolder Template 1: "Application (Crossplane)" (existing, expanded in v1.4) ───
+  Form inputs (NEW in v1.4 marked):
+    name, owner, image, host, port, replicas, healthCheckPath
+    dbNeeded, dbStorage
+    s3Needed
+    s3Versioning  ← NEW
+    s3LifecycleDays  ← NEW
+    s3CorsEnabled  ← NEW
+       │
+       ▼
+  Renders 3 files in base-apps/<name>/:
+       │
+       ├──► base-apps/<name>.yaml           ← FINALIZER ADDED in v1.4
+       │    metadata.finalizers:
+       │      - resources-finalizer.argocd.argoproj.io
+       │
+       ├──► base-apps/<name>/application-xr.yaml
+       │    (existing fields + conditional s3Versioning, s3LifecycleDays, s3CorsEnabled)
+       │
+       └──► base-apps/<name>/aws-resources.yaml  (when s3Needed:true)
+            ───────────────────────────────
+              5 EXISTING resources (Bucket, User, Policy, UserPolicyAttachment, AccessKey)
+              {%- if s3Versioning %} BucketVersioning {%- endif %}             ← NEW
+              {%- if s3LifecycleDays > 0 %} BucketLifecycleConfiguration {%- endif %}  ← NEW
+              {%- if s3CorsEnabled %} BucketCorsConfiguration {%- endif %}     ← NEW
+              ALWAYS BucketPublicAccessBlock (all 4 blocks enabled)            ← NEW
+
+─── Scaffolder Template 2: "Decommission Application (Crossplane)" (NEW in v1.4) ───
+  Form inputs:
+    name (required; can be free-text or catalog-entity-picker)
+       │
+       ▼
+  Scaffolder action: opens PR `chore/teardown-<name>` with:
+    - `git rm base-apps/<name>.yaml`
+    - `git rm -r base-apps/<name>/`
+    - PR title + body from template
+       │
+       ▼
+  After user merges:
+    - master-app prunes per-app Application
+    - finalizer cascades AWS resource deletion (versioning + lifecycle + CORS +
+      PAB sub-resources + the 5 main AWS resources)
+    - User runs `kubectl delete namespace <name>` (last manual step)
+```
+
+**Workload-side behavior:** No changes from v1.3.1. AWS sub-resources operate at the AWS API level (versioning state, lifecycle rules, CORS rules, public access block) — workloads don't see them directly.
+
+**Teardown behavior change** (the headline fix from item 1): with the finalizer, master-app pruning the per-app Application now cascades to ALL its managed manifests (including all 9 cluster-scoped AWS resources when s3Needed:true with all sub-fields). Crossplane provider controllers handle AWS-side dependency unwinding. **No manual `kubectl delete bucket,user,...` step required.**
+
+**Invariants preserved:**
+- v1.x patterns (composition emits namespaced resources; scaffolder emits cluster-scoped raw manifests for AWS) unchanged
+- chores-tracker untouched
+- `s3Needed:false` apps render byte-identical
+- Existing per-app Applications (loki-aws-infrastructure, argo-workflows-aws-infrastructure, chores-tracker, all infra apps) stay WITHOUT the finalizer (safety: their resources should NOT cascade-delete on accidental Application removal)
+- XRD apiVersion stays `v1alpha1` (additive optional fields with defaults)
+
+## 4. Components
+
+| # | Artifact | Repo | Path | Action |
+|---|---|---|---|---|
+| 1 | XRD: add 3 fields | `arigsela/kubernetes` | `base-apps/crossplane-compositions/xrd-application.yaml` | Add `s3Versioning: bool`, `s3LifecycleDays: int`, `s3CorsEnabled: bool` (all optional with defaults). Composition ignores them; XRD addition is for API-server validation only. |
+| 2 | Composition Python | `arigsela/kubernetes` | `base-apps/crossplane-compositions/composition-application.yaml` | **No change** — Composition doesn't manage AWS resources |
+| 3 | Test goldens | `arigsela/kubernetes` | `tests/composition/expected-xr-{minimal,with-db,with-s3}.yaml` | **No change** — Composition output unchanged for these fields |
+| 4 | Application scaffolder form | `arigsela/backstage` | `examples/templates/application/template.yaml` | Add 3 new optional form fields under "Resources (optional)" group: `s3Versioning`, `s3LifecycleDays`, `s3CorsEnabled`. Add to `fetch.values` mapping. |
+| 5 | Application scaffolder per-app App template (FINALIZER) | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml` | Add `metadata.finalizers: [resources-finalizer.argocd.argoproj.io]` |
+| 6 | Application scaffolder XR template | `arigsela/backstage` | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | Conditionally emit `s3Versioning` + `s3LifecycleDays` + `s3CorsEnabled` lines (Nunjucks `{%- if %}`) when their values are non-default |
+| 7 | Application scaffolder aws-resources.yaml | `arigsela/backstage` | (same dir) `aws-resources.yaml` | Append: `BucketVersioning` (when s3Versioning:true), `BucketLifecycleConfiguration` (when s3LifecycleDays > 0), `BucketCorsConfiguration` (when s3CorsEnabled:true), **`BucketPublicAccessBlock` (always emit when s3Needed:true; security default)**. All reference parent Bucket via `bucketSelector.matchLabels`. |
+| 8 | **NEW Decommission scaffolder template** | `arigsela/backstage` | `examples/templates/decommission/template.yaml` | New Backstage scaffolder template "Decommission Application (Crossplane)". One required form field (app name). Action: `publish:github:pull-request` with `git rm` of `base-apps/<name>.yaml` + `base-apps/<name>/`. |
+| 9 | Decommission scaffolder content | `arigsela/backstage` | `examples/templates/decommission/content/` | Empty directory or stub — the scaffolder uses an explicit delete-files action; no template content to render |
+| 10 | Backstage app-config: register Decommission template | `arigsela/backstage` | `app-config.yaml` + `app-config.production.yaml` | Add new entry under `catalog.locations` for the decommission template (mirrors how Application template is registered) |
+| 11 | Backstage image | `arigsela/backstage` | n/a | Image rebuild needed (3 template changes + new template + app-config) |
+| 12 | Crossplane AWS providers | n/a | n/a | **No change** — provider-aws-s3 v2.5.3 already installed; sub-resource CRDs available |
+
+**Things explicitly NOT in v1.4:**
+- ❌ Source-code repo creation in scaffolder — deferred to v1.5 (bigger design discussion)
+- ❌ Ownership controls (BucketOwnershipControls) — modern AWS default already correct
+- ❌ Multi-rule lifecycle (transitions Standard→IA→Glacier; abort multipart) — single expiration rule only
+- ❌ Granular CORS configuration (specific origins/methods/headers) — bool flag with permissive defaults; v1.5+ for granular
+- ❌ Public-bucket override — `BucketPublicAccessBlock` always-emitted, no opt-out (rare use case; v1.5+ if needed)
+- ❌ Retroactive finalizer patch on existing per-app Applications — scaffolder-only (existing infra apps SHOULDN'T have the finalizer; safety feature)
+- ❌ Composition-side AWS resource changes — Option B architecture preserved
+- ❌ Backstage AWS-resource UX (Crossplane tab limitation of Option B) — separate v1.5+ investigation
+- ❌ More AWS resource types (SQS, SNS, RDS) — separate iterations
+- ❌ Custom IAM policy override
+- ❌ Decommission template auto-merging the PR — user reviews the PR before merge (safety)
+- ❌ Decommission template running `kubectl delete namespace` — last manual cleanup step preserved (small, low-risk)
+
+## 5. XRD additions
+
+```yaml
+# In xrd-application.yaml, under spec.versions[0].schema.openAPIV3Schema.properties.spec.properties:
+s3Versioning:
+  type: boolean
+  default: false
+  description: |
+    When true (and s3Needed:true), emits BucketVersioning resource enabling
+    object versioning on the bucket. Useful for recovery from accidental
+    deletes or overwrites.
+    Note: AWS only supports `Suspended` (not full disable) once enabled —
+    flipping back to false suspends versioning but doesn't delete history.
+s3LifecycleDays:
+  type: integer
+  default: 0
+  minimum: 0
+  description: |
+    When > 0 (and s3Needed:true), emits BucketLifecycleConfiguration with a
+    single rule that expires all objects after N days. When 0, no lifecycle
+    rule is created.
+    Common values: 7 (transient logs), 30 (build artifacts), 365 (compliance
+    retention).
+s3CorsEnabled:
+  type: boolean
+  default: false
+  description: |
+    When true (and s3Needed:true), emits BucketCorsConfiguration with
+    permissive defaults: allow all origins, GET/PUT/POST/DELETE/HEAD methods,
+    all headers, max-age 3600s. Useful for web apps that load assets directly
+    from S3.
+    For granular CORS configuration, see v1.5+ (deferred).
+```
+
+**No XRD field for `BucketPublicAccessBlock`** — it's always emitted when `s3Needed:true`. Security-by-default; no opt-out exposed via the XR form.
+
+## 6. Scaffolder finalizer (the bug fix)
+
+### 6.1 Context (from v1.3.1 close-out bug #4)
+
+Per-app ArgoCD Application created by the scaffolder currently:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  ...
+```
+
+When master-app prunes this Application (after PR-delete), ArgoCD just removes the Application object. The cluster-scoped resources it managed (`Bucket`, `User`, `Policy`, `UserPolicyAttachment`, `AccessKey` — and now `BucketVersioning`, `BucketLifecycleConfiguration`, `BucketCorsConfiguration`, `BucketPublicAccessBlock`) get orphaned.
+
+### 6.2 The fix
+
+Add the finalizer to the Application metadata:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}
+  namespace: argo-cd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io   # NEW in v1.4
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  ...
+```
+
+### 6.3 Why scaffolder-only (NOT retroactive)
+
+This finalizer makes Application deletion CASCADE-DELETE all managed resources. For IDP-scaffolded apps, that's correct. For permanent infra apps (`loki-aws-infrastructure`, `argo-workflows-aws-infrastructure`, `crossplane-aws-provider`, `crossplane-compositions`, etc.), it would be **dangerous** — accidentally deleting their Application would destroy production infrastructure.
+
+Decision: **forward-fix only**. New IDP-scaffolded apps get the finalizer. Existing per-app Applications stay finalizer-free (safety feature for them).
+
+### 6.4 Failure mode: stuck finalizer
+
+If Crossplane providers fail to delete AWS resources (e.g., bucket force-destroy fails, AWS API throttling), the Application can stuck in `Terminating`. Admin escape hatch:
+
+```bash
+kubectl -n argo-cd patch application <name> --type=merge \
+  -p '{"metadata":{"finalizers":[]}}'
+# Removes the finalizer; ArgoCD then completes Application deletion. Cluster-
+# scoped resources orphaned — manual `kubectl delete` cleanup needed.
+```
+
+Documented; not expected for normal teardowns.
+
+## 7. Bucket sub-resources
+
+### 7.1 BucketVersioning (when `s3Versioning: true`)
+
+```yaml
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketVersioning
+metadata:
+  name: ${{ values.name }}-versioning
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-versioning
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    # ... TeraSky annotations (same set as parent Bucket) ...
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    versioningConfiguration:
+      - status: Enabled
+  providerConfigRef:
+    name: default
+```
+
+### 7.2 BucketLifecycleConfiguration (when `s3LifecycleDays > 0`)
+
+```yaml
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketLifecycleConfiguration
+metadata:
+  name: ${{ values.name }}-lifecycle
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-lifecycle
+    app.kubernetes.io/managed-by: crossplane
+  annotations: # TeraSky annotations
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    rule:
+      - id: expire-objects
+        status: Enabled
+        expiration:
+          - days: ${{ values.s3LifecycleDays }}
+  providerConfigRef:
+    name: default
+```
+
+### 7.3 BucketCorsConfiguration (when `s3CorsEnabled: true`)
+
+```yaml
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketCorsConfiguration
+metadata:
+  name: ${{ values.name }}-cors
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-cors
+    app.kubernetes.io/managed-by: crossplane
+  annotations: # TeraSky annotations
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    corsRule:
+      - allowedOrigins: ["*"]
+        allowedMethods: ["GET", "PUT", "POST", "DELETE", "HEAD"]
+        allowedHeaders: ["*"]
+        maxAgeSeconds: 3600
+  providerConfigRef:
+    name: default
+```
+
+### 7.4 BucketPublicAccessBlock (always emitted when `s3Needed: true`)
+
+```yaml
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: BucketPublicAccessBlock
+metadata:
+  name: ${{ values.name }}-pab
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket-public-access-block
+    app.kubernetes.io/managed-by: crossplane
+  annotations: # TeraSky annotations
+spec:
+  forProvider:
+    region: us-east-2
+    bucketSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: bucket
+    blockPublicAcls: true
+    blockPublicPolicy: true
+    ignorePublicAcls: true
+    restrictPublicBuckets: true
+  providerConfigRef:
+    name: default
+```
+
+**Security default:** all 4 blocks enabled. No XR field exposes this. If a user genuinely needs a public bucket, they'd edit the XR + scaffolder template post-scaffold (rare; v1.5+ may add an explicit opt-out field if demand emerges).
+
+## 8. Decommission scaffolder template (NEW in v1.4)
+
+### 8.1 Template definition
+
+New file `examples/templates/decommission/template.yaml`:
+
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: decommission-application
+  title: Decommission Application (Crossplane)
+  description: >-
+    Tear down a Crossplane-provisioned application by opening a PR that removes
+    its manifests from the kubernetes repo.
+  tags:
+    - crossplane
+    - kubernetes
+    - decommission
+spec:
+  owner: group:platform-engineering
+  type: service
+
+  parameters:
+    - title: Identity
+      required: [name]
+      properties:
+        name:
+          type: string
+          title: Application name to tear down
+          description: Must match an existing app under base-apps/ (e.g., smoke-v131)
+          pattern: "^[a-z][a-z0-9-]{2,38}[a-z0-9]$"
+
+  steps:
+    - id: prep
+      name: Prepare teardown branch
+      action: fetch:plain
+      input:
+        url: https://github.com/arigsela/kubernetes/tree/main/base-apps
+        # Note: no actual fetched content used; we just need a working dir
+        # for the publish step. The actual `git rm` happens via the PR's
+        # commit content (see step 2).
+
+    - id: publish
+      name: Open teardown PR
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=kubernetes&owner=arigsela
+        branchName: chore/teardown-${{ parameters.name | trim }}
+        title: "chore: tear down ${{ parameters.name | trim }} (decommission)"
+        description: |
+          Decommissioning ${{ parameters.name | trim }}. After merging:
+
+          1. master-app prunes the per-app Application within ~30s.
+          2. The v1.4 finalizer (resources-finalizer.argocd.argoproj.io) cascades
+             deletion of all managed resources (cluster-scoped AWS + namespaced ESO
+             config + composed app resources).
+          3. Run `kubectl delete namespace ${{ parameters.name | trim }}` to clean up
+             the namespace (the only manual step remaining).
+
+          Generated by Backstage `decommission-application` template.
+        targetPath: ""
+        # The actual file deletions happen via Backstage's git-based PR creation;
+        # the scaffolder action uses `git rm` semantics on the listed paths.
+        gitDeletePaths:
+          - base-apps/${{ parameters.name | trim }}.yaml
+          - base-apps/${{ parameters.name | trim }}/
+
+  output:
+    links:
+      - title: Teardown PR
+        url: ${{ steps.publish.output.remoteUrl }}
+```
+
+**Note:** Backstage's `publish:github:pull-request` action's `gitDeletePaths` is a real Backstage scaffolder feature (added in 1.20+). It handles the `git rm` of the specified paths atomically as part of the PR commit.
+
+### 8.2 Form behavior
+
+Single text input (app name). Pattern validation matches the original Application template (lowercase, hyphenated, 4-40 chars). Submit → PR opens automatically.
+
+### 8.3 Catalog registration
+
+Both `app-config.yaml` and `app-config.production.yaml` need to register the new template (mirror the existing `application` template registration):
+
+```yaml
+catalog:
+  locations:
+    - type: file
+      target: ./examples/templates/application/template.yaml
+      rules:
+        - allow: [Template]
+    - type: file                                    # NEW
+      target: ./examples/templates/decommission/template.yaml
+      rules:
+        - allow: [Template]
+```
+
+## 9. Failure modes
+
+| # | Failure | Symptom | Diagnosis | Fix |
+|---|---|---|---|---|
+| 1 | Sub-resource selector resolution lag | `BucketVersioning` / `BucketLifecycleConfiguration` / `BucketCorsConfiguration` / `BucketPublicAccessBlock` stuck `Pending` for ~10-30s | Bucket's `status.atProvider` needed first | Self-healing via Crossplane retries (same pattern as v1.3.1's UserPolicyAttachment) |
+| 2 | `s3LifecycleDays: 0` edge case | User leaves form field as 0 → Composition might emit one with `days: 0` (delete immediately!) | Nunjucks `{%- if values.s3LifecycleDays > 0 %}` correctly handles 0 | Conditional emission ensures `BucketLifecycleConfiguration` is NOT emitted when value is 0 |
+| 3 | Versioning enabled then disabled | User scaffolds with `versioning:true`, later wants to disable | AWS only supports `Suspended` (not full disable) once enabled | Documented limitation; user can change via XR edit but full undo requires bucket recreation |
+| 4 | Finalizer blocks Application deletion | Application stuck `Terminating` for >5min if Crossplane providers can't delete AWS resources | Bucket force-destroy fails, AWS API throttling | Admin override: `kubectl patch application ... --type=merge -p '{"metadata":{"finalizers":[]}}'` (orphans resources, then manual cleanup) |
+| 5 | Pre-existing per-app Apps without finalizer | They still orphan resources on accidental delete | By design (safety feature for permanent infra) | Documented; only IDP-scaffolded apps get the finalizer |
+| 6 | Decommission template targeting non-existent app | Scaffolder opens a PR with `git rm` of files that don't exist | Backstage's `publish:github:pull-request` action with `gitDeletePaths`: deletes files that match; non-matching paths produce empty PR | The PR opens but is empty — user closes it; no harm. Could be improved with a pre-check action in v1.5+ |
+| 7 | Decommission template race with active app changes | User scaffolds a teardown PR while another PR is in flight modifying the same app | git merge conflict at PR creation OR after | Standard git workflow — resolve conflict, re-submit |
+| 8 | User forgets `kubectl delete namespace` after teardown PR merges | Namespace lingers; resources inside (Pods, Secrets) are gone but namespace itself exists | Manual step preserved by design | Documented in teardown PR body (auto-generated) + plan Phase 4 |
+
+## 10. Acceptance criteria
+
+| AC | Check | How to verify |
+|---|---|---|
+| 1 — XRD has 3 new fields | `s3Versioning`, `s3LifecycleDays`, `s3CorsEnabled` in spec.properties | `kubectl get xrd ... -o jsonpath='...' \| jq 'keys'` |
+| 2 — Composition goldens unchanged | xr-with-s3, xr-minimal, xr-with-db PASS | `./tests/composition/render.sh ...` (regression) |
+| 3 — Scaffold with all sub-fields → 9 AWS resources | `s3Needed:true, s3Versioning:true, s3LifecycleDays:30, s3CorsEnabled:true` form → aws-resources.yaml has 5 + 4 sub-resources = 9 resources (PAB always emitted as 5th sub-resource) | Inspect scaffold PR diff |
+| 4 — Scaffold with no sub-fields → 6 AWS resources | `s3Needed:true` only → aws-resources.yaml has 5 + 1 (PAB always emitted) = 6 resources | Inspect scaffold PR diff |
+| 5 — `s3Needed:false` apps render unchanged | xr-minimal goldens PASS | Regression check |
+| 6 — Per-app Application has finalizer | `metadata.finalizers` includes `resources-finalizer.argocd.argoproj.io` | `kubectl -n argo-cd get app smoke-v14 -o jsonpath='{.metadata.finalizers}'` |
+| 7 — **Teardown cascade works** (the headline) | After PR-delete + master-app prune, AWS resources auto-delete (NO manual `kubectl delete bucket,user,...` step needed) | Wait 60-90s after master-app prunes; verify all AWS resources + Vault entry gone |
+| 8 — Decommission template visible in Backstage | Template appears at `/create` with title "Decommission Application (Crossplane)" | Visual check |
+| 9 — Decommission form opens correct PR | Submitting form with `name=smoke-v14` opens PR `chore/teardown-smoke-v14` with `git rm base-apps/smoke-v14.yaml` + `base-apps/smoke-v14/` | Inspect PR diff |
+| 10 — Versioning Enabled in AWS | `aws s3api get-bucket-versioning --bucket <name>` returns `Enabled` | AWS CLI |
+| 11 — Lifecycle rule active in AWS | `aws s3api get-bucket-lifecycle-configuration --bucket <name>` returns the rule | AWS CLI |
+| 12 — CORS active in AWS | `aws s3api get-bucket-cors --bucket <name>` returns the rule | AWS CLI |
+| 13 — PublicAccessBlock active in AWS | `aws s3api get-public-access-block --bucket <name>` returns all 4 blocks True | AWS CLI |
+| 14 — chores-tracker still healthy | Existing app unaffected | Spot-check |
+
+## 11. Sequencing
+
+```
+Phase 0 — Pre-flight (~3 min)
+   • Verify all 4 used Bucket sub-resource CRDs exist
+     (BucketVersioning, BucketLifecycleConfiguration,
+      BucketCorsConfiguration, BucketPublicAccessBlock)
+   • Confirm v1.3.1 close-out PR #243 merged
+   • Verify Backstage scaffolder version supports `gitDeletePaths`
+     in `publish:github:pull-request` (Backstage ≥1.20)
+       │
+       ▼
+Phase 1 (kubernetes — TINY PR) ━━━━━━ Phase 2 (backstage — bigger PR)
+   • XRD: add 3 optional fields           • template.yaml: 3 new form fields +
+   • That's it — no Composition change      fetch.values
+   • Goldens unchanged                     • application-xr.yaml: conditional
+                                             emit s3Versioning + s3LifecycleDays
+                                             + s3CorsEnabled
+                                           • aws-resources.yaml: append 4 new
+                                             sub-resources (3 conditional +
+                                             1 always-emitted PAB)
+                                           • per-app App template: ADD finalizer
+                                           • NEW examples/templates/decommission/
+                                             template.yaml + content/
+                                           • app-config.yaml + production
+                                             overlay: register new template
+        │                                                      │
+        └────────────────┬─────────────────────────────────────┘
+                         ▼
+                Phase 3 — USER GATE
+   • Merge both PRs
+   • Backstage image rebuild (same tag + relaunch pattern)
+   • Pre-create Vault role for smoke-v14 namespace
+                         │
+                         ▼
+Phase 4 — Smoke validation (smoke-v14, ~30 min)
+   • Scaffold smoke-v14 with: s3Needed:true, s3Versioning:true,
+     s3LifecycleDays:7, s3CorsEnabled:true (image: amazon/aws-cli:latest)
+   • Verify scaffold PR has all 9 AWS resources + finalizer on per-app App
+   • Merge → AWS resources created, sub-resources reconcile
+   • Verify ACs 6/7/10/11/12/13 (finalizer present, versioning/lifecycle/CORS/PAB
+     active in AWS)
+   • Optional: aws s3 cp test (re-validates v1.3.1 behavior)
+   • Visit Backstage `/create` → confirm Decommission template appears
+   • **CRITICAL TEST 1:** Use the Decommission template to open the teardown
+     PR (validates AC-9; ensures we don't accidentally break it via manual
+     `git rm`)
+   • Merge teardown PR → wait 90s → verify AC-7 cascade (all AWS resources
+     gone WITHOUT manual `kubectl delete bucket,user,...`)
+                         │
+                         ▼
+Phase 5 — Close-out (~5 min)
+   • Run notes appended; PR sequence
+```
+
+**Estimated time:** ~125 min including image rebuild gate (was 75 min for the smaller scope).
+
+## 12. Decision rationale (Q1–Q5 summary)
+
+| Q | Decision | Why |
+|---|---|---|
+| Q1 — bucket sub-fields scope | **Versioning + lifecycle** initially (A), expanded to also include CORS + PAB | Smallest viable initial bundle; expanded after user feedback to round out the bucket story. CORS opt-in flag; PAB always-on (security default). |
+| Q2 — lifecycle config shape | **Single `s3LifecycleDays: int` field** (A) | Simplest viable; one field, one managed resource, easy to explain. Multi-rule deferred. |
+| Q3 — finalizer scope | **Scaffolder-only (forward-fix)** (A) | Retroactive patch would be DANGEROUS — `loki-aws-infrastructure` etc. would become "delete = destroy production" traps. |
+| Q4 — Decommission template shape | **Minimal form (one input) → opens teardown PR** (A) | Smallest implementation; matches v1.x scaffolder pattern; namespace deletion stays manual (small cost vs server-side automation risk). |
+| Q5 — CORS shape | **Single `s3CorsEnabled: bool` field with permissive defaults** (A) | Bool flag is minimal scaffolder complexity; permissive defaults work for "web app loads from S3" common case; v1.5+ for granular config. |
+
+## 13. v1.x roadmap
+
+| Iteration | Goal | Status |
+|---|---|---|
+| v1 | IDP foundation | Shipped (2026-04-28) |
+| v1.1 | TeraSky plugins + auto-ingestion | Shipped (2026-04-29) |
+| v1.2 | Vault round-trip for DB credentials | Shipped (2026-05-01) |
+| v1.2.1 | Ergonomic close-out | Shipped (2026-05-01) |
+| v1.3 | AWS via Composition (Option A) | PAUSED — architectural blocker (2026-05-02) |
+| v1.3.1 | AWS via raw manifests (Option B) | Shipped (2026-05-02 → 03) |
+| **v1.4** | **Scaffolder finalizer + bucket sub-fields (versioning + lifecycle + CORS + PAB) + decommission template (this spec)** | **In progress (2026-05-09)** |
+| **v1.5** | **Source-code repo creation in scaffolder** (extends scaffolder to ALSO open a source-code repo with Dockerfile + GitHub Actions CI when creating an app) | Queued (next iteration) |
+| v1.6+ | More AWS resource types (SQS, SNS, RDS); custom IAM policy override; granular CORS; multi-rule lifecycle; Backstage AWS-resource UX investigation | Future |
+| v2 | Vault dynamic creds (CNPG + AWS via Vault Database secrets engine + Vault AWS Secrets Engine); IRSA / Pod Identity | Future |


### PR DESCRIPTION
## Summary

Brings v1.4 brainstorming + planning out of conversation context into the repo. Spec captures the 5 architectural decisions made during brainstorming (Q1-Q5); plan turns them into bite-sized executable tasks.

No code changes — pure docs.

## What's in this PR

| File | Lines | Purpose |
|---|---|---|
| docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md | 543 | Approved design spec — 5-item bundle |
| docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md | 1500+ | 5-phase implementation plan |

## v1.4 in one paragraph

Close-out polish for v1.3.1's rough edges: (1) scaffolder finalizer fix so teardowns cascade to AWS resources, (2-4) bucket sub-fields (versioning + lifecycle + CORS opt-in; PublicAccessBlock always-on as security default), (5) NEW Decommission scaffolder template that opens teardown PRs via Backstage form. AC-7 is the headline test: smoke-v14 teardown via Decommission template should require ZERO manual cleanup.

## Decisions captured

| Q | Decision |
|---|---|
| Bucket sub-fields scope | Versioning + lifecycle + CORS + always-on PAB |
| Lifecycle shape | Single `s3LifecycleDays: int` field |
| Finalizer scope | Scaffolder-only forward-fix (existing infra apps untouched for safety) |
| Decommission template shape | Minimal form (one input) → opens PR via gitDeletePaths |
| CORS shape | Single `s3CorsEnabled: bool` field with permissive defaults |

## Implementation scope

- ~125 min implementation budget
- Two PRs: arigsela/kubernetes (XRD-only, tiny) + arigsela/backstage (scaffolder + decommission template + app-config)
- Phase 3 USER GATE: image rebuild + Vault role binding
- Phase 4 smoke validation: scaffold smoke-v14 with all 4 sub-fields; CRITICAL test the decommission template's finalizer cascade end-to-end

## v1.5 deferred

Source-code repo creation in scaffolder explicitly deferred to v1.5 — too many open design questions (which language stacks? Dockerfile defaults? CI shape? repo location?) to bundle into v1.4.

## Test plan

- [x] Spec brainstorming complete (Q1-Q5 approved)
- [x] Spec self-reviewed for placeholders + ambiguity
- [x] Plan self-reviewed against spec coverage + type consistency
- [ ] User reviews this PR
- [ ] User merges → execution begins per chosen mode (subagent-driven recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)