### PR TITLE
feat(vcluster): deploy sandbox-1 reference vcluster

### DIFF
--- a/base-apps/vcluster-sandbox-1.yaml
+++ b/base-apps/vcluster-sandbox-1.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vcluster-sandbox-1
+  namespace: argo-cd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vcluster-sandbox-1
+  sources:
+    - repoURL: https://charts.loft.sh
+      chart: vcluster
+      targetRevision: 0.34.0
+      helm:
+        releaseName: vcluster
+        valuesObject:
+          controlPlane:
+            backingStore:
+              etcd:
+                embedded:
+                  enabled: false
+            statefulSet:
+              persistence:
+                volumeClaim:
+                  enabled: false
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            service:
+              spec:
+                type: ClusterIP
+            proxy:
+              extraSANs:
+                - sandbox-1.vcluster.arigsela.com
+          sync:
+            toHost:
+              ingresses:
+                enabled: false
+            fromHost:
+              storageClasses:
+                enabled: true
+    - repoURL: https://github.com/arigsela/kubernetes
+      targetRevision: main
+      path: base-apps/vcluster-sandbox-1
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/vcluster-sandbox-1/certificate.yaml
+++ b/base-apps/vcluster-sandbox-1/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vcluster-tls
+  namespace: vcluster-sandbox-1
+spec:
+  secretName: vcluster-tls
+  issuerRef:
+    name: letsencrypt-route53
+    kind: ClusterIssuer
+  commonName: sandbox-1.vcluster.arigsela.com
+  dnsNames:
+    - sandbox-1.vcluster.arigsela.com

--- a/base-apps/vcluster-sandbox-1/ingress.yaml
+++ b/base-apps/vcluster-sandbox-1/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vcluster
+  namespace: vcluster-sandbox-1
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: sandbox-1.vcluster.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vcluster
+                port:
+                  number: 443


### PR DESCRIPTION
## Summary
- Deploys the GitOps-managed reference vcluster `sandbox-1` (Phase 2 of the vcluster plan)
- vcluster OSS Helm chart v0.34.0, k3s control plane + sqlite (no PVC), ephemeral by design
- Exposed at `https://sandbox-1.vcluster.arigsela.com` via nginx ssl-passthrough

## Changes
### New ArgoCD Application
- `base-apps/vcluster-sandbox-1.yaml` — multi-source Application (ArgoCD v3.1.9, multi-source GA):
  - Source 1: `https://charts.loft.sh` chart `vcluster` v0.34.0 with inline values
  - Source 2: this git repo path `base-apps/vcluster-sandbox-1/` for Certificate + Ingress

### Namespace resources
- `base-apps/vcluster-sandbox-1/certificate.yaml` — cert-manager Certificate for `sandbox-1.vcluster.arigsela.com` via `letsencrypt-route53` ClusterIssuer
- `base-apps/vcluster-sandbox-1/ingress.yaml` — Ingress with `ssl-passthrough: "true"` and `backend-protocol: "HTTPS"`

### Key Helm values
- `controlPlane.backingStore.etcd.embedded.enabled: false` → uses sqlite
- `controlPlane.statefulSet.persistence.volumeClaim.enabled: false` → no PVC
- Resource limits: 1 CPU / 512Mi (ephemeral test workload sizing)
- `controlPlane.proxy.extraSANs: [sandbox-1.vcluster.arigsela.com]` → SAN baked into vcluster-issued cert
- `sync.toHost.ingresses.enabled: false` → vcluster ingresses don't bleed to host
- `sync.fromHost.storageClasses.enabled: true` → vcluster can see host StorageClasses

## Technical Implementation
With `ssl-passthrough`, nginx is a TCP proxy and the vcluster pod serves its own internal TLS cert (signed by vcluster's CA, with `sandbox-1.vcluster.arigsela.com` as a SAN). `vcluster connect` writes the vcluster CA into the kubeconfig's `certificate-authority-data`, so kubectl trusts the chain natively without `--insecure-skip-tls-verify`. The cert-manager `vcluster-tls` secret is unused on the kubectl path — it exists for future browser/curl access if we choose to mount it into the vcluster pod.

## Test Plan
After merge:
- [ ] `kubectl -n argo-cd get application vcluster-sandbox-1` shows `Synced`/`Healthy`
- [ ] `kubectl -n vcluster-sandbox-1 rollout status sts/vcluster --timeout=300s` succeeds
- [ ] `kubectl -n vcluster-sandbox-1 get certificate vcluster-tls -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` returns `True`
- [ ] `openssl s_client` to `sandbox-1.vcluster.arigsela.com:443` shows vcluster-internal CA issuer and SAN includes the host
- [ ] `vcluster connect sandbox-1 --namespace vcluster-sandbox-1 --server https://sandbox-1.vcluster.arigsela.com` writes a kubeconfig
- [ ] `kubectl get nodes` (in vcluster context) succeeds
- [ ] `kubectl create deployment nginx --image=nginx` (in vcluster context) produces a synced pod in host `vcluster-sandbox-1` namespace

## Related
- Design spec: `docs/superpowers/specs/2026-05-12-vcluster-design.md`
- Implementation plan: `docs/plans/vcluster-implementation-plan.md` (Phase 2)
- Prior PR: #261 (Phase 1: ssl-passthrough enablement)

## Rollback
Close this PR (or revert after merge). ArgoCD prune will remove the namespace and all resources.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>