### PR TITLE
feat(smoke-test): add XSmokeTestApp XRD + phase-1 Composition

### DIFF
--- a/base-apps/crossplane-compositions/composition-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-smoke-test.yaml
@@ -1,0 +1,104 @@
+# base-apps/crossplane-compositions/composition-smoke-test.yaml
+# Smoke-test app Composition. Pipeline-mode with function-python.
+# Phase 1 (this file): emits Namespace + vcluster Application only. Status: Provisioning.
+# Phase 2 (later PR): adds function-extra-resources step + ArgoCD cluster Secret + workload Application.
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: smoke-test
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  compositeTypeRef:
+    apiVersion: platform.arigsela.com/v1alpha1
+    kind: XSmokeTestApp
+  mode: Pipeline
+  pipeline:
+    - step: render-resources
+      functionRef:
+        name: function-python
+      input:
+        apiVersion: python.fn.crossplane.io/v1beta1
+        kind: Script
+        script: |
+          from crossplane.function import resource
+
+          def compose(req, rsp):
+              spec = req.observed.composite.resource.get("spec", {})
+              name = req.observed.composite.resource.get("metadata", {}).get("name", "unknown")
+              ns_name = f"vcluster-{name}"
+              host = spec.get("host", "")
+              ingress_host = f"{host}.smoke.arigsela.com"
+
+              # 1. Namespace
+              resource.update(rsp.desired.resources["namespace"], {
+                  "apiVersion": "v1",
+                  "kind": "Namespace",
+                  "metadata": {
+                      "name": ns_name,
+                      "labels": {
+                          "app.kubernetes.io/managed-by": "crossplane",
+                          "smoketest.platform.arigsela.com/owner": name,
+                      },
+                  },
+              })
+
+              # 2. ArgoCD Application for the vcluster Helm chart
+              vcluster_app = {
+                  "apiVersion": "argoproj.io/v1alpha1",
+                  "kind": "Application",
+                  "metadata": {
+                      "name": f"vcluster-{name}",
+                      "namespace": "argo-cd",
+                      "labels": {
+                          "smoketest.platform.arigsela.com/owner": name,
+                      },
+                  },
+                  "spec": {
+                      "project": "default",
+                      "destination": {
+                          "server": "https://kubernetes.default.svc",
+                          "namespace": ns_name,
+                      },
+                      "source": {
+                          "repoURL": "https://charts.loft.sh",
+                          "chart": "vcluster",
+                          "targetRevision": "0.34.0",
+                          "helm": {
+                              "releaseName": "vcluster",
+                              "valuesObject": {
+                                  "controlPlane": {
+                                      "backingStore": {"etcd": {"embedded": {"enabled": False}}},
+                                      "statefulSet": {
+                                          "persistence": {"volumeClaim": {"enabled": False}},
+                                          "resources": {
+                                              "limits": {"cpu": 1, "memory": "512Mi"},
+                                              "requests": {"cpu": "100m", "memory": "256Mi"},
+                                          },
+                                      },
+                                      "service": {"spec": {"type": "ClusterIP"}},
+                                  },
+                                  "sync": {
+                                      "toHost": {
+                                          "ingresses": {"enabled": True},
+                                          "services":  {"enabled": True},
+                                      },
+                                      "fromHost": {"storageClasses": {"enabled": True}},
+                                  },
+                              },
+                          },
+                      },
+                      "syncPolicy": {
+                          "automated": {"prune": True, "selfHeal": True},
+                          "syncOptions": ["CreateNamespace=true", "ServerSideApply=true"],
+                      },
+                  },
+              }
+              resource.update(rsp.desired.resources["vcluster-application"], vcluster_app)
+
+              # Status (Phase 1: always Provisioning)
+              rsp.desired.composite.resource.setdefault("status", {}).update({
+                  "phase": "Provisioning",
+                  "vclusterURL": f"https://vcluster.{ns_name}.svc:443",
+                  "ingressURL": f"http://{ingress_host}",
+              })

