### PR TITLE
fix(openshell): provision openshell-jwt-keys via Vault + ESO

### DIFF
--- a/base-apps/agent-sandbox-crds.yaml
+++ b/base-apps/agent-sandbox-crds.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-sandbox-crds
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/agent-sandbox-crds
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agent-sandbox-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/agent-sandbox-crds/kustomization.yaml
+++ b/base-apps/agent-sandbox-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.6/manifest.yaml

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -41,6 +41,15 @@ spec:
             - name: db-secret
               mountPath: /etc/kagent/secrets
               readOnly: true
+          # OpenShell integration (Phase 2). OPENSHELL_INSECURE skips TLS
+          # verification because the chart-issued openshell-ca-tls isn't yet
+          # mounted into the controller; tighten by mounting that CA and
+          # flipping this to "false" in a follow-up.
+          env:
+            - name: OPENSHELL_GATEWAY_URL
+              value: "https://openshell.openshell.svc.cluster.local:8080"
+            - name: OPENSHELL_INSECURE
+              value: "true"
 
         # LLM provider: use Anthropic with existing secret
         providers:

--- a/base-apps/kagent/build/Dockerfile
+++ b/base-apps/kagent/build/Dockerfile
@@ -54,8 +54,6 @@ RUN mkdir -p /app/ui/public \
     && chown -R nextjs:nginx /tmp/nginx/
 
 WORKDIR /app
-COPY conf/nginx.conf /etc/nginx/nginx.conf
-COPY conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY scripts/init.sh /usr/local/bin/init.sh
 
 WORKDIR /app/ui

--- a/base-apps/kagent/harnesses/homelab-harness.yaml
+++ b/base-apps/kagent/harnesses/homelab-harness.yaml
@@ -1,0 +1,9 @@
+apiVersion: kagent.dev/v1alpha2
+kind: AgentHarness
+metadata:
+  name: homelab-harness
+  namespace: kagent
+spec:
+  backend: openclaw
+  description: "Homelab remote execution environment for ad-hoc operator and agent shell access."
+  modelConfigRef: default-model-config

--- a/base-apps/openshell-secrets.yaml
+++ b/base-apps/openshell-secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshell-secrets
+  namespace: argo-cd
+  annotations:
+    # Sync-wave -2: must land before the openshell chart Application (-1)
+    # so the StatefulSet's sandbox-jwt volume finds Secret/openshell-jwt-keys
+    # on first mount attempt. (Wave -2 is also shared with istio-base — no
+    # ordering dependency between the two, just informational.)
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/openshell
+    # Intentionally not recursive: this directory is limited to the
+    # SecretStore + ExternalSecret pair. If you add a subdirectory
+    # (e.g., overlays, patches), flip this to true.
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshell
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshell
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    chart: helm-chart
+    repoURL: ghcr.io/nvidia/openshell
+    targetRevision: 0.0.49
+    helm:
+      valuesObject:
+        # PKI via cert-manager — chart auto-creates a namespaced Issuer and
+        # Certificates. Disable the bootstrap Job so we don't double-write the
+        # server/client TLS Secrets.
+        certManager:
+          enabled: true
+        pkiInitJob:
+          enabled: false
+
+        # Gateway pod resource bounds. Kyverno require-resource-limits policy
+        # only warns when missing, but declaring explicitly keeps events clean.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+        # Restricts sandbox-pod SSH ingress to the gateway only.
+        networkPolicy:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshell
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/openshell/external-secret.yaml
+++ b/base-apps/openshell/external-secret.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openshell-jwt-keys
+  namespace: openshell
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: openshell-jwt-keys
+    creationPolicy: Owner
+  data:
+    # The chart's StatefulSet mounts this Secret as files at /etc/openshell-jwt/
+    # with filenames signing.pem, public.pem, kid. We store the Vault fields
+    # under dot-free names (signing_pem, public_pem) because ESO's Vault
+    # provider parses remoteRef.property with gjson syntax, where `.` is a path
+    # separator. The secretKey renaming produces the dotted filenames the
+    # chart expects.
+    - secretKey: signing.pem
+      remoteRef:
+        key: openshell/jwt
+        property: signing_pem
+    - secretKey: public.pem
+      remoteRef:
+        key: openshell/jwt
+        property: public_pem
+    - secretKey: kid
+      remoteRef:
+        key: openshell/jwt
+        property: kid

--- a/base-apps/openshell/secret-store.yaml
+++ b/base-apps/openshell/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: openshell
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "openshell"
+          serviceAccountRef:
+            name: "default"

