### PR TITLE
chore(kagent): bump chart 0.8.6 -> 0.9.4 (Phase 1 of harness upgrade)

### DIFF
--- a/base-apps/kagent-crds.yaml
+++ b/base-apps/kagent-crds.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     chart: kagent-crds
     repoURL: ghcr.io/kagent-dev/kagent/helm
-    targetRevision: 0.8.6
+    targetRevision: 0.9.4
   destination:
     server: https://kubernetes.default.svc
     namespace: kagent

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: kagent
     repoURL: ghcr.io/kagent-dev/kagent/helm
-    targetRevision: 0.8.6
+    targetRevision: 0.9.4
     helm:
       valuesObject:
         # Database: use existing PostgreSQL with pgvector
@@ -52,14 +52,16 @@ spec:
             apiKeySecretKey: ANTHROPIC_API_KEY
 
         # UI image override: custom Node-20 build for older HP server CPUs.
-        # Upstream cr.kagent.dev/kagent-dev/kagent/ui:0.8.6 ships Node 24 with
+        # Upstream cr.kagent.dev/kagent-dev/kagent/ui:0.9.4 ships Node 24 with
         # x86-64-v2 baseline → SIGILL on this hardware.
         # Track upstream: https://github.com/kagent-dev/kagent/issues/1505
+        # NOTE: Image must be built via base-apps/kagent/build/build.sh BEFORE
+        # this PR merges to main, otherwise the kagent-ui pod will ImagePullBackOff.
         ui:
           image:
             registry: "852893458518.dkr.ecr.us-east-2.amazonaws.com"
             repository: "kagent-ui"
-            tag: "0.8.6-node20"
+            tag: "0.9.4-node20"
             pullPolicy: IfNotPresent
 
         # Right-sized agent resources (Task 3.3)

--- a/base-apps/kagent/build/Dockerfile
+++ b/base-apps/kagent/build/Dockerfile
@@ -72,7 +72,7 @@ RUN chown -R nextjs:nginx /app/ui \
 EXPOSE 8080
 
 LABEL org.opencontainers.image.source=https://github.com/arigsela/kubernetes
-LABEL org.opencontainers.image.description="Patched kagent UI v0.8.6 — Node 20 LTS for older x86-64 CPUs"
+LABEL org.opencontainers.image.description="Patched kagent UI v0.9.4 — Node 20 LTS for older x86-64 CPUs"
 
 USER 1001
 CMD ["/usr/local/bin/init.sh"]

--- a/base-apps/kagent/build/README.md
+++ b/base-apps/kagent/build/README.md
@@ -1,6 +1,6 @@
 # kagent UI custom image build
 
-Builds a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.8.6` so the Next.js process doesn't `SIGILL` on the HP server's older x86-64 CPU.
+Builds a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.9.4` so the Next.js process doesn't `SIGILL` on the HP server's older x86-64 CPU.
 
 **Background:** [Design spec](../../../docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md) · [Upstream issue #1505](https://github.com/kagent-dev/kagent/issues/1505)
 
@@ -25,9 +25,9 @@ From the repo root:
 ```
 
 This will:
-1. `git clone --depth 1 --branch v0.8.6 https://github.com/kagent-dev/kagent.git` into a tmp dir
+1. `git clone --depth 1 --branch v0.9.4 https://github.com/kagent-dev/kagent.git` into a tmp dir
 2. Copy our patched `Dockerfile` into `ui/`
-3. `docker buildx build --platform linux/amd64 --push` to `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.8.6-node20`
+3. `docker buildx build --platform linux/amd64 --push` to `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.9.4-node20`
 4. Clean up the tmp dir on exit
 
 Expected runtime: 3–5 min.

--- a/base-apps/kagent/build/build.sh
+++ b/base-apps/kagent/build/build.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # --- config ---
-KAGENT_VERSION="0.8.6"
+KAGENT_VERSION="0.9.4"
 ECR_REGISTRY="852893458518.dkr.ecr.us-east-2.amazonaws.com"
 ECR_REGION="us-east-2"
 IMAGE_NAME="kagent-ui"


### PR DESCRIPTION
## Summary

Phase 1 of a two-phase upgrade to unlock the **AgentHarness** / NemoClaw features described in [Implementing An Agent Harness For Agentic Workloads](https://www.cloudnativedeepdive.com/implementing-an-agent-harness-for-agentic-workloads/). The "New Agent Harness" option referenced in that article ships in kagent **v0.9.x** under `kagent.dev/v1alpha2` — this homelab is on v0.8.6, which is why the option isn't visible in the UI.

This PR is **chart bump only**. Phase 2 (separate PR) will wire OpenShell + agent-sandbox values and add a sample `AgentHarness` manifest.

## Changes

- `base-apps/kagent-crds.yaml` — chart `targetRevision` 0.8.6 → 0.9.4
- `base-apps/kagent.yaml` — chart `targetRevision` 0.8.6 → 0.9.4 + UI image tag `0.8.6-node20` → `0.9.4-node20`
- `base-apps/kagent/build/{build.sh,Dockerfile,README.md}` — bump `KAGENT_VERSION` so the patched Node-20 UI image rebuilds against the new release

## Prerequisites before merging to `main`

1. **Build the patched UI image first** — run `./base-apps/kagent/build/build.sh` so `kagent-ui:0.9.4-node20` exists in ECR. Otherwise the `kagent-ui` pod will `ImagePullBackOff` after ArgoCD syncs (upstream Node-24 image SIGILLs on this HP CPU — [kagent#1505](https://github.com/kagent-dev/kagent/issues/1505)).
2. **Back up the kagent Postgres DB.** v0.9 refactors the DB backend from GORM+AutoMigrate to `golang-migrate` + `sqlc` and runs schema migrations on first start.

## v0.9 breaking changes that do NOT affect this install

- `rbac.clusterScoped` was removed — never set here; defaults preserve cluster-scoped RBAC.
- `claude-3-5-haiku-20241022` retired — already on `claude-haiku-4-5-20251001` (`base-apps/kagent.yaml:50`).
- `v1alpha2` API + `spec.declarative` nesting — every `Agent`/`ModelConfig` under `base-apps/kagent/` is already on v1alpha2 (verified `dungeon-crawler-carl-agent.yaml`, `homelab-knowledge.yaml`, `skill-suggester.yaml`, `build-orchestrator.yaml`, `embedding-model-config.yaml`).

## Test plan

- [ ] Run `./base-apps/kagent/build/build.sh` and confirm `kagent-ui:0.9.4-node20` lands in ECR
- [ ] Back up the `kagent` database in PostgreSQL
- [ ] Merge → watch ArgoCD sync `kagent-crds` (sync-wave `-1`) before `kagent` (sync-wave `0`)
- [ ] `kubectl get pods -n kagent` — controller + UI + per-agent deployments healthy
- [ ] `kubectl get crd | grep kagent.dev` — confirm `agentharnesses.kagent.dev` (or equivalent v0.9 CRD) is present
- [ ] Hit `https://kagent.arigsela.com` and confirm the "New Agent Harness" option is now visible
- [ ] Existing chat sessions still work (verify Postgres migration succeeded)

## Phase 2 preview

- Deploy OpenShell (`helm upgrade --install openshell oci://ghcr.io/nvidia/openshell/helm-chart`) as a new ArgoCD app
- Add `OPENSHELL_GATEWAY_URL` / `OPENSHELL_INSECURE` to `controller.env` in `base-apps/kagent.yaml`
- Drop a sample `AgentHarness` resource under `base-apps/kagent/harnesses/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYUbMGHEs3vKQpKYiTimVK)_