### PR TITLE
feat(kagent): Phase 2 — OpenShell gateway + sample AgentHarness

### DIFF
--- a/base-apps/agent-sandbox-crds.yaml
+++ b/base-apps/agent-sandbox-crds.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-sandbox-crds
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/agent-sandbox-crds
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agent-sandbox-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/agent-sandbox-crds/kustomization.yaml
+++ b/base-apps/agent-sandbox-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.6/manifest.yaml

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -41,6 +41,15 @@ spec:
             - name: db-secret
               mountPath: /etc/kagent/secrets
               readOnly: true
+          # OpenShell integration (Phase 2). OPENSHELL_INSECURE skips TLS
+          # verification because the chart-issued openshell-ca-tls isn't yet
+          # mounted into the controller; tighten by mounting that CA and
+          # flipping this to "false" in a follow-up.
+          env:
+            - name: OPENSHELL_GATEWAY_URL
+              value: "https://openshell.openshell.svc.cluster.local:8080"
+            - name: OPENSHELL_INSECURE
+              value: "true"
 
         # LLM provider: use Anthropic with existing secret
         providers:

--- a/base-apps/kagent/build/Dockerfile
+++ b/base-apps/kagent/build/Dockerfile
@@ -54,8 +54,6 @@ RUN mkdir -p /app/ui/public \
     && chown -R nextjs:nginx /tmp/nginx/
 
 WORKDIR /app
-COPY conf/nginx.conf /etc/nginx/nginx.conf
-COPY conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY scripts/init.sh /usr/local/bin/init.sh
 
 WORKDIR /app/ui

--- a/base-apps/kagent/harnesses/homelab-harness.yaml
+++ b/base-apps/kagent/harnesses/homelab-harness.yaml
@@ -1,0 +1,9 @@
+apiVersion: kagent.dev/v1alpha2
+kind: AgentHarness
+metadata:
+  name: homelab-harness
+  namespace: kagent
+spec:
+  backend: openclaw
+  description: "Homelab remote execution environment for ad-hoc operator and agent shell access."
+  modelConfigRef: default-model-config

