### PR TITLE
fix(smoke-test): namespace ownership race + jobs/status RBAC

### DIFF
--- a/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-rbac-smoke-test.yaml
@@ -43,5 +43,5 @@ rules:
     resources: ["roles", "rolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["batch"]
-    resources: ["jobs"]
+    resources: ["jobs", "jobs/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/base-apps/crossplane-compositions/composition-smoke-test.yaml
+++ b/base-apps/crossplane-compositions/composition-smoke-test.yaml
@@ -101,7 +101,13 @@ spec:
                       },
                       "syncPolicy": {
                           "automated": {"prune": True, "selfHeal": True},
-                          "syncOptions": ["CreateNamespace=true", "ServerSideApply=true"],
+                          # NOTE: CreateNamespace=true is intentionally OMITTED — Crossplane
+                          # owns the namespace (resource #1). If ArgoCD raced ahead and
+                          # auto-created it via CreateNamespace, the namespace would lack
+                          # the crossplane.io/composition-resource-name annotation and
+                          # subsequent Crossplane reconciles would fail with
+                          # "composed resource without required annotation".
+                          "syncOptions": ["ServerSideApply=true"],
                       },
                   },
               })


### PR DESCRIPTION
## Summary
Two small fixes for Phase 2 issues that surfaced during the end-to-end test of #274:

### 1. Namespace ownership race
ArgoCD's `CreateNamespace=true` syncOption on the **vcluster Application** was racing Crossplane's emit and winning — the namespace was being created by ArgoCD WITHOUT the `crossplane.io/composition-resource-name` annotation. Crossplane's subsequent reconciles then refused to proceed:

```
cannot get existing composed resources: encountered composed resource
without required "crossplane.io/composition-resource-name" annotation
```

**Fix:** drop `CreateNamespace=true` from the vcluster Application's syncOptions. Crossplane owns the Namespace (resource #1 in the emit list); ArgoCD just needs to wait — `selfHeal` retries the vcluster sync until the namespace exists.

The workload Application's `CreateNamespace=true` is kept — it targets the vcluster's `default` namespace inside the registered cluster, where Crossplane has no role.

### 2. `jobs/status` RBAC permission
Same pattern as the existing `composition-rbac.yaml` needs for `clusters/status` (CNPG). Without it, Crossplane's informer for the bootstrap Job can't fully sync, producing:

```
system:serviceaccount:crossplane-system:crossplane is not allowed
to [get, list, watch, create, update, patch, delete] resource
jobs/status.batch/v1 in namespace ...
```

**Fix:** add `jobs/status` to the existing batch rule in `composition-rbac-smoke-test.yaml`.

## Test Plan
- [x] Existing test claim cleaned up (force-removed finalizers since cascade was stuck on the original RBAC issue)
- [ ] After merge: apply test claim again, watch all 10 resources come up cleanly, bootstrap Job completes, workload Application syncs, curl works, cascade-delete succeeds

## Related
- Plan: `docs/plans/smoke-test-app-implementation-plan.md` (Phase 4 fix)
- Original Phase 4: #274

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>