### PR TITLE
fix(vcluster): switch sandbox-1 ingress to nginx-terminated TLS

### DIFF
--- a/base-apps/vcluster-sandbox-1/ingress.yaml
+++ b/base-apps/vcluster-sandbox-1/ingress.yaml
@@ -4,10 +4,16 @@ metadata:
   name: vcluster
   namespace: vcluster-sandbox-1
   annotations:
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - sandbox-1.vcluster.arigsela.com
+      secretName: vcluster-tls
   rules:
     - host: sandbox-1.vcluster.arigsela.com
       http:


### PR DESCRIPTION
## Summary
- Updates the `vcluster-sandbox-1` Ingress to use **nginx-terminated TLS** instead of ssl-passthrough
- ssl-passthrough was reverted globally in #263 because it broke `whitelist-source-range` checks on every non-passthrough ingress (the inner nginx saw `client: 127.0.0.1` instead of the real source IP)
- This is a cleaner design that avoids the cluster-wide blast radius of passthrough

## Changes
### `base-apps/vcluster-sandbox-1/ingress.yaml`
- **Removed** `nginx.ingress.kubernetes.io/ssl-passthrough: "true"`
- **Added** `tls:` block referencing the existing `vcluster-tls` Certificate secret
- **Added** streaming-friendly annotations so kubectl `exec` / `port-forward` / `logs -f` work through the ingress:
  - `proxy-http-version: "1.1"` (needed for HTTP/1.1 Upgrade-based streaming)
  - `proxy-read-timeout: "3600"` (1h read for long streams)
  - `proxy-send-timeout: "3600"` (1h send for uploads/exec)
- Kept `backend-protocol: "HTTPS"` so nginx proxies HTTPS to the vcluster Service (vcluster's internal cert is not verified by nginx — fine for in-cluster traffic)

## Technical Implementation
**TLS path:**
- Client (kubectl) → nginx-ingress: TLS with the Let's Encrypt cert in `vcluster-tls` secret → kubectl trusts via OS CA bundle, no `--insecure-skip-tls-verify` needed and no kubeconfig CA override
- nginx-ingress → vcluster Service: HTTPS to port 443; backend cert is the vcluster-internal cert (not validated by nginx)
- vcluster authenticates the request via the bearer token in the kubeconfig that `vcluster connect` writes

The unused `controlPlane.proxy.extraSANs` in the Helm values is left in place to minimize the change set; it's a harmless no-op once nginx terminates TLS. Can be cleaned up later.

## Test Plan
After merge:
- [ ] `kubectl -n vcluster-sandbox-1 get ingress vcluster -o jsonpath='{.metadata.annotations}'` shows the new annotations and no `ssl-passthrough`
- [ ] `curl -v https://sandbox-1.vcluster.arigsela.com/healthz` returns a response with a Let's Encrypt-signed cert (no `-k` needed)
- [ ] `vcluster connect sandbox-1 --namespace vcluster-sandbox-1 --server https://sandbox-1.vcluster.arigsela.com --update-current=false --kube-config ./kubeconfig.yaml` produces a working kubeconfig
- [ ] `KUBECONFIG=./kubeconfig.yaml kubectl get nodes` succeeds (without `--insecure-skip-tls-verify`)
- [ ] `KUBECONFIG=./kubeconfig.yaml kubectl create deployment nginx --image=nginx` succeeds and produces a synced pod in host `vcluster-sandbox-1` namespace
- [ ] `KUBECONFIG=./kubeconfig.yaml kubectl logs deploy/nginx -f` streams output through the ingress (validates streaming annotations)

## Related
- Design spec: `docs/superpowers/specs/2026-05-12-vcluster-design.md`
- Implementation plan: `docs/plans/vcluster-implementation-plan.md` (Phase 2 redesign)
- Phase 2 original: #262
- ssl-passthrough revert: #263

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>