### PR TITLE
feat(crossplane): add function-extra-resources for smoke-test composition

### DIFF
--- a/base-apps/crossplane-functions/function-extra-resources.yaml
+++ b/base-apps/crossplane-functions/function-extra-resources.yaml
@@ -1,0 +1,15 @@
+# base-apps/crossplane-functions/function-extra-resources.yaml
+# Reads existing K8s resources during Composition rendering so the smoke-test
+# Composition can pick up vcluster's generated kubeconfig secret on the second
+# reconcile pass. See docs/superpowers/specs/2026-05-13-smoke-test-app-design.md.
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-extra-resources
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
+  packagePullPolicy: IfNotPresent
+  revisionActivationPolicy: Automatic
+  revisionHistoryLimit: 1


### PR DESCRIPTION
## Summary
- Installs the `function-extra-resources` Crossplane Function (v0.3.0) needed for the smoke-test Composition's two-phase reconcile pattern
- Single new file, no changes to existing platform components
- Phase 1 of the smoke-test-app implementation plan

## Changes
- `base-apps/crossplane-functions/function-extra-resources.yaml` — Function manifest pinned to upstream xpkg image v0.3.0, sync wave 1 (same as `function-python`)

## Why
The smoke-test Composition (coming in later PRs) needs to read vcluster's generated `vc-vcluster` kubeconfig Secret to emit an ArgoCD cluster registration Secret. `function-extra-resources` is the Crossplane-native way to fetch existing K8s resources during render. This PR just installs the function — it's not wired into any Composition yet.

## Test Plan
After merge:
- [ ] ArgoCD `crossplane-functions` Application syncs cleanly
- [ ] `kubectl get function function-extra-resources -o jsonpath='{.status.conditions[?(@.type=="Healthy")].status}'` → `True`
- [ ] Function runtime pod is Running in `crossplane-system` (visible via `kubectl -n crossplane-system get pods -l pkg.crossplane.io/function=function-extra-resources`)
- [ ] No regressions in existing XApplication Compositions

## Related
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 1)
- Spec: `docs/superpowers/specs/2026-05-13-smoke-test-app-design.md`

## Rollback
Revert this PR. function-python and all existing Compositions are unaffected.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>