### PR TITLE
fix(smoke-test): use struct_to_dict to read XR observed state

### DIFF
--- a/base-apps/crossplane-compositions/composition-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-smoke-test.yaml
@@ -24,8 +24,10 @@ spec:
           from crossplane.function import resource
 
           def compose(req, rsp):
-              spec = req.observed.composite.resource.get("spec", {})
-              name = req.observed.composite.resource.get("metadata", {}).get("name", "unknown")
+              # req.observed.composite.resource is a protobuf Struct; convert to dict before access.
+              xr = resource.struct_to_dict(req.observed.composite.resource)
+              spec = xr.get("spec", {})
+              name = xr.get("metadata", {}).get("name", "unknown")
               ns_name = f"vcluster-{name}"
               host = spec.get("host", "")
               ingress_host = f"{host}.smoke.arigsela.com"
@@ -96,9 +98,5 @@ spec:
               }
               resource.update(rsp.desired.resources["vcluster-application"], vcluster_app)
 
-              # Status (Phase 1: always Provisioning)
-              rsp.desired.composite.resource.setdefault("status", {}).update({
-                  "phase": "Provisioning",
-                  "vclusterURL": f"https://vcluster.{ns_name}.svc:443",
-                  "ingressURL": f"http://{ingress_host}",
-              })
+              # NOTE: status writing on the XR uses protobuf Struct semantics — defer to Phase 2
+              # where we'll add it properly alongside the function-extra-resources wiring.


### PR DESCRIPTION
## Summary
- Fixes the smoke-test Composition introduced in #271 — it was crashing with `AttributeError: 'get'` when the XR claim was applied
- `req.observed.composite.resource` is a protobuf `Struct`, not a plain dict — needed `resource.struct_to_dict(...)` to convert first (matches the existing XApplication composition's pattern)
- Also defers the XR `status` write to Phase 2 (`rsp.desired.composite.resource` has the same protobuf concern; cleaner to address alongside the function-extra-resources wiring)

## Verified the bug live
Applied a test claim post-merge of #271:
```
cannot run Composition pipeline step "render-resources":
cannot run Function "function-python": rpc error: code = Unknown
desc = Unexpected <class 'AttributeError'>: get
```

Test claim was cleaned up; vcluster namespace is gone.

## Test Plan
- [x] Diff confirmed: same `struct_to_dict` pattern as `composition-application.yaml:375`
- [ ] After merge: re-apply the test claim, confirm vcluster pod comes up within ~60s, then tear it down

## Related
- Breaks Phase 3 of: `docs/plans/smoke-test-app-implementation-plan.md`
- Original Phase 3 PR: #271

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>