### PR TITLE
feat(kagent): add nginx ingress for UI on kagent.arigsela.com

### DIFF
--- a/base-apps/kagent/nginx-ingress.yaml
+++ b/base-apps/kagent/nginx-ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kagent-ui-nginx
+  namespace: kagent
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    # Admin-tool whitelist: home IPs + internal cluster network.
+    # Matches backstage/argo-rollouts/argo-workflows pattern.
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - kagent.arigsela.com
+    secretName: kagent-tls
+  rules:
+  - host: kagent.arigsela.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kagent-ui
+            port:
+              number: 8080


### PR DESCRIPTION
## Summary
- Expose the kagent UI externally at `https://kagent.arigsela.com` behind the shared nginx-ingress with TLS via cert-manager (`letsencrypt-prod`).
- Follow the existing admin-tool ingress pattern (Backstage / Argo Rollouts / Argo Workflows): source-range whitelist limiting access to home IPs + internal cluster CIDR, since kagent UI has no built-in auth and controls cluster operations through AI agents.
- Pure follow-up to #250 — independent of the UI image patch.

## Changes
### New File
- **`base-apps/kagent/nginx-ingress.yaml`** — single Ingress object, no other resources needed (TLS secret is provisioned by cert-manager from the ClusterIssuer)

### Configuration
| Setting | Value | Rationale |
|---|---|---|
| `ingressClassName` | `nginx` | Matches all other ingresses in the repo |
| `host` | `kagent.arigsela.com` | New subdomain on the existing zone |
| TLS issuer | `letsencrypt-prod` | Same as backstage/argo |
| TLS secret | `kagent-tls` | Matches `<app>-tls` naming convention |
| Backend | `kagent-ui:8080` | Existing ClusterIP Service |
| `ssl-redirect` / `force-ssl-redirect` | `true` | Matches repo standard |
| Proxy timeouts | `60s` | Matches backstage; allows agent A2A calls to complete |
| `whitelist-source-range` | `73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,10.0.0.0/8` | Identical to backstage/argo-rollouts/argo-workflows admin-tool pattern |

## Test Plan
- [x] `yaml.safe_load` parses the file cleanly
- [ ] Post-merge cluster verification:
  - [ ] `kubectl -n kagent get ingress kagent-ui-nginx` → Ingress object exists with the expected backend
  - [ ] `kubectl -n kagent get certificate kagent-tls` → cert-manager picks up the request and issues the cert
  - [ ] DNS A/CNAME record for `kagent.arigsela.com` points to the nginx-ingress controller's external IP/LB
  - [ ] `curl -I https://kagent.arigsela.com/` from a whitelisted IP → HTTP 200 with valid LE chain
  - [ ] `curl -I https://kagent.arigsela.com/` from a non-whitelisted IP → 403 (whitelist enforcement)

## Risks & Mitigations
| Risk | Mitigation |
|---|---|
| DNS record for `kagent.arigsela.com` not yet pointing at the cluster's ingress LB | Add the A/CNAME before merging (or merge and add — Ingress will be inert until DNS resolves) |
| cert-manager fails the ACME HTTP-01 challenge during issuance | Check `kubectl -n kagent describe certificate kagent-tls` and `kubectl -n cert-manager logs deploy/cert-manager` if the cert doesn't materialize within ~2 min |
| Whitelist locks out a legitimate IP (e.g., a remote you didn't anticipate) | Edit `whitelist-source-range` annotation and push; ingress controller re-loads in seconds |

## Rollback
Remove `base-apps/kagent/nginx-ingress.yaml` and push — ArgoCD prunes the Ingress and cert-manager cleans up the Certificate. Service falls back to in-cluster access via `kubectl port-forward` (which is how access works today).

## Related
- Builds on #250 (kagent UI Node-20 image fix). That PR got the UI running; this PR makes it reachable from a browser without `kubectl port-forward`.

🤖 Generated with [Claude Code](https://claude.ai/code)