### PR TITLE
feat(kagent): custom UI image to fix SIGILL on older x86-64 CPUs

### DIFF
--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -51,6 +51,17 @@ spec:
             apiKeySecretRef: kagent-anthropic
             apiKeySecretKey: ANTHROPIC_API_KEY
 
+        # UI image override: custom Node-20 build for older HP server CPUs.
+        # Upstream cr.kagent.dev/kagent-dev/kagent/ui:0.8.6 ships Node 24 with
+        # x86-64-v2 baseline → SIGILL on this hardware.
+        # Track upstream: https://github.com/kagent-dev/kagent/issues/1505
+        ui:
+          image:
+            registry: "852893458518.dkr.ecr.us-east-2.amazonaws.com"
+            repository: "kagent-ui"
+            tag: "0.8.6-node20"
+            pullPolicy: IfNotPresent
+
         # Right-sized agent resources (Task 3.3)
         # Read-heavy agents: 512Mi limit; Write-heavy agents: keep 1Gi
         agents:

--- a/base-apps/kagent/build/Dockerfile
+++ b/base-apps/kagent/build/Dockerfile
@@ -1,0 +1,78 @@
+### STAGE 1: Dependencies
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM node:20-bookworm-slim AS deps
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV DO_NOT_TRACK=1
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV CYPRESS_INSTALL_BINARY=0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl bash openssl unzip ca-certificates nginx supervisor python3 build-essential \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/ui
+
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm,rw \
+    npm ci
+
+### STAGE 2: Build
+FROM --platform=$BUILDPLATFORM deps AS builder
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.npm,rw \
+    --mount=type=cache,target=/app/ui/.next/cache,rw \
+    export NEXT_TELEMETRY_DEBUG=1 \
+    && npm run build \
+    && mkdir -p /app/ui/public
+
+### STAGE 3: Runtime
+FROM node:20-bookworm-slim AS final
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV NODE_ENV=production
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl bash openssl unzip ca-certificates nginx supervisor \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app/ui/public \
+        /tmp/nginx/client_temp /tmp/nginx/proxy_temp /tmp/nginx/fastcgi_temp \
+        /tmp/nginx/uwsgi_temp /tmp/nginx/scgi_temp \
+    && groupadd -g 1001 nginx \
+    && useradd -u 1001 -g nginx -s /bin/bash -M nextjs \
+    && useradd -u 1002 -g nginx -s /bin/bash -M nginx \
+    && chown -R nextjs:nginx /app/ui \
+    && chown -R nextjs:nginx /tmp/nginx/
+
+WORKDIR /app
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+COPY conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY scripts/init.sh /usr/local/bin/init.sh
+
+WORKDIR /app/ui
+COPY --from=builder /app/ui/next.config.ts ./
+COPY --from=builder /app/ui/public ./public
+COPY --from=builder /app/ui/package.json ./package.json
+COPY --from=builder --chown=nextjs:nginx /app/ui/.next/standalone ./
+COPY --from=builder --chown=nextjs:nginx /app/ui/.next/static ./.next/static
+
+RUN chown -R nextjs:nginx /app/ui \
+    && chmod -R 755 /app \
+    && chmod +x /usr/local/bin/init.sh
+
+EXPOSE 8080
+
+LABEL org.opencontainers.image.source=https://github.com/arigsela/kubernetes
+LABEL org.opencontainers.image.description="Patched kagent UI v0.8.6 — Node 20 LTS for older x86-64 CPUs"
+
+USER 1001
+CMD ["/usr/local/bin/init.sh"]

