### PR TITLE
docs(idp): v1.4 close-out — run notes + spec gitDeletePaths correction

### DIFF
--- a/docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md
+++ b/docs/superpowers/plans/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields.md
@@ -1358,3 +1358,70 @@ Phase boundaries:
 - **Phase 5** — final close-out subagent
 
 Phases 1 and 2 are independent (different repos, no shared files) — can run in parallel as two subagents (or sequentially per v1.3.1 precedent).
+
+---
+
+## Run Notes (2026-05-10)
+
+**Outcome:** v1.4 of the IDP shipped. The headline win — finalizer cascade — is fully validated end-to-end. Per-app ArgoCD Applications now carry `resources-finalizer.argocd.argoproj.io` so master-app prune cascades to all 9 cluster-scoped AWS resources. Bucket has versioning + lifecycle + CORS + public-access-block sub-resources via opt-in form fields (PAB always-on as security default). Decommission template ships with one known limitation (renders teardown commands instead of opening PR automatically; queued for v1.4.1).
+
+**E2E validation** (`smoke-v14`, all 4 sub-fields enabled — versioning + 7-day lifecycle + CORS + auto-on PAB):
+
+- ✅ Scaffold PR had 3 files (smoke-v14.yaml + application-xr.yaml + aws-resources.yaml)
+- ✅ aws-resources.yaml emitted **9 AWS resources** (5 base + 4 sub-resources)
+- ✅ Per-app Application has `resources-finalizer.argocd.argoproj.io` finalizer
+- ✅ Bucket created at `s3://852893458518-smoke-v14/`
+- ✅ `aws s3api get-bucket-versioning` returned `Status: Enabled`
+- ✅ `aws s3api get-bucket-lifecycle-configuration` returned the 7-day rule
+- ✅ `aws s3api get-bucket-cors` returned the rule (5 methods, * origins, 3600s max-age)
+- ✅ `aws s3api get-public-access-block` returned all 4 blocks True
+- ✅ Backstage `/create` shows Decommission Application (Crossplane) template
+- ⚠️ Decommission template renders teardown commands (NOT opens PR automatically — see Bug #1)
+- ✅ **AC-7 PASSED** — after teardown PR merged: ALL 9 AWS resources gone within 30s WITHOUT manual `kubectl delete bucket,user,...`. Bucket: `NoSuchBucket`. IAM User: `NoSuchEntity`. IAM Policy: `NoSuchEntity`. Vault entry: `No value found`. **The headline v1.4 promise delivered.**
+- ✅ chores-tracker untouched
+
+**Comparison against v1.3.1 teardown:**
+- v1.3.1: required 5 manual `kubectl delete` commands (Bucket, User, UserPolicyAttachment, AccessKey, Policy) after merge
+- **v1.4: zero manual cleanup commands** — finalizer fired cascade automatically
+
+**Bugs caught during execution:**
+
+| # | Bug | Severity | Fix |
+|---|---|---|---|
+| 1 | Spec §8 assumed `publish:github:pull-request` action supports `gitDeletePaths` field; it does not. Backstage's scaffolder backend has no native action that supports file-deletion-as-PR-content. | blocking AC-9 | Hotfix shipped via [arigsela/backstage#14](https://github.com/arigsela/backstage/pull/14) — decommission template degraded to render teardown commands via `debug:log` + `output.text`. Spec §8 corrected with post-shakeout note. v1.4.1 will introduce a custom scaffolder action to fully automate. |
+| 2 | AccessKey transient `NoSuchEntity` for `smoke-v14-app` user during AWS-side selector resolution lag (~30s) | minor | Self-healed via Crossplane retries (same pattern as v1.3.1's UserPolicyAttachment lag) |
+| 3 | BucketLifecycleConfiguration transient `cannot resolve references: bucket reference empty` (~30s) | minor | Self-healed via Crossplane retries |
+
+**Things that worked unexpectedly well:**
+- **Finalizer cascade fired in <30s** — much faster than expected. AWS-side dependency unwinding (UserPolicyAttachment → AccessKey → User → Policy → Bucket force-destroy) all completed within the first verification window. Crossplane provider controllers handled the order seamlessly.
+- **All 4 bucket sub-resources reconciled cleanly** — no chicken-and-egg issues with the parent Bucket (selector-based references resolved within seconds of Bucket becoming Ready).
+- **Backstage `output.text` is a clean fallback pattern** — when an automated action isn't available, rendering markdown commands the user can copy-paste keeps the template useful instead of completely broken.
+
+**v1.4.1 / v1.5+ follow-up candidates:**
+
+- **v1.4.1 — Custom Backstage scaffolder action `crossplane:teardown:delete-files`** that uses Octokit's `repos.deleteFile` API to fully automate the decommission flow. ~30-60 min implementation. Restores AC-9 to "opens PR automatically." This is the natural close-out for v1.4.
+- **v1.5 — Source-code repo creation in scaffolder** (deferred from v1.4 due to too many open design questions). The big remaining v2-original-candidate.
+- **v1.6+ — More AWS resource types (SQS, SNS, RDS) via Option B pattern**
+- **v1.6+ — Granular CORS configuration; multi-rule lifecycle**
+- **v1.6+ — Custom IAM policy override**
+- **v1.6+ — Backstage AWS-resource UX** (cluster-scoped resources don't appear in Crossplane tab — architectural limitation of Option B documented since v1.3.1)
+- **v2 — Vault dynamic credentials + IRSA / Pod Identity**
+
+**Spec correction in this close-out PR:**
+- §8: Added post-shakeout correction note to the decommission template's `gitDeletePaths` reference, with rationale + v1.4.1 follow-up.
+
+**Final PR sequence:**
+
+| PR | Status |
+|---|---|
+| [#245 spec/plan](https://github.com/arigsela/kubernetes/pull/245) | Merged |
+| [#246 v1.4 XRD additions](https://github.com/arigsela/kubernetes/pull/246) | Merged |
+| [arigsela/backstage#13 v1.4 scaffolder](https://github.com/arigsela/backstage/pull/13) | Merged |
+| (image rebuild — same tag, no manifest PR) | User reused tag + restarted Pod |
+| [#247 smoke-v14 scaffold](https://github.com/arigsela/kubernetes/pull/247) | Merged |
+| [arigsela/backstage#14 decommission template hotfix](https://github.com/arigsela/backstage/pull/14) | Merged |
+| (image rebuild #2 — same tag) | User reused tag + restarted Pod |
+| [#248 smoke-v14 teardown](https://github.com/arigsela/kubernetes/pull/248) | Merged |
+| (this PR) | docs: v1.4 close-out run notes |
+
+**v1.4 status: shipped** with one documented limitation (AC-9 downgraded to "renders correct teardown commands"; v1.4.1 will fix via custom scaffolder action).

--- a/docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
+++ b/docs/superpowers/specs/2026-05-03-idp-v1.4-scaffolder-finalizer-and-bucket-subfields-design.md
@@ -405,7 +405,18 @@ spec:
         url: ${{ steps.publish.output.remoteUrl }}
 ```
 
-**Note:** Backstage's `publish:github:pull-request` action's `gitDeletePaths` is a real Backstage scaffolder feature (added in 1.20+). It handles the `git rm` of the specified paths atomically as part of the PR commit.
+**⚠️ POST-SHAKEOUT CORRECTION (2026-05-10):** This spec assumed `publish:github:pull-request` action supported a `gitDeletePaths` field. **It does not** — Backstage's scaffolder backend has no native action that supports file-deletion-as-PR-content. Verified at smoke-v14 teardown attempt:
+
+```
+Error: Invalid input passed to action publish:github:pull-request,
+instance is not allowed to have the additional property "gitDeletePaths"
+```
+
+**v1.4 hotfix shipped (PR arigsela/backstage#14):** template degraded to render teardown commands via `debug:log` + `output.text` instead of opening the PR automatically. AC-9 downgraded from "decommission opens correct PR" to "decommission renders correct teardown commands."
+
+**v1.4.1 follow-up:** introduce a custom Backstage scaffolder action (`crossplane:teardown:delete-files`) using Octokit's `repos.deleteFile` API to fully automate. ~30-60 min implementation when prioritized.
+
+**Lesson learned:** Phase 0 P.4 verified the Backstage scaffolder VERSION supports `gitDeletePaths` based on documentation that turned out to be hallucinated. Should have validated at the action-schema level (e.g., test-run the action against a sandbox repo) before committing the spec.
 
 ### 8.2 Form behavior
 


### PR DESCRIPTION
Captures v1.4's outcome (shipped end-to-end with headline AC-7 finalizer cascade fully validated), the 3 bugs caught during smoke validation, and v1.4.1/v1.5+ follow-up candidates.

## Outcome

**v1.4 shipped.** The headline win — finalizer cascade — is the v1.4 promise: smoke-v14 teardown completed in <30 seconds with **zero manual kubectl delete commands**. Compare to v1.3.1's teardown which required 5 manual kubectl delete commands.

## ACs scorecard

13/14 ACs green. AC-9 downgraded to "decommission renders correct teardown commands" (template-only fix; v1.4.1 will introduce a custom scaffolder action to restore full "opens PR automatically" automation).

## Bugs caught + documented

1. **gitDeletePaths spec error** — Backstage `publish:github:pull-request` action does NOT support gitDeletePaths field. Hotfix in arigsela/backstage#14 made template render teardown commands via `debug:log` + `output.text` instead.
2. AccessKey transient resolve lag — self-healed
3. BucketLifecycleConfiguration transient resolve lag — self-healed

## Spec backport

§8: Added post-shakeout correction note to gitDeletePaths reference + v1.4.1 follow-up plan.

## v1.4.1 / v1.5+ candidates

| Iteration | What |
|---|---|
| v1.4.1 | Custom `crossplane:teardown:delete-files` scaffolder action — restores AC-9 to full PR automation |
| v1.5 | Source-code repo creation in scaffolder (the big remaining v2-original-candidate) |
| v1.6+ | SQS/SNS/RDS, granular CORS, multi-rule lifecycle, custom IAM policy, Backstage AWS-resource UX |
| v2 | Vault dynamic creds + IRSA / Pod Identity |

🤖 Generated with [Claude Code](https://claude.com/claude-code)