### PR TITLE
feat(kagent): backfill v1.8 labels on homelab-knowledge

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -5,7 +5,10 @@ metadata:
   namespace: kagent
   labels:
     app.kubernetes.io/part-of: kagent
-    app.kubernetes.io/managed-by: backstage-scaffolder
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: homelab-knowledge
+    app: kagent
+    arigsela.com/idp-managed: "true"
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent


### PR DESCRIPTION
## Summary

Kubernetes half of the v1.8 kagent IDP work. Companion to `arigsela/backstage` PR #22.

Updates the existing `homelab-knowledge` Agent CRD labels to match what the new v1.8 scaffolder template renders for future agents. Without this backfill, the existing agent stays on the old label set and won't appear in the Backstage Kubernetes tab's Custom Resources panel (label selector mismatch) AND would become "un-decommissionable" by the new safety check (missing the new IDP-managed label).

## Changes

`base-apps/kagent/agents/homelab-knowledge.yaml`:
- `app.kubernetes.io/managed-by`: `backstage-scaffolder` → `kagent`
- `+` `app.kubernetes.io/name: homelab-knowledge`
- `+` `app: kagent`
- `+` `arigsela.com/idp-managed: "true"`

Net: -1 / +4 lines. Labels block only — no other changes.

## Why the label changes

The Backstage K8s plugin's `backstage.io/kubernetes-label-selector` annotation (auto-generated by TeraSky from the **Deployment**'s labels) requires three labels for a match: `app=kagent`, `app.kubernetes.io/managed-by=kagent`, `app.kubernetes.io/name=<agent-name>`. The Pod/Deployment/Service that kagent's controller spawns have all three. The Agent CRD itself didn't — so it never appeared in the Custom Resources panel even after PR #22's `customResources` config goes live.

Adding the labels makes the Agent CRD discoverable by the same selector.

The `managed-by` value change (from `backstage-scaffolder` to `kagent`) decouples the runtime-manager signal from the IDP-provenance signal. The new `arigsela.com/idp-managed: "true"` label is what the decommission action's safety check looks at after PR #22.

## Coordination order

1. **`arigsela/backstage` PR #22 merges + image rebuilt + redeployed FIRST**.
2. **Then merge this PR**. ArgoCD syncs the relabeled Agent CRD (~3 min). Decommission action accepts the new label, K8s plugin's selector matches the Agent CRD.

If you merge this PR before deploying the new Backstage image, the old image still runs and homelab-knowledge becomes briefly un-decommissionable (no destructive action — just refuses to delete). Safe but annoying.

## Test plan

- [x] `python3 yaml.safe_load(...)` passes (well-formed YAML)
- [x] Diff is purely the labels block (no other changes)
- [ ] After Backstage v1.8 deploy + this PR merge + ArgoCD sync: `kubectl get agent -n kagent homelab-knowledge -o jsonpath='{.metadata.labels}' | jq` includes the 4 new/changed labels
- [ ] After all above: `https://backstage.arigsela.com/catalog/default/component/homelab-knowledge` shows 3 tabs (Overview / Kubernetes / Docs) and the K8s tab has both workload + Agent in Custom Resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)