--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshell
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    chart: helm-chart
+    repoURL: ghcr.io/nvidia/openshell
+    targetRevision: 0.0.49
+    helm:
+      valuesObject:
+        # PKI via cert-manager — chart auto-creates a namespaced Issuer and
+        # Certificates. Disable the bootstrap Job so we don't double-write the
+        # server/client TLS Secrets.
+        certManager:
+          enabled: true
+        pkiInitJob:
+          enabled: false
+
+        # Gateway pod resource bounds. Kyverno require-resource-limits policy
+        # only warns when missing, but declaring explicitly keeps events clean.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+        # Restricts sandbox-pod SSH ingress to the gateway only.
+        networkPolicy:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshell
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Phase 2 of the kagent harness upgrade (Phase 1 = PR #303, the v0.8.6 → v0.9.4 chart bump). Wires up the OpenShell gateway + the `agent-sandbox` CRDs that back the new `AgentHarness` resource, plus a minimal sample harness so the UI's "New Agent Harness" option has something to point at.

Also fixes the `base-apps/kagent/build/Dockerfile` that was inadvertently broken by PR #303. Upstream kagent v0.9.4 moved `conf/nginx.conf` + `conf/supervisord.conf` into `helm/kagent/files/` (now mounted via ConfigMap by the Helm chart), so the two `COPY conf/...` lines fail at build time. The ECR image `kagent-ui:0.9.4-node20` (`sha256:28ba83cd…`) was already built from a corrected /tmp copy on 2026-05-27; this PR makes the committed Dockerfile reproduce that working build.

## Changes

| File | Purpose |
| --- | --- |
| `base-apps/agent-sandbox-crds.yaml` | New ArgoCD Application, sync-wave **-2**. Hard prereq for OpenShell. |
| `base-apps/agent-sandbox-crds/kustomization.yaml` | Kustomize wrapper pulling `sigs.k8s.io/agent-sandbox` v0.4.6 release manifest (ArgoCD can't pull raw URLs; Kustomize can). |
| `base-apps/openshell.yaml` | New ArgoCD Application, sync-wave **-1**, chart `oci://ghcr.io/nvidia/openshell/helm-chart:0.0.49`. cert-manager PKI on, pkiInitJob off, explicit gateway resource requests/limits, default NetworkPolicy. |
| `base-apps/kagent.yaml` | Adds `controller.env` with `OPENSHELL_GATEWAY_URL` + temporary `OPENSHELL_INSECURE=true`. |
| `base-apps/kagent/harnesses/homelab-harness.yaml` | Minimal sample `AgentHarness` (`backend: openclaw`, `modelConfigRef: default-model-config`). Auto-synced by the existing `kagent-secrets` Application (which is a `directory.recurse: true` source on `base-apps/kagent/`). |
| `base-apps/kagent/build/Dockerfile` | Drops the two broken `COPY conf/...` lines. |

## Sync-wave order

| Wave | App | Why |
| --- | --- | --- |
| -2 | `agent-sandbox-crds` | CRDs + controller from sigs.k8s.io agent-sandbox |
| -1 | `openshell` | Gateway + cert-manager Issuer/Certificates |
| 0 | `kagent` | Patched env, controller can now reach the gateway. Sample harness lands via `kagent-secrets`. |

## Pre-merge gates (already validated on the cluster)

- ✅ Sandbox image `ghcr.io/nvidia/openshell-community/sandboxes/base:latest` runs cleanly on `k3s-worker-02` (Intel Xeon E5-2670, the old HP CPU). Ubuntu 24.04.3, Node 22 LTS, Python 3.13, no SIGILL.
- ✅ K8s server `v1.33.5+k3s1` — supervisor `sideloadMethod` will auto-pick init-container path (<1.35); user namespaces available if we want them later.
- ✅ cert-manager healthy; 3 ClusterIssuers ready.
- ✅ Patched UI image `kagent-ui:0.9.4-node20` already in ECR (from PR #303's deploy).

## Known follow-ups (not blockers for this PR)

- **`OPENSHELL_INSECURE=true`** is a deliberate first-deploy shortcut. The kagent controller doesn't yet have `openshell-ca-tls` mounted, so it can't validate the gateway cert. Tighten in a follow-up by mounting the CA secret across namespaces and flipping the env to `false`.
- The OpenShell chart references the sandbox image as `:latest`. Worth pinning to a digest once we know which one we want to stay on.
- The `base-apps/kagent/build/README.md` calls the SIGILL trigger "x86-64-v2"; the actual gate is **x86-64-v3** (the Sandy Bridge CPU we tested has `avx` but not `avx2`/`bmi1`/`bmi2`/`fma`). Doc nit, not code.

## Test plan

- [ ] After merge, ArgoCD syncs `agent-sandbox-crds` (wave -2) → `openshell` (wave -1) → `kagent` (wave 0) in order.
- [ ] `kubectl get crd | grep -E '(sandbox|harness)'` shows both `agent-sandbox` and `kagent.dev` CRDs.
- [ ] `kubectl -n openshell get pods` — gateway pod healthy.
- [ ] `kubectl -n openshell get secrets` — `openshell-server-tls`, `openshell-client-tls`, `openshell-ca-tls` all present (created by cert-manager).
- [ ] `kubectl -n kagent get agentharness homelab-harness -o yaml` — reaches `status.conditions[?(@.type=='Ready')].status: True` with a `status.backendRef.id`.
- [ ] `kagent-controller` logs — no errors connecting to `https://openshell.openshell.svc.cluster.local:8080`.
- [ ] Kagent UI shows the "New Agent Harness" option in the agent list, plus the sample harness.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)