### PR TITLE
feat(xrd): v1.4 add s3Versioning + s3LifecycleDays + s3CorsEnabled fields

### DIFF
--- a/base-apps/crossplane-compositions/xrd-application.yaml
+++ b/base-apps/crossplane-compositions/xrd-application.yaml
@@ -83,6 +83,34 @@ spec:
                     BUCKET_NAME env vars (zero application-side configuration).
                     WARNING: bucket is forceDestroy:true — contents are permanently
                     deleted on teardown.
+                s3Versioning:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true (and s3Needed:true), emits BucketVersioning resource enabling
+                    object versioning on the bucket. Useful for recovery from accidental
+                    deletes or overwrites.
+                    Note: AWS only supports `Suspended` (not full disable) once enabled —
+                    flipping back to false suspends versioning but doesn't delete history.
+                s3LifecycleDays:
+                  type: integer
+                  default: 0
+                  minimum: 0
+                  description: |
+                    When > 0 (and s3Needed:true), emits BucketLifecycleConfiguration with a
+                    single rule that expires all objects after N days. When 0, no lifecycle
+                    rule is created.
+                    Common values: 7 (transient logs), 30 (build artifacts), 365 (compliance
+                    retention).
+                s3CorsEnabled:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true (and s3Needed:true), emits BucketCorsConfiguration with
+                    permissive defaults: allow all origins, GET/PUT/POST/DELETE/HEAD methods,
+                    all headers, max-age 3600s. Useful for web apps that load assets directly
+                    from S3.
+                    For granular CORS configuration, see v1.5+ (deferred).
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Summary

XApplication XRD gains 3 new optional fields supporting v1.4's bucket sub-resources. Composition Python ignores them — they're for API-server validation only (so XRs containing them are accepted). All AWS resource emission happens via the companion arigsela/backstage scaffolder PR per Option B architecture (v1.3.1).

## Changes

| Change | File | Impact |
|---|---|---|
| Add `s3Versioning: bool` (default false) | `base-apps/crossplane-compositions/xrd-application.yaml` | When true, scaffolder emits BucketVersioning |
| Add `s3LifecycleDays: int` (default 0, min 0) | (same file) | When > 0, scaffolder emits BucketLifecycleConfiguration |
| Add `s3CorsEnabled: bool` (default false) | (same file) | When true, scaffolder emits BucketCorsConfiguration |

## Test plan

- [x] `./tests/composition/render.sh xr-minimal` PASS (regression — Composition output unchanged)
- [x] `./tests/composition/render.sh xr-with-db` PASS (regression)
- [x] `./tests/composition/render.sh xr-with-s3` PASS (regression)
- [ ] Companion arigsela/backstage PR: scaffolder template + decommission template + finalizer
- [ ] User rebuilds Backstage image
- [ ] Smoke validation: scaffold smoke-v14 with all 3 sub-fields enabled

## Things explicitly NOT in this PR

- Composition Python changes (Option B: AWS resources via scaffolder, not Composition)
- Test golden updates (Composition output unchanged for these fields)
- Scaffolder logic (companion arigsela/backstage PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)