### PR TITLE
feat(smoke-test): Composition phase 2 — Job-based ArgoCD cluster registration

### DIFF
--- a/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
@@ -32,3 +32,16 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications", "applications/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Phase 2 — bootstrap Job + its RBAC (cross-namespace SA pattern).
+  # The bootstrap Job reads vcluster's generated kubeconfig Secret and
+  # patches the placeholder ArgoCD cluster Secret with TLS material.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/base-apps/crossplane-compositions/composition-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-smoke-test.yaml
@@ -1,7 +1,22 @@
 # base-apps/crossplane-compositions/composition-smoke-test.yaml
 # Smoke-test app Composition. Pipeline-mode with function-python.
-# Phase 1 (this file): emits Namespace + vcluster Application only. Status: Provisioning.
-# Phase 2 (later PR): adds function-extra-resources step + ArgoCD cluster Secret + workload Application.
+#
+# Emits 10 host-cluster resources per claim:
+#   1.  Namespace                          vcluster-<xr>
+#   2.  ArgoCD Application                 vcluster-<xr>      (vcluster Helm chart)
+#   3.  ServiceAccount    (vcluster-<xr>)  bootstrap
+#   4.  Role              (vcluster-<xr>)  bootstrap-read-vc-secret
+#   5.  RoleBinding       (vcluster-<xr>)  bootstrap-read-vc-secret
+#   6.  Role              (argo-cd)        bootstrap-patch-cluster-<xr>
+#   7.  RoleBinding       (argo-cd)        bootstrap-patch-cluster-<xr>
+#   8.  Job               (vcluster-<xr>)  bootstrap   (reads vc-vcluster, patches the placeholder secret)
+#   9.  Secret            (argo-cd)        cluster-<xr>     ← placeholder; Job fills server/config
+#   10. ArgoCD Application (argo-cd)       smoke-<xr>-workload  (helm chart in this repo, target=cluster-<xr>)
+#
+# Phase 2 design notes: function-extra-resources v0.3.0 has only static name/namespace lookup
+# (no field-path templating), so we use an in-cluster Job for the dynamic kubeconfig read.
+# See docs/superpowers/specs/2026-05-13-smoke-test-app-design.md and the Phase 4 deviation
+# notes in the implementation plan.
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
@@ -23,45 +38,42 @@ spec:
         script: |
           from crossplane.function import resource
 
+          # Image used by the bootstrap Job — has kubectl + base64 + awk/grep/sed.
+          BOOTSTRAP_IMAGE = "bitnami/kubectl:1.30"
+
           def compose(req, rsp):
-              # req.observed.composite.resource is a protobuf Struct; convert to dict before access.
+              # req.observed.composite.resource is a protobuf Struct; convert to dict.
               xr = resource.struct_to_dict(req.observed.composite.resource)
               spec = xr.get("spec", {})
               name = xr.get("metadata", {}).get("name", "unknown")
               ns_name = f"vcluster-{name}"
               host = spec.get("host", "")
               ingress_host = f"{host}.smoke.arigsela.com"
+              cluster_name = f"smoke-{name}"
+              owner_label = {"smoketest.platform.arigsela.com/owner": name}
 
-              # 1. Namespace
+              # ---------- 1. Namespace ----------
               resource.update(rsp.desired.resources["namespace"], {
                   "apiVersion": "v1",
                   "kind": "Namespace",
                   "metadata": {
                       "name": ns_name,
-                      "labels": {
-                          "app.kubernetes.io/managed-by": "crossplane",
-                          "smoketest.platform.arigsela.com/owner": name,
-                      },
+                      "labels": {"app.kubernetes.io/managed-by": "crossplane", **owner_label},
                   },
               })
 
