### PR TITLE
fix(crossplane): PushSecret deletionPolicy Retain → None (v1.5.1)

### DIFF
--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -99,7 +99,7 @@ spec:
                   },
                   "spec": {
                       "refreshInterval": "5m",
-                      "deletionPolicy": "Retain",
+                      "deletionPolicy": "None",
                       "secretStoreRefs": [
                           {"name": "vault-backend", "kind": "SecretStore"},
                       ],
@@ -169,7 +169,7 @@ spec:
                   },
                   "spec": {
                       "refreshInterval": "5m",
-                      "deletionPolicy": "Retain",
+                      "deletionPolicy": "None",
                       "secretStoreRefs": [
                           {"name": "vault-backend", "kind": "SecretStore"},
                       ],

--- a/tests/composition/expected-xr-with-db.yaml
+++ b/tests/composition/expected-xr-with-db.yaml
@@ -296,7 +296,7 @@ spec:
           property: username
           remoteKey: platform-smoke/db
         secretKey: username
-  deletionPolicy: Retain
+  deletionPolicy: None
   refreshInterval: 5m
   secretStoreRefs:
     - kind: SecretStore

--- a/tests/composition/expected-xr-with-s3.yaml
+++ b/tests/composition/expected-xr-with-s3.yaml
@@ -213,7 +213,7 @@ spec:
           property: AWS_SECRET_ACCESS_KEY
           remoteKey: platform-smoke/aws-creds
         secretKey: password
-  deletionPolicy: Retain
+  deletionPolicy: None
   refreshInterval: 5m
   secretStoreRefs:
     - kind: SecretStore


### PR DESCRIPTION
## Summary
v1.5 (PR #255, merged earlier today) flipped \`PushSecret.spec.deletionPolicy\` to \`Retain\` on the assumption it was a valid enum value. Cluster-side validation at \`smoke-v15\` deploy time revealed:

\`\`\`
cannot apply composed resource "pushsecret": PushSecret.external-secrets.io "smoke-v15-db-push" is invalid:
spec.deletionPolicy: Unsupported value: "Retain": supported values: "Delete", "None"
\`\`\`

ESO v0.11.0's \`external-secrets.io/v1alpha1\` PushSecret CRD enum is \`["Delete", "None"]\` — no \`Retain\`.

## Fix
\`None\` is semantically identical to what v1.5 intended (no remote cleanup on deletion → no Vault call → no SecretStore-deletion race). 4 lines flipped Retain → None:

- \`base-apps/crossplane-compositions/composition-application.yaml\`: lines 102 + 172 (both helpers)
- \`tests/composition/expected-xr-with-db.yaml\`: line 299
- \`tests/composition/expected-xr-with-s3.yaml\`: line 216

## Test plan
- [x] All three render-test cases pass (xr-minimal, xr-with-db, xr-with-s3)
- [ ] After merge, \`smoke-v15\` XApplication will self-heal (Crossplane re-applies the corrected PushSecrets)
- [ ] Companion Backstage PR updates the decommission scaffolder's PR body text from \"Delete → Retain\" to \"Delete → None\" (linked separately)

## Why this slipped past v1.5 review
The render-test goldens accept any string for \`deletionPolicy\`; they don't validate against the CRD enum. The 2-stage subagent review checked spec compliance (which said \"Retain\") and code quality (no typos) but neither verifier had ESO v0.11.0 API knowledge to flag the wrong enum value. **Follow-up:** v1.6+ should add a \`kubectl apply --dry-run=server\` check in the render-test harness to catch CRD-level schema violations in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)