### PR TITLE
docs(kagent): add third finding — ArgoCD directory.recurse needed

### DIFF
--- a/docs/superpowers/plans/2026-05-18-kagent-idp.md
+++ b/docs/superpowers/plans/2026-05-18-kagent-idp.md
@@ -1928,3 +1928,37 @@ kubectl exec -n backstage <pod> -- node -e \
 in `template.yaml` (no `| dump`), and iterate with
 `{% for skill in values.skills %}` in the content template (no `parseJson`).
 Tasks 4 and 5 above now reflect this.
+
+### 3. ArgoCD Directory source needs `recurse: true`
+
+The plan assumed `base-apps/kagent-secrets.yaml` already synced
+`base-apps/kagent/` recursively. It did not — ArgoCD's Directory source
+defaults to `recurse: false`, so files in `base-apps/kagent/agents/` were
+silently skipped at sync time even after ArgoCD reconciled to the
+post-merge commit.
+
+**Symptom:** the agent's PR merges cleanly, ArgoCD reconciles to the
+post-merge commit, but the Agent CRD never appears (`kubectl get agent
+-n kagent <name>` returns NotFound) and is missing from the Application's
+resources tree.
+
+**Diagnosis tool:**
+```bash
+kubectl get application kagent-secrets -n argo-cd -o yaml | yq '.status.resources[].name'
+```
+
+**Required pre-work for this plan:** before running Phase 3 smoke tests
+(or before merging any IDP-created agent PR), `base-apps/kagent-secrets.yaml`
+in `arigsela/kubernetes` must include `directory.recurse: true`:
+
+```yaml
+spec:
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/kagent
+    directory:
+      recurse: true   # REQUIRED for the agents/ subdir to be synced
+```
+
+This was done in `arigsela/kubernetes` PR #279.

--- a/docs/superpowers/specs/2026-05-18-kagent-idp-design.md
+++ b/docs/superpowers/specs/2026-05-18-kagent-idp-design.md
@@ -434,3 +434,38 @@ the dry-run fails with `Error: filter not found: parseJson`.
 `skills: ${{ parameters.skills }}` (no `| dump`); in the content template
 iterate with `{% if values.skills | length > 0 %}` / `{% for skill in
 values.skills %}` (no `| parseJson`).
+
+### 3. ArgoCD Directory source needs `recurse: true`
+
+The plan assumed dropping a rendered Agent CRD into
+`base-apps/kagent/agents/<name>.yaml` would be picked up automatically by
+the existing `kagent-secrets` ArgoCD Application. It is not — ArgoCD's
+Directory source has `recurse: false` by default, so files inside
+subdirectories are silently skipped at sync time.
+
+**Symptom:** PR merges cleanly, ArgoCD reconciles to the post-merge
+commit and reports `Synced`, but the new Agent CRD never appears in the
+cluster and is missing from the Application's resources tree. The kagent
+UI shows no new agent.
+
+**Diagnosis tool:**
+```bash
+kubectl get application kagent-secrets -n argo-cd -o yaml | yq '.status.resources[].name'
+```
+If your IDP-created agent isn't in the list, the parent directory isn't
+recursing.
+
+**Required:** the `kagent-secrets` Application's `spec.source` must include
+`directory.recurse: true`:
+
+```yaml
+spec:
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/kagent
+    directory:
+      recurse: true   # REQUIRED — without this, agents/ subdir is ignored
+```
+
+Fixed in `arigsela/kubernetes` PR #279.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #277. Adds the third finding from the v1.6 production deployment to both the spec and the implementation plan.

## The finding

ArgoCD's Directory source defaults to `recurse: false`. The kagent IDP spec assumed the existing `kagent-secrets` Application (which syncs `base-apps/kagent/`) would automatically pick up new files under `base-apps/kagent/agents/`. It does not — subdirectory files are silently skipped at sync time.

**Surfaced when** the first IDP-created agent (`homelab-knowledge`, PR #278) merged cleanly, ArgoCD reconciled to the post-merge commit `2c589a5` and reported `Synced`, but the Agent CRD never appeared in the cluster and was missing from the Application's resources tree.

**Fix is in flight:** PR #279 adds `directory.recurse: true` to `base-apps/kagent-secrets.yaml`.

## Changes

- `docs/superpowers/specs/2026-05-18-kagent-idp-design.md` — adds the third finding to the "Findings from production deployment" section with symptom, diagnosis command, and the required Application spec change
- `docs/superpowers/plans/2026-05-18-kagent-idp.md` — same finding added to the "Findings from production deployment" section, plus a "Required pre-work" note so re-running this plan from scratch ensures the recurse setting is in place before Phase 3 smoke tests

## Test plan

- [x] Spec and plan both build correctly (no broken markdown)
- [x] PR #279 (the actual fix) tested live in cluster
- No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)