-              # 2. ArgoCD Application for the vcluster Helm chart
-              vcluster_app = {
+              # ---------- 2. ArgoCD Application: vcluster Helm chart ----------
+              resource.update(rsp.desired.resources["vcluster-application"], {
                   "apiVersion": "argoproj.io/v1alpha1",
                   "kind": "Application",
                   "metadata": {
                       "name": f"vcluster-{name}",
                       "namespace": "argo-cd",
-                      "labels": {
-                          "smoketest.platform.arigsela.com/owner": name,
-                      },
+                      "labels": owner_label,
                   },
                   "spec": {
                       "project": "default",
-                      "destination": {
-                          "server": "https://kubernetes.default.svc",
-                          "namespace": ns_name,
-                      },
+                      "destination": {"server": "https://kubernetes.default.svc", "namespace": ns_name},
                       "source": {
                           "repoURL": "https://charts.loft.sh",
                           "chart": "vcluster",
@@ -81,10 +93,7 @@ spec:
                                       "service": {"spec": {"type": "ClusterIP"}},
                                   },
                                   "sync": {
-                                      "toHost": {
-                                          "ingresses": {"enabled": True},
-                                          "services":  {"enabled": True},
-                                      },
+                                      "toHost": {"ingresses": {"enabled": True}, "services": {"enabled": True}},
                                       "fromHost": {"storageClasses": {"enabled": True}},
                                   },
                               },
@@ -95,8 +104,159 @@ spec:
                           "syncOptions": ["CreateNamespace=true", "ServerSideApply=true"],
                       },
                   },
-              }
-              resource.update(rsp.desired.resources["vcluster-application"], vcluster_app)
+              })
 
