### PR TITLE
fix(kagent): drop observability-agent delegation from homelab-knowledge

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -65,7 +65,6 @@ spec:
           CRDs, namespaces) → delegate to k8s-agent. Always prefer this over guessing.
         - For Helm release questions (what charts are installed, versions, values
           diffs, release history) → delegate to helm-agent.
-        - For metrics, dashboards, alert investigation → delegate to observability-agent.
         - For repo/manifest questions (what's in base-apps/<x>/, ArgoCD sync status,
           Vault role names, ingress hostnames) → answer from your own knowledge if
           possible, then cross-check live state via k8s-agent.
@@ -129,9 +128,6 @@ spec:
     - type: Agent
       agent:
         name: helm-agent
-    - type: Agent
-      agent:
-        name: observability-agent
     deployment:
       resources:
         requests:


### PR DESCRIPTION
## Summary

The `homelab-knowledge` Agent (created via the IDP, PR #278) is stuck at `Accepted=False` after deploying. The kagent controller refuses to translate it with:

```
failed to translate agent kagent/homelab-knowledge:
Agent.kagent.dev "promql-agent" not found
```

**Root cause:** transitive failure. `homelab-knowledge` delegates to `observability-agent`, which itself delegates to `promql-agent` — but `promql-agent` is disabled in our kagent Helm values (`base-apps/kagent.yaml: agents.promql-agent.enabled = false`). kagent's translator walks the full delegation graph at acceptance time, so even though `homelab-knowledge` doesn't reference `promql-agent` directly, the transitive failure kills it.

This is the **pre-existing broken dependency #2** already flagged in the IDP design spec under "Known limitations" — I should have warned the user when recommending `observability-agent` as a delegate. The fix is local to homelab-knowledge: drop the observability delegation until the chart-level issue is fixed.

## Changes

`base-apps/kagent/agents/homelab-knowledge.yaml`:
- Remove `observability-agent` from `spec.declarative.tools` (3 lines)
- Remove the matching "delegate to observability-agent for metrics" line from the `systemMessage` (1 line) so the prompt and tools stay consistent

Net: -4 lines.

## Trade-off

The agent loses the ability to answer metrics/Grafana questions until observability-agent is unblocked. The remaining `k8s-agent` + `helm-agent` delegations still cover the core use cases (live cluster state, Helm releases, repo/manifest questions, deployment guidance).

## Follow-up (not in this PR)

The bigger fix is at the chart level: either enable `promql-agent` in `base-apps/kagent.yaml`, or override observability-agent's tools list in the Helm values to drop the promql-agent reference. Worth doing eventually so observability-agent becomes a usable delegate again.

## Test plan

- [x] Confirmed bug live: `kubectl get agent -n kagent homelab-knowledge -o jsonpath='{.status.conditions[0].message}'` returned the promql-agent translation error
- [x] Diff verified: only 4 lines removed, no other changes
- [ ] After merge: ArgoCD reconciles, kagent re-translates, `kubectl get agent -n kagent homelab-knowledge` should show `Accepted=True` and `Ready=True`
- [ ] Agent appears in the kagent UI at https://kagent.arigsela.com and answers a test query

🤖 Generated with [Claude Code](https://claude.com/claude-code)