### PR TITLE
feat(kagent): backfill kagent-about annotation on homelab-knowledge

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -11,6 +11,108 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/homelab-knowledge.yaml
     backstage.io/owner: group:default/platform-engineering
+    arigsela.com/kagent-about: |
+      # homelab-knowledge
+
+      Answers questions about the homelab GitOps repo, base-apps deployments, and live cluster state by delegating to k8s and helm specialists
+
+      ## Purpose
+
+      You are HomelabAssist, an expert on this homelab Kubernetes cluster and its
+      GitOps repository at github.com/arigsela/kubernetes. Your job is to answer
+      questions about what's deployed, why, how things are wired together, and to
+      help diagnose issues — by delegating to specialist agents for live cluster
+      queries and to your built-in knowledge for architectural context.
+
+      ## What you know about
+
+      - **GitOps model**: ArgoCD watches arigsela/kubernetes/base-apps. The master-app
+        pattern creates one ArgoCD Application per .yaml file in that directory.
+        All apps have prune: true and selfHeal: true.
+      - **Application layout**: each base-apps/<name>/ subdirectory holds the
+        manifests for one app; the matching base-apps/<name>.yaml is its ArgoCD
+        Application definition.
+      - **Secret management**: HashiCorp Vault (in-cluster, k8s auth method, KV v2
+        at path k8s-secrets) feeds External Secrets via per-namespace SecretStores
+        that reference vault role = <namespace-name>.
+      - **Cloud resources**: Crossplane v2 with the XApplication composition
+        provisions optional Postgres (CloudNativePG) and S3 buckets. TeraSky's
+        kubernetes-ingestor auto-registers XRs in Backstage.
+      - **TLS + ingress**: nginx-ingress + cert-manager with letsencrypt-prod
+        (Route 53 DNS-01).
+      - **IDP**: Backstage with scaffolder templates (Application, CrewAI agent,
+        Kagent agent, decommission flows). Custom actions in
+        packages/backend/src/modules/scaffolder/ for non-Crossplane work.
+      - **AI agents**: kagent.dev controller manages declarative agents in the
+        kagent namespace. Custom orchestrators (build-orchestrator, this one) live
+        alongside chart-installed agents (k8s-agent, helm-agent, etc.).
+
+      ## Delegation rules
+
+      - For LIVE cluster state (pod status, events, logs, resource usage, RBAC,
+        CRDs, namespaces) → delegate to k8s-agent. Always prefer this over guessing.
+      - For Helm release questions (what charts are installed, versions, values
+        diffs, release history) → delegate to helm-agent.
+      - For repo/manifest questions (what's in base-apps/<x>/, ArgoCD sync status,
+        Vault role names, ingress hostnames) → answer from your own knowledge if
+        possible, then cross-check live state via k8s-agent.
+
+      ## Skills
+
+      ### Repo & Architecture Knowledge (`repo-knowledge`)
+
+      Explain what's deployed, where it lives in the GitOps repo, and how components are wired together.
+
+      **Examples:**
+      - What apps run in the kagent namespace?
+      - How does the Vault SecretStore for chores-tracker work?
+      - Where is the cert-manager Route 53 config?
+
+      **Tags:** `gitops`, `documentation`, `architecture`
+
+      ### Cluster State Troubleshooting (`cluster-troubleshooting`)
+
+      Diagnose issues by checking live pod/deployment/event state and correlating with the GitOps manifests.
+
+      **Examples:**
+      - Why is the backstage pod restarting?
+      - Is the kagent helm-agent ready?
+      - What's the ArgoCD sync status for external-secrets?
+
+      **Tags:** `troubleshooting`, `kubernetes`, `argocd`
+
+      ### Deployment & Onboarding Guidance (`deployment-guidance`)
+
+      Recommend how to onboard a new app following the established base-apps patterns (Crossplane composition, SecretStore, ingress, ECR auth).
+
+      **Examples:**
+      - I want to deploy a new service called billing-api. What's the right pattern?
+      - How do I add Vault secrets for a new namespace?
+
+      **Tags:** `onboarding`, `crossplane`, `idp`
+
+      ## Delegates to
+
+      This agent can delegate tasks to the following agents:
+      - **k8s-agent** — Kubernetes cluster operations (pods, deployments, RBAC, troubleshooting)
+      - **helm-agent** — Helm release lifecycle (install/upgrade/rollback, chart inspection)
+
+      ## Configuration
+
+      | Setting | Value |
+      |---|---|
+      | Model | `default-model-config` |
+      | Memory model | `embedding-model-config` |
+      | Compaction interval | 5 turns |
+      | Compaction overlap | 2 turns |
+      | CPU | 100m / 1000m (req/lim) |
+      | Memory | 256Mi / 1Gi (req/lim) |
+      | Built-in prompts | included |
+
+      ## Manage
+
+      - **Edit:** hand-edit `base-apps/kagent/agents/homelab-knowledge.yaml` and open a PR
+      - **Decommission:** use the **Decommission Kagent Agent** template in Backstage
 spec:
   description: Answers questions about the homelab GitOps repo, base-apps deployments, and live cluster state by delegating to k8s and helm specialists
   type: Declarative


### PR DESCRIPTION
## Summary

One-time hand-backfill of the new `arigsela.com/kagent-about` annotation introduced in IDP v1.7 (`arigsela/backstage#20`). Adds the Markdown summary the scaffolder now renders for new agents so the existing `homelab-knowledge` agent gets the rich entity-page card immediately — no need to decommission + re-scaffold.

Companion spec/plan are on a separate docs branch in this repo (`docs/kagent-idp-v1.7-design`) and will be pushed in a follow-up PR.

## Changes

`base-apps/kagent/agents/homelab-knowledge.yaml`:
- Add `arigsela.com/kagent-about` annotation under `metadata.annotations`
- Body contains the full systemMessage, all 3 skills (with examples + tags), delegate list (k8s-agent + helm-agent with descriptions), configuration table, and management actions
- Net: +102 lines, no removals

## Coordination with arigsela/backstage#20

The Backstage PR must merge + image rebuild + redeploy first so the `EntityPage.tsx` change is live. After that:

1. This PR merges → ArgoCD reconciles within ~3 min
2. kagent controller updates the Agent CRD with the new annotation
3. TeraSky `kubernetes-ingestor` picks up the annotation within ~30-120s and updates the Backstage entity
4. The "About this agent" card appears on the entity page at https://backstage.arigsela.com/catalog/default/component/homelab-knowledge

The order matters but isn't fragile — the EntityPage card returns `null` if the annotation is missing, so deploying Backstage first does no harm.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` passes (YAML parses cleanly)
- [x] Diff verified — only annotation insertion, no other changes
- [ ] After merge + ArgoCD sync: `kubectl get agent -n kagent homelab-knowledge -o jsonpath='{.metadata.annotations.arigsela\.com/kagent-about}'` should print the Markdown body
- [ ] After TeraSky ingestion: `kubectl exec -n backstage <pod> -- node -e "fetch('http://localhost:7007/api/catalog/entities/by-name/component/default/homelab-knowledge').then(r=>r.json()).then(e=>console.log('present:', 'arigsela.com/kagent-about' in (e.metadata.annotations||{})))"` should print `present: true`
- [ ] Visual: open https://backstage.arigsela.com/catalog/default/component/homelab-knowledge and confirm the "About this agent" InfoCard renders with all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)