### PR TITLE
fix(crossplane): PushSecret deletionPolicy Delete → Retain (v1.5 teardown race fix)

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -99,7 +99,7 @@ spec:
                   },
                   "spec": {
                       "refreshInterval": "5m",
-                      "deletionPolicy": "Delete",
+                      "deletionPolicy": "Retain",
                       "secretStoreRefs": [
                           {"name": "vault-backend", "kind": "SecretStore"},
                       ],
@@ -169,7 +169,7 @@ spec:
                   },
                   "spec": {
                       "refreshInterval": "5m",
-                      "deletionPolicy": "Delete",
+                      "deletionPolicy": "Retain",
                       "secretStoreRefs": [
                           {"name": "vault-backend", "kind": "SecretStore"},
                       ],

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -296,7 +296,7 @@ spec:
           property: username
           remoteKey: platform-smoke/db
         secretKey: username
-  deletionPolicy: Delete
+  deletionPolicy: Retain
   refreshInterval: 5m
   secretStoreRefs:
     - kind: SecretStore

--- a/tests/composition/expected-xr-with-s3.yaml
+++ b/tests/composition/expected-xr-with-s3.yaml
@@ -213,7 +213,7 @@ spec:
           property: AWS_SECRET_ACCESS_KEY
           remoteKey: platform-smoke/aws-creds
         secretKey: password
-  deletionPolicy: Delete
+  deletionPolicy: Retain
   refreshInterval: 5m
   secretStoreRefs:
     - kind: SecretStore


### PR DESCRIPTION
## Summary
Fixes the teardown race surfaced during v1.4.1 smoke validation. SecretStore deletion was beating PushSecret's \`deletionPolicy: Delete\` cleanup call, leaving PushSecret stuck and the per-app Application unable to finalize.

Both Composition-emitted PushSecrets (\`make_push_secret\` for DB-creds, \`make_aws_push_secret\` for AWS-creds) now use \`deletionPolicy: Retain\`. PushSecret deletion is a pure CR removal — no SecretStore dependency, no race.

## Trade-off
Vault entries at \`k8s-secrets/<app>/db-creds\` and \`k8s-secrets/<app>/aws-creds\` orphan after teardown. The Backstage decommission scaffolder PR body will be updated (separate PR in arigsela/backstage) to enumerate the explicit \`vault kv delete\` commands operators must run post-teardown.

## Test plan
- [x] Render-test goldens updated FIRST (TDD): \`expected-xr-with-db.yaml:299\` and \`expected-xr-with-s3.yaml:216\`
- [x] \`./tests/composition/render.sh xr-with-db\` and \`xr-with-s3\` failed BEFORE the Composition change (proved goldens detected the bug)
- [x] Composition Python updated: \`composition-application.yaml:102\` (DB) + \`:172\` (AWS)
- [x] All three render cases pass AFTER the change (xr-minimal, xr-with-db, xr-with-s3)
- [ ] Smoke validation via \`smoke-v15\` (deferred to post-merge; depends on the matching backstage PR for the new cleanup PR body)

## Spec / Plan
- Spec: \`docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)