-              # NOTE: status writing on the XR uses protobuf Struct semantics — defer to Phase 2
-              # where we'll add it properly alongside the function-extra-resources wiring.
+              # ---------- 3. ServiceAccount (vcluster-<xr> ns) ----------
+              resource.update(rsp.desired.resources["bootstrap-sa"], {
+                  "apiVersion": "v1",
+                  "kind": "ServiceAccount",
+                  "metadata": {"name": "bootstrap", "namespace": ns_name, "labels": owner_label},
+              })
+
+              # ---------- 4. Role: read vc-vcluster Secret in vcluster-<xr> ----------
+              resource.update(rsp.desired.resources["bootstrap-read-role"], {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "Role",
+                  "metadata": {"name": "bootstrap-read-vc-secret", "namespace": ns_name, "labels": owner_label},
+                  "rules": [{
+                      "apiGroups": [""], "resources": ["secrets"],
+                      "resourceNames": ["vc-vcluster"],
+                      "verbs": ["get", "list", "watch"],
+                  }],
+              })
+
+              # ---------- 5. RoleBinding: bind SA to the read Role ----------
+              resource.update(rsp.desired.resources["bootstrap-read-rolebinding"], {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "RoleBinding",
+                  "metadata": {"name": "bootstrap-read-vc-secret", "namespace": ns_name, "labels": owner_label},
+                  "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": "bootstrap-read-vc-secret"},
+                  "subjects": [{"kind": "ServiceAccount", "name": "bootstrap", "namespace": ns_name}],
+              })
+
+              # ---------- 6. Role (argo-cd ns): patch the placeholder cluster Secret ----------
+              resource.update(rsp.desired.resources["bootstrap-patch-role"], {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "Role",
+                  "metadata": {"name": f"bootstrap-patch-cluster-{name}", "namespace": "argo-cd", "labels": owner_label},
+                  "rules": [{
+                      "apiGroups": [""], "resources": ["secrets"],
+                      "resourceNames": [f"cluster-{name}"],
+                      "verbs": ["get", "list", "watch", "patch", "update"],
+                  }],
+              })
+
+              # ---------- 7. RoleBinding (argo-cd ns) — cross-namespace SA reference ----------
+              resource.update(rsp.desired.resources["bootstrap-patch-rolebinding"], {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "RoleBinding",
+                  "metadata": {"name": f"bootstrap-patch-cluster-{name}", "namespace": "argo-cd", "labels": owner_label},
+                  "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": f"bootstrap-patch-cluster-{name}"},
+                  "subjects": [{"kind": "ServiceAccount", "name": "bootstrap", "namespace": ns_name}],
+              })
+
+              # ---------- 8. Job: read vc-vcluster, build config JSON, patch placeholder Secret ----------
+              # Script is intentionally pure bash — bitnami/kubectl doesn't ship python3.
+              # Polls for vc-vcluster (vcluster pod takes ~30s to write it).
+              bootstrap_script = f"""set -euo pipefail
+              echo "Waiting for vc-vcluster Secret in {ns_name}..."
+              for i in $(seq 1 60); do
+                if kubectl -n {ns_name} get secret vc-vcluster -o name >/dev/null 2>&1; then
+                  echo "Found vc-vcluster after ${{i}}*5s"
+                  break
+                fi
+                sleep 5
+              done
+              KUBECONFIG_B64=$(kubectl -n {ns_name} get secret vc-vcluster -o jsonpath='{{.data.config}}')
+              echo "$KUBECONFIG_B64" | base64 -d > /tmp/kubeconfig.yaml
+              CA_B64=$(grep -E "^\\s*certificate-authority-data:" /tmp/kubeconfig.yaml | head -1 | awk '{{print $2}}')
+              CERT_B64=$(grep -E "^\\s*client-certificate-data:" /tmp/kubeconfig.yaml | head -1 | awk '{{print $2}}')
+              KEY_B64=$(grep -E "^\\s*client-key-data:" /tmp/kubeconfig.yaml | head -1 | awk '{{print $2}}')
+              if [ -z "$CA_B64" ] || [ -z "$CERT_B64" ] || [ -z "$KEY_B64" ]; then
+                echo "ERROR: could not extract TLS material from kubeconfig" >&2
+                exit 1
+              fi
+              CONFIG_JSON='{{"tlsClientConfig":{{"insecure":false,"caData":"'"$CA_B64"'","certData":"'"$CERT_B64"'","keyData":"'"$KEY_B64"'"}}}}'
+              CONFIG_B64=$(echo -n "$CONFIG_JSON" | base64 | tr -d '\\n')
+              SERVER_B64=$(echo -n "https://vcluster.{ns_name}.svc:443" | base64 | tr -d '\\n')
+              echo "Patching argo-cd/cluster-{name} ..."
+              kubectl -n argo-cd patch secret cluster-{name} --type=merge -p "{{\\"data\\":{{\\"server\\":\\"$SERVER_B64\\",\\"config\\":\\"$CONFIG_B64\\"}}}}"
+              echo "Bootstrap complete."
+              """
+              resource.update(rsp.desired.resources["bootstrap-job"], {
+                  "apiVersion": "batch/v1",
+                  "kind": "Job",
+                  "metadata": {"name": "bootstrap", "namespace": ns_name, "labels": owner_label},
+                  "spec": {
+                      "backoffLimit": 5,
+                      "ttlSecondsAfterFinished": 600,
+                      "template": {
+                          "metadata": {"labels": owner_label},
+                          "spec": {
+                              "serviceAccountName": "bootstrap",
+                              "restartPolicy": "OnFailure",
+                              "containers": [{
+                                  "name": "bootstrap",
+                                  "image": BOOTSTRAP_IMAGE,
+                                  "command": ["/bin/bash", "-c", bootstrap_script],
+                                  "resources": {
+                                      "requests": {"cpu": "20m", "memory": "32Mi"},
+                                      "limits": {"cpu": "200m", "memory": "128Mi"},
+                                  },
+                              }],
+                          },
+                      },
+                  },
+              })
+
+              # ---------- 9. Placeholder ArgoCD cluster Secret ----------
+              # Created with `name` set so ArgoCD recognizes the entry; `server` and `config`
+              # are filled by the bootstrap Job once the vcluster's kubeconfig is available.
+              # Until then, the workload Application below will be "ComparisonError" — that's expected.
+              resource.update(rsp.desired.resources["argocd-cluster-secret"], {
+                  "apiVersion": "v1",
+                  "kind": "Secret",
+                  "metadata": {
+                      "name": f"cluster-{name}",
+                      "namespace": "argo-cd",
+                      "labels": {"argocd.argoproj.io/secret-type": "cluster", **owner_label},
+                  },
+                  "type": "Opaque",
+                  "stringData": {
+                      "name": cluster_name,
+                      # server/config intentionally absent — Job patches them in.
+                  },
+              })
+
+              # ---------- 10. Workload ArgoCD Application ----------
+              resource.update(rsp.desired.resources["workload-application"], {
+                  "apiVersion": "argoproj.io/v1alpha1",
+                  "kind": "Application",
+                  "metadata": {
+                      "name": f"smoke-{name}-workload",
+                      "namespace": "argo-cd",
+                      "labels": owner_label,
+                  },
+                  "spec": {
+                      "project": "default",
+                      "destination": {"name": cluster_name, "namespace": "default"},
+                      "source": {
+                          "repoURL": "https://github.com/arigsela/kubernetes",
+                          "targetRevision": "main",
+                          "path": "charts/smoke-test-workload",
+                          "helm": {
+                              "releaseName": "smoke",
+                              "valuesObject": {
+                                  "image": spec.get("image", ""),
+                                  "port": spec.get("port", 80),
+                                  "host": ingress_host,
+                                  "replicas": spec.get("replicas", 1),
+                              },
+                          },
+                      },
+                      "syncPolicy": {
+                          "automated": {"prune": True, "selfHeal": True},
+                          "syncOptions": ["CreateNamespace=true", "ServerSideApply=true"],
+                      },
+                  },
+              })