--- a/docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md
+++ b/docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md
@@ -1,0 +1,716 @@
+# OpenShell JWT Keys Bootstrap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock the new kagent v0.9.4 controller (`CrashLoopBackOff`) and the openshell-0 pod (`ContainerCreating`) by provisioning the missing `Secret/openshell-jwt-keys` in the `openshell` namespace via Vault + External Secrets Operator.
+
+**Architecture:** Generate an Ed25519 JWT keypair once via a committed local bootstrap script, store it in Vault at `k8s-secrets/openshell/jwt`, and sync it into the cluster as `Secret/openshell-jwt-keys` via a new ESO `SecretStore` + `ExternalSecret`. Wire up a new ArgoCD `Application` at sync-wave `-2` so the secret lands before the openshell Helm chart's StatefulSet tries to mount it.
+
+**Tech Stack:** ArgoCD, External Secrets Operator (v1beta1), HashiCorp Vault (KV v2 + Kubernetes auth), OpenSSL (Ed25519 keypair generation), Bash, kubectl, openshell Helm chart v0.0.49.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md`
+
+**Branch:** `feat/phase2-openshell-agentharness`
+
+---
+
+## Important execution notes
+
+- **User commit policy:** The user's CLAUDE.md says "NEVER commit changes unless the user explicitly asks you to." Treat every `git commit` step as: stage the files, show the proposed commit message, and **ask before committing**. If the user replies "go ahead" or "commit", proceed; otherwise leave staged.
+- **No auto-push:** Pushing to remote triggers ArgoCD auto-sync, which is a multi-namespace cluster mutation. Ask explicitly before `git push`.
+- **Vault prerequisites for Task 5 (executed by user):** User needs `vault` CLI on PATH with `VAULT_ADDR` exported and a valid non-root token. If the user normally accesses Vault via `kubectl port-forward svc/vault -n vault 8200:8200`, they should run that in a separate terminal first.
+- **kubectl --dry-run=server:** Used throughout for manifest validation because the cluster has the relevant CRDs installed (ESO, ArgoCD). This catches schema errors that `--dry-run=client` misses.
+
+---
+
+## File structure
+
+```
+base-apps/
+├── openshell-secrets.yaml          # NEW: ArgoCD Application (sync-wave -2)
+├── openshell.yaml                  # UNCHANGED: existing chart Application
+└── openshell/                      # NEW directory
+    ├── secret-store.yaml           # NEW: ESO SecretStore (Vault backend)
+    └── external-secret.yaml        # NEW: ExternalSecret → openshell-jwt-keys
+
+scripts/
+└── bootstrap-openshell-jwt.sh      # NEW: idempotent local bootstrap
+
+docs/superpowers/
+├── specs/2026-05-27-openshell-jwt-keys-fix-design.md  # STAGED (not committed yet)
+└── plans/2026-05-27-openshell-jwt-keys-fix.md         # this file
+```
+
+**File responsibilities:**
+
+- `scripts/bootstrap-openshell-jwt.sh` — one job: get the keypair into Vault. Handles keypair generation, Vault role/policy/KV bootstrap, idempotency, rotation.
+- `base-apps/openshell/secret-store.yaml` — Vault-auth wiring for the `openshell` namespace. Single resource.
+- `base-apps/openshell/external-secret.yaml` — declares which Vault fields → which Secret data keys. Single resource.
+- `base-apps/openshell-secrets.yaml` — ArgoCD Application binding the directory above to the master-app pattern at sync-wave `-2`.
+
+Each file has one concern. Manifests live next to each other in `base-apps/openshell/` so they're discoverable.
+
+---
+
+## Task 1: Bootstrap script — `scripts/bootstrap-openshell-jwt.sh`
+
+**Files:**
+- Create: `scripts/bootstrap-openshell-jwt.sh`
+
+This task produces the full script. We build it up incrementally, validating with `bash -n` (syntax check) and `--dry-run` (semantic check) along the way.
+
+- [ ] **Step 1: Create skeleton with shebang, strict mode, usage text**
+
+Write to `scripts/bootstrap-openshell-jwt.sh`:
+
+```bash
+#!/usr/bin/env bash
+#
+# bootstrap-openshell-jwt.sh — one-time provisioning of the openshell-jwt-keys
+# secret material into Vault. Idempotent by default; pass --rotate to regenerate.
+#
+# Spec: docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
+
+set -euo pipefail
+
+VAULT_PATH="k8s-secrets/openshell/jwt"
+VAULT_POLICY="openshell-read"
+VAULT_ROLE="openshell"
+K8S_NAMESPACE="openshell"
+K8S_SA="default"
+
+ROTATE=false
+DRY_RUN=false
+ALLOW_ROOT=false
+
+usage() {
+  cat <<EOF
+Usage: $0 [--rotate] [--dry-run] [--allow-root]
+
+  --rotate       Regenerate keypair even if Vault already has one.
+                 Existing minted tokens fail validation on TTL expiry.
+  --dry-run      Print every vault/kubectl command without executing.
+  --allow-root   Permit running with a Vault root token (off by default).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rotate)      ROTATE=true; shift ;;
+    --dry-run)     DRY_RUN=true; shift ;;
+    --allow-root)  ALLOW_ROOT=true; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+main() {
+  echo "TODO: implement"
+}
+
+main "$@"
+```
+
+- [ ] **Step 2: Verify script parses**
+
+Run: `bash -n scripts/bootstrap-openshell-jwt.sh`
+Expected: no output, exit 0.
+
+Run: `chmod +x scripts/bootstrap-openshell-jwt.sh && ./scripts/bootstrap-openshell-jwt.sh --help`
+Expected: prints the usage block above and exits 0.
+
+- [ ] **Step 3: Add preconditions check**
+
+Replace the `main()` stub and add a `preconditions()` function above it. Insert these functions between the flag parsing block and `main "$@"`:
+
+```bash
+log() { echo "[bootstrap-openshell-jwt] $*"; }
+die() { echo "[bootstrap-openshell-jwt] ERROR: $*" >&2; exit 1; }
+
+run() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY-RUN: $*"
+  else
+    eval "$@"
+  fi
+}
+
+preconditions() {
+  for bin in vault openssl jq kubectl; do
+    command -v "$bin" >/dev/null 2>&1 || die "$bin not found on PATH"
+  done
+  [[ -n "${VAULT_ADDR:-}" ]] || die "VAULT_ADDR not set"
+  vault token lookup >/dev/null 2>&1 || die "vault token lookup failed (no active token?)"
+  if [[ "$ALLOW_ROOT" != "true" ]]; then
+    if vault token lookup -format=json | jq -e '.data.policies | index("root")' >/dev/null 2>&1; then
+      die "refusing to run with a root token; pass --allow-root to override"
+    fi
+  fi
+  log "preconditions OK"
+}
+
+main() {
+  preconditions
+}
+```
+
+- [ ] **Step 4: Verify preconditions logic**
+
+Run: `bash -n scripts/bootstrap-openshell-jwt.sh`
+Expected: no output, exit 0.
+
+Note: actually running `main` requires `vault` and `VAULT_ADDR` — we'll do that in Task 5. For now syntax-check is enough.
+
+- [ ] **Step 5: Add Vault role/policy bootstrap**
+
+Append a `bootstrap_vault_auth()` function above `main()`:
+
+```bash
+bootstrap_vault_auth() {
+  if ! vault policy read "$VAULT_POLICY" >/dev/null 2>&1; then
+    log "creating Vault policy $VAULT_POLICY"
+    local policy_hcl
+    policy_hcl=$(cat <<EOF
+path "k8s-secrets/data/openshell/*" {
+  capabilities = ["read"]
+}
+EOF
+)
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "DRY-RUN: vault policy write $VAULT_POLICY <<EOF"
+      echo "$policy_hcl"
+      echo "EOF"
+    else
+      echo "$policy_hcl" | vault policy write "$VAULT_POLICY" -
+    fi
+  else
+    log "Vault policy $VAULT_POLICY already exists"
+  fi
+
+  if ! vault read "auth/kubernetes/role/$VAULT_ROLE" >/dev/null 2>&1; then
+    log "creating Vault Kubernetes auth role $VAULT_ROLE"
+    run "vault write auth/kubernetes/role/$VAULT_ROLE \
+      bound_service_account_names=$K8S_SA \
+      bound_service_account_namespaces=$K8S_NAMESPACE \
+      policies=$VAULT_POLICY \
+      ttl=24h"
+  else
+    log "Vault role $VAULT_ROLE already exists"
+  fi
+}
+```
+
+Update `main()`:
+
+```bash
+main() {
+  preconditions
+  bootstrap_vault_auth
+}
+```
+
+- [ ] **Step 6: Add keypair generation + idempotency + KV write**
+
+Append three functions above `main()`:
+
+```bash
+secret_exists() {
+  vault kv get "$VAULT_PATH" >/dev/null 2>&1
+}
+
+generate_keypair() {
+  local outdir="$1"
+  openssl genpkey -algorithm ED25519 -out "$outdir/signing.pem" 2>/dev/null
+  openssl pkey -in "$outdir/signing.pem" -pubout -out "$outdir/public.pem" 2>/dev/null
+  # kid = first 16 chars of base64url(sha256(SPKI DER))
+  openssl pkey -pubin -in "$outdir/public.pem" -outform der \
+    | openssl dgst -sha256 -binary \
+    | base64 \
+    | tr '+/' '-_' \
+    | tr -d '=' \
+    | cut -c1-16 > "$outdir/kid"
+}
+
+write_vault_secret() {
+  local outdir="$1"
+  local kid
+  kid=$(cat "$outdir/kid")
+  run "vault kv put $VAULT_PATH \
+    signing_pem=@$outdir/signing.pem \
+    public_pem=@$outdir/public.pem \
+    kid=$kid"
+  log "wrote Vault secret at $VAULT_PATH (kid=$kid)"
+}
+```
+
+Update `main()`:
+
+```bash
+main() {
+  preconditions
+  bootstrap_vault_auth
+
+  if secret_exists && [[ "$ROTATE" != "true" ]]; then
+    log "already bootstrapped at $VAULT_PATH — pass --rotate to regenerate"
+    exit 0
+  fi
+
+  local tmp
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+
+  generate_keypair "$tmp"
+  write_vault_secret "$tmp"
+
+  if [[ "$ROTATE" == "true" ]]; then
+    log "ROTATED. Tokens minted under the previous kid will fail validation on TTL expiry."
+    log "To pick up the new kid immediately: kubectl delete pod -n openshell openshell-0"
+  fi
+
+  cat <<EOF
+
+Bootstrap complete.
+
+  kid: $(cat "$tmp/kid")
+
+To force ESO sync immediately rather than waiting on refreshInterval:
+  kubectl annotate externalsecret/openshell-jwt-keys -n openshell \\
+    force-sync=\$(date +%s) --overwrite
+
+Public key (safe to share):
+$(cat "$tmp/public.pem")
+EOF
+}
+```
+
+- [ ] **Step 7: Final syntax check**
+
+Run: `bash -n scripts/bootstrap-openshell-jwt.sh`
+Expected: no output, exit 0.
+
+Run: `./scripts/bootstrap-openshell-jwt.sh --help`
+Expected: usage block prints, exit 0.
+
+- [ ] **Step 8: Verify executable bit + line count**
+
+Run: `ls -la scripts/bootstrap-openshell-jwt.sh && wc -l scripts/bootstrap-openshell-jwt.sh`
+Expected: `-rwxr-xr-x`, between 130 and 180 lines.
+
+- [ ] **Step 9: Stage and ask before committing**
+
+Run: `git add scripts/bootstrap-openshell-jwt.sh && git status --short scripts/`
+
+Proposed commit message (ASK USER BEFORE COMMITTING):
+
+```
+feat(openshell): add JWT keypair bootstrap script
+
+Idempotent script that generates an Ed25519 keypair, configures the
+Vault `openshell` role + `openshell-read` policy, and writes the
+keypair material to `k8s-secrets/openshell/jwt`. Supports --rotate,
+--dry-run, and --allow-root flags. Spec:
+docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md.
+```
+
+If approved, commit with that message.
+
+---
+
+## Task 2: SecretStore manifest
+
+**Files:**
+- Create: `base-apps/openshell/secret-store.yaml`
+
+- [ ] **Step 1: Create the file**
+
+Write to `base-apps/openshell/secret-store.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: openshell
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "openshell"
+          serviceAccountRef:
+            name: "default"
+```
+
+This mirrors `base-apps/kagent/secret-store.yaml` exactly, swapping `namespace` and `role` to `openshell`.
+
+- [ ] **Step 2: Validate against the live cluster (server-side dry-run)**
+
+Run: `kubectl apply --dry-run=server -f base-apps/openshell/secret-store.yaml`
+Expected: `secretstore.external-secrets.io/vault-backend created (server dry run)` — no schema errors.
+
+If you get `error validating "...": ... no matches for kind "SecretStore"`, ESO CRDs aren't installed. That would be a separate problem; stop and surface it.
+
+- [ ] **Step 3: Stage**
+
+Run: `git add base-apps/openshell/secret-store.yaml`
+
+Do NOT commit yet — bundling with the rest of the manifests in Task 4.
+
+---
+
+## Task 3: ExternalSecret manifest
+
+**Files:**
+- Create: `base-apps/openshell/external-secret.yaml`
+
+- [ ] **Step 1: Create the file**
+
+Write to `base-apps/openshell/external-secret.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openshell-jwt-keys
+  namespace: openshell
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: openshell-jwt-keys
+    creationPolicy: Owner
+  data:
+    # The chart's StatefulSet mounts this Secret as files at /etc/openshell-jwt/
+    # with filenames signing.pem, public.pem, kid. We store the Vault fields
+    # under dot-free names (signing_pem, public_pem) because ESO's Vault
+    # provider parses remoteRef.property with gjson syntax, where `.` is a path
+    # separator. The secretKey renaming produces the dotted filenames the
+    # chart expects.
+    - secretKey: signing.pem
+      remoteRef:
+        key: openshell/jwt
+        property: signing_pem
+    - secretKey: public.pem
+      remoteRef:
+        key: openshell/jwt
+        property: public_pem
+    - secretKey: kid
+      remoteRef:
+        key: openshell/jwt
+        property: kid
+```
+
+- [ ] **Step 2: Validate against the live cluster**
+
+Run: `kubectl apply --dry-run=server -f base-apps/openshell/external-secret.yaml`
+Expected: `externalsecret.external-secrets.io/openshell-jwt-keys created (server dry run)`.
+
+- [ ] **Step 3: Stage**
+
+Run: `git add base-apps/openshell/external-secret.yaml`
+
+Do NOT commit yet.
+
+---
+
+## Task 4: ArgoCD Application + manifest commit
+
+**Files:**
+- Create: `base-apps/openshell-secrets.yaml`
+
+- [ ] **Step 1: Create the ArgoCD Application**
+
+Write to `base-apps/openshell-secrets.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshell-secrets
+  namespace: argo-cd
+  annotations:
+    # Sync-wave -2: must land before the openshell chart Application (-1)
+    # so the StatefulSet's sandbox-jwt volume finds Secret/openshell-jwt-keys
+    # on first mount attempt.
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/openshell
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshell
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+```
+
+- [ ] **Step 2: Validate**
+
+Run: `kubectl apply --dry-run=server -f base-apps/openshell-secrets.yaml`
+Expected: `application.argoproj.io/openshell-secrets created (server dry run)`.
+
+- [ ] **Step 3: Stage all manifests**
+
+Run: `git add base-apps/openshell-secrets.yaml base-apps/openshell/ && git status --short base-apps/`
+
+You should see exactly three new files staged:
+- `base-apps/openshell-secrets.yaml`
+- `base-apps/openshell/external-secret.yaml`
+- `base-apps/openshell/secret-store.yaml`
+
+- [ ] **Step 4: Verify master-app pattern picks up the new Application file**
+
+The master-app watches `base-apps/*.yaml`. Confirm by reading: `cat base-apps/master-app.yaml | grep -A2 path:`
+
+Expected: `path: base-apps` (or equivalent recursive directory source). The new `base-apps/openshell-secrets.yaml` will be auto-discovered on next sync.
+
+- [ ] **Step 5: Stage the spec doc too**
+
+The spec was written but not yet committed. Run: `git add docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md`
+
+- [ ] **Step 6: Ask before committing**
+
+Proposed commit message (ASK USER):
+
+```
+fix(openshell): provision openshell-jwt-keys via Vault + ESO
+
+Phase 2 of openshell rollout unblocks the new kagent v0.9.4 controller
+that's been CrashLooping because openshell-0 was stuck in
+ContainerCreating waiting on Secret/openshell-jwt-keys.
+
+The chart bundles JWT-keypair generation inside its pkiInitJob, which
+we disabled to avoid duplicating cert-manager TLS work — this PR
+replaces the missing key generation with a Vault-backed ExternalSecret
+mirroring our existing kagent secrets pattern.
+
+- scripts/bootstrap-openshell-jwt.sh: one-time local keypair gen + Vault write
+- base-apps/openshell/secret-store.yaml: Vault SecretStore (role openshell)
+- base-apps/openshell/external-secret.yaml: ExternalSecret -> openshell-jwt-keys
+- base-apps/openshell-secrets.yaml: ArgoCD Application at sync-wave -2
+
+Spec: docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
+Plan: docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md
+```
+
+If approved, commit. (If Task 1 was already committed separately, drop the `scripts/...` line from the body.)
+
+---
+
+## Task 5: Bootstrap the Vault keypair (USER-EXECUTED, local)
+
+This task is run by the user from their local machine after the code is staged/committed. The cluster is not yet touched.
+
+- [ ] **Step 1: Confirm Vault prerequisites are in place**
+
+User runs in their shell:
+
+```bash
+which vault openssl jq kubectl
+echo "VAULT_ADDR=$VAULT_ADDR"
+vault token lookup -format=json | jq '.data.policies'
+```
+
+Expected: all four binaries resolved, `VAULT_ADDR` non-empty, token policies do NOT include `"root"`. If running root token is the only option, the user must add `--allow-root` in step 3.
+
+If `vault` is not on PATH because Vault is only reachable in-cluster, run in a separate terminal:
+```bash
+kubectl port-forward -n vault svc/vault 8200:8200
+```
+Then `export VAULT_ADDR=http://127.0.0.1:8200` and `vault login ...` in this terminal.
+
+- [ ] **Step 2: Run the script in dry-run mode first**
+
+```bash
+./scripts/bootstrap-openshell-jwt.sh --dry-run
+```
+
+Expected output includes:
+- `[bootstrap-openshell-jwt] preconditions OK`
+- A `DRY-RUN: vault policy write openshell-read <<EOF` block with the read policy HCL
+- A `DRY-RUN: vault write auth/kubernetes/role/openshell ...` line
+- A `DRY-RUN: vault kv put k8s-secrets/openshell/jwt signing_pem=@... public_pem=@... kid=...` line
+- The "Bootstrap complete." block with a `kid` and a public key PEM
+
+If any line looks wrong (e.g., wrong namespace, wrong SA, wrong path), stop and fix the script before continuing.
+
+- [ ] **Step 3: Run for real**
+
+```bash
+./scripts/bootstrap-openshell-jwt.sh
+```
+
+Expected: same flow as dry-run, but Vault writes actually happen. Final block prints the `kid` and public key. Save the `kid` somewhere (not secret, but useful for debugging later).
+
+- [ ] **Step 4: Verify Vault state**
+
+```bash
+vault kv get k8s-secrets/openshell/jwt
+```
+Expected: three fields shown — `signing_pem`, `public_pem`, `kid`. Each non-empty.
+
+```bash
+vault read auth/kubernetes/role/openshell
+```
+Expected:
+```
+bound_service_account_names      [default]
+bound_service_account_namespaces [openshell]
+policies                         [openshell-read]
+ttl                              24h
+```
+
+```bash
+vault policy read openshell-read
+```
+Expected: the policy HCL granting `read` on `k8s-secrets/data/openshell/*`.
+
+- [ ] **Step 5: (Idempotency check, optional)**
+
+```bash
+./scripts/bootstrap-openshell-jwt.sh
+```
+Expected: prints `already bootstrapped at k8s-secrets/openshell/jwt — pass --rotate to regenerate` and exits 0. Vault state is unchanged.
+
+---
+
+## Task 6: Push branch and watch ArgoCD sync
+
+- [ ] **Step 1: Verify branch state**
+
+Run: `git log --oneline -5 && git status`
+
+Expected: the Task 1 + Task 4 commits are present; working tree is clean. No unstaged or untracked files in `base-apps/openshell*` or `scripts/`.
+
+- [ ] **Step 2: Ask before pushing**
+
+Pushing triggers ArgoCD auto-sync as soon as the PR merges to `main`. ASK USER explicitly before running:
+
+```bash
+git push origin feat/phase2-openshell-agentharness
+```
+
+If the user wants to open a PR first (standard GitOps flow), use `gh pr create` per `docs/pr_template.md` — but that's outside the scope of this plan. The plan ends at push; merging is a user gate.
+
+- [ ] **Step 3: After merge to main, watch ArgoCD reconcile (USER-EXECUTED)**
+
+The user watches sync progress:
+
+```bash
+kubectl get applications -n argo-cd openshell-secrets openshell -w
+```
+
+Expected ordering (Status / Sync columns):
+1. `openshell-secrets` reaches `Synced / Healthy` first (sync-wave -2).
+2. `openshell` reconciles next; its StatefulSet pod should leave `ContainerCreating` once the Secret materializes.
+
+Stop watching once both are `Synced / Healthy`. If `openshell-secrets` stalls at `OutOfSync`, run `argocd app sync openshell-secrets` (or use the UI).
+
+---
+
+## Task 7: Cleanup stuck state + end-to-end verification
+
+All steps in this task are USER-EXECUTED against the live cluster.
+
+- [ ] **Step 1: Force the stuck openshell-0 to re-mount immediately**
+
+Without this, kubelet's mount backoff can hold the pod in `ContainerCreating` for up to ~2 minutes after the Secret appears.
+
+```bash
+kubectl delete pod -n openshell openshell-0
+```
+
+Expected: pod deletes; the StatefulSet immediately recreates it. The new pod should reach `1/1 Running` within ~30s once the Secret is in place.
+
+- [ ] **Step 2: Confirm ExternalSecret synced**
+
+```bash
+kubectl get externalsecret -n openshell openshell-jwt-keys \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+```
+Expected: `True`
+
+```bash
+kubectl get secret -n openshell openshell-jwt-keys -o jsonpath='{.data}' | jq 'keys'
+```
+Expected: `["kid", "public.pem", "signing.pem"]` (sorted).
+
+- [ ] **Step 3: Confirm openshell-0 is Ready**
+
+```bash
+kubectl get pod -n openshell openshell-0
+```
+Expected: `READY 1/1`, `STATUS Running`, `RESTARTS` low (0–2). Age may be a few minutes.
+
+```bash
+kubectl logs -n openshell openshell-0 --tail=30
+```
+Expected: gateway-startup log lines. No `signing key`, `jwt`, or `secret not found` errors.
+
+- [ ] **Step 4: Confirm gateway is reachable on cluster network**
+
+```bash
+kubectl run -n openshell --rm -i --restart=Never --image=busybox:1.36 net-test -- \
+  wget -qO- --no-check-certificate https://openshell.openshell.svc.cluster.local:8080/healthz
+```
+Expected: a 200-OK style response (e.g., `ok` or `{"status":"ok"}`).
+
+If this fails with TLS errors, the gateway cert may not be reconciled yet — wait 30s and retry. If it fails with connection refused, openshell-0 isn't actually listening; check `kubectl logs`.
+
+- [ ] **Step 5: Confirm the new kagent controller exited CrashLoop**
+
+```bash
+kubectl get pods -n kagent -l app.kubernetes.io/component=controller
+```
+Expected: exactly **one** controller pod, on ReplicaSet `568c7b55fb` (the new hash), STATUS `Running`, RESTARTS low. The old ReplicaSet (`857c56b6`) should be scaled to 0 by the rollout.
+
+```bash
+kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=30 | grep -iE 'openshell|sandbox|error'
+```
+Expected: NO `unable to build openshell sandbox backends` line. Expected to see a benign `openshell sandbox backends initialized` (or chart's equivalent successful-init log).
+
+- [ ] **Step 6: End-to-end smoke (sample AgentHarness from commit 5fa23e7)**
+
+```bash
+kubectl get agentharness -n kagent
+```
+Expected: the `homelab-harness` resource exists. Check whatever READY/SYNCED column is shown — should not be `Failed`.
+
+Optional manual smoke: from the kagent UI (`kagent.arigsela.com`), invoke the sample harness with a trivial command (e.g., `echo hello`). Confirm a response comes back and that the kagent-controller logs do not show `OPENSHELL_GATEWAY_URL`-related errors during the request.
+
+- [ ] **Step 7: Mark verification complete**
+
+If steps 1–6 all pass, the rollout is done. Update the task list to mark Task 7 complete.
+
+---
+
+## Self-review notes
+
+Cross-checked against spec sections:
+
+- **Problem & root cause** → captured in plan header (Goal/Architecture).
+- **Architecture** → Task 4 (ArgoCD Application) + Tasks 2/3 (SecretStore/ExternalSecret) + Task 1 (bootstrap script).
+- **Files added/changed** → Tasks 1–4 cover every file in the spec's file table.
+- **Bootstrap script behavior (preconditions, default flow, --rotate, --dry-run, safety)** → Task 1, steps 3–6.
+- **ExternalSecret field naming (gjson pitfall)** → Task 3 step 1 includes the inline comment in the manifest itself for the implementer.
+- **Argo ordering & rollout sequence** → Task 4 step 1 sets sync-wave -2 explicitly; Task 6 step 3 watches the wave order.
+- **Cleanup of stuck state** → Task 7 step 1.
+- **Verification (5 checks)** → Task 7 steps 2–6 implement all five spec checks plus an explicit pod-replacement check (step 5).
+- **Out of scope items** → respected (no changes to `base-apps/openshell.yaml`, `base-apps/kagent.yaml`, or controller mTLS).
+
+No placeholders ("TODO", "TBD", "implement later") remain. Type/name consistency checked: `openshell-jwt-keys` appears identically in spec, ExternalSecret target, chart expectation, and verification commands.

--- a/docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
+++ b/docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
@@ -1,0 +1,282 @@
+# OpenShell JWT Keys Bootstrap — Design
+
+**Date:** 2026-05-27
+**Branch:** `feat/phase2-openshell-agentharness`
+**Status:** Spec — awaiting user review before implementation plan
+
+## Problem
+
+The kagent v0.9.4 controller deployed in commit `5fa23e7` is in `CrashLoopBackOff` (12 restarts over 40 minutes at the time of diagnosis). Its startup logs show:
+
+```
+unable to build openshell sandbox backends:
+openshell: dial https://openshell.openshell.svc.cluster.local:8080: context deadline exceeded
+```
+
+The gateway it's dialing — pod `openshell-0` in the `openshell` namespace — has been stuck in `ContainerCreating` for the same window. Kubelet events show:
+
+```
+MountVolume.SetUp failed for volume "sandbox-jwt":
+secret "openshell-jwt-keys" not found
+```
+
+### Root cause
+
+OpenShell Helm chart `ghcr.io/nvidia/openshell/helm-chart:0.0.49` couples **JWT signing key generation** to the **PKI bootstrap Job**. From `templates/certgen.yaml`:
+
+```yaml
+{{- if .Values.pkiInitJob.enabled }}
+# ... single Job whose args include:
+#   - --server-secret-name=...
+#   - --client-secret-name=...
+#   - --jwt-secret-name=openshell-jwt-keys
+{{- end }}
+```
+
+`base-apps/openshell.yaml` correctly set `pkiInitJob.enabled: false` (because `certManager.enabled: true` is providing TLS — the chart explicitly fails if both are true). That decision unintentionally also removed JWT-keypair generation, because the chart bundles the two responsibilities into one hook. Cert-manager produces `openshell-server-tls`, `openshell-client-tls`, and `openshell-ca-tls` correctly, but nothing produces the JWT keypair Secret the StatefulSet mounts at `/etc/openshell-jwt`.
+
+The Secret must contain three keys:
+- `signing.pem` — Ed25519 private key, PKCS#8 PEM
+- `public.pem` — Ed25519 public key, SPKI PEM
+- `kid` — key identifier, plain text
+
+## Architecture
+
+Materialize `Secret/openshell-jwt-keys` in the `openshell` namespace via **External Secrets Operator** syncing from Vault. This mirrors the existing `kagent` namespace pattern (`base-apps/kagent/secret-store.yaml`, `base-apps/kagent/external-secrets.yaml`).
+
+```
+Vault (k8s-secrets/openshell/jwt)
+        │
+        ▼
+ExternalSecret/openshell-jwt-keys (ESO reconciles)
+        │
+        ▼
+Secret/openshell-jwt-keys ───▶ openshell-0 StatefulSet (mount: /etc/openshell-jwt)
+                                        │
+                                        ▼
+                       kagent-controller dials openshell:8080 ✓
+```
+
+A new ArgoCD Application **`openshell-secrets`** at sync-wave `-2` provisions the SecretStore + ExternalSecret **before** the existing `openshell` chart Application (sync-wave `-1`) reconciles, so the StatefulSet finds its Secret on first mount attempt.
+
+The keypair is generated **once, locally**, by `scripts/bootstrap-openshell-jwt.sh` and written to Vault. The script is idempotent — re-running with the secret already present is a no-op unless `--rotate` is passed.
+
+## Files added / changed
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `base-apps/openshell-secrets.yaml` | ArgoCD `Application` at sync-wave `-2` pointing at `base-apps/openshell/`. Auto-discovered by the master app. |
+| `base-apps/openshell/secret-store.yaml` | `SecretStore` in `openshell` ns, Vault Kubernetes auth, role `openshell`. Copy of `base-apps/kagent/secret-store.yaml` with namespace + role swapped. |
+| `base-apps/openshell/external-secret.yaml` | `ExternalSecret` whose `target.name: openshell-jwt-keys`. Three `data` entries map dot-free Vault field names to the dotted filenames the chart expects: `secretKey: signing.pem` ← `remoteRef.property: signing_pem`; `secretKey: public.pem` ← `public_pem`; `secretKey: kid` ← `kid`. All entries `remoteRef.key: openshell/jwt`. `refreshInterval: 1h`. |
+| `scripts/bootstrap-openshell-jwt.sh` | One-time bootstrap. Generates keypair, writes to Vault, configures Vault role + policy. Committed so it's reviewable and reproducible. |
+
+### Unchanged
+
+- `base-apps/openshell.yaml` — chart values stay as-is. The chart still emits the StatefulSet that mounts `openshell-jwt-keys`; we just supply that Secret from a different source.
+- `base-apps/kagent.yaml` — unchanged. The controller will heal itself once the gateway is reachable.
+- `base-apps/agent-sandbox-crds.yaml` — unchanged.
+
+### Vault side (provisioned by the script)
+
+- Role `openshell` under `auth/kubernetes/role/openshell`, bound to `system:serviceaccount:openshell:default`, attached to policy `openshell-read`.
+- Policy `openshell-read` granting `read` on `k8s-secrets/data/openshell/*`.
+- KV-v2 entry at `k8s-secrets/openshell/jwt` with fields `signing_pem`, `public_pem`, `kid`. (Dot-free Vault keys avoid an ESO gjson-syntax pitfall — see "ExternalSecret field naming" note below. The chart-facing Secret keys keep the dotted form via `secretKey` renaming.)
+
+## Bootstrap script — `scripts/bootstrap-openshell-jwt.sh`
+
+**Invocation:** `./scripts/bootstrap-openshell-jwt.sh [--rotate] [--dry-run] [--allow-root]`
+
+### Preconditions
+
+Script exits non-zero with a clear message if any of these fail:
+- `vault`, `openssl`, `jq`, `kubectl` on `PATH`
+- `VAULT_ADDR` env var is set
+- `vault token lookup` succeeds (active token)
+- Token is not a root token unless `--allow-root` is passed
+
+### Default flow (no flags)
+
+1. Check Vault for `k8s-secrets/openshell/jwt`. If present, log `already bootstrapped — pass --rotate to regenerate` and exit 0. **Idempotent.**
+2. Create a temp dir via `mktemp -d`, register `trap cleanup EXIT` so private key material is removed on any exit path (including signal/error).
+3. Generate the keypair entirely within the temp dir:
+   - `openssl genpkey -algorithm ED25519 -out $tmp/signing.pem` → PKCS#8 private key
+   - `openssl pkey -in $tmp/signing.pem -pubout -out $tmp/public.pem` → SPKI public key
+   - `kid` = first 16 chars of `base64url(sha256(public-key-DER))` — deterministic from public key, matches common JWT/JWK `kid` conventions.
+4. Configure Vault if not already configured:
+   - If policy `openshell-read` doesn't exist: write it with `path "k8s-secrets/data/openshell/*" { capabilities = ["read"] }`.
+   - If role `auth/kubernetes/role/openshell` doesn't exist: create it bound to SA `default` in ns `openshell`, policy `openshell-read`, TTL 24h.
+5. `vault kv put k8s-secrets/openshell/jwt signing_pem=@$tmp/signing.pem public_pem=@$tmp/public.pem kid=<kid>`. (Underscored field names; the dotted filenames the chart wants are produced by the ExternalSecret's `secretKey` mapping.)
+6. Print to stdout: the `kid`, the contents of `public.pem` (safe to share), and a one-liner to force ESO sync immediately rather than waiting on `refreshInterval`:
+   ```bash
+   kubectl annotate externalsecret/openshell-jwt-keys -n openshell \
+     force-sync=$(date +%s) --overwrite
+   ```
+
+### `--rotate` flow
+
+Same as default but **skips** the idempotency check in step 1. After Vault write, prints a clearly-formatted warning:
+
+```
+ROTATED. Tokens minted under the previous kid will fail validation on TTL
+expiry (default 3600s). To pick up the new kid immediately:
+  kubectl delete pod -n openshell openshell-0
+```
+
+### `--dry-run` flow
+
+Prints every `vault` and `kubectl` command the script would execute, including the policy HCL body, then exits 0 without mutating anything. Useful for reviewing the Vault role/policy before committing to a write.
+
+### Safety
+
+- All private key material lives only inside `$tmp/` and is removed by the `trap`.
+- `vault kv` (KV-v2 aware) — not `vault write` directly — to avoid the common `data/data/` path mistake.
+- Root token guard (`--allow-root` required) encourages running with a scoped admin token.
+- No `set -x`; only `set -euo pipefail`.
+
+## ExternalSecret field naming (implementer note)
+
+ESO's Vault provider evaluates `remoteRef.property` with [gjson](https://github.com/tidwall/gjson) syntax, where `.` is a path separator. A Vault field literally named `signing.pem` would be interpreted as `signing → pem` (nested lookup), not the literal key, and the sync would fail with a key-not-found error.
+
+We dodge this by storing under dot-free Vault keys (`signing_pem`, `public_pem`, `kid`) and using ESO's `secretKey` to rename to the dotted filenames the chart's StatefulSet mounts:
+
+```yaml
+# base-apps/openshell/external-secret.yaml (sketch)
+data:
+  - secretKey: signing.pem          # becomes file in mounted Secret
+    remoteRef:
+      key: openshell/jwt
+      property: signing_pem          # field name in Vault
+  - secretKey: public.pem
+    remoteRef:
+      key: openshell/jwt
+      property: public_pem
+  - secretKey: kid
+    remoteRef:
+      key: openshell/jwt
+      property: kid
+```
+
+The resulting `Secret/openshell-jwt-keys` has data keys `signing.pem`, `public.pem`, `kid` — exactly what the chart's `sandbox-jwt` volume mounts.
+
+## Argo ordering & rollout sequence
+
+### Pre-merge (manual, once)
+
+1. Pull the branch locally.
+2. Run `./scripts/bootstrap-openshell-jwt.sh`. Vault now has the keypair + role + policy.
+3. Verify:
+   ```bash
+   vault kv get k8s-secrets/openshell/jwt        # three fields: signing_pem, public_pem, kid
+   vault read auth/kubernetes/role/openshell     # binding shown
+   ```
+
+### Post-merge (ArgoCD auto-sync)
+
+ArgoCD reconciles by sync-wave, lowest first:
+
+| Wave | Application | Resources | Notes |
+|---|---|---|---|
+| `-2` | `agent-sandbox-crds` (existing) | sigs.k8s.io agent-sandbox CRDs | Unchanged. |
+| `-2` | `openshell-secrets` **(new)** | `SecretStore`, `ExternalSecret` → `Secret/openshell-jwt-keys` | Must land before the chart so the StatefulSet's volume mount sees the Secret. |
+| `-1` | `openshell` (existing) | Chart 0.0.49: Issuer, Certificates, StatefulSet, Service, GRPCRoute, NetworkPolicy | Chart unchanged. StatefulSet mount succeeds because the Secret already exists. |
+| `0` | `kagent` (existing) | Controller, agents, UI, etc. | Controller dials gateway, succeeds, new ReplicaSet rolls out, old ReplicaSet scales to 0. |
+
+### Race window
+
+ESO reconciles asynchronously — the `ExternalSecret` resource exists at wave `-2`, but the actual `Secret` materializes seconds later when ESO polls Vault. The openshell StatefulSet retries `MountVolume.SetUp` on a kubelet backoff (capped at ~2 minutes). Worst case is a slow first start, not a deadlock. **No explicit sync wait/hook needed.**
+
+### One-time cleanup of current stuck state
+
+```bash
+# Force the stuck openshell-0 to re-attempt mount immediately, rather than
+# wait out kubelet's mount backoff:
+kubectl delete pod -n openshell openshell-0
+
+# The kagent-controller CrashLoopBackOff pod will self-heal on next restart
+# once openshell-0 is Ready — no manual delete needed.
+```
+
+### Rollback
+
+- Revert the merge commit. ArgoCD prunes the `openshell-secrets` Application → ExternalSecret + Secret deleted. openshell-0 returns to `ContainerCreating` (the failure mode we're already in — no worse off).
+- Vault entry stays (Vault is intentionally not pruned by ArgoCD). Safe to leave; or `vault kv delete k8s-secrets/openshell/jwt` manually.
+
+## Verification
+
+Run after the merge + bootstrap. Each step has a clear pass/fail signal.
+
+### 1. ExternalSecret reached `SecretSynced`
+
+```bash
+kubectl get externalsecret -n openshell openshell-jwt-keys \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# expect: True
+
+kubectl get secret -n openshell openshell-jwt-keys -o jsonpath='{.data}' | jq 'keys'
+# expect: ["kid","public.pem","signing.pem"]
+```
+
+### 2. openshell-0 mounts and goes Ready
+
+```bash
+kubectl get pod -n openshell openshell-0
+# expect: 1/1 Running, RESTARTS small (<3)
+
+kubectl logs -n openshell openshell-0 --tail=30
+# expect: gateway-startup log lines, no "signing key" / "jwt" errors
+```
+
+### 3. Gateway reachable on cluster network
+
+```bash
+kubectl run -n openshell --rm -it --image=busybox:1.36 net-test --restart=Never -- \
+  wget -qO- --no-check-certificate https://openshell.openshell.svc.cluster.local:8080/healthz
+# expect: 200 OK / healthy response
+```
+
+### 4. New kagent controller exits CrashLoop
+
+```bash
+kubectl get pods -n kagent -l app.kubernetes.io/component=controller
+# expect: exactly one Running pod on ReplicaSet 568c7b55fb (the new hash)
+
+kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=20 | grep -i openshell
+# expect: NO "unable to build openshell sandbox backends" line
+# expect: a benign "openshell sandbox backends initialized" or equivalent
+```
+
+### 5. End-to-end smoke
+
+```bash
+kubectl get agentharness -n kagent
+# expect: homelab-harness (from commit 5fa23e7) shows Ready/Synced
+```
+
+Run one trivial sandbox-backed task through the kagent UI (e.g., ask the harness to `echo hello`). Pass = response without `OPENSHELL_GATEWAY_URL`-related errors in controller logs.
+
+### Failure-mode triage
+
+| Symptom | First check |
+|---|---|
+| ExternalSecret stuck `SecretSyncError` | `kubectl describe externalsecret -n openshell openshell-jwt-keys` — most likely Vault role/policy mismatch. Re-run script with `--dry-run` to inspect role/policy definition. |
+| openshell-0 Running but readinessProbe failing | `kubectl logs -n openshell openshell-0` — chart may complain about kid/public.pem mismatch if rotated mid-run. |
+| New kagent controller still crashlooping after openshell-0 is Ready | Likely a TLS or `OPENSHELL_INSECURE` issue, **not** JWT. Out of scope for this fix — see below. |
+
+## Out of scope
+
+- **Controller mTLS to the gateway.** `OPENSHELL_INSECURE=true` stays. The TODO in `base-apps/kagent.yaml:44-47` already tracks mounting `openshell-ca-tls` + flipping to `false`. Independent of the JWT-keys bug.
+- **Upstream chart fix.** The real chart bug is `templates/certgen.yaml` gating JWT key generation behind `pkiInitJob.enabled`. Worth an upstream issue/PR to `nvidia/openshell`; unblocking ourselves first. Tracked separately.
+- **JWT key rotation policy.** Script supports `--rotate`, but no automated rotation cadence (cron, Vault auto-rotate) is wired up. Phase-2 keys are bootstrap-only.
+- **Per-tenant / multi-gateway JWT keys.** Single keypair, single gateway, single `kid`.
+- **OIDC gateway configuration.** Chart `server.oidc.*` stays at defaults (disabled). Not needed for the controller→gateway path.
+- **Existing `agent-sandbox-crds` Application.** Unchanged.
+
+## References
+
+- Failing pod logs (kagent controller): `unable to build openshell sandbox backends ... context deadline exceeded`
+- Failing event (openshell-0): `MountVolume.SetUp failed for volume "sandbox-jwt" : secret "openshell-jwt-keys" not found`
+- Chart template: `ghcr.io/nvidia/openshell/helm-chart:0.0.49`, `templates/certgen.yaml` (JWT gen behind `pkiInitJob.enabled`), `templates/statefulset.yaml:137-140` (sandbox-jwt volume), `templates/gateway-config.yaml:72-77` (signing/public/kid paths).
+- Pattern to mirror: `base-apps/kagent/secret-store.yaml`, `base-apps/kagent/external-secrets.yaml`.
+- Phase 2 context commit: `5fa23e7 feat(kagent): Phase 2 — OpenShell gateway + sample AgentHarness`.

--- a/scripts/bootstrap-openshell-jwt.sh
+++ b/scripts/bootstrap-openshell-jwt.sh
@@ -16,6 +16,7 @@ K8S_SA="default"
 ROTATE=false
 DRY_RUN=false
 ALLOW_ROOT=false
+tmp=""
 
 usage() {
   cat <<EOF
@@ -140,7 +141,6 @@ main() {
     exit 0
   fi
 
-  local tmp
   tmp=$(mktemp -d)
   trap 'rm -rf "$tmp"' EXIT
 

--- a/scripts/bootstrap-openshell-jwt.sh
+++ b/scripts/bootstrap-openshell-jwt.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# bootstrap-openshell-jwt.sh — one-time provisioning of the openshell-jwt-keys
+# secret material into Vault. Idempotent by default; pass --rotate to regenerate.
+#
+# Spec: docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
+
+set -euo pipefail
+
+VAULT_PATH="k8s-secrets/openshell/jwt"
+VAULT_POLICY="openshell-read"
+VAULT_ROLE="openshell"
+K8S_NAMESPACE="openshell"
+K8S_SA="default"
+
+ROTATE=false
+DRY_RUN=false
+ALLOW_ROOT=false
+
+usage() {
+  cat <<EOF
+Usage: $0 [--rotate] [--dry-run] [--allow-root]
+
+  --rotate       Regenerate keypair even if Vault already has one.
+                 Existing minted tokens fail validation on TTL expiry.
+  --dry-run      Print every vault/kubectl command without executing.
+                 Note: precondition checks and idempotency probe still
+                 require an active VAULT_ADDR and valid token.
+  --allow-root   Permit running with a Vault root token (off by default).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rotate)      ROTATE=true; shift ;;
+    --dry-run)     DRY_RUN=true; shift ;;
+    --allow-root)  ALLOW_ROOT=true; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+log() { echo "[bootstrap-openshell-jwt] $*"; }
+die() { echo "[bootstrap-openshell-jwt] ERROR: $*" >&2; exit 1; }
+
+run() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY-RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+preconditions() {
+  for bin in vault openssl jq kubectl; do
+    command -v "$bin" >/dev/null 2>&1 || die "$bin not found on PATH"
+  done
+  [[ -n "${VAULT_ADDR:-}" ]] || die "VAULT_ADDR not set"
+  local token_info
+  token_info=$(vault token lookup -format=json 2>/dev/null) \
+    || die "vault token lookup failed (no active token?)"
+  if [[ "$ALLOW_ROOT" != "true" ]]; then
+    if jq -e '.data.policies | index("root")' <<<"$token_info" >/dev/null 2>&1; then
+      die "refusing to run with a root token; pass --allow-root to override"
+    fi
+  fi
+  log "preconditions OK"
+}
+
+bootstrap_vault_auth() {
+  if ! vault policy read "$VAULT_POLICY" >/dev/null 2>&1; then
+    log "creating Vault policy $VAULT_POLICY"
+    local policy_hcl
+    policy_hcl=$(cat <<EOF
+# Policy uses the raw KV v2 API path (k8s-secrets/data/...). VAULT_PATH
+# above uses the KV-aware CLI path. If VAULT_PATH changes, update here too.
+path "k8s-secrets/data/openshell/*" {
+  capabilities = ["read"]
+}
+EOF
+)
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "DRY-RUN: vault policy write $VAULT_POLICY <<EOF"
+      echo "$policy_hcl"
+      echo "EOF"
+    else
+      echo "$policy_hcl" | vault policy write "$VAULT_POLICY" -
+    fi
+  else
+    log "Vault policy $VAULT_POLICY already exists"
+  fi
+
+  if ! vault read "auth/kubernetes/role/$VAULT_ROLE" >/dev/null 2>&1; then
+    log "creating Vault Kubernetes auth role $VAULT_ROLE"
+    run vault write "auth/kubernetes/role/$VAULT_ROLE" \
+      "bound_service_account_names=$K8S_SA" \
+      "bound_service_account_namespaces=$K8S_NAMESPACE" \
+      "policies=$VAULT_POLICY" \
+      "ttl=24h"
+  else
+    log "Vault role $VAULT_ROLE already exists"
+  fi
+}
+
+secret_exists() {
+  vault kv get "$VAULT_PATH" >/dev/null 2>&1
+}
+
+generate_keypair() {
+  local outdir="$1"
+  openssl genpkey -algorithm ED25519 -out "$outdir/signing.pem" \
+    || die "openssl genpkey -algorithm ED25519 failed — is Ed25519 supported? (OpenSSL >= 1.1.1 required)"
+  openssl pkey -in "$outdir/signing.pem" -pubout -out "$outdir/public.pem" 2>/dev/null
+  # kid = first 16 chars of base64url(sha256(SPKI DER))
+  openssl pkey -pubin -in "$outdir/public.pem" -outform der \
+    | openssl dgst -sha256 -binary \
+    | base64 \
+    | tr '+/' '-_' \
+    | tr -d '=' \
+    | cut -c1-16 > "$outdir/kid"
+}
+
+write_vault_secret() {
+  local outdir="$1"
+  local kid
+  kid=$(cat "$outdir/kid")
+  run vault kv put "$VAULT_PATH" \
+    "signing_pem=@$outdir/signing.pem" \
+    "public_pem=@$outdir/public.pem" \
+    "kid=$kid"
+  [[ "$DRY_RUN" == "true" ]] || log "wrote Vault secret at $VAULT_PATH (kid=$kid)"
+}
+
+main() {
+  preconditions
+  bootstrap_vault_auth
+
+  if secret_exists && [[ "$ROTATE" != "true" ]]; then
+    log "already bootstrapped at $VAULT_PATH — pass --rotate to regenerate"
+    exit 0
+  fi
+
+  local tmp
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+
+  generate_keypair "$tmp"
+  write_vault_secret "$tmp"
+
+  if [[ "$ROTATE" == "true" ]]; then
+    log "ROTATED. Tokens minted under the previous kid will fail validation on TTL expiry."
+    log "To pick up the new kid immediately: kubectl delete pod -n openshell openshell-0"
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo
+    echo "Dry-run complete (no changes made)."
+  else
+    echo
+    echo "Bootstrap complete."
+  fi
+  cat <<EOF
+
+  kid: $(cat "$tmp/kid")
+
+To force ESO sync immediately rather than waiting on refreshInterval:
+  kubectl annotate externalsecret/openshell-jwt-keys -n openshell \\
+    force-sync=\$(date +%s) --overwrite
+
+Public key (safe to share):
+$(cat "$tmp/public.pem")
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Unblocks the new kagent v0.9.4 controller (`CrashLoopBackOff`, 12+ restarts) and `openshell-0` (`ContainerCreating` for 40+min) caused by missing `Secret/openshell-jwt-keys`.
- Root cause: OpenShell chart v0.0.49 couples JWT-keypair generation to `pkiInitJob.enabled`, which we disabled (correctly) to avoid duplicating cert-manager TLS. Disabling that flag silently removed JWT key gen too — chart bug, see [openshell chart `templates/certgen.yaml`](https://github.com/nvidia/openshell).
- Fix: provision the keypair via Vault + External Secrets Operator at sync-wave -2 so it lands before the chart Application at -1.

## Changes

### New manifests (GitOps)
- `base-apps/openshell-secrets.yaml` — ArgoCD `Application` at sync-wave `-2`. Auto-discovered by master-app.
- `base-apps/openshell/secret-store.yaml` — ESO `SecretStore` in the `openshell` namespace, Vault role `openshell`. Mirrors the existing `base-apps/kagent/secret-store.yaml` pattern.
- `base-apps/openshell/external-secret.yaml` — `ExternalSecret` producing `Secret/openshell-jwt-keys` with three data keys (`signing.pem`, `public.pem`, `kid`).

### New bootstrap tooling
- `scripts/bootstrap-openshell-jwt.sh` — idempotent local script: generates Ed25519 keypair (PKCS#8 signing key + SPKI public key + base64url(sha256(SPKI DER))[:16] kid), configures Vault `openshell-read` policy + Kubernetes-auth role `openshell`, writes keypair to `k8s-secrets/openshell/jwt`. Flags: `--dry-run`, `--rotate`, `--allow-root`.

### Bug fix from real execution
- Trap-scoping fix (commit `06b0523`): previous version declared `local tmp` inside `main()`, so when main returned, the EXIT trap referenced an out-of-scope variable, hit `set -u`'s nounset, and died before `rm -rf` — leaking the private signing key on disk. Two leaked temp dirs were observed during initial bootstrap and manually cleaned up.

### Documentation
- `docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md` — full design with root cause, alternatives, file structure, Argo ordering analysis, ExternalSecret field-naming gotcha (gjson dot-as-path-separator), out-of-scope.
- `docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md` — implementation plan with TDD-style validation steps.

## Key Features
- **gjson safety:** Vault fields use dot-free names (`signing_pem`, `public_pem`); ExternalSecret `secretKey` renames to the dotted filenames the chart's StatefulSet expects at mount.
- **Idempotency:** Re-running the bootstrap script after success is a no-op (`vault kv get` probe). `--rotate` opts into regeneration.
- **Argo ordering:** Sync-wave -2 ensures the Secret materializes before openshell chart (wave -1) reconciles.
- **Vault role hardening:** Bound to `default` SA in `openshell` ns only. Policy grants only `read` on `k8s-secrets/data/openshell/*`.

## Technical Implementation
- `creationPolicy: Owner` on the ExternalSecret — Secret is exclusively owned by ESO, GC'd on ExternalSecret deletion.
- `directory.recurse: false` on the new Application — intentional, with inline comment for future maintainers.
- Script `run()` helper uses `"$@"` (not `eval`) so all Vault command args are array-safe quoted.
- Trap cleanup of temp dir works correctly on all exit paths after the scoping fix.

## Testing
**Manifest validation:** All three manifests validated against the live cluster via `kubectl apply --dry-run=server` — confirms CRD schema compliance.

**Bootstrap script:** Executed against production Vault. Vault state verified:
- `vault kv get k8s-secrets/openshell/jwt` → three fields present (`signing_pem`, `public_pem`, `kid`)
- `vault read auth/kubernetes/role/openshell` → bound to `default`/`openshell`, policy `openshell-read`, ttl 24h
- `vault policy read openshell-read` → grants `read` on `k8s-secrets/data/openshell/*`

**Code review:** Bootstrap script went through code-quality review (3 Important + 4 Minor findings, all resolved). Manifests reviewed for ESO/ArgoCD conventions and gjson-pitfall.

## Test Plan
After merge, ArgoCD reconciles in wave order. Verify with:

- [ ] `kubectl get applications -n argo-cd openshell-secrets openshell -w` — both reach `Synced / Healthy`
- [ ] `kubectl get externalsecret -n openshell openshell-jwt-keys -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` → `True`
- [ ] `kubectl get secret -n openshell openshell-jwt-keys -o jsonpath='{.data}' | jq 'keys'` → `["kid","public.pem","signing.pem"]`
- [ ] `kubectl delete pod -n openshell openshell-0` (force fast re-mount; kubelet backoff would otherwise hold the pod up to ~2min)
- [ ] `kubectl get pod -n openshell openshell-0` → `1/1 Running`
- [ ] `kubectl run -n openshell --rm -i --restart=Never --image=busybox:1.36 net-test -- wget -qO- --no-check-certificate https://openshell.openshell.svc.cluster.local:8080/healthz` → 200 OK
- [ ] `kubectl get pods -n kagent -l app.kubernetes.io/component=controller` → exactly one Running pod on the new ReplicaSet hash, no CrashLoopBackOff
- [ ] `kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=30 | grep -iE 'openshell|sandbox'` → no `unable to build openshell sandbox backends` errors
- [ ] `kubectl get agentharness -n kagent` → `homelab-harness` Ready/Synced

## Deployment Notes
**Vault prerequisite already satisfied** — the keypair has been written to `k8s-secrets/openshell/jwt` and the `openshell` Vault role + `openshell-read` policy are configured. No additional bootstrap required for this PR. (Reproducing on another env: run `./scripts/bootstrap-openshell-jwt.sh --allow-root` against that env's Vault first.)

**Rollback:** Revert the merge commit. ArgoCD prunes `openshell-secrets`. openshell-0 returns to its current stuck state — no worse off than today. Vault entry stays (not pruned by ArgoCD).

## Related
- Builds on `5fa23e7` (`feat(kagent): Phase 2 — OpenShell gateway + sample AgentHarness`).
- Mirrors `base-apps/kagent/secret-store.yaml` + `external-secrets.yaml` patterns.
- Upstream chart bug worth filing against `nvidia/openshell`: `templates/certgen.yaml` should not couple JWT key gen to `pkiInitJob.enabled`. Tracked as out-of-scope; see design doc.

🤖 Generated with [Claude Code](https://claude.ai/code)