### PR TITLE
chore(deps): bump nginx-ingress 4.11.2 → 4.15.1 and cert-manager 1.18.2 → 1.20.2

### DIFF
--- a/base-apps/cert-manager.yaml
+++ b/base-apps/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://charts.jetstack.io
     chart: cert-manager
-    targetRevision: v1.18.2
+    targetRevision: v1.20.2
     helm:
       parameters:
         - name: installCRDs

--- a/base-apps/nginx-ingress/nginx-ingress-controller.yaml
+++ b/base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -8,7 +8,7 @@ spec:
   repo: https://kubernetes.github.io/ingress-nginx
   targetNamespace: ingress-nginx
   createNamespace: true
-  version: v4.11.2
+  version: v4.15.1
   valuesContent: |-
     controller:
       nodeSelector:


### PR DESCRIPTION
## Summary
- Bump nginx-ingress chart `v4.11.2` → `v4.15.1` (controller `v1.11.2` → `v1.15.1`) — **patches IngressNightmare CVEs**
- Bump cert-manager chart `v1.18.2` → `v1.20.2`
- Both upgrades are non-breaking for this repo based on pre-flight audits

## Changes

### nginx-ingress (`base-apps/nginx-ingress/nginx-ingress-controller.yaml`)
Controller `v1.11.2` (2024-08-16) predates the IngressNightmare disclosure series (March 2025), patched in `v1.11.5` / `v1.12.1`:
- CVE-2025-1097, CVE-2025-1098
- CVE-2025-1974 (RCE)
- CVE-2025-24513, CVE-2025-24514

Jumping straight to the current `v1.15.x` line since older minors are EOL or near-EOL.

### cert-manager (`base-apps/cert-manager.yaml`)
- `v1.19` removes high-cardinality `path` label from `certmanager_acme_client_request_count` / `_duration_seconds` metrics
- `v1.20` requires no special upgrade steps per upstream upgrade doc
- Skipping `v1.19.0` due to upstream re-issue bug; landing on patch-current `v1.20.2`

## Pre-flight audits
- ✅ Zero `nginx.ingress.kubernetes.io/(server|configuration|auth|modsecurity|stream)-snippet` annotations across `base-apps/` — no `controller.allowSnippetAnnotations=true` needed
- ✅ Zero references to deprecated `certmanager_acme_client_request_*` `path` label across the repo — no dashboard/alert updates needed

## ⚠️ Breaking Changes
None for this repo, given the audits above.

## Deployment Notes
- **nginx-ingress** is deployed via the k3s `HelmChart` CRD (not ArgoCD) — the chart upgrade triggers automatically once the manifest reconciles in `kube-system`
- **cert-manager** is deployed via ArgoCD — auto-syncs after merge
- Existing `installCRDs=true` parameter is preserved; CRDs will be reconciled during chart upgrade
- No rollback procedure required beyond reverting this PR

## Test Plan
- [ ] Verify k3s `HelmChart` controller picks up nginx version bump (`kubectl -n kube-system get helmchart ingress-nginx -o jsonpath='{.spec.version}'`)
- [ ] Verify `ingress-nginx-controller` DaemonSet rolls to `v1.15.1` image (`kubectl -n ingress-nginx get ds`)
- [ ] Spot-check one external Ingress (e.g., `n8n.arigsela.com`, `kagent.arigsela.com`) end-to-end via Cloudflare Tunnel
- [ ] Verify ArgoCD `cert-manager` Application syncs cleanly to `v1.20.2`
- [ ] Verify all cert-manager pods (`cert-manager`, `webhook`, `cainjector`) come up healthy
- [ ] Spot-check a `Certificate` resource still reconciles (`kubectl get certificates -A`)

## Related
- Follow-up: stage Argo CD chart `9.0.5 → 9.5.14` via Terraform (separate work, not in this PR)

🤖 Generated with [Claude Code](https://claude.ai/code)