### PR TITLE
docs(idp): v1.5 design spec + implementation plan + close-out run notes

### DIFF
--- a/docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md
+++ b/docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md
@@ -1419,11 +1419,7 @@ Single-repo iteration (arigsela/backstage only). No parallel subagent split need
 
 **v1.5+ follow-up candidates** (refined from earlier):
 
-- **v1.5 — PushSecret + SecretStore deletion ordering** (NEW — discovered in v1.4.1):
-  - Option A: add ArgoCD `sync-wave` annotation on the per-app Application that orders ESO resource deletion. SecretStore wave `+10`; PushSecret wave `0`. On teardown, ArgoCD prunes in reverse-wave order → PushSecret deletes first, can still reach Vault, then SecretStore deletes.
-  - Option B: add a Crossplane finalizer to SecretStore that holds it until no PushSecret references it. Complex; requires custom controller.
-  - Option C: accept the current behavior, document the orphaned Vault entry as expected, and add `vault kv delete` to the decommission action OR a post-teardown step.
-  - **Likely Option A** — minimal change, leverages existing ArgoCD mechanism.
+- **v1.5 — PushSecret + SecretStore deletion ordering** — **RESOLVED in v1.5 + v1.5.1 + v1.5.2 (merged 2026-05-12).** During brainstorming we chose Option D (not listed above): flip `PushSecret.spec.deletionPolicy` from `Delete` → `None` so PushSecret deletion is a pure CR removal with no Vault call and no SecretStore dependency. Sync-wave annotations (Option A as originally drafted) turned out to be inapplicable — ArgoCD doesn't track composition-emitted resources during cascade, so wave ordering wouldn't fire for them. Option D is cleaner and works at the right layer (ESO API). Vault entries orphan after teardown; manual `vault kv delete` commands are enumerated in the decommission scaffolder PR body. PRs: arigsela/kubernetes#255 (initial v1.5 — wrong `Retain` enum), arigsela/kubernetes#257 (v1.5.1 — corrected to `None`), arigsela/backstage#16/#17 (Backstage PR body update + v1.5.1 sync), arigsela/backstage#18 (v1.5.2 — corrected DB Vault path `db-creds` → `db`). Smoke validation against `smoke-v15` showed zero `could not get SecretStore` events during teardown cascade.
 - **v1.5 — Source-code repo creation in scaffolder** (carried forward from v1.4 close-out — the big remaining v2-original-candidate)
 - **v1.6+ — Tests for existing custom actions** (vault:setup, aws:ecr:create, etc.) — v1.4.1 set the pattern via Q3=B; backfill the others
 - **v1.6+ — More AWS resource types** (SQS, SNS, RDS) via Option B pattern