--- a/base-apps/crossplane-compositions/xrd-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/xrd-smoke-test.yaml
@@ -1,0 +1,57 @@
+# base-apps/crossplane-compositions/xrd-smoke-test.yaml
+# XSmokeTestApp — namespaced XR for IDP smoke-test app provisioning.
+# Spec: docs/superpowers/specs/2026-05-13-smoke-test-app-design.md
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xsmoketestapps.platform.arigsela.com
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  group: platform.arigsela.com
+  names:
+    kind: XSmokeTestApp
+    plural: xsmoketestapps
+  claimNames:
+    kind: SmokeTestApp
+    plural: smoketestapps
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [image, host]
+              properties:
+                image:
+                  type: string
+                  description: Container image to deploy (e.g. nginx, ghcr.io/me/app:v1)
+                host:
+                  type: string
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                  maxLength: 30
+                  description: Subdomain label — ingress at <host>.smoke.arigsela.com
+                port:
+                  type: integer
+                  default: 80
+                  minimum: 1
+                  maximum: 65535
+                replicas:
+                  type: integer
+                  default: 1
+                  minimum: 1
+                  maximum: 3
+            status:
+              type: object
+              properties:
+                vclusterURL:
+                  type: string
+                ingressURL:
+                  type: string
+                phase:
+                  type: string
+                  enum: [Provisioning, Ready, Failed]


### PR DESCRIPTION
## Summary
- Adds `XSmokeTestApp` XRD (claim kind `SmokeTestApp`) and a **phase-1-only** Composition
- The Composition emits Namespace + an ArgoCD Application for the vcluster Helm chart
- Status is stamped `Provisioning`; no workload deployed yet
- Phase 2 (next PR) adds the `function-extra-resources` step + ArgoCD cluster Secret + workload Application

## Why split phases 1 & 2?
This is a safe checkpoint: apply a `SmokeTestApp` claim manually, confirm a vcluster comes up, then add the more complex kubeconfig-parsing logic on top. If something's wrong with the simpler emit path, we catch it before introducing the harder bits.

## Files
- `base-apps/crossplane-compositions/xrd-smoke-test.yaml` — XRD with required image/host, defaults port=80 replicas=1, replicas capped at 3, status fields
- `base-apps/crossplane-compositions/composition-smoke-test.yaml` — Pipeline-mode Composition with one `function-python` step

## Key Composition logic (Python)
- Reads `spec` from observed XR
- Emits Namespace `vcluster-<claim-name>` with managed-by + owner labels
- Emits ArgoCD Application `vcluster-<claim-name>` in `argo-cd` ns:
  - Source: `charts.loft.sh/vcluster` v0.34.0
  - **`sync.toHost.ingresses.enabled: true`** — key difference from sandbox-1; required so the workload Ingress (coming Phase 4) reaches the host nginx
  - `controlPlane.persistence` disabled (sqlite, ephemeral)
- Stamps `status.phase: Provisioning`, `status.vclusterURL`, `status.ingressURL`

## Test Plan
- [x] `kubectl apply --dry-run=client` on both files → both accepted (deprecation warning on `apiextensions.crossplane.io/v1` is consistent with existing `xrd-application.yaml`)
- [ ] After merge: ArgoCD `crossplane-compositions` Application syncs cleanly
- [ ] `kubectl get xrd xsmoketestapps.platform.arigsela.com` shows `ESTABLISHED=True`
- [ ] `kubectl api-resources --api-group=platform.arigsela.com` lists `smoketestapps` and `xsmoketestapps`
- [ ] After merge: I will apply a manual test claim (NOT via Backstage) and verify a vcluster pod comes up in `vcluster-<name>` namespace, then clean up the claim

## Related
- Spec: `docs/superpowers/specs/2026-05-13-smoke-test-app-design.md`
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 3)
- Phase 1 (merged): #269 — function-extra-resources install
- Phase 2 (merged): #270 — workload Helm chart

## Rollback
Revert this PR. No active claims exist yet, so no smoke-test instances to clean up. Existing XApplication is untouched.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>