### PR TITLE
feat(kagent): add dungeoncrawler-crawl-agent agent

### DIFF
--- a/base-apps/kagent/agents/dungeoncrawler-crawl-agent.yaml
+++ b/base-apps/kagent/agents/dungeoncrawler-crawl-agent.yaml
@@ -1,0 +1,68 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: dungeoncrawler-crawl-agent
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: dungeoncrawler-crawl-agent
+    app: kagent
+    arigsela.com/idp-managed: "true"
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/dungeoncrawler-crawl-agent.yaml
+    backstage.io/owner: group:default/platform-engineering
+    # === agents.platform.ai/* v1 contract ===
+    # Structured metadata mirrored to the Backstage catalog by the TeraSky
+    # kubernetes-ingestor. Consumed by future MCP-backed assistants to
+    # enumerate and call this agent. Contract spec:
+    # docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+    agents.platform.ai/version: "v1"
+    agents.platform.ai/runtime: kagent
+    agents.platform.ai/description: |-
+      Agent that is an expert in the book dungeon crawler carl
+    # Port 8080 is the kagent default A2A service port.
+    agents.platform.ai/a2a-endpoint: http://dungeoncrawler-crawl-agent.kagent.svc.cluster.local:8080
+    agents.platform.ai/skills: |-
+      [{"id":"book-knowledge-retrieval","name":"Book Knowledge Retrieval","description":"Retrieves and recalls detailed information about Dungeon Crawler Carl's plot, characters, and world-building from the series."},{"id":"character-analysis","name":"Character Analysis","description":"Analyzes the motivations, development, and relationships of Carl and other characters throughout the Dungeon Crawler Carl narrative."},{"id":"dungeon-mechanics-explanation","name":"Dungeon Mechanics Explanation","description":"Explains the game mechanics, dungeon rules, and progression systems featured in the Dungeon Crawler Carl storyline."}]
+    agents.platform.ai/delegates: |-
+      []
+    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
+spec:
+  description: |-
+    Agent that is an expert in the book dungeon crawler carl
+  type: Declarative
+  declarative:
+    modelConfig: default-model-config
+    memory:
+      modelConfig: embedding-model-config
+    runtime: python
+    stream: true
+    context:
+      compaction:
+        compactionInterval: 5
+        overlapSize: 2
+    systemMessage: |
+      you are an expert in all resources related to dungeon crawler carl and should be able to answer any questions related to the book and its characters without ever giving out spoilers for the next books.
+    a2aConfig:
+      skills:
+      - id: book-knowledge-retrieval
+        name: Book Knowledge Retrieval
+        description: Retrieves and recalls detailed information about Dungeon Crawler Carl's plot, characters, and world-building from the series.
+      - id: character-analysis
+        name: Character Analysis
+        description: Analyzes the motivations, development, and relationships of Carl and other characters throughout the Dungeon Crawler Carl narrative.
+      - id: dungeon-mechanics-explanation
+        name: Dungeon Mechanics Explanation
+        description: Explains the game mechanics, dungeon rules, and progression systems featured in the Dungeon Crawler Carl storyline.
+    tools: []
+    deployment:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi


### PR DESCRIPTION
Adds a new IDP-managed kagent.dev Agent: `dungeoncrawler-crawl-agent`.

Agent that is an expert in the book dungeon crawler carl

Generated by Backstage `kagent-agent-template`.