### PR DESCRIPTION
## Summary
- Implements Phase 2 of the smoke-test Composition (cluster registration + workload delivery)
- **Design pivot from the plan**: function-extra-resources v0.3.0 has no namespace templating (verified against the function's Go source), so we use an in-cluster Job to do the dynamic kubeconfig read instead of having the Composition's Python read it directly
- All 10 emitted resources are Crossplane-managed → cascade-delete still works cleanly

## Why the redesign
The original plan called for `function-extra-resources` to read `Secret/vc-vcluster` in namespace `vcluster-<xr-name>` and have the Composition's Python emit the ArgoCD cluster Secret. The function's `Reference.Name` and `Namespace` fields are both static strings — no `valueFromFieldPath` for Reference mode, and Selector mode only supports `FromCompositeFieldPath` for label **values**, which can't reach the auto-generated vc-vcluster Secret (vcluster's chart doesn't propagate custom labels to it).

Job-based bootstrap is the pragmatic alternative that keeps everything Crossplane-managed.

## Resources emitted by Composition (10 total)
| # | Kind | Namespace | Purpose |
|---|---|---|---|
| 1 | Namespace | (cluster) | `vcluster-<xr>` |
| 2 | Application | argo-cd | vcluster Helm chart |
| 3 | ServiceAccount | vcluster-<xr> | for bootstrap Job |
| 4 | Role | vcluster-<xr> | read `vc-vcluster` |
| 5 | RoleBinding | vcluster-<xr> | bind SA → read Role |
| 6 | Role | argo-cd | patch `cluster-<xr>` |
| 7 | RoleBinding | argo-cd | cross-ns SA binding |
| 8 | Job | vcluster-<xr> | runs bootstrap script |
| 9 | Secret | argo-cd | placeholder `cluster-<xr>` |
| 10 | Application | argo-cd | workload app |

## Bootstrap Job
- Image: `bitnami/kubectl:1.30` (no python3 needed)
- Polls for `Secret/vc-vcluster` (vcluster pod takes ~30s to write it after pod boots)
- Decodes the kubeconfig, extracts `certificate-authority-data` / `client-certificate-data` / `client-key-data` via grep+awk
- Builds the ArgoCD cluster config JSON
- `kubectl patch` the placeholder Secret with `server` + `config` fields
- Idempotent (merge patch), `backoffLimit: 5`, `ttlSecondsAfterFinished: 600` for tidy cleanup

## Test Plan
- [x] `kubectl apply --dry-run=client` accepts both files
- [x] Embedded bash passes `bash -n` (verified after Python f-string rendering — `${i}` not `${{i}}`, JSON properly escaped)
- [ ] After merge: apply a test claim, watch all 10 resources come up
- [ ] After ~90s: workload Application transitions from `ComparisonError` → `Synced/Healthy` once Job patches the cluster Secret
- [ ] `curl http://<host>.smoke.arigsela.com` returns nginx welcome page
- [ ] Cascade-delete on `kubectl delete smoketestapp <name>` removes all 10 resources within ~60s, no orphans in `argo-cd` ns

## Related
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 4 — to be amended with design deviation notes after this is validated)
- Spec: `docs/superpowers/specs/2026-05-13-smoke-test-app-design.md`
- Phase 1 (merged): #269 — function-extra-resources install (now unused by smoke-test but left installed; harmless and available for future Compositions)
- Phase 3 PRs: #271, #272, #273

## Rollback
Revert. No active claims → no orphans.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>