### PR TITLE
fix(kagent): rename kagent-about annotation to terasky.backstage.io namespace

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -11,7 +11,7 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/homelab-knowledge.yaml
     backstage.io/owner: group:default/platform-engineering
-    arigsela.com/kagent-about: |
+    terasky.backstage.io/kagent-about: |
       # homelab-knowledge
 
       Answers questions about the homelab GitOps repo, base-apps deployments, and live cluster state by delegating to k8s and helm specialists


### PR DESCRIPTION
## Summary

Companion fix to `arigsela/backstage` PR #20 (the v1.7 entity-page card branch).

Smoke testing v1.7 in the live cluster revealed the `arigsela.com/kagent-about` annotation never reached the Backstage catalog despite being correctly written to the `homelab-knowledge` Agent CRD by the v1.7 backfill (PR #282).

## Root cause — two-layer filtering

1. **The kagent controller**, when spawning a `Deployment` from an `Agent` CRD, only forwards annotations from known namespaces (`terasky.backstage.io/*`, `backstage.io/*`, `argocd*`, `deployment.kubernetes.io/*`). Custom namespaces like `arigsela.com/*` are silently dropped.
2. **TeraSky's `kubernetes-ingestor`** reads from the **Deployment** the controller created (not from the Agent CRD itself — confirmed by the entity carrying `deployment.kubernetes.io/revision`).

So the annotation made it into the Agent CRD via GitOps, the controller didn't propagate it to the Deployment, and TeraSky never saw it. The Backstage entity ends up with no `kagent-about` annotation, the EntityPage card has nothing to render.

## Fix

Rename `arigsela.com/kagent-about` → `terasky.backstage.io/kagent-about`. The `terasky.backstage.io/*` namespace is proven to pass through the kagent controller (it forwards `terasky.backstage.io/add-to-catalog` and `terasky.backstage.io/component-type` — both confirmed present on the live Deployment). TeraSky's ingestor's annotation handler is a generic passthrough (only excludes `terasky.backstage.io/links`) so the renamed annotation will reach the catalog entity.

Cosmetically squats on TeraSky's namespace, but TeraSky's plugin has no logic that reads `kagent-about` — it's pure metadata for our `EntityPage.tsx` consumer.

## Coordination with backstage PR #20

The Backstage PR has been updated (commit `61dc4e6`) to look up `terasky.backstage.io/kagent-about` and to render that namespace in the scaffolder template for future agents. The image needs to be rebuilt from that branch and redeployed before/after this PR merges — order doesn't matter, the card returns `null` when the annotation is missing.

## Test plan

- [x] Diff verified — single-line rename, no other changes
- [x] `python3 yaml.safe_load(...)` passes
- [ ] After merge + ArgoCD sync + (rebuilt Backstage if needed): `kubectl exec -n backstage <pod> -- node -e "fetch('http://localhost:7007/api/catalog/entities/by-name/component/default/homelab-knowledge').then(r=>r.json()).then(e=>console.log(Object.keys(e.metadata.annotations||{}).filter(k=>k.includes('kagent'))))"` should print `[ 'terasky.backstage.io/kagent-about' ]`
- [ ] Visual: https://backstage.arigsela.com/catalog/default/component/homelab-knowledge shows the "About this agent" card

🤖 Generated with [Claude Code](https://claude.com/claude-code)