--- a/docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md
+++ b/docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md
@@ -1,0 +1,1065 @@
+# IDP v1.5 — PushSecret `deletionPolicy: Retain` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flip `PushSecret.spec.deletionPolicy` from `Delete` to `Retain` for both Composition-emitted PushSecrets (DB-creds and AWS-creds) so the v1.4.1-surfaced teardown race disappears; update the Backstage decommission scaffolder PR body to enumerate the manual `vault kv delete` commands operators must run post-teardown.
+
+**Architecture:** Two-line change in the Crossplane Composition Python (`composition-application.yaml` lines 102 + 172) gated by TDD against render-test goldens. One string update in the Backstage custom decommission action's `buildPrBody` function, gated by TDD against the existing Jest test suite. Two separate PRs ship in sequence. Smoke validation against a fresh `smoke-v15` app proves the bug is fixed.
+
+**Tech Stack:**
+- Crossplane v2 + function-python (in-cluster Composition rendering)
+- External Secrets Operator (PushSecret + SecretStore + ExternalSecret) with `deletionPolicy` field
+- `crossplane render` CLI + `yq` + bash for render-test harness (`tests/composition/render.sh`)
+- Backstage scaffolder custom action (TypeScript + Jest + Octokit REST API)
+- ArgoCD for GitOps + master-app pattern
+- HashiCorp Vault (KV v2 at `k8s-secrets/` path) for credential storage
+
+**Spec:** `docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md` (commit `bea83a6` on branch `docs/idp-v1.5-spec`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change Type |
+|---|---|---|
+| `base-apps/crossplane-compositions/composition-application.yaml` | Crossplane Composition Python; emits SecretStore + PushSecret + ExternalSecret + AWS resources | Modify (2 lines: 102 + 172) |
+| `tests/composition/expected-xr-with-db.yaml` | Render-test golden for `dbNeeded: true` case | Modify (1 line: 299) |
+| `tests/composition/expected-xr-with-s3.yaml` | Render-test golden for `s3Needed: true` case | Modify (1 line: 216) |
+| `tests/composition/expected-xr-minimal.yaml` | Render-test golden for minimal XR (no PushSecret emitted) | No change (regression-protected by re-run) |
+| `arigsela/backstage:packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts` | Custom scaffolder action; `buildPrBody` returns the PR body string | Modify (`buildPrBody` body content + footer version bump) |
+| `arigsela/backstage:packages/backend/src/modules/scaffolder/decommissionPullRequestAction.test.ts` | Jest unit tests for the action | Modify (add body-content assertion to happy_path test) |
+| `docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md` | This iteration's spec | No change — already committed |
+| `docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md` | This plan (you are reading it) | Modify post-implementation (run notes) |
+| `docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md` | v1.4.1 close-out doc | Modify post-smoke (mark the v1.5 follow-up resolved) |
+
+---
+
+## Pre-flight Checks
+
+### Task 0.1: Verify v1.4.1 close-out PR merged
+
+- [ ] **Step 1: Check PR #251 state**
+
+Run: `gh pr view 251 --repo arigsela/kubernetes --json state,mergedAt`
+
+Expected: `"state": "MERGED"` with a non-null `mergedAt` timestamp.
+
+If NOT merged: STOP — coordinate with the user. v1.5 builds on v1.4.1's close-out (spec + plan + run notes); shipping v1.5 against an unmerged v1.4.1 would create a confusing PR stack.
+
+- [ ] **Step 2: Pull latest main**
+
+Run from `/Users/arisela/git/kubernetes`:
+```bash
+git checkout main
+git pull origin main
+```
+
+Expected: working tree clean, HEAD now reflects v1.4.1's merge commit.
+
+### Task 0.2: Verify smoke-v141 fully cleaned up
+
+- [ ] **Step 1: Confirm no smoke-v141 resources exist**
+
+Run:
+```bash
+kubectl get namespace smoke-v141 2>&1 | head -3
+kubectl get application -n argo-cd smoke-v141 2>&1 | head -3
+```
+
+Expected: both return `not found` (NotFound). If the namespace still exists from v1.4.1 validation, run `kubectl delete namespace smoke-v141` and wait for it to clear. We need a clean cluster baseline so v1.5's smoke run isn't conflated with v1.4.1 residue.
+
+### Task 0.3: Verify `crossplane` CLI available
+
+- [ ] **Step 1: Check crossplane CLI**
+
+Run: `crossplane version`
+
+Expected: any version output. The `tests/composition/render.sh` script invokes `crossplane render`; if the CLI isn't installed locally, install it per https://docs.crossplane.io/latest/cli/ before proceeding.
+
+- [ ] **Step 2: Verify yq available**
+
+Run: `yq --version`
+
+Expected: any version output. `render.sh` uses `yq` for golden normalization.
+
+### Task 0.4: Verify Backstage repo state
+
+- [ ] **Step 1: Confirm Backstage repo is on main**
+
+Run from `/Users/arisela/git/backstage`:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5
+```
+
+Expected: latest commit is the v1.4.1 decommission action merge.
+
+---
+
+## Phase 1: Kubernetes Composition — TDD + PR
+
+This phase ships the actual bug fix: flip `deletionPolicy` for both PushSecrets in the Composition Python, gated by render-test goldens.
+
+### Task 1.1: Create v1.5 implementation branch
+
+**Files:** none modified; new branch.
+
+- [ ] **Step 1: Create branch from main**
+
+Run from `/Users/arisela/git/kubernetes`:
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/idp-v1.5-pushsecret-retain
+```
+
+Expected: `Switched to a new branch 'feat/idp-v1.5-pushsecret-retain'`.
+
+### Task 1.2: Update DB-creds golden (TDD step 1 — write the failing expectation)
+
+**Files:**
+- Modify: `tests/composition/expected-xr-with-db.yaml:299`
+
+- [ ] **Step 1: Flip line 299**
+
+In `tests/composition/expected-xr-with-db.yaml`, change line 299:
+
+```yaml
+# Before
+  deletionPolicy: Delete
+
+# After
+  deletionPolicy: Retain
+```
+
+Use the `Edit` tool with `old_string: "  deletionPolicy: Delete\n  refreshInterval: 5m"` (the surrounding context disambiguates the line — both PushSecret and other fields exist in the golden, but this exact 2-line pair is unique to the PushSecret).
+
+### Task 1.3: Update AWS-creds golden (TDD step 1 — write the failing expectation, part 2)
+
+**Files:**
+- Modify: `tests/composition/expected-xr-with-s3.yaml:216`
+
+- [ ] **Step 1: Flip line 216**
+
+In `tests/composition/expected-xr-with-s3.yaml`, change line 216:
+
+```yaml
+# Before
+  deletionPolicy: Delete
+
+# After
+  deletionPolicy: Retain
+```
+
+Use the `Edit` tool with `old_string: "  deletionPolicy: Delete\n  refreshInterval: 5m"` (same disambiguation pattern as Task 1.2; the AWS-creds PushSecret in this golden has the same 2-line pair structure).
+
+### Task 1.4: Run render tests — expect FAIL (TDD: confirm test detects the bug)
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run DB case — expect diff**
+
+Run from `/Users/arisela/git/kubernetes`:
+```bash
+./tests/composition/render.sh xr-with-db
+```
+
+Expected: NON-ZERO exit code. The diff should show:
+```
+<   deletionPolicy: Delete
+---
+>   deletionPolicy: Retain
+```
+on a line in the PushSecret block. (The `<` side is the actual Composition rendering, the `>` side is the golden.) This proves the golden change "sees" the Composition still emitting `Delete`.
+
+- [ ] **Step 2: Run S3 case — expect diff**
+
+Run:
+```bash
+./tests/composition/render.sh xr-with-s3
+```
+
+Expected: NON-ZERO exit code. Same kind of diff as Step 1, in the AWS-creds PushSecret block.
+
+- [ ] **Step 3: Run minimal case — expect PASS**
+
+Run:
+```bash
+./tests/composition/render.sh xr-minimal
+```
+
+Expected: exit code 0 (no diff). This case doesn't emit a PushSecret, so it must remain green throughout — proves we didn't accidentally break anything unrelated.
+
+If Step 1 or Step 2 passes (exit 0): the goldens were already on `Retain` somehow OR the test harness isn't running. Investigate before proceeding — Phase 1 cannot make a meaningful TDD claim without seeing the FAIL.
+
+### Task 1.5: Update Composition Python — make_push_secret (TDD step 3 — minimal implementation)
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml:102`
+
+- [ ] **Step 1: Flip line 102**
+
+Use `Edit` tool with the following surrounding context (the helper function name uniquely identifies the location):
+
+```python
+# Before
+          def make_push_secret(name, namespace, annotations):
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-db-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+
+# After
+          def make_push_secret(name, namespace, annotations):
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-db-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Retain",
+```
+
+The unique `f"{name}-db-push"` name + 11-line context window disambiguates this from `make_aws_push_secret`.
+
+### Task 1.6: Update Composition Python — make_aws_push_secret (TDD step 3 — minimal implementation, part 2)
+
+**Files:**
+- Modify: `base-apps/crossplane-compositions/composition-application.yaml:172`
+
+- [ ] **Step 1: Flip line 172**
+
+Use `Edit` tool with the following surrounding context (the `aws-push` name and the docstring disambiguate from `make_push_secret`):
+
+```python
+# Before
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Delete",
+
+# After
+          def make_aws_push_secret(name, namespace, annotations):
+              """Pushes 2 keys (id + secret) from <name>-aws-key (AccessKey-generated)
+              to Vault path k8s-secrets/<namespace>/aws-creds with key remap to
+              AWS SDK convention (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."""
+              return {
+                  "apiVersion": "external-secrets.io/v1alpha1",
+                  "kind": "PushSecret",
+                  "metadata": {
+                      "name": f"{name}-aws-push",
+                      "namespace": namespace,
+                      "labels": std_labels(name),
+                      "annotations": annotations,
+                  },
+                  "spec": {
+                      "refreshInterval": "5m",
+                      "deletionPolicy": "Retain",
+```
+
+### Task 1.7: Re-run render tests — expect PASS (TDD step 4)
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run all three cases**
+
+Run from `/Users/arisela/git/kubernetes`:
+```bash
+./tests/composition/render.sh xr-with-db && \
+./tests/composition/render.sh xr-with-s3 && \
+./tests/composition/render.sh xr-minimal && \
+echo "ALL THREE PASS"
+```
+
+Expected output ends with `ALL THREE PASS`. Exit code 0.
+
+If any case fails (diff present): the Composition emission doesn't match the golden. Inspect the diff — likely indicates a typo (e.g., `Retains` instead of `Retain`, or `retain` lowercase). Fix the Composition Python and re-run.
+
+### Task 1.8: Commit the kubernetes change
+
+**Files:** none additional.
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add base-apps/crossplane-compositions/composition-application.yaml \
+        tests/composition/expected-xr-with-db.yaml \
+        tests/composition/expected-xr-with-s3.yaml
+
+git commit -m "$(cat <<'EOF'
+fix(crossplane): set PushSecret deletionPolicy to Retain (v1.5)
+
+Fixes the v1.4.1-surfaced teardown race where SecretStore deletes
+before PushSecret's deletionPolicy:Delete can fire its Vault cleanup
+call. Both Composition-emitted PushSecrets (DB-creds via make_push_secret
+and AWS-creds via make_aws_push_secret) now use deletionPolicy:Retain,
+making PushSecret deletion a pure CR removal with no SecretStore
+dependency.
+
+Trade-off accepted: Vault entries at k8s-secrets/<app>/db-creds and
+/aws-creds orphan after teardown. The Backstage decommission scaffolder
+PR body (updated in a separate Backstage PR) enumerates the explicit
+'vault kv delete' commands operators must run post-teardown.
+
+Render-test goldens (expected-xr-with-db.yaml + expected-xr-with-s3.yaml)
+updated to reflect the new policy; xr-minimal unchanged.
+
+Spec: docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md
+Plan: docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds, working tree clean.
+
+### Task 1.9: Push branch and open PR
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/idp-v1.5-pushsecret-retain
+```
+
+Expected: `Branch 'feat/idp-v1.5-pushsecret-retain' set up to track 'origin/feat/idp-v1.5-pushsecret-retain'`.
+
+- [ ] **Step 2: Open PR**
+
+Run:
+```bash
+gh pr create \
+  --repo arigsela/kubernetes \
+  --base main \
+  --head feat/idp-v1.5-pushsecret-retain \
+  --title "fix(crossplane): PushSecret deletionPolicy Delete → Retain (v1.5 teardown race fix)" \
+  --body "$(cat <<'EOF'
+## Summary
+Fixes the teardown race surfaced during v1.4.1 smoke validation. SecretStore deletion was beating PushSecret's `deletionPolicy: Delete` cleanup call, leaving PushSecret stuck and the per-app Application unable to finalize.
+
+Both Composition-emitted PushSecrets (`make_push_secret` for DB-creds, `make_aws_push_secret` for AWS-creds) now use `deletionPolicy: Retain`. PushSecret deletion is a pure CR removal — no SecretStore dependency, no race.
+
+## Trade-off
+Vault entries at `k8s-secrets/<app>/db-creds` and `k8s-secrets/<app>/aws-creds` orphan after teardown. The Backstage decommission scaffolder PR body will be updated (separate PR in arigsela/backstage) to enumerate the explicit `vault kv delete` commands operators must run post-teardown.
+
+## Test plan
+- [x] Render-test goldens updated FIRST (TDD): `expected-xr-with-db.yaml:299` and `expected-xr-with-s3.yaml:216`
+- [x] `./tests/composition/render.sh xr-with-db` and `xr-with-s3` failed BEFORE the Composition change (proved goldens detected the bug)
+- [x] Composition Python updated: `composition-application.yaml:102` (DB) + `:172` (AWS)
+- [x] All three render cases pass AFTER the change (xr-minimal, xr-with-db, xr-with-s3)
+- [ ] Smoke validation via `smoke-v15` (deferred to post-merge; depends on the matching backstage PR for the new cleanup PR body)
+
+## Spec / Plan
+- Spec: `docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md`
+- Plan: `docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Capture the PR number — you'll reference it later.
+
+---
+
+## Phase 2: USER GATE — Merge Kubernetes PR
+
+### Task 2.1: USER merges the kubernetes PR
+
+- [ ] **Step 1: USER ACTION — Review and merge the PR opened in Task 1.9.**
+
+After merge:
+- ArgoCD reconciles `base-apps/crossplane-compositions/` and picks up the updated Composition.
+- function-python hot-loads the new Composition (no image rebuild required for the Composition Python — Crossplane's function-python reads YAML on every reconciliation).
+- The change is now live: any subsequent XR rendering emits `deletionPolicy: Retain`.
+
+- [ ] **Step 2: Verify Composition is live**
+
+After the user confirms merge:
+```bash
+kubectl get composition application -o yaml | grep -A1 "deletionPolicy"
+```
+
+Expected: at least two `deletionPolicy: "Retain"` matches (both in the Python script field).
+
+Note: `deletionPolicy` here is INSIDE the Composition's Python source field, so it'll be a string match within a multi-line Python block. Both `make_push_secret` and `make_aws_push_secret` should now show `Retain`.
+
+---
+
+## Phase 3: Backstage Decommission Action — TDD + PR
+
+This phase updates the PR body the v1.4.1 custom scaffolder action renders, adding the manual Vault cleanup instructions.
+
+### Task 3.1: Create Backstage feature branch
+
+**Files:** none modified; new branch.
+
+- [ ] **Step 1: Create branch from main**
+
+Run from `/Users/arisela/git/backstage`:
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/idp-v1.5-cleanup-pr-body
+```
+
+Expected: `Switched to a new branch 'feat/idp-v1.5-cleanup-pr-body'`.
+
+### Task 3.2: Add body-content assertion to happy_path test (TDD step 1)
+
+**Files:**
+- Modify: `packages/backend/src/modules/scaffolder/decommissionPullRequestAction.test.ts:124-128` (extend the existing `pulls.create` assertion)
+
+- [ ] **Step 1: Extend happy_path assertion**
+
+In `decommissionPullRequestAction.test.ts`, find the existing assertion in the `happy_path` test (around line 124-128):
+
+```typescript
+    expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
+      head: 'chore/teardown-smoke-v141',
+      base: 'main',
+      title: 'chore: tear down smoke-v141 (decommission)',
+    }));
+```
+
+Add a body-content assertion immediately after this block (insert as new lines, do not modify the existing assertion):
+
+```typescript
+    // v1.5: assert PR body includes Manual Vault cleanup section with the
+    // two specific `vault kv delete` commands operators run post-teardown.
+    expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Manual Vault cleanup (v1.5)'),
+    }));
+    expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('vault kv delete k8s-secrets/smoke-v141/db-creds'),
+    }));
+    expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('vault kv delete k8s-secrets/smoke-v141/aws-creds'),
+    }));
+```
+
+Three separate `expect` calls (each asserting `stringContaining`) keeps the failure messages crystal clear — if the section heading is missing vs. just one of the commands, the failure points to the specific string that wasn't found.
+
+Use the `Edit` tool with `old_string` covering the full existing happy_path `pulls.create` assertion + the next line break.
+
+### Task 3.3: Run Backstage tests — expect FAIL (TDD step 2)
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the scaffolder test file**
+
+Run from `/Users/arisela/git/backstage`:
+```bash
+yarn workspace backend test --testPathPattern=decommissionPullRequestAction 2>&1 | tail -30
+```
+
+Expected: FAIL on the happy_path test with a message like `Expected substring: "Manual Vault cleanup (v1.5)"` followed by the actual body string (the current v1.4.1 body, which doesn't have the section). All other tests should still pass.
+
+If the test passes: the body already contains the new section somehow — verify the current `buildPrBody` function and confirm.
+
+### Task 3.4: Update `buildPrBody` (TDD step 3 — minimal implementation)
+
+**Files:**
+- Modify: `packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts:41-56` (the entire `buildPrBody` function)
+
+- [ ] **Step 1: Replace `buildPrBody` body content**
+
+The current function (line 41):
+
+```typescript
+function buildPrBody(name: string): string {
+  return [
+    `Decommissioning ${name}. After merge:`,
+    '',
+    '1. master-app prunes the per-app Application within ~30s.',
+    '2. The v1.4 finalizer (resources-finalizer.argocd.argoproj.io)',
+    '   cascades deletion of all managed resources (cluster-scoped AWS +',
+    '   namespaced ESO config + composed app resources).',
+    '3. Wait ~60-90s for AWS-side resources to fully unwind.',
+    '4. Run `kubectl delete namespace ' + name + '` for the last manual',
+    '   cleanup step.',
+    '',
+    'Generated by Backstage `decommission-application` template (v1.4.1',
+    'with custom scaffolder action).',
+  ].join('\n');
+}
+```
+
+Replace with:
+
+```typescript
+function buildPrBody(name: string): string {
+  return [
+    `Decommissioning ${name}. After merge:`,
+    '',
+    '1. master-app prunes the per-app Application within ~30s.',
+    '2. The v1.4 finalizer (resources-finalizer.argocd.argoproj.io)',
+    '   cascades deletion of all managed resources (cluster-scoped AWS +',
+    '   namespaced ESO config + composed app resources).',
+    '3. Wait ~60-90s for AWS-side resources to fully unwind.',
+    '4. Run `kubectl delete namespace ' + name + '` for the last manual',
+    '   cleanup step.',
+    '',
+    '## Manual Vault cleanup (v1.5)',
+    '',
+    'PushSecret entries in Vault are NOT auto-deleted (v1.5 changed',
+    'deletionPolicy: Delete → Retain to fix a teardown race). After',
+    'namespace deletion, run:',
+    '',
+    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db-creds',
+    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/aws-creds',
+    '',
+    'Skip whichever entry does not exist (an app without dbNeeded won\'t',
+    'have db-creds; an app without s3Needed won\'t have aws-creds).',
+    '',
+    'Generated by Backstage `decommission-application` template (v1.5',
+    'with custom scaffolder action).',
+  ].join('\n');
+}
+```
+
+Three substantive edits:
+1. New `## Manual Vault cleanup (v1.5)` heading + paragraph + two `vault kv delete` commands (templated with `name`)
+2. Skip-clause sentence (handles apps without DB or without S3)
+3. Footer version bump: `(v1.4.1` → `(v1.5`
+
+The two `vault kv delete` lines use string concatenation with `name` so the test assertion `stringContaining('vault kv delete k8s-secrets/smoke-v141/db-creds')` matches against the rendered template.
+
+Use the `Edit` tool with `old_string` covering the entire current function (from `function buildPrBody(name: string): string {` through the closing `}`).
+
+### Task 3.5: Re-run Backstage tests — expect PASS (TDD step 4)
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the scaffolder test file**
+
+Run from `/Users/arisela/git/backstage`:
+```bash
+yarn workspace backend test --testPathPattern=decommissionPullRequestAction 2>&1 | tail -30
+```
+
+Expected: PASS for all 7 happy_path + edge-case tests. The output should include `Tests:       7 passed, 7 total`.
+
+If any test fails: inspect the failure. Likely culprits:
+- Typo in `buildPrBody` (e.g., `Manual Vault Cleanup` instead of `Manual Vault cleanup` — case-sensitive)
+- Wrong `name` interpolation (`${name}` vs concatenation)
+- Other unrelated tests broken by accident — re-read the diff
+
+### Task 3.6: Commit the Backstage change
+
+**Files:** none additional.
+
+- [ ] **Step 1: Stage and commit**
+
+Run from `/Users/arisela/git/backstage`:
+```bash
+git add packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts \
+        packages/backend/src/modules/scaffolder/decommissionPullRequestAction.test.ts
+
+git commit -m "$(cat <<'EOF'
+feat(scaffolder): add Manual Vault cleanup section to teardown PR body (v1.5)
+
+v1.5 flipped PushSecret deletionPolicy from Delete to Retain in the
+Crossplane Composition to fix a teardown race. The trade-off is that
+Vault KV entries at k8s-secrets/<app>/{db-creds,aws-creds} orphan
+after teardown and require manual cleanup.
+
+This PR updates the decommission scaffolder action's PR body to
+enumerate the two specific 'vault kv delete' commands operators must
+run post-teardown. Both commands are listed unconditionally; operator
+skips whichever path doesn't exist.
+
+Test: happy_path now asserts on body content (3 substring checks for
+section heading + both vault kv delete commands). All 7 unit tests
+pass.
+
+Spec: arigsela/kubernetes:docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds, working tree clean.
+
+### Task 3.7: Push branch and open PR
+
+**Files:** none modified.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/idp-v1.5-cleanup-pr-body
+```
+
+- [ ] **Step 2: Open PR**
+
+Run:
+```bash
+gh pr create \
+  --repo arigsela/backstage \
+  --base main \
+  --head feat/idp-v1.5-cleanup-pr-body \
+  --title "feat(scaffolder): add Manual Vault cleanup section to teardown PR body (v1.5)" \
+  --body "$(cat <<'EOF'
+## Summary
+Companion PR to arigsela/kubernetes v1.5 (PushSecret `deletionPolicy: Retain` for the teardown race fix).
+
+With `Retain`, Vault KV entries at `k8s-secrets/<app>/{db-creds,aws-creds}` orphan after teardown. The decommission scaffolder action's PR body now enumerates both `vault kv delete` commands explicitly so operators have a copy-pasteable cleanup step.
+
+## Test plan
+- [x] Body-content assertion added FIRST to happy_path test (TDD): `expect.stringContaining('Manual Vault cleanup (v1.5)')` + both `vault kv delete` commands
+- [x] Test FAILED against current `buildPrBody` (proved the assertion detects the missing section)
+- [x] `buildPrBody` updated with new section + footer version bump v1.4.1 → v1.5
+- [x] All 7 unit tests pass after update
+- [ ] Smoke validation via `smoke-v15` after image rebuild (Phase 5 of the kubernetes plan)
+
+## Spec / Plan
+- Spec: arigsela/kubernetes:`docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md`
+- Plan: arigsela/kubernetes:`docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Capture the PR number.
+
+---
+
+## Phase 4: USER GATE — Merge Backstage PR + Rebuild Image
+
+### Task 4.1: USER merges the Backstage PR
+
+- [ ] **Step 1: USER ACTION — Review and merge the PR from Task 3.7.**
+
+### Task 4.2: USER rebuilds Backstage image + redeploys
+
+- [ ] **Step 1: USER ACTION — Per `/Users/arisela/.claude/CLAUDE.md` ("I will handle running the builds of images"), rebuild the Backstage container image with the new merge and redeploy the Pod.**
+
+This is required because the `buildPrBody` change is baked into the compiled TypeScript that ships in the image. Composition Python is hot-reloaded by Crossplane; Backstage code is NOT.
+
+- [ ] **Step 2: Verify the new code is live**
+
+After user confirms image rebuild + Pod restart:
+```bash
+kubectl get pods -n backstage -o jsonpath='{.items[*].spec.containers[*].image}' | tr ' ' '\n'
+kubectl logs -n backstage deployment/backstage 2>&1 | grep -i "decommission" | head -5
+```
+
+Expected:
+- Pod image tag matches the freshly-rebuilt tag
+- Logs show `crossplane:teardown:open-decommission-pr` action registered at startup
+
+---
+
+## Phase 5: Smoke Validation (`smoke-v15`)
+
+This phase proves the bug is fixed by deploying a real app with both DB and S3 enabled, tearing it down, and verifying the cascade is clean (no `could not get SecretStore` events, per-app Application finalizes, Vault entries STILL EXIST because `Retain` worked).
+
+### Task 5.1: Scaffold smoke-v15
+
+- [ ] **Step 1: USER ACTION — Submit Backstage `application` template form**
+
+In the Backstage UI:
+- Template: `Application (Crossplane)`
+- Name: `smoke-v15`
+- `dbNeeded`: `true`
+- `s3Needed`: `true`
+- Other fields: defaults
+
+Submit and wait for the scaffolder PR to be opened in `arigsela/kubernetes`. Merge it.
+
+- [ ] **Step 2: Wait for ArgoCD to sync the new app**
+
+Run:
+```bash
+kubectl wait --for=condition=Healthy application/smoke-v15 -n argo-cd --timeout=300s
+```
+
+Expected: `application.argoproj.io/smoke-v15 condition met` within 5 minutes.
+
+- [ ] **Step 3: Verify all expected resources exist**
+
+Run:
+```bash
+kubectl get pushsecret,secretstore,externalsecret -n smoke-v15
+```
+
+Expected:
+- 1 SecretStore named `vault-backend`
+- 2 PushSecrets (`smoke-v15-db-push` for DB-creds, `smoke-v15-aws-push` for AWS-creds)
+- 2 ExternalSecrets (one for DB, one for AWS-creds consumption — depending on Composition emission; verify with the spec's expected output)
+
+- [ ] **Step 4: Verify the `Retain` deletionPolicy is live on both PushSecrets**
+
+Run:
+```bash
+kubectl get pushsecret -n smoke-v15 -o yaml | grep -A1 "name:.*-push" | grep deletionPolicy
+```
+
+Expected: TWO matches, both showing `deletionPolicy: Retain`. If any show `Delete`, the Composition merge from Phase 2 didn't propagate — re-check ArgoCD sync state for `crossplane-compositions`.
+
+### Task 5.2: Verify Vault entries created
+
+- [ ] **Step 1: Check db-creds entry**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv get -field=password k8s-secrets/smoke-v15/db-creds 2>&1 | head -5
+```
+
+Expected: a non-empty string (the auto-generated DB password).
+
+- [ ] **Step 2: Check aws-creds entry**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv get -field=AWS_ACCESS_KEY_ID k8s-secrets/smoke-v15/aws-creds 2>&1 | head -5
+```
+
+Expected: a non-empty AWS access key ID (starts with `AKIA`).
+
+If either fails: the PushSecret hasn't reached the remote yet (5m refresh interval). Wait 5 minutes and retry. If it still fails, inspect `kubectl describe pushsecret -n smoke-v15` for errors.
+
+### Task 5.3: Open teardown PR via Backstage
+
+- [ ] **Step 1: USER ACTION — Submit Backstage `decommission-application` template**
+
+In the Backstage UI:
+- Template: `Decommission Application (Crossplane)`
+- Application name to tear down: `smoke-v15`
+
+Submit. The custom action opens a teardown PR in `arigsela/kubernetes`.
+
+- [ ] **Step 2: Verify the teardown PR body**
+
+Open the PR in the browser (or `gh pr view <number>`) and confirm the body contains:
+- The original "Decommissioning smoke-v15..." preamble (v1.4.1 content)
+- The new `## Manual Vault cleanup (v1.5)` section
+- The two literal commands:
+  - `kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/smoke-v15/db-creds`
+  - `kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/smoke-v15/aws-creds`
+- Footer: `(v1.5 with custom scaffolder action).`
+
+If the body doesn't include the new section: the new Backstage image isn't actually serving — re-verify Phase 4 Step 2.
+
+### Task 5.4: Start collecting evidence — pre-merge baseline
+
+- [ ] **Step 1: Capture pre-teardown state**
+
+Run (output goes to a file for later attachment to close-out):
+```bash
+mkdir -p /tmp/v1.5-smoke-evidence
+kubectl get application smoke-v15 -n argo-cd -o yaml > /tmp/v1.5-smoke-evidence/01-app-before-merge.yaml
+kubectl get pushsecret,secretstore -n smoke-v15 -o yaml > /tmp/v1.5-smoke-evidence/02-eso-before-merge.yaml
+kubectl get events -n smoke-v15 --sort-by='.lastTimestamp' > /tmp/v1.5-smoke-evidence/03-events-before-merge.txt
+```
+
+Expected: three files written. Application should be `Healthy/Synced`.
+
+### Task 5.5: Merge teardown PR + watch cascade
+
+- [ ] **Step 1: USER ACTION — Merge the teardown PR**
+
+After merge, master-app prunes the per-app Application within ~30s.
+
+- [ ] **Step 2: Watch the cascade in real time**
+
+Run (in a separate terminal — this is a foreground watch):
+```bash
+kubectl get pushsecret,secretstore,externalsecret,application -A | grep smoke-v15
+```
+
+Run this every ~15s. Expected progression:
+- T+0s: all resources present
+- T+15-30s: per-app Application enters `Deleting` state (finalizer holding)
+- T+30-60s: ESO resources start disappearing
+- T+60-90s: all ESO resources gone, Application finalizer completes, Application gone
+- T+90-120s: namespace `smoke-v15` still present (it isn't auto-deleted — explicit final step)
+
+- [ ] **Step 3: Capture cascade-time events**
+
+Run:
+```bash
+kubectl get events -n smoke-v15 --sort-by='.lastTimestamp' > /tmp/v1.5-smoke-evidence/04-events-during-cascade.txt
+```
+
+Expected: NO events with the string `could not get SecretStore`. If present, the bug is NOT fixed — investigate.
+
+```bash
+grep -i "could not get SecretStore" /tmp/v1.5-smoke-evidence/04-events-during-cascade.txt | wc -l
+```
+
+Expected output: `0`.
+
+### Task 5.6: Verify clean teardown
+
+- [ ] **Step 1: Confirm Application gone**
+
+Run:
+```bash
+kubectl get application smoke-v15 -n argo-cd 2>&1 | head -3
+```
+
+Expected: `Error from server (NotFound): applications.argoproj.io "smoke-v15" not found`.
+
+- [ ] **Step 2: Confirm ESO resources gone**
+
+Run:
+```bash
+kubectl get pushsecret,secretstore,externalsecret -n smoke-v15 2>&1 | head -3
+```
+
+Expected: `No resources found in smoke-v15 namespace.`
+
+- [ ] **Step 3: Confirm cluster-scoped AWS resources gone**
+
+Run:
+```bash
+kubectl get bucket,user,policy -A | grep smoke-v15
+```
+
+Expected: empty output (no matches). All v1.4 cluster-scoped AWS resources (bucket, IAM user, IAM policy, bucket-public-access-block, lifecycle config, etc.) have cascaded.
+
+### Task 5.7: Verify Vault entries STILL EXIST (proves `Retain` worked)
+
+- [ ] **Step 1: Check db-creds still in Vault**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/db-creds 2>&1 | head -10
+```
+
+Expected: Vault returns the entry's contents (the DB credentials). If Vault returns `No value found at k8s-secrets/data/smoke-v15/db-creds`, the entry was deleted — meaning `Retain` did NOT take effect. CRITICAL FAILURE: the Composition merge didn't propagate or the wrong line was changed.
+
+- [ ] **Step 2: Check aws-creds still in Vault**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/aws-creds 2>&1 | head -10
+```
+
+Expected: Vault returns the entry's contents (AWS access key + secret).
+
+### Task 5.8: Run the documented `vault kv delete` cleanup
+
+- [ ] **Step 1: Delete db-creds**
+
+Run (this is exactly the command from the PR body):
+```bash
+kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/smoke-v15/db-creds
+```
+
+Expected: `Success! Data deleted (if it existed) at: k8s-secrets/data/smoke-v15/db-creds`.
+
+- [ ] **Step 2: Delete aws-creds**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/smoke-v15/aws-creds
+```
+
+Expected: `Success! Data deleted (if it existed) at: k8s-secrets/data/smoke-v15/aws-creds`.
+
+- [ ] **Step 3: Verify both entries are gone**
+
+Run:
+```bash
+kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/db-creds 2>&1 | head -3
+kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/aws-creds 2>&1 | head -3
+```
+
+Expected: both output `No value found at k8s-secrets/data/smoke-v15/db-creds` (and `/aws-creds`).
+
+### Task 5.9: Final namespace cleanup
+
+- [ ] **Step 1: Delete the smoke-v15 namespace**
+
+Run:
+```bash
+kubectl delete namespace smoke-v15
+```
+
+Expected: completes within ~30s. If it hangs, there are residual finalizers — `kubectl get all,pushsecret,secretstore,externalsecret -n smoke-v15` and address.
+
+- [ ] **Step 2: Verify namespace gone**
+
+Run:
+```bash
+kubectl get namespace smoke-v15 2>&1 | head -3
+```
+
+Expected: `Error from server (NotFound): namespaces "smoke-v15" not found`.
+
+### Task 5.10: Acceptance criteria check
+
+Map each AC from the spec to evidence:
+
+- [ ] **AC-1:** `composition-application.yaml` `make_push_secret` emits `"deletionPolicy": "Retain"` → verified via Task 1.7 (xr-with-db case passes against `Retain` golden)
+- [ ] **AC-2:** `composition-application.yaml` `make_aws_push_secret` emits `"deletionPolicy": "Retain"` → verified via Task 1.7 (xr-with-s3 case passes)
+- [ ] **AC-3:** Goldens reflect `Retain` → verified via Tasks 1.2 + 1.3
+- [ ] **AC-4:** All three render cases pass → verified via Task 1.7
+- [ ] **AC-5:** Smoke teardown shows zero `could not get SecretStore` events → verified via Task 5.5 Step 3 (grep returns 0)
+- [ ] **AC-6:** Per-app Application reaches NotFound within ~90s → verified via Task 5.6 Step 1
+- [ ] **AC-7:** Teardown PR body includes "Manual Vault cleanup (v1.5)" section + both commands → verified via Task 5.3 Step 2
+- [ ] **AC-8:** Operator `vault kv delete` succeeds + follow-up gets return NotFound → verified via Task 5.8 Steps 1-3
+
+If any AC is unmet: document the gap in the close-out and decide whether to (a) fix and re-validate or (b) ship as-is with a follow-up note.
+
+---
+
+## Phase 6: Run-Notes Close-Out
+
+### Task 6.1: Append run notes to this plan
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md` (this file)
+
+- [ ] **Step 1: Append a "Run Notes" section at the end**
+
+Append to the bottom of this plan file:
+
+```markdown
+---
+
+## Run Notes (post-implementation)
+
+**Implemented:** YYYY-MM-DD by Ari Sela (subagent-driven execution).
+
+**PRs:**
+- kubernetes: arigsela/kubernetes#NNN (merged YYYY-MM-DD)
+- backstage: arigsela/backstage#NNN (merged YYYY-MM-DD)
+
+**Smoke validation:** smoke-v15 deployed YYYY-MM-DD; teardown PR #NNN merged YYYY-MM-DD; clean cascade observed (zero `could not get SecretStore` events). Vault entries retained as expected; manual `vault kv delete` cleanup succeeded.
+
+**ACs:** all 8 met. Evidence files at /tmp/v1.5-smoke-evidence/.
+
+**Follow-ups:** none — v1.5 closed out clean.
+```
+
+Fill in the YYYY-MM-DD dates and PR numbers from actual implementation.
+
+### Task 6.2: Mark v1.4.1's follow-up as resolved
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md` (v1.4.1's plan/close-out doc)
+
+- [ ] **Step 1: Locate the v1.5 follow-up note in v1.4.1's close-out**
+
+Run:
+```bash
+grep -n "v1.5" docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md | head -10
+```
+
+Expected: at least one line mentioning the v1.5 follow-up (the PushSecret/SecretStore deletion ordering bug).
+
+- [ ] **Step 2: Mark the follow-up resolved**
+
+Edit the relevant lines (use `Edit` tool with the exact context from Step 1) to indicate resolution. For example, if the line says:
+
+```markdown
+- **v1.5 follow-up:** PushSecret/SecretStore deletion ordering — TODO
+```
+
+Change to:
+
+```markdown
+- **v1.5 follow-up:** PushSecret/SecretStore deletion ordering — RESOLVED in v1.5 (PR #NNN, merged YYYY-MM-DD). PushSecret deletionPolicy flipped Delete → Retain; manual Vault cleanup documented in decommission PR body.
+```
+
+### Task 6.3: Commit close-out changes
+
+- [ ] **Step 1: Stage and commit**
+
+Run from `/Users/arisela/git/kubernetes` (on the `feat/idp-v1.5-pushsecret-retain` branch, or a fresh `docs/idp-v1.5-close-out` branch if you prefer the kubernetes v1.5 PR to be merged and unchanged):
+
+If keeping it on the same v1.5 branch (only if Phase 2 hasn't merged yet):
+```bash
+git add docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md \
+        docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md
+
+git commit -m "$(cat <<'EOF'
+docs(idp): v1.5 close-out — run notes + v1.4.1 follow-up resolution
+
+Smoke validation against smoke-v15 confirmed the teardown race is fixed.
+All 8 ACs met. Vault entries retained as expected; manual cleanup
+commands documented in the decommission PR body work as advertised.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If Phase 2 already merged (the v1.5 kubernetes PR has been merged to main): create a new branch first.
+
+```bash
+git checkout main && git pull origin main
+git checkout -b docs/idp-v1.5-close-out
+git add docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md \
+        docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md
+git commit -m "..."  # same message as above
+git push -u origin docs/idp-v1.5-close-out
+gh pr create --repo arigsela/kubernetes --title "docs(idp): v1.5 close-out" --body "Run notes + v1.4.1 follow-up resolution after smoke validation."
+```
+
+### Task 6.4: Mark task #93 complete
+
+- [ ] **Step 1: TaskUpdate #93 → completed**
+
+Use `TaskUpdate` tool: `{ taskId: "93", status: "completed" }`.
+
+---
+
+## Self-Review (writing-plans skill checklist)
+
+**1. Spec coverage:** Every requirement from the spec is covered by at least one task:
+- §2 Goal (flip deletionPolicy for both PushSecrets) → Tasks 1.5 + 1.6
+- §4.1 Change Surface → Tasks 1.5 + 1.6
+- §5.1 TDD on goldens → Tasks 1.2-1.7
+- §5.2 Smoke validation → Phase 5 (Tasks 5.1-5.10)
+- §6 PR body update → Tasks 3.4 (with TDD via 3.2-3.5)
+- §7 ACs → mapped explicitly in Task 5.10
+- §8 Files modified → file structure table at top
+- §11 Ship PRs (k8s first, then backstage) → Phase 1-2 then 3-4 ordering
+
+**2. Placeholder scan:** No `TBD`, `TODO`, `fill in details`, `add appropriate error handling`, `similar to Task N`, or `Write tests for the above` patterns. The only `TODO` reference is the literal example text in Task 6.2 showing v1.4.1's pre-resolution string — not a plan placeholder. Run-note dates (Task 6.1) are intentional `YYYY-MM-DD` placeholders for the implementer to fill in with actual dates — this is correct (the implementation hasn't happened yet so we don't know the dates).
+
+**3. Type consistency:** Function names used in later tasks match earlier definitions:
+- `make_push_secret` and `make_aws_push_secret` (Composition helpers) — used consistently in Tasks 1.5 + 1.6 + acceptance evidence
+- `buildPrBody` (Backstage helper) — used consistently in Tasks 3.2 + 3.4
+- Branch names: `feat/idp-v1.5-pushsecret-retain` (kubernetes) and `feat/idp-v1.5-cleanup-pr-body` (backstage) — used consistently
+- File paths: composition-application.yaml line numbers (102, 172) match across pre-flight context, Task 1.5, Task 1.6, and the spec
+
+**Fixes applied during review:** None — first pass was clean.

--- a/docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md
+++ b/docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md
@@ -1063,3 +1063,76 @@ Use `TaskUpdate` tool: `{ taskId: "93", status: "completed" }`.
 - File paths: composition-application.yaml line numbers (102, 172) match across pre-flight context, Task 1.5, Task 1.6, and the spec
 
 **Fixes applied during review:** None — first pass was clean.
+
+---
+
+## Run Notes (post-implementation, 2026-05-12)
+
+**Implementation status:** ✅ shipped (after two follow-on hotfixes).
+
+### What actually shipped
+
+v1.5 took **three PR cycles** to land cleanly. Each iteration surfaced a defect that the prior cycle's review (or even smoke validation) didn't catch:
+
+| Cycle | Kubernetes PR | Backstage PR | What broke |
+|---|---|---|---|
+| **v1.5** (initial) | [#255](https://github.com/arigsela/kubernetes/pull/255) | [#16](https://github.com/arigsela/backstage/pull/16) | Used wrong enum value `Retain` — ESO v0.11.0's PushSecret CRD only accepts `["Delete", "None"]` |
+| **v1.5.1** (enum fix) | [#257](https://github.com/arigsela/kubernetes/pull/257) | [#17](https://github.com/arigsela/backstage/pull/17) | Flip `Retain` → `None` in Composition + goldens + PR body explanation. Functionally equivalent. |
+| **v1.5.2** (path fix) | (none — Backstage-only) | [#18](https://github.com/arigsela/backstage/pull/18) | Decommission PR body advertised `vault kv delete k8s-secrets/<name>/db-creds` but the Composition (since v1.2) writes DB creds to `<name>/db`. AWS path was correct; only DB path was wrong. |
+
+Plus the **smoke validation** PRs:
+- [#256](https://github.com/arigsela/kubernetes/pull/256) — scaffolded `smoke-v15` with `dbNeeded:true, s3Needed:true, image:amazon/aws-cli:latest`
+- [#258](https://github.com/arigsela/kubernetes/pull/258) — teardown PR opened by the v1.4.1 decommission scaffolder action
+
+### Smoke validation outcome (all 8 ACs met)
+
+| AC | Evidence |
+|---|---|
+| AC-1 | `make_push_secret` emits `"None"` — render-test `xr-with-db` PASS + live `kubectl get pushsecret -n smoke-v15` showed `deletionPolicy=None` |
+| AC-2 | `make_aws_push_secret` emits `"None"` — render-test `xr-with-s3` PASS + live cluster verified |
+| AC-3 | Goldens reflect `None` after v1.5.1 (initial v1.5 was `Retain` in goldens too) |
+| AC-4 | All 3 render cases pass (`xr-minimal`, `xr-with-db`, `xr-with-s3`) — verified locally |
+| AC-5 | **0 `could not get SecretStore` events** during cascade — `grep ... /tmp/v1.5-smoke-evidence/04-events-during-cascade.txt \| wc -l = 0` |
+| AC-6 | Application reached `NotFound` at **T+54s** after merge (~36s ahead of the 90s budget) |
+| AC-7 | PR #258 body included `## Manual Vault cleanup (v1.5)` heading + both correct commands (after v1.5.2 path correction) |
+| AC-8 | `vault kv delete` succeeded; follow-up `kv get -field=password` returned `No data found` for both `db` and `aws-creds` paths. KV v2 caveat: a metadata stub remains visible via `kv metadata get`, but the data fields are unreadable — operationally equivalent to "deleted." Spec said `kv get` would return NotFound; that's KV v1 semantics. The truer evidence is "no field data retrievable post-delete." |
+
+Evidence files captured at `/tmp/v1.5-smoke-evidence/`:
+- `01-app-before-merge.yaml` (Application state pre-teardown)
+- `02-eso-before-merge.yaml` (ESO resources pre-teardown)
+- `03-events-before-merge.txt` (smoke-v15 namespace events pre-merge)
+- `04-events-during-cascade.txt` (the smoking gun — zero `could not get SecretStore` matches)
+
+### Operational gap surfaced separately
+
+**The Backstage `vault:setup` scaffolder action didn't fire for smoke-v15.** Result: the `smoke-v15` K8s auth role didn't exist in Vault when the XR reconciled, so SecretStore failed with `InvalidProviderConfig: invalid role name "smoke-v15"`. Worked around by manually creating the role via `vault write auth/kubernetes/role/smoke-v15` using the root token from the `vault-unseal-keys` secret. This is **unrelated to the v1.5 race fix** — would have happened on any v1.4-era smoke app too if `vault:setup` had silently skipped. Queued as v1.6 follow-up (see below).
+
+### Why the v1.5 enum + path bugs slipped past review
+
+Both v1.5.1 and v1.5.2 represent the same class of defect: **the test harness validates structure, not target-system semantics.**
+
+- **v1.5.1 (`Retain` → `None`):** The render-test goldens accept any string for `deletionPolicy`. The 2-stage subagent review verified (a) goldens match Composition output and (b) `"Retain"` is spelled correctly. Neither check has knowledge of the ESO v0.11.0 PushSecret CRD enum. A `kubectl apply --dry-run=server` step in the render harness would have caught this at TDD-time instead of smoke-validation-time.
+- **v1.5.2 (`db-creds` → `db`):** The spec invented the path `db-creds` without checking what the existing v1.2 DB-creds PushSecret actually writes to. The unit-test assertion happily checked the string the spec said — both the spec and assertion were wrong about the actual Vault path. Cross-checking the Composition's `remoteKey` field against the spec's advertised path would have caught this.
+
+**v1.6 should add to the render-test harness:** a `kubectl apply --dry-run=server -f -` round-trip that validates emitted resources against live CRD schemas. Cheap to add; catches both classes of bug.
+
+### Follow-ups queued for v1.6+
+
+1. **`vault:setup` reliability investigation** — figure out why the action silently skipped for smoke-v15 (was it never invoked? did Backstage Pod's Vault token rotate?). Either way, automated post-scaffold verification that the Vault role exists for the new app would prevent the trap.
+2. **CRD schema validation in render-test harness** — `kubectl apply --dry-run=server` against the rendered Composition output, or `kubeconform`-style local validation. Catches enum-value bugs at TDD-time.
+3. **Spec-to-Composition cross-check** — when adding/changing Vault paths in the spec, programmatically verify they match what the Composition Python actually writes. Could be a one-liner CI step that greps the Composition Python for `remoteKey` and compares against spec-advertised paths.
+4. **KV v2 cleanup semantics in the operator-facing PR body** — current "Manual Vault cleanup" instructions don't note that `kv delete` is a soft delete in KV v2. If hard-purge is required, document `vault kv metadata delete` explicitly.
+
+### Acknowledged: the spec body still says "Retain"
+
+The committed spec (`docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md`) and the body of this plan reference `Retain` throughout. Both are preserved as-is for historical fidelity — they show what the brainstorming/design phase concluded before cluster-validation surfaced the wrong-enum bug. The corrected enum is shipped in code (`None`), documented in the v1.5.1 PR commit message, and noted here. Future readers should treat the spec as **historic-design**, not **as-shipped**.
+
+### Mapping back to the original task list (#93 → completed)
+
+- Phase 0 pre-flight: ✅ all 4 checks passed
+- Phase 1 (kubernetes TDD chain): ✅ shipped via subagent dispatch + 2-stage review; PR #255 (later hotfixed via #257)
+- Phase 2 USER gate: ✅ kubernetes PR merged + ArgoCD reconciled
+- Phase 3 (Backstage TDD chain): ✅ shipped via subagent dispatch + 2-stage review; PR #16 (later hotfixed via #17 + #18)
+- Phase 4 USER gate: ✅ Backstage PR merged + Pod restarted
+- Phase 5 smoke validation: ✅ all 8 ACs met (with v1.5.1 + v1.5.2 + manual Vault role workaround)
+- Phase 6 close-out: ✅ (this section)

--- a/docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md
+++ b/docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md
@@ -1,0 +1,222 @@
+# IDP v1.5 — PushSecret `deletionPolicy: Retain` (Teardown Race Fix)
+
+**Status:** Approved
+**Date:** 2026-05-11
+**Author:** Ari Sela (via brainstorming with Claude)
+**Type:** Scoped iteration (~30-45 min implementation)
+**Predecessors:**
+- v1.4.1 (custom decommission scaffolder action — exposed the bug)
+- v1.4 (per-app finalizer + bucket sub-fields — masked the same bug via timing luck)
+- v1.2 (Vault round-trip for DB credentials — first introduced the same architectural pattern for DB creds)
+
+---
+
+## 1. Motivation
+
+v1.4.1's smoke validation against `smoke-v141` surfaced a teardown race:
+
+```
+Warning  Errored  pushsecret  Failed to Delete Secrets from Provider:
+could not get SecretStore "vault-backend": SecretStore.external-secrets.io
+"vault-backend" not found
+```
+
+**Sequence:**
+1. Teardown PR merged → master-app prunes the per-app Application.
+2. ArgoCD's `resources-finalizer.argocd.argoproj.io` (added in v1.4) cascades managed-resource deletion.
+3. The XApplication XR deletes → Kubernetes garbage collection removes Composition-emitted children (SecretStore + PushSecret + ExternalSecret) **in parallel** via `ownerReferences`.
+4. PushSecret has `deletionPolicy: Delete`, so on deletion ESO's controller attempts to remove the remote entry from Vault. The call requires resolving the referenced SecretStore.
+5. If the SecretStore is already gone (or being deleted concurrently), ESO's reconciler logs `could not get SecretStore` and the PushSecret stays stuck in a finalized state with errors.
+6. The per-app Application's finalizer cannot complete because at least one tracked resource (the PushSecret) is permanently stuck.
+
+**v1.4 had the same architectural pattern** but won the race timing (PushSecret resolved + completed the Vault delete before SecretStore was reaped). v1.4.1's smoke run lost the race — the bug was always there.
+
+**The same race window exists in v1.2's DB-creds PushSecret** (same Composition Python helper pattern). It hasn't manifested because no app with `dbNeeded: true` has been torn down in production yet, but the bug is identical.
+
+## 2. Goal
+
+Eliminate the race by flipping both Composition-emitted PushSecrets from `deletionPolicy: Delete` to `deletionPolicy: Retain`. With `Retain`, PushSecret deletion is a no-op against Vault — no SecretStore lookup, no race, clean cascade. Vault KV entries orphan and are cleaned up by the operator post-teardown.
+
+## 3. Non-Goals (Out of Scope)
+
+- Automating Vault entry cleanup (deferred — see §7 for the manual cleanup story).
+- Adding Vault credentials to the Backstage backend (rejected during brainstorming — too much new attack surface for one `vault kv delete` call per teardown).
+- Crossplane-finalizer-based cross-resource deletion ordering (rejected — complex; custom controller).
+- ArgoCD sync-wave annotations on Composition-emitted resources (rejected — ArgoCD doesn't directly track XR-owned children, so sync-waves don't apply during the cascade).
+- Any change to AWS-side resources (IAM users, S3 buckets, etc.) — the v1.4 cascade already handles those correctly.
+- Any change to the v1.4.1 decommission scaffolder action's core flow — only the PR body text gets a new "Manual cleanup" section.
+
+## 4. Architecture
+
+### 4.1 Change Surface
+
+The fix is two single-line changes in one file:
+
+**File:** `base-apps/crossplane-compositions/composition-application.yaml`
+
+**Helper 1 — `make_push_secret(name, namespace, annotations)` (DB-creds)** at line 90:
+- Line 102: `"deletionPolicy": "Delete"` → `"deletionPolicy": "Retain"`
+
+**Helper 2 — `make_aws_push_secret(name, namespace, annotations)`** at line 157:
+- Line 172: `"deletionPolicy": "Delete"` → `"deletionPolicy": "Retain"`
+
+### 4.2 Why This Works
+
+`PushSecret.spec.deletionPolicy` is a documented field in the External Secrets Operator API:
+- `Delete` — on PushSecret deletion, ESO attempts to delete the remote entry via the referenced SecretStore.
+- `Retain` — on PushSecret deletion, ESO performs no remote operation; the PushSecret CR is just removed.
+
+With `Retain`:
+- The PushSecret deletion is a pure CR removal — no controller call to Vault, no SecretStore dependency.
+- Owner-reference GC removes PushSecret + SecretStore in parallel without any ordering requirement.
+- The per-app Application's finalizer completes (no stuck child resources).
+- Cluster-scoped AWS resources (the v1.4 work) cascade as designed.
+- The Vault KV entries at `k8s-secrets/<app>/db-creds` and `k8s-secrets/<app>/aws-creds` survive — operator deletes them manually post-teardown.
+
+### 4.3 Trade-off Accepted
+
+**Vault entries orphan.** At homelab scale (handful of app teardowns per year), the operational burden of a manual `vault kv delete` per teardown is small. The cleanup steps are explicitly enumerated in the decommission scaffolder's PR body (see §6) so the operator has a copy-pasteable command.
+
+If orphan accumulation becomes painful at higher volume, a future v1.6+ iteration can either:
+- Add scheduled Vault KV TTL/cleanup policies (Vault-native).
+- Add a Vault delete step to the decommission scaffolder action (requires the Backstage Pod to hold a Vault token — was rejected in this iteration's scope).
+
+## 5. Test Strategy
+
+### 5.1 TDD on Render-Test Goldens
+
+The repo's Composition test harness lives at `tests/composition/` and uses bash + `crossplane render` + `yq` + `diff`. Three test cases are wired:
+- `xr-minimal` — no PushSecret emitted (out of scope for this change)
+- `xr-with-db` — emits one PushSecret (DB-creds)
+- `xr-with-s3` — emits one PushSecret (AWS-creds)
+
+**TDD loop:**
+
+1. Update `tests/composition/expected-xr-with-db.yaml` line 299: `deletionPolicy: Delete` → `deletionPolicy: Retain`.
+2. Update `tests/composition/expected-xr-with-s3.yaml` line 216: `deletionPolicy: Delete` → `deletionPolicy: Retain`.
+3. Run `./tests/composition/render.sh xr-with-db` → expect FAIL (diff shows Composition still emits `Delete`).
+4. Run `./tests/composition/render.sh xr-with-s3` → expect FAIL (same).
+5. Update `composition-application.yaml` lines 102 + 172: both `Delete` → `Retain`.
+6. Re-run both test cases → expect PASS.
+7. Run `./tests/composition/render.sh xr-minimal` → expect PASS (unchanged; no PushSecret).
+8. Commit (one commit: goldens + Composition + spec).
+
+### 5.2 Smoke Validation (`smoke-v15`)
+
+Deploy a real app with both DB and S3 enabled, tear it down, and verify the cascade is clean.
+
+**Setup:**
+- Scaffold via Backstage `application` template with: `name: smoke-v15`, `dbNeeded: true`, `s3Needed: true`.
+- Wait for ArgoCD sync → per-app Application reaches `Healthy/Synced`.
+- Verify Vault entries exist: `kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/db-creds` (and `/aws-creds`).
+
+**Teardown:**
+- Submit Backstage `decommission-application` template with `name: smoke-v15`.
+- Verify the opened teardown PR's body now includes the §6 "Manual cleanup" section with two specific `vault kv delete` commands.
+- Merge the teardown PR.
+
+**Acceptance evidence to collect:**
+- `kubectl get events -n smoke-v15` shows NO `could not get SecretStore` events on either PushSecret during the cascade.
+- `kubectl get application smoke-v15 -n argo-cd` returns NotFound within ~90s of merge (per-app App finalizer completed cleanly).
+- `kubectl get pushsecret,secretstore,externalsecret -n smoke-v15` returns NotFound for all three.
+- `kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/db-creds` STILL returns the entry (proves `Retain` worked).
+- `kubectl exec -n vault vault-0 -- vault kv get k8s-secrets/smoke-v15/aws-creds` STILL returns the entry.
+- Operator runs the two `vault kv delete` commands from the PR body → both entries return NotFound.
+- Final manual step: `kubectl delete namespace smoke-v15` completes cleanly (no stuck finalizers).
+
+## 6. Decommission Scaffolder PR Body Update
+
+**File:** `arigsela/backstage:packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts`
+
+**Function:** `buildPrBody(name)` (line 41)
+
+**Change:** Append a "Manual cleanup" section enumerating the Vault commands. New body content:
+
+```
+Decommissioning <name>. After merge:
+
+1. master-app prunes the per-app Application within ~30s.
+2. The v1.4 finalizer (resources-finalizer.argocd.argoproj.io)
+   cascades deletion of all managed resources (cluster-scoped AWS +
+   namespaced ESO config + composed app resources).
+3. Wait ~60-90s for AWS-side resources to fully unwind.
+4. Run `kubectl delete namespace <name>` for the last manual
+   cleanup step.
+
+## Manual Vault cleanup (v1.5)
+
+PushSecret entries in Vault are NOT auto-deleted (v1.5 changed
+deletionPolicy: Delete → Retain to fix a teardown race). After
+namespace deletion, run:
+
+  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/<name>/db-creds
+  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/<name>/aws-creds
+
+Skip whichever entry doesn't exist (an app without dbNeeded won't
+have db-creds; an app without s3Needed won't have aws-creds).
+
+Generated by Backstage `decommission-application` template (v1.5
+with custom scaffolder action).
+```
+
+Both Vault commands are listed unconditionally — the operator skips whichever is irrelevant. We don't try to detect `dbNeeded` / `s3Needed` from the scaffolder action because that would require either reading the XR (more API calls + auth scope) or threading bool inputs through the template form (more UX friction for what is genuinely an operator-eyeball decision).
+
+## 7. Acceptance Criteria
+
+- **AC-1:** `composition-application.yaml` `make_push_secret` helper emits `"deletionPolicy": "Retain"`.
+- **AC-2:** `composition-application.yaml` `make_aws_push_secret` helper emits `"deletionPolicy": "Retain"`.
+- **AC-3:** `expected-xr-with-db.yaml` and `expected-xr-with-s3.yaml` goldens reflect `deletionPolicy: Retain`.
+- **AC-4:** `./tests/composition/render.sh xr-with-db`, `xr-with-s3`, and `xr-minimal` all pass.
+- **AC-5:** Smoke teardown of `smoke-v15` shows zero `could not get SecretStore` events on either the DB-creds or AWS-creds PushSecret during the cascade.
+- **AC-6:** Per-app Application for `smoke-v15` reaches NotFound state within ~90s of teardown PR merge (finalizer completed cleanly).
+- **AC-7:** Decommission scaffolder PR body includes the "Manual Vault cleanup (v1.5)" section with both `vault kv delete` commands.
+- **AC-8:** Operator-run `vault kv delete` against both orphaned Vault entries succeeds (returns "Success! Data deleted") and a follow-up `vault kv get` returns NotFound.
+
+## 8. Files Modified
+
+### `arigsela/kubernetes`
+
+| File | Change |
+|---|---|
+| `base-apps/crossplane-compositions/composition-application.yaml` | Lines 102 + 172: `"Delete"` → `"Retain"` (2 chars per line) |
+| `tests/composition/expected-xr-with-db.yaml` | Line 299: `Delete` → `Retain` |
+| `tests/composition/expected-xr-with-s3.yaml` | Line 216: `Delete` → `Retain` |
+| `docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md` | NEW (this file) |
+| `docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md` | NEW (next step — writing-plans) |
+
+### `arigsela/backstage`
+
+| File | Change |
+|---|---|
+| `packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts` | `buildPrBody` body updated with "Manual Vault cleanup (v1.5)" section + footer version bump v1.4.1 → v1.5 |
+
+## 9. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Operator forgets to run `vault kv delete` post-teardown → Vault entries accumulate | Medium (homelab — easy to forget) | PR body explicitly lists the commands; volume is small so even months of forgotten cleanup is manageable; can sweep with a one-off script if needed |
+| Operator runs `vault kv delete` against the wrong path | Low | Path is templated from the same app name used in the PR title; copy-paste safe |
+| Future Composition change re-introduces `Delete` somewhere | Low | Render-test goldens enforce `Retain`; CI run on any Composition PR catches the regression |
+| ESO API changes `deletionPolicy: Retain` semantics | Very low | `Retain` has been stable in ESO since v0.7; pinned versions in cluster |
+| Some other Composition-emitted resource has the same race we haven't found | Low | The race needs (a) a resource with a remote-cleanup-on-delete behavior AND (b) a dependency on another short-lived child. PushSecret was the only such pair. ExternalSecret + SecretStore have the same dependency but ExternalSecret has no remote-cleanup behavior, so no race. |
+
+## 10. Estimated Effort
+
+| Phase | Time |
+|---|---|
+| Spec writing (this doc) | 15 min — DONE |
+| Implementation plan (writing-plans) | 10 min |
+| TDD + Composition change | 10 min |
+| Backstage PR body update + test | 10 min |
+| Smoke validation (`smoke-v15` deploy + teardown) | 15-20 min |
+| Close-out PR + run notes | 5 min |
+| **Total** | **~65-75 min wall clock** |
+
+## 11. Ship PRs
+
+Two PRs:
+
+1. **`arigsela/kubernetes`** — Composition + goldens + spec + plan. Single commit per the TDD step ordering (or two commits if we want golden-first then Composition-second visible in history; both are fine).
+2. **`arigsela/backstage`** — `decommissionPullRequestAction.ts` `buildPrBody` update only. Requires image rebuild + Pod restart for the new body to take effect (USER step per CLAUDE.md — "I will handle running the builds of images").
+
+Order: ship the kubernetes PR first (the actual fix). Ship the Backstage PR second so the PR body reflects the deployed Composition state. Smoke validation happens after both are merged + Backstage image is rebuilt.


### PR DESCRIPTION
## Summary
v1.5 design + plan + post-implementation run notes for the **PushSecret/SecretStore deletion ordering bug** discovered during v1.4.1 smoke validation.

The actual fix shipped over **three PR cycles** + a manual Vault role workaround. Run notes section in the plan captures the full as-shipped reality (including the bugs the original spec got wrong).

## What's in this PR
- \`docs/superpowers/specs/2026-05-11-idp-v1.5-pushsecret-retain-design.md\` (NEW) — the design spec (historic-design; references \`Retain\` which the cluster rejected at apply-time)
- \`docs/superpowers/plans/2026-05-11-idp-v1.5-pushsecret-retain.md\` (NEW) — the implementation plan with **Run Notes section** documenting the v1.5.1 (\`Retain\`→\`None\`) + v1.5.2 (\`/db-creds\`→\`/db\`) hotfixes + smoke validation results
- \`docs/superpowers/plans/2026-05-10-idp-v1.4.1-decommission-scaffolder-action.md\` (MODIFIED) — marks the v1.5 follow-up RESOLVED with links to the actual shipped PRs

## v1.5 acceptance criteria (all 8 met)
| AC | Evidence |
|---|---|
| AC-1, AC-2 | Both Composition PushSecret helpers emit \`\"None\"\` (live verified on smoke-v15) |
| AC-3 | Render-test goldens updated |
| AC-4 | All 3 render cases pass |
| AC-5 | **0 \`could not get SecretStore\` events** during smoke-v15 cascade |
| AC-6 | Application reached \`NotFound\` at T+54s (under 90s budget) |
| AC-7 | Teardown PR body included \`## Manual Vault cleanup (v1.5)\` + correct commands (after v1.5.2 path fix) |
| AC-8 | \`vault kv delete\` succeeded; data unreadable post-cleanup |

## Related PRs
| PR | Repo | Purpose |
|---|---|---|
| #255 | kubernetes | v1.5 initial — \`Retain\` (wrong enum) |
| #257 | kubernetes | v1.5.1 — \`Retain\` → \`None\` hotfix |
| #258 | kubernetes | smoke-v15 teardown (validation evidence) |
| arigsela/backstage#16 | backstage | v1.5 Backstage PR body update |
| arigsela/backstage#17 | backstage | v1.5.1 Backstage sync |
| arigsela/backstage#18 | backstage | v1.5.2 DB path correction |

## v1.6+ follow-ups queued
1. \`vault:setup\` reliability investigation (silently skipped for smoke-v15)
2. CRD schema validation in render-test harness (\`kubectl apply --dry-run=server\`)
3. Spec-to-Composition path cross-check (would have caught the \`db-creds\` typo)
4. KV v2 cleanup semantics noted in operator-facing PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)