### PR TITLE
fix(smoke-test): grant Crossplane SA permissions for Namespace + ArgoCD Application

### DIFF
--- a/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
@@ -1,0 +1,34 @@
+# base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
+# RBAC extension for the smoke-test Composition.
+#
+# The default `crossplane` ClusterRole does not grant the Crossplane controller
+# SA permission to create Namespaces or ArgoCD Applications, which the smoke-test
+# Composition emits. Without this:
+#   - Phase 1 fails to create namespaces/<ns> ("forbidden: cannot patch resource namespaces")
+#   - Phase 2 fails to create applications.argoproj.io ("forbidden: cannot patch ...")
+#
+# Aggregated into the existing `crossplane` ClusterRole via the standard
+# rbac.crossplane.io/aggregate-to-crossplane label — no extra binding needed.
+#
+# Mirrors the existing composition-rbac.yaml (which handles the application
+# Composition's Ingress/CNPG/ESO needs); split into its own file so each
+# Composition's RBAC stays scoped and discoverable.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:compositions:smoke-test
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+rules:
+  # Namespaces — the Composition creates one per smoke test (vcluster-<name>)
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # ArgoCD Applications — the Composition emits the vcluster Application
+  # (Phase 1) and the workload Application (Phase 2)
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applications/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary
- Adds a new aggregated ClusterRole granting the Crossplane controller SA the permissions it needs to emit Namespaces and ArgoCD Applications
- One new file, follows the existing `composition-rbac.yaml` pattern exactly
- Without this, Phase 1 of the smoke-test Composition fails on the first emitted resource (Namespace)

## Verified the bug live
Applied a test claim after #272 merged:
```
cannot apply composed resource "namespace":
namespaces "vcluster-..." is forbidden:
User "system:serviceaccount:crossplane-system:crossplane" cannot patch resource "namespaces"
```

The stuck XR was force-cleaned by removing its finalizer.

## File
- `base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml` — `ClusterRole crossplane:compositions:smoke-test` with `rbac.crossplane.io/aggregate-to-crossplane: "true"` label
  - Grants `get/list/watch/create/update/patch/delete` on:
    - `""/namespaces`
    - `argoproj.io/applications` and `applications/status`

## Why a separate RBAC file?
The existing `composition-rbac.yaml` already follows the pattern of "one aggregated ClusterRole per Composition's needs". Splitting keeps each Composition's RBAC scoped + discoverable, and avoids touching the file that gates the existing `application` Composition.

## Test Plan
- [x] `kubectl apply --dry-run=client` accepts the manifest
- [ ] After merge: re-apply test claim, confirm Namespace + vcluster Application are emitted, watch vcluster pod come up

## Related
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 3 fix)
- Existing precedent: `base-apps/crossplane-compositions/composition-rbac.yaml`
- Original Phase 3 PR: #271; struct_to_dict fix: #272

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>