### PR TITLE
Revert "feat(nginx-ingress): enable ssl-passthrough"

### DIFF
--- a/base-apps/nginx-ingress/nginx-ingress-controller.yaml
+++ b/base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -18,8 +18,6 @@ spec:
         effect: NoSchedule
       kind: DaemonSet
       hostNetwork: true
-      extraArgs:
-        enable-ssl-passthrough: "true"
       service:
         type: ClusterIP
         ports:


### PR DESCRIPTION
## Summary
- Reverts the ssl-passthrough flag introduced in #261
- **Restores LAN access to argocd, atlantis, backstage** (and any other ingress that uses `whitelist-source-range`)
- vcluster-sandbox-1 deployment from #262 remains merged but its Ingress will not be reachable until a follow-up PR switches the vcluster design to nginx-terminated TLS

## Why
With `--enable-ssl-passthrough=true`, ingress-nginx restructures to two nginx instances: an SNI-aware TCP front-end on :443 forwards non-passthrough hosts to an inner nginx on :442 over PROXY protocol. The inner nginx evaluates `whitelist-source-range`, but it sees `client: 127.0.0.1` (the SNI router) instead of the real client IP — because the inner nginx ConfigMap doesn't have `use-proxy-protocol: "true"` to parse the PROXY header.

Result: every ingress with a `whitelist-source-range` returns 403 from the LAN, even though the LAN CIDR is in the allowlist.

Confirmed via nginx error log:
```
access forbidden by rule, client: 127.0.0.1, server: argocd.arigsela.com
```

## Follow-up
Redesign vcluster TLS to use **nginx-terminated TLS** instead of passthrough:
- Removes `ssl-passthrough` annotation from the vcluster Ingress
- Adds a `tls:` block referencing the existing `vcluster-tls` Certificate
- nginx terminates Let's Encrypt cert at the edge; kubectl trusts it via OS CA bundle
- nginx proxies HTTPS to vcluster service (`backend-protocol: HTTPS`); no backend cert verification needed
- No kubeconfig CA gymnastics required

This is actually a cleaner design and would have been the right call from the start.

## Test Plan
After merge:
- [ ] ArgoCD reconciles → Helm job runs → DaemonSet rolls out without the flag
- [ ] LAN access to argocd.arigsela.com returns the UI (or auth challenge), not 403
- [ ] `kubectl -n ingress-nginx get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].spec.containers[0].args}'` no longer contains `--enable-ssl-passthrough`

## Related
- Original: #261
- Phase 2 (still deployed but Ingress non-functional until follow-up): #262

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>