### PR TITLE
fix(kagent): enable directory.recurse on kagent-secrets app

### DIFF
--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -11,6 +11,8 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/kagent
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: kagent


### PR DESCRIPTION
## Summary

Surfaced during validation of PR #278 (`homelab-knowledge` agent). The agent file was merged into `base-apps/kagent/agents/homelab-knowledge.yaml` and ArgoCD reconciled to the post-merge commit, but the Agent CRD never appeared in the cluster — the kagent-secrets app was simply ignoring the `agents/` subdirectory.

**Root cause:** ArgoCD's Directory source has `recurse: false` by default. The kagent-secrets Application points at `base-apps/kagent` but doesn't override the default, so files in `base-apps/kagent/agents/` are skipped at sync time.

**Fix:** add `directory.recurse: true` to the Application spec (2-line change). After merging, ArgoCD will walk the directory tree and pick up `homelab-knowledge.yaml` (plus any future IDP-created agents).

This was a real gap in the IDP design spec — both the spec and the implementation plan assumed the existing kagent-secrets app would recurse automatically. A follow-up commit to PR #277 will document this as the third finding from the v1.6 deployment so future template work avoids the same trap.

## Diff

```diff
   source:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/kagent
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: kagent
```

## Test plan

- [x] Verified the bug live: `kubectl get application kagent-secrets -n argo-cd -o yaml` shows `revision: 2c589a575...` (post-merge of #278) but the resources list only contains the 5 top-level files; `homelab-knowledge` is missing
- [x] Confirmed file exists in repo: `git ls-tree --name-only origin/main base-apps/kagent/agents/` → `base-apps/kagent/agents/homelab-knowledge.yaml`
- [ ] After merge: wait ~3 min for ArgoCD reconcile, then `kubectl get agent -n kagent homelab-knowledge` should return Accepted=True / Ready=True
- [ ] After merge: the kagent UI at https://kagent.arigsela.com should list `homelab-knowledge` and accept queries that delegate to k8s-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)