### PR TITLE
fix(backstage): grant kagent.dev read RBAC for v1.7 entity-page card

### DIFF
--- a/base-apps/backstage/rbac.yaml
+++ b/base-apps/backstage/rbac.yaml
@@ -121,3 +121,34 @@ roleRef:
   kind: ClusterRole
   name: backstage-crossplane-read
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+# kagent IDP v1.7 — Backstage entity-page card fetches the live Agent CRD via
+# the Kubernetes plugin proxy at render time (it can't use the annotation
+# approach we originally tried because the kagent controller drops multi-line
+# annotations during Deployment creation). Without this RBAC the proxy fetch
+# returns 403 Forbidden and the card shows "Could not load agent details".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-kagent-read
+rules:
+  - apiGroups: ["kagent.dev"]
+    resources: ["agents", "modelconfigs", "remotemcpservers"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-kagent-read
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+roleRef:
+  kind: ClusterRole
+  name: backstage-kagent-read
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

The v1.7 kagent IDP entity-page card (arigsela/backstage PR #20, pivoted to live K8s fetch in commit `743f4f1`) makes a proxied request to the K8s API to read the live `Agent` CRD's `spec.declarative.*` fields. Without RBAC, the request fails with:

```
status: 403
{"kind":"Status","apiVersion":"v1","status":"Failure",
 "message":"agents.kagent.dev \"homelab-knowledge\" is forbidden:
   User \"system:serviceaccount:backstage:backstage\" cannot get resource \"agents\"
   in API group \"kagent.dev\" in the namespace \"kagent\"",
 "reason":"Forbidden","code":403}
```

(Reproduced live via `kubectl exec -n backstage <pod> -- node -e "fetch(...)..."`.)

## Fix

New `backstage-kagent-read` ClusterRole + ClusterRoleBinding granting `get/list/watch` on the kagent CRD types. Follows the same per-concern role pattern as the existing `backstage-crossplane-read` (PR #foo from v1.x days).

Resources granted:
- `agents.kagent.dev` — what the card actually fetches today
- `modelconfigs.kagent.dev` — needed for future features (display embedding model name, etc.)
- `remotemcpservers.kagent.dev` — needed if we eventually surface MCP tool details

Minimal verbs (`get`, `list`, `watch`) — read-only, no write access.

## Test plan

- [x] `python3 yaml.safe_load_all(...)` passes (well-formed YAML)
- [x] Diff is purely additive (new ClusterRole + ClusterRoleBinding); no changes to existing RBAC
- [ ] After merge + ArgoCD sync: from inside the backstage pod, `fetch('http://localhost:7007/api/kubernetes/proxy/apis/kagent.dev/v1alpha2/namespaces/kagent/agents/homelab-knowledge', {headers:{'Backstage-Kubernetes-Cluster':'homelab'}}).then(r=>console.log(r.status))` should return 200 (was 403)
- [ ] Visual: visit `https://backstage.arigsela.com/catalog/default/component/homelab-knowledge` and confirm the "About this agent" card renders the agent's content (no "Could not load agent details" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)