### PR TITLE
feat(smoke-test): add curated workload Helm chart

### DIFF
--- a/charts/smoke-test-workload/.helmignore
+++ b/charts/smoke-test-workload/.helmignore
@@ -1,0 +1,2 @@
+.DS_Store
+README.md

--- a/charts/smoke-test-workload/Chart.yaml
+++ b/charts/smoke-test-workload/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: smoke-test-workload
+description: Minimal hello-world workload for IDP smoke tests
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/smoke-test-workload/README.md
+++ b/charts/smoke-test-workload/README.md
@@ -1,0 +1,17 @@
+# smoke-test-workload chart
+
+Minimal Helm chart consumed by the `XSmokeTestApp` Crossplane Composition.
+Templates a hello-world Deployment + Service + Ingress.
+
+| Value | Type | Default | Description |
+|---|---|---|---|
+| `image` | string | _required_ | Container image |
+| `port` | integer | 80 | Container port |
+| `host` | string | _required_ | Ingress hostname (full FQDN) |
+| `replicas` | integer | 1 | Pod replicas |
+
+Not for direct user consumption — the Composition fills these values from the `SmokeTestApp` claim.
+
+See:
+- `docs/superpowers/specs/2026-05-13-smoke-test-app-design.md`
+- `docs/plans/smoke-test-app-implementation-plan.md`

--- a/charts/smoke-test-workload/templates/deployment.yaml
+++ b/charts/smoke-test-workload/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-app
+  labels:
+    app.kubernetes.io/name: smoke-app
+    app.kubernetes.io/managed-by: smoke-test-workload
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smoke-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: smoke-app
+    spec:
+      containers:
+        - name: app
+          image: {{ .Values.image | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { cpu: 500m, memory: 256Mi }

--- a/charts/smoke-test-workload/templates/ingress.yaml
+++ b/charts/smoke-test-workload/templates/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: smoke-app
+  labels:
+    app.kubernetes.io/name: smoke-app
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ .Values.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: smoke-app
+                port:
+                  number: 80

--- a/charts/smoke-test-workload/templates/service.yaml
+++ b/charts/smoke-test-workload/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-app
+  labels:
+    app.kubernetes.io/name: smoke-app
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.port }}
+  selector:
+    app.kubernetes.io/name: smoke-app

--- a/charts/smoke-test-workload/values.yaml
+++ b/charts/smoke-test-workload/values.yaml
@@ -1,0 +1,8 @@
+# Image to deploy (required — no default)
+image: ""
+# Container port the Service routes to
+port: 80
+# Full hostname for the Ingress (Composition passes <host>.smoke.arigsela.com)
+host: ""
+# Pod replica count
+replicas: 1


### PR DESCRIPTION
## Summary
- Adds `charts/smoke-test-workload/` — the minimal Helm chart that the upcoming smoke-test Composition will reference for the user's hello-world workload
- 7 files, ~90 lines total. Not consumed by anything yet; the Composition (Phase 4) will reference it
- Introduces a new top-level `charts/` directory in the repo

## Chart structure
```
charts/smoke-test-workload/
├── Chart.yaml
├── values.yaml
├── .helmignore
├── README.md
└── templates/
    ├── deployment.yaml
    ├── service.yaml
    └── ingress.yaml
```

## Parameters
| Value | Type | Default | Description |
|---|---|---|---|
| `image` | string | _required_ | Container image |
| `port` | integer | 80 | Container port |
| `host` | string | _required_ | Ingress hostname (full FQDN) |
| `replicas` | integer | 1 | Pod replicas |

## Hardcoded (intentional)
- Resource requests/limits: 50m/64Mi req, 500m/256Mi lim — prevents smoke tests from becoming load tests
- Service: ClusterIP on port 80, targets the container port
- Ingress: nginx class, plain HTTP (no TLS — smoke tests are LAN-only, ephemeral)
- Resource names: hardcoded `smoke-app` (each smoke test gets its own vcluster, so namespace handles isolation)

## Test Plan
- [x] `helm lint charts/smoke-test-workload` → 0 failures (one info note about missing icon, ignored)
- [x] `helm template smoke-test charts/smoke-test-workload --set image=nginx --set host=hello.smoke.arigsela.com` → clean YAML
- [x] Rendered output piped through `kubectl apply --dry-run=client` → 3 resources accepted (service/smoke-app, deployment.apps/smoke-app, ingress.networking.k8s.io/smoke-app)
- [ ] After merge: no cluster impact (chart not yet wired into any Composition)

## Related
- Spec: `docs/superpowers/specs/2026-05-13-smoke-test-app-design.md`
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 2)
- Phase 1 (merged): #269

## Rollback
Delete the directory and revert this PR. No runtime impact — nothing consumes the chart yet.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>