--- a/base-apps/kagent/build/README.md
+++ b/base-apps/kagent/build/README.md
@@ -1,0 +1,59 @@
+# kagent UI custom image build
+
+Builds a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.8.6` so the Next.js process doesn't `SIGILL` on the HP server's older x86-64 CPU.
+
+**Background:** [Design spec](../../../docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md) · [Upstream issue #1505](https://github.com/kagent-dev/kagent/issues/1505)
+
+## Prerequisites (one-time)
+
+1. AWS CLI configured with ECR push permissions in account `852893458518` / region `us-east-2`:
+   ```bash
+   aws configure   # or: export AWS_PROFILE=<your-profile>
+   ```
+2. Docker buildx builder (only if not already configured):
+   ```bash
+   docker buildx create --use
+   ```
+3. ECR repository `kagent-ui` (created by Phase 1 of the implementation plan; nothing to do here unless it was deleted).
+
+## Usage
+
+From the repo root:
+
+```bash
+./base-apps/kagent/build/build.sh
+```
+
+This will:
+1. `git clone --depth 1 --branch v0.8.6 https://github.com/kagent-dev/kagent.git` into a tmp dir
+2. Copy our patched `Dockerfile` into `ui/`
+3. `docker buildx build --platform linux/amd64 --push` to `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.8.6-node20`
+4. Clean up the tmp dir on exit
+
+Expected runtime: 3–5 min.
+
+## Bumping `KAGENT_VERSION`
+
+If you need to rebuild this patch against a newer kagent release (because upstream issue #1505 still isn't fixed):
+
+1. Edit `KAGENT_VERSION` at the top of `build.sh`
+2. Update `IMAGE_TAG` if you want a different suffix
+3. Re-run `./build.sh`
+4. Verify upstream's `ui/Dockerfile` hasn't changed in ways our patch is incompatible with — if it has, re-merge the upstream changes into our `Dockerfile` here
+
+## Risk A/B contingency: nginx / supervisord path patches
+
+If the `kagent-ui` pod fails to start because Debian's nginx or supervisord paths differ from the wolfi originals, drop a patch file in this directory:
+
+- `nginx.conf.patch` — patches `ui/conf/nginx.conf` (likely needed if logs hit `/var/log/nginx` instead of `/tmp/nginx/`)
+- `supervisord.conf.patch` — patches `ui/conf/supervisord.conf` (likely needed if it references absolute binary paths)
+
+Then uncomment the matching block in `build.sh` and re-run.
+
+## Cleanup
+
+When upstream fixes [#1505](https://github.com/kagent-dev/kagent/issues/1505):
+
+1. Remove the `ui:` block from `base-apps/kagent.yaml`
+2. Bump `targetRevision` in `base-apps/kagent.yaml` and `base-apps/kagent-crds.yaml` to the fixed version
+3. Delete this directory

--- a/base-apps/kagent/build/build.sh
+++ b/base-apps/kagent/build/build.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build & push a custom kagent UI image that uses Node 20 LTS instead of Node 24,
+# so the Next.js process doesn't SIGILL on older x86-64 CPUs (the HP server's CPU
+# lacks the x86-64-v2 instruction baseline that Node 24 requires).
+#
+# See: docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md
+# Upstream issue: https://github.com/kagent-dev/kagent/issues/1505
+
+set -euo pipefail
+
+# --- config ---
+KAGENT_VERSION="0.8.6"
+ECR_REGISTRY="852893458518.dkr.ecr.us-east-2.amazonaws.com"
+ECR_REGION="us-east-2"
+IMAGE_NAME="kagent-ui"
+IMAGE_TAG="${KAGENT_VERSION}-node20"
+PLATFORM="linux/amd64"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Building $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+echo "==> Working in $WORK_DIR"
+
+# --- 1. Clone upstream at the pinned tag ---
+echo "==> Cloning kagent-dev/kagent at v${KAGENT_VERSION}"
+git clone --depth 1 --branch "v${KAGENT_VERSION}" \
+  https://github.com/kagent-dev/kagent.git "$WORK_DIR/kagent"
+
+# --- 2. Swap in the patched Dockerfile ---
+echo "==> Applying patched Dockerfile"
+cp "$SCRIPT_DIR/Dockerfile" "$WORK_DIR/kagent/ui/Dockerfile"
+
+# --- (optional) Risk A/B contingency: patch nginx.conf / supervisord.conf if needed ---
+# Enable these by un-commenting and dropping the corresponding .patch file in this dir.
+# if [[ -f "$SCRIPT_DIR/nginx.conf.patch" ]]; then
+#   echo "==> Applying nginx.conf patch"
+#   patch "$WORK_DIR/kagent/ui/conf/nginx.conf" < "$SCRIPT_DIR/nginx.conf.patch"
+# fi
+# if [[ -f "$SCRIPT_DIR/supervisord.conf.patch" ]]; then
+#   echo "==> Applying supervisord.conf patch"
+#   patch "$WORK_DIR/kagent/ui/conf/supervisord.conf" < "$SCRIPT_DIR/supervisord.conf.patch"
+# fi
+
+# --- 3. ECR login ---
+echo "==> Logging in to ECR"
+aws ecr get-login-password --region "$ECR_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+# --- 4. Build & push (single-platform amd64) ---
+echo "==> Building and pushing $PLATFORM image"
+docker buildx build \
+  --platform "$PLATFORM" \
+  --tag "$ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG" \
+  --push \
+  "$WORK_DIR/kagent/ui"
+
+echo ""
+echo "==> Done. Pushed: $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG"

--- a/docs/plans/kagent-ui-custom-image-implementation-plan.md
+++ b/docs/plans/kagent-ui-custom-image-implementation-plan.md
@@ -1,0 +1,269 @@
+# Custom kagent UI Image Implementation Plan
+
+**Status:** Approved — ready to execute
+**Date:** 2026-05-09
+**Owner:** Ari Sela
+**Spec:** [docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md](../superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md)
+**Upstream issue:** [kagent-dev/kagent#1505](https://github.com/kagent-dev/kagent/issues/1505)
+
+## Overview
+
+Build a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.8.6` to fix the SIGILL crash on the HP server's older CPU. One-shot patch, amd64-only, hosted in ECR.
+
+## Success Criteria
+
+- [ ] `kagent-ui:0.8.6-node20` image lives in `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui`
+- [ ] kagent-ui pod runs **without SIGILL crashes** on the HP server (no "Illegal instruction" in logs, RESTARTS stable)
+- [ ] kagent UI is reachable via port-forward and renders pages without errors
+- [ ] Repo contains build artifacts under `base-apps/kagent/build/` so the image is reproducible
+- [ ] `base-apps/kagent.yaml` overrides the UI image; ArgoCD shows the kagent app as Synced/Healthy
+
+## Research Findings
+
+### Relevant Files
+
+| File | Relevance |
+|---|---|
+| `base-apps/kagent.yaml` | kagent ArgoCD Application; helm values get the `ui:` override |
+| `base-apps/kagent/` | currently holds Agent CRDs and Vault wiring; we add `build/` subdir |
+| `base-apps/kyverno-policies/inject-ecr-pull-secret.yaml` | auto-injects `imagePullSecrets: [{name: ecr-registry}]` for any ECR image |
+| `base-apps/ecr-auth/cronjobs.yaml` | refreshes ECR tokens cluster-wide (the `ecr-registry` Secret) |
+| `base-apps/chores-tracker-backend/deployments.yaml` (and ~15 others) | reference ECR pattern: bare image reference, no explicit pull secret in manifest |
+
+### Existing Patterns
+
+- ECR registry/region: `852893458518.dkr.ecr.us-east-2.amazonaws.com`, `us-east-2`
+- ECR image references are bare in manifests (e.g., `852893458518.dkr.ecr.us-east-2.amazonaws.com/chores-tracker:7.1.0`); Kyverno handles pull secrets transparently
+- ArgoCD GitOps: changes deploy on commit-to-main with `prune: true, selfHeal: true`
+
+### Dependencies
+
+- `aws` CLI configured with ECR push perms (account `852893458518`, region `us-east-2`)
+- `docker buildx` (for amd64 builds, especially on Mac/M-series)
+- The `ecr-registry` Secret must already exist (or get created) in the `kagent` namespace — verified in Phase 1
+
+## Architecture Decisions (from spec)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | One-shot patch (no CI) | Minimal overhead; delete when upstream fixes #1505 |
+| 2 | `node:20-bookworm-slim` | Distro Node 20 binary, no `x86-64-v2` baseline; satisfies Next.js 16's Node ≥20.9 requirement |
+| 3 | AWS ECR | Matches existing repo conventions |
+| 4 | `linux/amd64` only | HP server is the only target |
+| 5 | Vendored Dockerfile + manual local build | Two files in repo; lowest ceremony |
+
+## Implementation
+
+### Phase 1: Pre-flight (cluster-side checks, no commits)
+
+#### Task 1.1: Verify ECR repo exists
+
+**Files:** none (cluster check)
+
+**Steps:**
+1. `aws ecr describe-repositories --repository-names kagent-ui --region us-east-2`
+2. If it errors `RepositoryNotFoundException`, create it:
+   ```
+   aws ecr create-repository --repository-name kagent-ui --region us-east-2 \
+     --image-scanning-configuration scanOnPush=true
+   ```
+3. Confirm registry URI is `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui`
+
+**Testing:**
+- [ ] `describe-repositories` returns 200 with the expected `repositoryUri`
+
+#### Task 1.2: Verify `ecr-registry` Secret exists in `kagent` namespace
+
+**Files:** none (cluster check)
+
+**Steps:**
+1. `kubectl -n kagent get secret ecr-registry`
+2. If missing, look at `base-apps/ecr-auth/cronjobs.yaml` to understand how it's seeded; the cronjob may target only certain namespaces
+3. If the cronjob doesn't include `kagent`, add it (separate small change, follow the pattern in `base-apps/ecr-auth/cronjobs.yaml`)
+
+**Testing:**
+- [ ] `kubectl -n kagent get secret ecr-registry` returns a Secret of type `kubernetes.io/dockerconfigjson`
+- [ ] `kubectl -n kagent get secret ecr-registry -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq` shows valid auth for `852893458518.dkr.ecr.us-east-2.amazonaws.com`
+
+---
+
+### Phase 2: Author build artifacts
+
+#### Task 2.1: Create `base-apps/kagent/build/` with the patched Dockerfile
+
+**Files:** `base-apps/kagent/build/Dockerfile`
+
+**Steps:**
+1. `mkdir -p base-apps/kagent/build`
+2. Author `Dockerfile` per the spec's "Full patched Dockerfile" section verbatim
+
+**Testing:**
+- [ ] `docker buildx build --platform linux/amd64 -t kagent-ui:test .` succeeds when run in a manually-cloned `kagent-dev/kagent@v0.8.6/ui` directory with this Dockerfile dropped in (manual smoke before `build.sh` exists)
+
+#### Task 2.2: Author `build.sh`
+
+**Files:** `base-apps/kagent/build/build.sh`
+
+**Steps:**
+1. Author per spec's "Component 2" section
+2. Hardcode the resolved values (no longer placeholders):
+   - `ECR_REGISTRY="852893458518.dkr.ecr.us-east-2.amazonaws.com"`
+   - `ECR_REGION="us-east-2"`
+3. Make executable: `chmod +x base-apps/kagent/build/build.sh`
+
+**Testing:**
+- [ ] `bash -n build.sh` (syntax check) passes
+- [ ] `shellcheck build.sh` (if available) returns no errors
+
+#### Task 2.3: Author `README.md`
+
+**Files:** `base-apps/kagent/build/README.md`
+
+**Steps:**
+1. Document prereqs: `aws configure` w/ ECR perms, `docker buildx create --use`
+2. Document usage: `./build.sh`
+3. Document how to bump `KAGENT_VERSION` if upstream releases a new tag while we still need the patch
+4. Cross-link to the design spec
+5. Cross-link to upstream issue [#1505](https://github.com/kagent-dev/kagent/issues/1505)
+
+**Testing:**
+- [ ] Markdown renders cleanly (visual check)
+
+---
+
+### Phase 3: Build & push the image
+
+#### Task 3.1: Run `build.sh`
+
+**Files:** none committed (image goes to ECR)
+
+**Steps:**
+1. From the repo root: `./base-apps/kagent/build/build.sh`
+2. Watch for: clone success, `npm ci` success, `next build` success, ECR login success, push success
+
+**Testing:**
+- [ ] Script exits 0
+- [ ] `aws ecr describe-images --repository-name kagent-ui --region us-east-2 --image-ids imageTag=0.8.6-node20` shows the image
+- [ ] Image manifest reports `architecture: amd64`, `os: linux`
+
+#### Task 3.2: (contingency) Local smoke test before cluster deploy
+
+**Files:** none
+
+**Steps:**
+1. `docker pull 852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.8.6-node20`
+2. `docker run --rm -p 8080:8080 852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.8.6-node20`
+3. In another shell: `curl -sS http://localhost:8080/ | head -20` — expect Next.js HTML
+
+**Testing:**
+- [ ] Container stays running for 30+ seconds (no startup crash)
+- [ ] supervisord starts both `nginx` and `nextjs` (visible in container logs)
+- [ ] Curl returns HTML (not connection-refused)
+- [ ] If this fails: jump to Risk A/B mitigation in Phase 5 *before* cluster deploy
+
+---
+
+### Phase 4: Wire into the cluster (GitOps)
+
+#### Task 4.1: Override `ui.image` in `base-apps/kagent.yaml`
+
+**Files:** `base-apps/kagent.yaml`
+
+**Steps:**
+1. Add the `ui:` block from the spec's "Component 3" between `providers:` and `agents:` in `helm.valuesObject`
+2. Use the resolved values:
+   ```yaml
+   ui:
+     image:
+       registry: "852893458518.dkr.ecr.us-east-2.amazonaws.com"
+       repository: "kagent-ui"
+       tag: "0.8.6-node20"
+       pullPolicy: IfNotPresent
+   ```
+
+**Testing:**
+- [ ] `yamllint base-apps/kagent.yaml` passes
+- [ ] `helm template` (locally with the chart) renders the kagent-ui Deployment with the expected image
+
+#### Task 4.2: Commit & push
+
+**Files:** all artifacts from Phase 2 + the `kagent.yaml` edit
+
+**Steps:**
+1. Pre-commit credential scan: `git diff --cached | grep -iE "(api[_-]?key|token|password|aws_access)"` returns nothing
+2. Commit covering build artifacts + helm override (or split into two commits — one per concern — depending on user preference)
+3. `git push` to feature branch, open PR per repo convention
+
+**Testing:**
+- [ ] Commit has no credentials
+- [ ] Commit message follows repo conventional-commits style (e.g., `feat(kagent): custom UI image for older x86-64 CPUs`)
+
+#### Task 4.3: ArgoCD sync
+
+**Files:** none
+
+**Steps:**
+1. After PR merge to `main`: watch ArgoCD UI / `argocd app get kagent`
+2. Confirm the kagent Application detects diff → syncs → kagent-ui Deployment updated
+3. New pod rolls out; old pod terminates
+
+**Testing:**
+- [ ] `argocd app get kagent` reports `Sync Status: Synced`, `Health: Healthy`
+- [ ] `kubectl -n kagent get pods -l app.kubernetes.io/name=kagent-ui` shows new pod (different age than the rest)
+
+---
+
+### Phase 5: Verify & contingency
+
+#### Task 5.1: Run all 5 acceptance tests from spec
+
+**Files:** none
+
+**Steps:** Execute each test from the spec's "Verification" section in order, capture outputs.
+
+**Testing:**
+- [ ] Test 1: image pulled (no `ImagePullBackOff`)
+- [ ] Test 2: **no SIGILL** — pod stays Running, RESTARTS stable, "Ready in <Xms>" log line present
+- [ ] Test 3: no nginx EROFS / permission errors
+- [ ] Test 4: `supervisorctl status` shows nginx & nextjs RUNNING
+- [ ] Test 5: UI loads in browser via port-forward, Agents and Model Configs pages render
+
+#### Task 5.2: (contingency) Risk A/B mitigation
+
+**Files:** `base-apps/kagent/build/nginx.conf.patch` and/or `supervisord.conf.patch` (only if needed)
+
+**Steps:** *(Only if Test 3 or Test 4 fails.)*
+1. Diagnose from logs which paths/binaries are wrong
+2. Author the minimal `.patch` file
+3. Uncomment the corresponding block in `build.sh`
+4. Re-run `build.sh`
+5. ArgoCD will not detect the change automatically (same tag) — either bump tag to `0.8.6-node20-r1` and update `base-apps/kagent.yaml`, OR `kubectl rollout restart deploy/kagent-ui -n kagent` to force a re-pull
+
+**Testing:**
+- [ ] Re-run Phase 5.1 tests after the new image deploys
+
+#### Task 5.3: Capture run notes
+
+**Files:** Optionally `docs/kagent-ui-custom-image-run-notes.md`
+
+**Steps:**
+1. Document image SHA, build timestamp, any Risk A/B patches actually applied
+2. Document upstream-fix-watch: when to remove the patch (when #1505 is fixed in v0.8.7+ or v0.9.x)
+
+**Testing:**
+- [ ] (Optional) Run notes committed
+
+## End-to-End Testing
+
+The whole feature is verified by: **the kagent UI pod is `Running` with no restarts, and a user can hit the UI in their browser and click around without errors.** That's the headline. Everything else (image existence, supervisord, nginx logs) is supporting evidence.
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Debian nginx default log paths conflict with `readOnlyRootFilesystem: true` | Medium — depends on what upstream's `conf/nginx.conf` overrides | Phase 5.2: ship `nginx.conf.patch` redirecting `error_log`/`access_log` to `/tmp/nginx/` |
+| `supervisord.conf` references absolute paths (e.g., `/usr/sbin/nginx`) that differ between Debian and wolfi | Low–Medium — most modern supervisord configs use bare binary names | Phase 5.2: ship `supervisord.conf.patch` updating paths |
+| Next.js 16 has a runtime issue with Node 20 we don't catch in Phase 3.2 local smoke | Low — Next.js 16 docs explicitly support Node ≥20.9 | Phase 5.1 Test 5 (browser smoke) catches it; rollback by removing `ui:` block from `kagent.yaml` |
+| ECR push permissions misconfigured on local AWS profile | Low — but easy to forget | Task 1.1 surfaces this immediately; fix `aws configure` or `AWS_PROFILE` and rerun |
+| `ecr-registry` Secret missing in `kagent` namespace → ImagePullBackOff | Medium — depends on whether the existing ecr-auth cronjob already targets `kagent` | Task 1.2 surfaces this before deploy; fix by extending the cronjob's namespace list |
+| Bumping `KAGENT_VERSION` later breaks because upstream `ui/` directory layout changed | Low — only relevant if we end up needing this for >1 kagent version | Documented in `README.md` Task 2.3; if it bites, re-merge upstream's Dockerfile changes manually |

--- a/docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md
+++ b/docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md
@@ -1,0 +1,371 @@
+# Custom kagent UI Image for Older x86-64 CPUs
+
+**Status:** Design — pending user review
+**Date:** 2026-05-09
+**Owner:** Ari Sela
+**Related issue:** [kagent-dev/kagent#1505](https://github.com/kagent-dev/kagent/issues/1505)
+
+## Problem
+
+The kagent UI pod (v0.8.6) crashes immediately with `SIGILL (Illegal Instruction)` on the old HP server's k3s node. The Next.js process exits on every HTTP request with `WARN exited: nextjs (terminated by SIGILL (core dumped); not expected)`, restarts under supervisord, and crashes again — making the UI unreachable.
+
+**Root cause:** Between v0.7.x and v0.8.x, kagent-dev replaced the UI's runtime from Bun to Node.js 24 (`ui/Dockerfile` switched from `bun install && bun run build` to `npm ci && npm run build`, and the runtime stage now installs `nodejs~24.13.0` from Chainguard's `wolfi-base`). Node.js v23+ binaries are compiled with `-march=x86-64-v2` baseline, which requires CPU instructions (POPCNT, SSE4.2, etc.) that the HP server's CPU lacks. Same bug class as upstream issue #1505 (filed for ARM64 Raspberry Pi).
+
+**Confirmation:**
+- Upstream maintainer comments on #1505 attribute the regression to "switching away from bun" and "node using some native modules that are not built for the proper platform."
+- Reporter confirms: "Version 0.7.23 works correctly on the same hardware."
+- Dockerfile diff `v0.7.23 → v0.8.6` shows: `bun` → `npm`, `BUN_INSTALL` env stack removed, `nodejs~24.13.0` apk pin added.
+
+## Goal
+
+Get the kagent UI running on the existing HP server k3s node, without rolling the entire kagent stack back to v0.7.x. Keep all other kagent components (controller, agents, CRDs) on the official upstream v0.8.6 images.
+
+## Non-goals
+
+- Not tracking upstream kagent UI releases. This is a one-shot patch pinned to v0.8.6.
+- Not maintaining a permanent fork of `kagent-dev/kagent`.
+- Not setting up CI to auto-rebuild on every kagent tag.
+- Not multi-arch (amd64 only).
+- Not addressing other unrelated UI bugs (#1614 wizard tool selection, #1767 cluster-domain, #1785 IPv6 RemoteMCPServer).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | One-shot patch (no CI, no upstream tracking) | Lowest overhead. Rebuild manually if/when v0.8.6 needs a refresh; delete the patch when upstream fixes #1505. |
+| 2 | Substitute Node 20 LTS on Debian (`node:20-bookworm-slim`) | Distro-built Node binary, no `x86-64-v2` baseline. Highest compatibility guarantee. Next.js 16.2.2 requires Node ≥20.9, so 20 LTS is the floor of viability. |
+| 3 | Publish to AWS ECR | Matches existing repo conventions (CLAUDE.md references ECR for images). |
+| 4 | `linux/amd64` only | The HP server is the only target; multi-arch buildx adds emulation cost for no benefit. |
+| 5 | Dockerfile + build script vendored in this repo, manual local build | Two files (~80 lines). No CI, no submodules, no separate repo. |
+
+## Architecture
+
+### What lands in this repo
+
+```
+base-apps/kagent/
+├── build/
+│   ├── Dockerfile               # ~50 lines (patched copy of upstream ui/Dockerfile)
+│   ├── build.sh                 # ~25 lines (clone + build + push)
+│   ├── README.md                # ~10 lines (prereqs + usage)
+│   ├── nginx.conf.patch         # OPTIONAL — only added if Risk A materializes
+│   └── supervisord.conf.patch   # OPTIONAL — only added if Risk B materializes
+└── kagent.yaml                  # +5 lines: ui.image override block
+```
+
+### What does NOT change
+
+- `kagent` Helm chart version (still 0.8.6)
+- `kagent-crds` Application
+- `kagent-secrets` Application
+- Controller / agent / kmcp / tools images (stay on `cr.kagent.dev`)
+- Vault, External Secrets, model configs, post-deploy patches
+
+### Flow
+
+```
+[laptop]                              [ECR]                          [cluster]
+   │                                    │                              │
+   │ ./build.sh                         │                              │
+   │  ├─ git clone --depth 1 \          │                              │
+   │  │    --branch v0.8.6 \            │                              │
+   │  │    kagent-dev/kagent ───── (read upstream v0.8.6) ─────────────┤
+   │  ├─ cp Dockerfile ui/Dockerfile    │                              │
+   │  ├─ docker buildx build \          │                              │
+   │  │    --platform linux/amd64 \     │                              │
+   │  └─ docker push ─────────────────► <acct>.dkr.ecr.<region>.       │
+   │                                    amazonaws.com/kagent-ui:       │
+   │                                    0.8.6-node20                   │
+   │                                    │                              │
+   │ git commit base-apps/kagent.yaml   │                              │
+   │ git push ────────────────► ArgoCD detects diff ─► UI Deployment ──►│
+   │                              syncs values                  pulls  │
+   │                                                            from ECR
+```
+
+## Component 1: Patched `ui/Dockerfile`
+
+The diff against upstream `ui/Dockerfile@v0.8.6` is mechanical — five concrete changes:
+
+| # | Change | Why |
+|---|---|---|
+| 1 | `FROM chainguard/wolfi-base:latest` → `FROM node:20-bookworm-slim` (both `deps` and `final` stages) | Node 20 binary built without `x86-64-v2` baseline. Runs on POPCNT-less CPUs. |
+| 2 | Remove `ARG TOOLS_NODE_VERSION=24.13.0` and the `nodejs~${TOOLS_NODE_VERSION}` apk pin | Node + npm now ship in the base image. Drop the explicit pin. |
+| 3 | `apk add --no-cache curl bash openssl unzip ca-certificates nginx supervisor` → `apt-get update && apt-get install -y --no-install-recommends curl bash openssl unzip ca-certificates nginx supervisor && rm -rf /var/lib/apt/lists/*` | Debian package manager. Build stage adds `python3 build-essential` for any node-gyp native compiles. |
+| 4 | `addgroup -g 1001 nginx && adduser -u 1001 -G nginx -s /bin/bash -D nextjs && adduser -u 1002 -G nginx -s /bin/bash -D nginx` → `groupadd -g 1001 nginx && useradd -u 1001 -g nginx -s /bin/bash -M nextjs && useradd -u 1002 -g nginx -s /bin/bash -M nginx` | Debian's `useradd` instead of Alpine's `adduser`. Same UIDs/GIDs preserved (1001/1002) so file ownership and the `USER 1001` directive at the bottom continue to work. |
+| 5 | `&& rm -rf /var/lib/apt/lists/*` after each `apt-get install` | Debian cleanliness; not needed with apk. |
+
+### Everything else stays byte-for-byte identical to upstream
+
+- All three stages (`deps`, `builder`, `final`)
+- The `npm ci` / `npm run build` commands
+- The `COPY --from=builder` lines pulling `.next/standalone`, `.next/static`, `public/`, `package.json`, `next.config.ts`
+- The nginx + supervisord + init.sh wiring (`conf/nginx.conf`, `conf/supervisord.conf`, `scripts/init.sh` all copied from upstream as-is)
+- `EXPOSE 8080`, `USER 1001`, `CMD ["/usr/local/bin/init.sh"]`
+
+### Full patched Dockerfile
+
+```dockerfile
+### STAGE 1: Dependencies
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM node:20-bookworm-slim AS deps
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV DO_NOT_TRACK=1
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV CYPRESS_INSTALL_BINARY=0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl bash openssl unzip ca-certificates nginx supervisor python3 build-essential \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/ui
+
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm,rw \
+    npm ci
+
+### STAGE 2: Build
+FROM --platform=$BUILDPLATFORM deps AS builder
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.npm,rw \
+    --mount=type=cache,target=/app/ui/.next/cache,rw \
+    export NEXT_TELEMETRY_DEBUG=1 \
+    && npm run build \
+    && mkdir -p /app/ui/public
+
+### STAGE 3: Runtime
+FROM node:20-bookworm-slim AS final
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV NODE_ENV=production
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl bash openssl unzip ca-certificates nginx supervisor \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app/ui/public \
+        /tmp/nginx/client_temp /tmp/nginx/proxy_temp /tmp/nginx/fastcgi_temp \
+        /tmp/nginx/uwsgi_temp /tmp/nginx/scgi_temp \
+    && groupadd -g 1001 nginx \
+    && useradd -u 1001 -g nginx -s /bin/bash -M nextjs \
+    && useradd -u 1002 -g nginx -s /bin/bash -M nginx \
+    && chown -R nextjs:nginx /app/ui \
+    && chown -R nextjs:nginx /tmp/nginx/
+
+WORKDIR /app
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+COPY conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY scripts/init.sh /usr/local/bin/init.sh
+
+WORKDIR /app/ui
+COPY --from=builder /app/ui/next.config.ts ./
+COPY --from=builder /app/ui/public ./public
+COPY --from=builder /app/ui/package.json ./package.json
+COPY --from=builder --chown=nextjs:nginx /app/ui/.next/standalone ./
+COPY --from=builder --chown=nextjs:nginx /app/ui/.next/static ./.next/static
+
+RUN chown -R nextjs:nginx /app/ui \
+    && chmod -R 755 /app \
+    && chmod +x /usr/local/bin/init.sh
+
+EXPOSE 8080
+
+LABEL org.opencontainers.image.source=https://github.com/arigsela/kubernetes
+LABEL org.opencontainers.image.description="Patched kagent UI v0.8.6 — Node 20 LTS for older x86-64 CPUs"
+
+USER 1001
+CMD ["/usr/local/bin/init.sh"]
+```
+
+### Known risks
+
+**Risk A — Debian nginx vs wolfi nginx path differences.** Debian's nginx defaults to `/var/log/nginx` and `/var/lib/nginx`, which conflict with `readOnlyRootFilesystem: true`. Upstream's `conf/nginx.conf` likely already redirects logs to `/tmp/nginx/` (the upstream image runs read-only too), but this needs verification at test time.
+
+Mitigation if it breaks: bind a writable `emptyDir` over `/var/log/nginx` via helm `ui.volumes`, OR ship a `conf/nginx.conf` patch via `build.sh` (see Component 2 below).
+
+**Risk B — `supervisord.conf` binary paths.** If upstream's supervisord config uses absolute paths like `/usr/sbin/nginx` (Debian) vs `/usr/bin/nginx` (wolfi/Alpine), supervisor will fail to start one of the children.
+
+Mitigation: same shape as A — patch `conf/supervisord.conf` post-clone in `build.sh`.
+
+Both risks have a single mitigation pattern: **post-clone patches applied during build**. The build script includes a commented-out hook for this so we can enable it without restructuring.
+
+## Component 2: `build.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- config ---
+KAGENT_VERSION="0.8.6"
+ECR_REGISTRY="<account>.dkr.ecr.<region>.amazonaws.com"   # to be filled in during impl
+ECR_REGION="<region>"                                     # to be filled in during impl
+IMAGE_NAME="kagent-ui"
+IMAGE_TAG="${KAGENT_VERSION}-node20"
+PLATFORM="linux/amd64"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# --- 1. Clone upstream at the pinned tag ---
+git clone --depth 1 --branch "v${KAGENT_VERSION}" \
+  https://github.com/kagent-dev/kagent.git "$WORK_DIR/kagent"
+
+# --- 2. Swap in the patched Dockerfile ---
+cp "$SCRIPT_DIR/Dockerfile" "$WORK_DIR/kagent/ui/Dockerfile"
+
+# --- (optional) Risk A/B contingency: patch nginx.conf / supervisord.conf if needed ---
+# Enable these by un-commenting and dropping the corresponding .patch file in this dir.
+# if [[ -f "$SCRIPT_DIR/nginx.conf.patch" ]]; then
+#   patch "$WORK_DIR/kagent/ui/conf/nginx.conf" < "$SCRIPT_DIR/nginx.conf.patch"
+# fi
+# if [[ -f "$SCRIPT_DIR/supervisord.conf.patch" ]]; then
+#   patch "$WORK_DIR/kagent/ui/conf/supervisord.conf" < "$SCRIPT_DIR/supervisord.conf.patch"
+# fi
+
+# --- 3. ECR login ---
+aws ecr get-login-password --region "$ECR_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+# --- 4. Build & push (single-platform amd64) ---
+docker buildx build \
+  --platform "$PLATFORM" \
+  --tag "$ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG" \
+  --push \
+  "$WORK_DIR/kagent/ui"
+
+echo "Pushed: $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+```
+
+### Why this shape
+
+- **`mktemp -d` + cleanup trap**: nothing pollutes the working tree, no submodules, no vendored upstream code in the repo. Re-running is idempotent.
+- **`--depth 1 --branch`**: fast, deterministically pinned. Bumping `KAGENT_VERSION` automatically pulls matching upstream sources.
+- **`docker buildx build` (not `docker build`)**: lets the user build amd64 from a Mac/M-series laptop (uses qemu under the hood) without changing the script. On a Linux/amd64 host, buildx still works natively.
+- **`--push` not `--load`**: amd64-only on a non-amd64 host can't be `docker load`ed locally anyway.
+
+### Prerequisites (one-time)
+
+1. `aws configure` (or `AWS_PROFILE`) with ECR push perms in the target account/region
+2. `aws ecr create-repository --repository-name kagent-ui --region <region>` (one-time, or via Terraform)
+3. `docker buildx create --use` (one-time, only if not already configured)
+
+### Expected runtime
+
+3–5 minutes on a modern laptop. `npm ci` + `next build` dominates; clone and push are small.
+
+## Component 3: Helm Values Override
+
+Diff against `base-apps/kagent.yaml` (insert under `helm.valuesObject`):
+
+```yaml
+        # LLM provider: use Anthropic with existing secret
+        providers:
+          default: anthropic
+          ...
+
++       # UI image override: custom Node 20 build for older HP server CPUs.
++       # Upstream cr.kagent.dev/kagent-dev/kagent/ui:0.8.6 ships Node 24 with
++       # x86-64-v2 baseline → SIGILL on this hardware.
++       # Track upstream issue: https://github.com/kagent-dev/kagent/issues/1505
++       ui:
++         image:
++           registry: "<account>.dkr.ecr.<region>.amazonaws.com"
++           repository: "kagent-ui"
++           tag: "0.8.6-node20"
++           pullPolicy: IfNotPresent
+
+        # Right-sized agent resources (Task 3.3)
+        agents:
+          ...
+```
+
+### Why this shape
+
+- **No chart fork.** The kagent helm chart already exposes `ui.image.{registry,repository,tag,pullPolicy}` (verified in `helm/kagent/values.yaml@v0.8.6`).
+- **Surgically replaces only the UI container.** Controller, agents, kmcp, tools all keep the upstream `cr.kagent.dev` images.
+- **`pullPolicy: IfNotPresent`** matches the chart default.
+
+### ECR pull credentials — open question
+
+The `kagent` namespace needs to pull from ECR. Two paths depending on existing cluster wiring (to be verified in implementation, not designed up-front):
+
+1. **Node-level IAM with ECR read perms** — common on AWS-hosted nodes; nothing else needed.
+2. **`imagePullSecrets` referencing an ECR pull secret** — common on on-prem or external clusters. Either: add `imagePullSecrets` to the helm values, or copy the existing pull secret into the `kagent` namespace via External Secrets / a ServiceAccount patch.
+
+The HP server is on-prem, so path 2 is the more likely answer. The implementation plan will check what other ECR-hosted apps in this cluster do today and follow the established pattern.
+
+## Verification
+
+Acceptance tests after deployment, in order:
+
+1. **Image pulled successfully.**
+   ```bash
+   kubectl -n kagent describe pod -l app.kubernetes.io/name=kagent-ui | grep -A2 "Image:"
+   # expect: <account>.dkr.ecr.<region>.amazonaws.com/kagent-ui:0.8.6-node20
+   ```
+   `ImagePullBackOff` here = ECR pull creds issue.
+
+2. **No SIGILL — process stays up.** *(Headline acceptance test.)*
+   ```bash
+   kubectl -n kagent logs deploy/kagent-ui --tail=50
+   kubectl -n kagent get pod -l app.kubernetes.io/name=kagent-ui
+   # expect: STATUS=Running, RESTARTS not climbing
+   # expect logs: NO "terminated by SIGILL" or "Illegal instruction"
+   # expect logs: see Next.js "Ready in <Xms>" startup line
+   ```
+
+3. **Risk A — nginx paths.**
+   ```bash
+   kubectl -n kagent logs deploy/kagent-ui 2>&1 | grep -iE "nginx|permission denied|read-only|EROFS"
+   # expect: no permission/EROFS errors
+   ```
+
+4. **Risk B — supervisord paths.**
+   ```bash
+   kubectl -n kagent exec deploy/kagent-ui -- supervisorctl status
+   # expect: both nginx and nextjs in RUNNING state
+   ```
+
+5. **End-to-end smoke — UI loads in browser.**
+   ```bash
+   kubectl port-forward -n kagent svc/kagent-ui 8080:8080
+   ```
+   Hit `http://localhost:8080`, click through Agents list and Model Configs pages. Catches Next.js 16-on-Node 20 runtime issues that wouldn't show up in static checks.
+
+If Risk A or B bites: add the corresponding `nginx.conf.patch` or `supervisord.conf.patch` to `base-apps/kagent/build/`, uncomment the patching block in `build.sh`, rebuild, push, ArgoCD re-syncs.
+
+## Rollback
+
+| Trigger | Action | Recovery time |
+|---|---|---|
+| Custom image broken, want upstream back | Remove the `ui:` block from `base-apps/kagent.yaml`, push. ArgoCD reverts to upstream image. | ~2 min |
+| Whole 0.8.6 line is the problem | Roll the chart back: `targetRevision: 0.7.23` in `kagent.yaml` and `kagent-crds.yaml`. CRD downgrades can be tricky — test in a branch first. | ~5 min |
+| Nuclear option | Delete the kagent ArgoCD Application; redeploy with whatever values needed | ~10 min, **destroys kagent Postgres data** unless PVC reclaim policy is Retain |
+
+The first row is the realistic rollback. The custom image is purely additive — pulling it out leaves the rest of the deployment exactly as it is today.
+
+## Cleanup (when upstream fixes #1505)
+
+If kagent-dev fixes [#1505](https://github.com/kagent-dev/kagent/issues/1505) in v0.8.7 / v0.9.x:
+
+1. Remove the `ui:` block from `base-apps/kagent.yaml`
+2. Bump `targetRevision` in `kagent.yaml` and `kagent-crds.yaml`
+3. (optional) Delete `base-apps/kagent/build/` from the repo
+
+## Out-of-scope reminders
+
+These were called out as separate issues and explicitly *not* addressed by this design:
+
+- [#1614](https://github.com/kagent-dev/kagent/issues/1614) — Quick-builder wizard "Select Tools" page broken on k3s in 0.8.3 (UI bug, separate)
+- [#1767](https://github.com/kagent-dev/kagent/issues/1767) — `cluster.local` hardcoded in helm chart (only matters with custom cluster-domain)
+- [#1785](https://github.com/kagent-dev/kagent/issues/1785) — Controller hangs registering RemoteMCPServer on IPv4-only k3s with AAAA records


### PR DESCRIPTION
## Summary
- Build a Node-20-on-Debian replacement for the kagent UI v0.8.6 image to fix the `SIGILL (Illegal Instruction)` crash on the HP server's older x86-64 CPU.
- Root cause: kagent v0.8.x switched the UI runtime from Bun to Node.js 24 (Chainguard wolfi). Node 24 binaries require the `x86-64-v2` CPU baseline (POPCNT, SSE4.2, etc.) that this hardware lacks.
- Surgical override — only the UI image changes; controller, agents, kmcp, and tools keep the upstream `cr.kagent.dev` images. Intended as a one-shot patch until upstream fixes [kagent-dev/kagent#1505](https://github.com/kagent-dev/kagent/issues/1505).

## Changes

### Technical Implementation
- **`base-apps/kagent/build/Dockerfile`** — patched copy of upstream `ui/Dockerfile@v0.8.6`. Replaces `chainguard/wolfi-base:latest` + `nodejs~24.13.0` with `node:20-bookworm-slim` (Debian, no `x86-64-v2` baseline). Same UIDs/GIDs (1001/1002), same supervisord+nginx wiring, same `EXPOSE 8080` / `USER 1001` / `CMD ["/usr/local/bin/init.sh"]`.
- **`base-apps/kagent/build/build.sh`** — clones `kagent-dev/kagent@v0.8.6` into a tmp dir, copies in the patched Dockerfile, builds `linux/amd64`, pushes to ECR. Self-cleaning via mktemp + trap.
- **`base-apps/kagent/build/README.md`** — prereqs, usage, contingency patch hooks, cleanup-when-upstream-fixes-1505.
- **`base-apps/kagent.yaml`** — adds an 11-line `ui:` block under `helm.valuesObject` pointing the kagent-ui Deployment at the custom ECR image. Surgical: doesn't touch `controller`, `agentImage`, `skillsInitImage`, `kmcp`, or any other upstream image reference.

### Configuration
- **Image**: `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.8.6-node20`
- **Architecture**: `linux/amd64`
- **Pull credentials**: automatic via the existing Kyverno `inject-ecr-pull-secret` ClusterPolicy (verified the `ecr-registry` Secret is already present in the `kagent` namespace via the `ecr-auth` cronjob)
- **Helm chart**: still `kagent-dev/kagent` v0.8.6 — no chart fork, just values override

## Testing
- ✅ Image builds successfully (`docker buildx build --platform linux/amd64 --push`)
- ✅ Local smoke test (`docker run -p 8080:8080 ...`):
  - supervisord starts both `nextjs` and `nginx` children → both `RUNNING`
  - Next.js 16.2.2 reports `✓ Ready in 0ms` on Node 20
  - `curl http://localhost:8080/` → HTTP 200, 15482-byte SSR HTML with `<title>kagent.dev</title>`
  - No `SIGILL` / `Illegal instruction` / `EROFS` / `permission denied` matches in container logs
- ⏸ In-cluster verification pending after merge → ArgoCD sync (running with `readOnlyRootFilesystem: true` is the only condition not exercised locally)

## Test Plan
- [x] Build image: `./base-apps/kagent/build/build.sh` → exits 0, image in ECR with manifest digest `sha256:619670c241c5...`
- [x] Local smoke: container runs, HTTP 200, no errors in logs
- [ ] Post-merge cluster verification:
  - [ ] `kubectl -n kagent describe pod -l app.kubernetes.io/name=kagent-ui` → image matches override, `Pulled` event success
  - [ ] `kubectl -n kagent logs deploy/kagent-ui` → no `SIGILL` / `Illegal instruction`, `Ready in <Xms>` log line present, `RESTARTS` stable
  - [ ] `kubectl -n kagent exec deploy/kagent-ui -- supervisorctl status` → both children `RUNNING`
  - [ ] Browser smoke via `kubectl port-forward -n kagent svc/kagent-ui 8080:8080` → UI loads, Agents and Model Configs pages render

## Risks & Mitigations
| Risk | Mitigation |
|---|---|
| Debian nginx default log paths conflict with `readOnlyRootFilesystem: true` | If observed: add `nginx.conf.patch` to `base-apps/kagent/build/`, uncomment block in `build.sh`, rebuild |
| `supervisord.conf` references absolute paths that differ between Debian and wolfi | Same pattern: add `supervisord.conf.patch` |
| Whole 0.8.6 line proves problematic | Roll chart back: `targetRevision: 0.7.23` in `kagent.yaml` and `kagent-crds.yaml` |

## Rollback
If the custom image breaks anything, remove the `ui:` block from `base-apps/kagent.yaml` and push — ArgoCD reverts to the upstream image. ~2 min recovery.

## Related
- **Spec**: [`docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md`](docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md)
- **Plan**: [`docs/plans/kagent-ui-custom-image-implementation-plan.md`](docs/plans/kagent-ui-custom-image-implementation-plan.md)
- **Upstream issue**: [kagent-dev/kagent#1505](https://github.com/kagent-dev/kagent/issues/1505) — same SIGILL bug class, originally reported on ARM64 Pi

## Cleanup (when upstream fixes #1505)
1. Remove the `ui:` block from `base-apps/kagent.yaml`
2. Bump `targetRevision` in `base-apps/kagent.yaml` and `base-apps/kagent-crds.yaml` to the fixed version
3. Delete `base-apps/kagent/build/`

🤖 Generated with [Claude Code](https://claude.ai/code)