### PR TITLE
fix(openshell): controller mTLS — server-TLS-only gateway + CA-verifying controller

### DIFF
--- a/base-apps/eso-kubernetes-clusterstore.yaml
+++ b/base-apps/eso-kubernetes-clusterstore.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: eso-kubernetes-clusterstore
+  namespace: argo-cd
+  annotations:
+    # Sync-wave -3: the ClusterSecretStore + RBAC must exist before any
+    # ExternalSecret that references it reconciles. ESO ExternalSecrets in
+    # downstream apps (e.g. kagent) live at the default wave 0.
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/eso-kubernetes-clusterstore
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    # Destination namespace is nominal for cluster-scoped resources
+    # (ClusterRole + ClusterSecretStore); the SA lives in external-secrets
+    # and the RoleBinding lives in openshell — both specified per-manifest.
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/base-apps/eso-kubernetes-clusterstore/clusterrole.yaml
+++ b/base-apps/eso-kubernetes-clusterstore/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eso-kubernetes-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["openshell-ca-tls"]
+    verbs: ["get", "list", "watch"]

--- a/base-apps/eso-kubernetes-clusterstore/clustersecretstore.yaml
+++ b/base-apps/eso-kubernetes-clusterstore/clustersecretstore.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-cluster-reader
+spec:
+  provider:
+    kubernetes:
+      server:
+        # In-cluster API server. caProvider points at the kube-root-ca ConfigMap
+        # that kubelet projects into every namespace.
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-kubernetes-reader
+          namespace: external-secrets
+      # Defense-in-depth: even if the bound RBAC were over-permissive, ESO
+      # only consults the openshell namespace when resolving references.
+      remoteNamespace: openshell

--- a/base-apps/eso-kubernetes-clusterstore/rolebinding.yaml
+++ b/base-apps/eso-kubernetes-clusterstore/rolebinding.yaml
@@ -1,0 +1,16 @@
+# Intentional: RoleBinding (not ClusterRoleBinding). The ClusterRole is
+# cluster-scoped but the binding is namespace-scoped to `openshell`, so the
+# effective permission grant is bounded to that single namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-kubernetes-reader
+  namespace: openshell
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eso-kubernetes-reader
+subjects:
+  - kind: ServiceAccount
+    name: eso-kubernetes-reader
+    namespace: external-secrets

--- a/base-apps/eso-kubernetes-clusterstore/serviceaccount.yaml
+++ b/base-apps/eso-kubernetes-clusterstore/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-kubernetes-reader
+  namespace: external-secrets

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -28,7 +28,7 @@ spec:
             urlFile: /etc/kagent/secrets/db-url
             vectorEnabled: true
 
-        # Mount the database URL secret as a file
+        # Mount the database URL secret + the openshell CA cert.
         controller:
           volumes:
             - name: db-secret
@@ -37,19 +37,37 @@ spec:
                 items:
                   - key: db-url
                     path: db-url
+            - name: openshell-ca
+              secret:
+                # Mirrored from openshell ns/openshell-ca-tls via the
+                # kubernetes-cluster-reader ClusterSecretStore. See
+                # base-apps/kagent/external-secret-openshell-ca.yaml.
+                secretName: kagent-openshell-ca
+                items:
+                  - key: ca.crt
+                    path: ca.crt
           volumeMounts:
             - name: db-secret
               mountPath: /etc/kagent/secrets
               readOnly: true
-          # OpenShell integration (Phase 2). OPENSHELL_INSECURE skips TLS
-          # verification because the chart-issued openshell-ca-tls isn't yet
-          # mounted into the controller; tighten by mounting that CA and
-          # flipping this to "false" in a follow-up.
+            - name: openshell-ca
+              mountPath: /etc/openshell-tls/ca
+              readOnly: true
+          # OpenShell integration (Phase 2). The kagent v0.9.4 controller's
+          # openshell client only supports server-cert verification — there
+          # is no client-cert config field in the openshell.Config struct.
+          # We verify the gateway's cert with the chart-issued CA mounted
+          # above (OPENSHELL_TLS_CA_FILE). The gateway has been put into
+          # server-TLS-only mode via the openshell chart values; full mTLS
+          # is blocked on upstream kagent adding client-cert support.
+          # See issue #306 and docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md.
           env:
             - name: OPENSHELL_GATEWAY_URL
               value: "https://openshell.openshell.svc.cluster.local:8080"
             - name: OPENSHELL_INSECURE
-              value: "true"
+              value: "false"
+            - name: OPENSHELL_TLS_CA_FILE
+              value: "/etc/openshell-tls/ca/ca.crt"
 
         # LLM provider: use Anthropic with existing secret
         providers:

--- a/base-apps/kagent/external-secret-openshell-ca.yaml
+++ b/base-apps/kagent/external-secret-openshell-ca.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-openshell-ca
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    # Cluster-scoped store defined in base-apps/eso-kubernetes-clusterstore/.
+    # Backed by a narrowly-scoped SA that can only read
+    # Secret/openshell-ca-tls in the openshell namespace.
+    name: kubernetes-cluster-reader
+    kind: ClusterSecretStore
+  target:
+    name: kagent-openshell-ca
+    creationPolicy: Owner
+  data:
+    # The openshell chart issues openshell-ca-tls via cert-manager. We only
+    # need the CA cert (tls.crt) so the kagent controller can verify the
+    # gateway's server certificate. Rotation is automatic — ESO re-syncs on
+    # refreshInterval and cert-manager rotates the CA every certificateDuration
+    # (chart default 8760h / 1 year).
+    - secretKey: ca.crt
+      remoteRef:
+        key: openshell-ca-tls
+        property: tls.crt

--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -16,8 +16,17 @@ spec:
         # PKI via cert-manager — chart auto-creates a namespaced Issuer and
         # Certificates. Disable the bootstrap Job so we don't double-write the
         # server/client TLS Secrets.
+        #
+        # clientCaFromServerTlsSecret=false drops the gateway's client_ca_path
+        # config line — gateway no longer requires mTLS client certs.
+        # Rationale: kagent v0.9.4's openshell client supports server-cert
+        # verification only (no CertPEM/KeyPEM config fields). Server-TLS-only
+        # is the sane interim posture; re-enable mTLS once upstream kagent
+        # adds client-cert support. See issue #306 and the design spec at
+        # docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md.
         certManager:
           enabled: true
+          clientCaFromServerTlsSecret: false
         pkiInitJob:
           enabled: false
 

--- a/docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md
+++ b/docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md
@@ -679,6 +679,8 @@ kubectl get pods -n kagent -l app.kubernetes.io/component=controller
 ```
 Expected: exactly **one** controller pod, on ReplicaSet `568c7b55fb` (the new hash), STATUS `Running`, RESTARTS low. The old ReplicaSet (`857c56b6`) should be scaled to 0 by the rollout.
 
+> **Post-merge note (2026-05-28):** This step did NOT pass after PR #305 merged. The new controller continued to CrashLoop with the same surface error (`context deadline exceeded`) for a different root cause: the openshell gateway requires mTLS client certs (chart's `client_ca_path` is set) and the kagent v0.9.4 controller does not support client certs. `OPENSHELL_INSECURE=true` only addresses one half of TLS. Tracked as issue #306 and resolved in a follow-up PR (spec: `docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md`). The old ReplicaSet remained 1/1 Running throughout, so no user-facing impact.
+
 ```bash
 kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=30 | grep -iE 'openshell|sandbox|error'
 ```

--- a/docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
+++ b/docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md
@@ -262,7 +262,7 @@ Run one trivial sandbox-backed task through the kagent UI (e.g., ask the harness
 |---|---|
 | ExternalSecret stuck `SecretSyncError` | `kubectl describe externalsecret -n openshell openshell-jwt-keys` — most likely Vault role/policy mismatch. Re-run script with `--dry-run` to inspect role/policy definition. |
 | openshell-0 Running but readinessProbe failing | `kubectl logs -n openshell openshell-0` — chart may complain about kid/public.pem mismatch if rotated mid-run. |
-| New kagent controller still crashlooping after openshell-0 is Ready | Likely a TLS or `OPENSHELL_INSECURE` issue, **not** JWT. Out of scope for this fix — see below. |
+| New kagent controller still crashlooping after openshell-0 is Ready | Gateway-required mTLS + kagent v0.9.4 controller lacks client-cert support. `OPENSHELL_INSECURE=true` only skips server-cert verify; it does NOT make the gateway stop demanding a client cert. Resolved in a follow-up PR — see issue #306 and `docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md`. |
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
+++ b/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
@@ -1,0 +1,211 @@
+# OpenShell Controller TLS — Design
+
+**Date:** 2026-05-28
+**Branch:** `fix/openshell-controller-mtls`
+**Status:** Spec — approved during brainstorming, design pieces validated section-by-section
+**Tracking:** GitHub issue #306, follow-up to PR #305
+
+## Problem
+
+After PR #305 merged, `openshell-0` came up healthy but the new `kagent-controller-568c7b55fb-*` pod continued to `CrashLoopBackOff` with the same surface error:
+
+```
+unable to build openshell sandbox backends:
+openshell: dial https://openshell.openshell.svc.cluster.local:8080: context deadline exceeded
+```
+
+Post-merge investigation confirmed a deeper, separate bug:
+
+1. The chart-rendered `openshell-config` ConfigMap sets `[openshell.gateway.tls].client_ca_path = "/etc/openshell-tls/client-ca/ca.crt"`. Whenever `client_ca_path` is set, the gateway switches into **mTLS-required** mode — every connecting client must present a client certificate signed by the chart's CA.
+
+2. The kagent v0.9.4 controller's openshell client (`go/core/pkg/sandboxbackend/openshell/client.go`) has **no support for client certificates**. The `Config` struct fields are `GatewayURL`, `Insecure`, `TLSCAPEM`, `Token`, `TokenFile`, `DialTimeout`, `CallTimeout` — no `CertPEM` / `KeyPEM` / cert-path field anywhere. The Dial function selects one of three credential modes (insecure, TLS-with-CA, TLS-with-system-CAs), none of which present a client cert.
+
+3. `OPENSHELL_INSECURE=true` (currently set) only skips **server-cert verification** on the controller's outbound TLS. It does nothing to make the gateway stop demanding a client cert. The TLS handshake stalls; `DialTimeout=10s` fires; "context deadline exceeded".
+
+Net effect: every connection from the new controller to the gateway is structurally impossible until either the gateway stops requiring client certs OR upstream kagent adds client-cert support.
+
+**Functional impact today:** none. The old (pre-0.9.4) kagent controller (`kagent-controller-857c56b6-*`) remains 1/1 Running. The new ReplicaSet is stuck failing readiness, so the rollout sits idle rather than failing forward.
+
+## Approach
+
+Two changes, applied in the same PR:
+
+1. **Disable the gateway's client-cert requirement** by setting `certManager.clientCaFromServerTlsSecret: false` in `base-apps/openshell.yaml`. This is a single helm value flip. The openshell chart's `templates/gateway-config.yaml` gates the `client_ca_path` line on:
+
+   ```
+   {{- if or .Values.server.tls.clientCaSecretName
+          .Values.pkiInitJob.enabled
+          (and .Values.certManager.enabled .Values.certManager.clientCaFromServerTlsSecret) }}
+   client_ca_path = "/etc/openshell-tls/client-ca/ca.crt"
+   {{- end }}
+   ```
+
+   With all three branches false, `client_ca_path` is omitted; gateway becomes server-TLS-only.
+
+2. **Tighten the controller's outbound TLS** by mounting the chart-issued CA cert and flipping `OPENSHELL_INSECURE` to `false`. The controller will still encrypt the connection (TLS) and now also verify the gateway's server cert. Server-TLS-only, but with proper identity verification on the controller side.
+
+Why this combo: we lose the gateway's verification of client identity (was: cert-manager-signed cert; now: nothing) but keep encryption and add proper server identity verification by the controller. In a single-cluster homelab/lab with NetworkPolicies + RBAC, this is a reasonable posture. When upstream kagent adds client-cert support, we can flip both back.
+
+## Architecture
+
+```
+Gateway side (openshell ns)                       Controller side (kagent ns)
+──────────────────────────────────                ──────────────────────────────
+openshell.yaml chart values:                      kagent.yaml chart values:
+  certManager.clientCaFromServerTlsSecret:        controller.env:
+    false  ◄── flip                                 OPENSHELL_GATEWAY_URL: …
+                                                    OPENSHELL_INSECURE: "false"  ◄── flip
+                                                    OPENSHELL_TLS_CA_FILE:
+                                                      /etc/openshell-tls/ca/ca.crt
+                                                  controller.volumes:
+                                                    openshell-ca (Secret-backed)
+                                                  controller.volumeMounts:
+                                                    /etc/openshell-tls/ca
+
+Cross-namespace CA delivery
+──────────────────────────────────────────────────────────────────────────────
+openshell ns: Secret/openshell-ca-tls (cert-manager managed; ~yearly rotation)
+                  │ tls.crt field
+                  ▼
+   ClusterSecretStore "kubernetes-cluster-reader"  ◄── new, cluster-scoped
+   provider: kubernetes
+   auth: SA eso-kubernetes-reader in external-secrets ns
+   remoteNamespace: openshell
+                  │
+                  ▼
+kagent ns:    ExternalSecret/kagent-openshell-ca
+                  │  pulls openshell-ca-tls.tls.crt
+                  ▼
+              Secret/kagent-openshell-ca (data: ca.crt)
+                  │
+                  ▼  mounted readOnly
+              kagent-controller container /etc/openshell-tls/ca/ca.crt
+                  │
+                  ▼  OPENSHELL_TLS_CA_FILE=/etc/openshell-tls/ca/ca.crt
+              controller's openshell-client TLS dial verifies gateway server cert
+```
+
+## Files changed / added
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `base-apps/openshell.yaml` | Add `certManager.clientCaFromServerTlsSecret: false` under `spec.source.helm.valuesObject`. |
+| `base-apps/kagent.yaml` | Three changes to the `controller` block: (a) `env` — set `OPENSHELL_INSECURE: "false"` and add `OPENSHELL_TLS_CA_FILE: /etc/openshell-tls/ca/ca.crt` (env-var name derived from the `--openshell-tls-ca-file` flag via `app.LoadFromEnv`'s kebab→upper-snake convention); (b) extend `volumes` with `openshell-ca` (Secret-backed, `kagent-openshell-ca`); (c) extend `volumeMounts` with `/etc/openshell-tls/ca` readOnly. Also replace the misleading comment at lines 44–47 with an accurate description of the new posture. |
+
+### New
+
+| Path | Purpose |
+|---|---|
+| `base-apps/eso-kubernetes-clusterstore.yaml` | ArgoCD `Application` at sync-wave `-3` sourcing the directory below. Auto-discovered by the master-app. Sync-wave `-3` ensures the ClusterSecretStore exists before any ExternalSecret references it (the kagent ExternalSecret materializes at the default wave `0`). |
+| `base-apps/eso-kubernetes-clusterstore/` | Directory containing the actual ESO RBAC + ClusterSecretStore manifests. |
+| `base-apps/eso-kubernetes-clusterstore/serviceaccount.yaml` | `ServiceAccount/eso-kubernetes-reader` in the `external-secrets` namespace. The identity ESO impersonates when reading Secrets via this store. |
+| `base-apps/eso-kubernetes-clusterstore/clusterrole.yaml` | `ClusterRole/eso-kubernetes-reader` — narrow grant: `get/list/watch` on `secrets` with `resourceNames: ["openshell-ca-tls"]` only. |
+| `base-apps/eso-kubernetes-clusterstore/rolebinding.yaml` | `RoleBinding` (not ClusterRoleBinding) in the `openshell` namespace, binding the ClusterRole to the SA. Namespace-bounded grant. |
+| `base-apps/eso-kubernetes-clusterstore/clustersecretstore.yaml` | `ClusterSecretStore/kubernetes-cluster-reader` using the built-in `kubernetes` provider, authenticating as the SA above, with `remoteNamespace: openshell`. |
+| `base-apps/kagent/external-secret-openshell-ca.yaml` | `ExternalSecret/kagent-openshell-ca` in the `kagent` namespace using the new `ClusterSecretStore`. Pulls `openshell-ca-tls.tls.crt` from the openshell ns into `Secret/kagent-openshell-ca` with key `ca.crt`. `refreshInterval: 1h`. |
+
+### Documentation updates (stale from PR #305)
+
+| Path | Change |
+|---|---|
+| `docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md` | Failure-mode triage row for "New kagent controller still crashlooping after openshell-0 is Ready" — replace "Likely a TLS or `OPENSHELL_INSECURE` issue" with a pointer to issue #306 and this spec for the precise diagnosis (gateway-required mTLS + controller lacks client cert support in v0.9.4). |
+| `docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md` | Footnote on Task 7 Step 5 acknowledging the actual post-merge outcome (controller continued to fail; second bug; resolved in this follow-up PR). |
+| `base-apps/kagent.yaml` (lines 44–47) | Replace the existing misleading comment ("OPENSHELL_INSECURE skips TLS verification ... tighten by mounting that CA and flipping this to 'false' in a follow-up") with an accurate description: the controller now verifies the gateway's server cert via the mounted CA; full mTLS (client + server) is blocked on upstream kagent adding client-cert support. |
+
+### Unchanged
+
+- `scripts/bootstrap-openshell-jwt.sh` — unrelated; stays.
+- `base-apps/openshell/{secret-store,external-secret}.yaml` — JWT-keys flow stays as-is.
+- `base-apps/openshell-secrets.yaml` — unchanged.
+
+## ClusterSecretStore RBAC (security-sensitive)
+
+The ClusterSecretStore needs RBAC to read Secrets across namespaces. The scoping is **deliberately narrow** to limit blast radius.
+
+**ServiceAccount:** `eso-kubernetes-reader` in `external-secrets` ns (where ESO controllers run).
+
+**ClusterRole:**
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["openshell-ca-tls"]
+    verbs: ["get", "list", "watch"]
+```
+
+- `resourceNames` set → limited to one Secret name only.
+- `secrets` only.
+- Read-only verbs.
+
+**RoleBinding (NOT ClusterRoleBinding):**
+
+Binding lives in the `openshell` namespace, references the cluster-scoped ClusterRole, subject is the SA in `external-secrets`. Because it's a `RoleBinding` (namespace-scoped) rather than a `ClusterRoleBinding`, the effective grant is **bounded to the `openshell` namespace**: the SA can read Secret `openshell-ca-tls` in `openshell` and nothing else, anywhere.
+
+**Net effective permission:** `get/list/watch` on `Secret/openshell-ca-tls` in namespace `openshell`. No other Secrets. No other namespaces. No write/delete.
+
+**ClusterSecretStore defense-in-depth:** `spec.provider.kubernetes.remoteNamespace: openshell` constrains ESO to only consult that namespace when resolving references — even if RBAC were over-permissive, ESO scopes its lookups.
+
+## ArgoCD sync-wave ordering
+
+| Wave | Application | Purpose |
+|---|---|---|
+| `-3` | `eso-kubernetes-clusterstore` (new) | ClusterSecretStore + RBAC must exist before any ExternalSecret references it. |
+| `-2` | `agent-sandbox-crds`, `istio-base`, `openshell-secrets` (existing) | Unchanged. |
+| `-1` | `openshell` (existing) | Now reconciles with `clientCaFromServerTlsSecret: false`. Gateway config will lose `client_ca_path` and the `tls-client-ca` volume mount — pod will roll. |
+| `0` | `kagent` (existing) | ExternalSecret `kagent-openshell-ca` (in this app's directory) materializes the Secret; controller env + volumes pick up the CA mount; controller dial succeeds; new ReplicaSet becomes Ready; old ReplicaSet is scaled to 0. |
+
+Race window: the `kagent-openshell-ca` ExternalSecret depends on the upstream `openshell-ca-tls` Secret existing and the ClusterSecretStore being healthy. ESO's reconciliation will retry until both are present. Worst case is a slow first roll, not a deadlock.
+
+## Verification
+
+After merge + sync, expect:
+
+1. ClusterSecretStore healthy:
+   ```bash
+   kubectl get clustersecretstore kubernetes-cluster-reader -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+   # expect: True
+   ```
+
+2. ExternalSecret synced:
+   ```bash
+   kubectl get externalsecret -n kagent kagent-openshell-ca -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+   # expect: True
+   kubectl get secret -n kagent kagent-openshell-ca -o jsonpath='{.data}' | jq 'keys'
+   # expect: ["ca.crt"]
+   ```
+
+3. Gateway pod rolled (`client_ca_path` removed from config triggers ConfigMap checksum change → StatefulSet pod restarts):
+   ```bash
+   kubectl get pod -n openshell openshell-0
+   # expect: 1/1 Running, RESTARTS >= 1 (one restart from this PR's roll)
+   kubectl exec -n openshell openshell-0 -- cat /etc/openshell/gateway.toml | grep client_ca_path || echo "absent (expected)"
+   ```
+
+4. New kagent controller exits CrashLoop:
+   ```bash
+   kubectl get pods -n kagent -l app.kubernetes.io/component=controller
+   # expect: exactly one Running pod on the new ReplicaSet hash
+   kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=30 \
+     | grep -iE 'openshell|sandbox'
+   # expect: NO "unable to build openshell sandbox backends"
+   # expect: successful init message
+   ```
+
+5. End-to-end smoke (sample AgentHarness from PR #305 / commit 5fa23e7):
+   ```bash
+   kubectl get agentharness -n kagent homelab-harness
+   ```
+
+## Rollback
+
+Single commit revert. ArgoCD prunes the new Application + ExternalSecret + RBAC. The `kagent.yaml` env-var changes revert; controller goes back to `INSECURE=true` and stops trying to verify the gateway. `openshell.yaml` reverts and the gateway goes back to mTLS-required mode. Net effect: cluster returns to the pre-PR state (controller CrashLoop, old controller still serving). No data loss.
+
+## Out of scope
+
+- **Upstream kagent client-cert support.** Not opening an upstream issue or PR. If/when kagent adds `CertPEM`/`KeyPEM` config fields, a future follow-up can swap our server-TLS-only posture back to full mTLS.
+- **Bearer-token / OIDC integration.** Would require running an OIDC issuer in-cluster. Out of scope.
+- **Per-tenant gateway certs / SAN tuning.** Out of scope.
+- **Migrating other cross-namespace secret needs to this ClusterSecretStore.** The store is intentionally narrow (one Secret name). When the next cross-ns mirroring need arises, add a new RoleBinding (and possibly broaden the ClusterRole's `resourceNames`) — but don't pre-emptively widen it now.


### PR DESCRIPTION
## Summary
- Closes #306. Unblocks the new kagent v0.9.4 controller that has been `CrashLoopBackOff` since PR #305 merged.
- Root cause: gateway requires mTLS client certs (chart's `client_ca_path` is set), but kagent v0.9.4's openshell client has **no client-cert config fields**. Verified by reading `go/core/pkg/sandboxbackend/openshell/{client,config}.go` at tag `v0.9.4` — only `GatewayURL`, `Insecure`, `TLSCAPEM`, `Token`, `TokenFile`, `CAFile`, timeouts. The Dial function selects one of three credential modes; none present a client cert.
- Fix: drop the gateway's client-cert requirement (server-TLS-only) and tighten the controller's outbound TLS posture (mount CA + verify server cert + flip `OPENSHELL_INSECURE=false`).

## Changes

### Gateway side
- `base-apps/openshell.yaml` — add `certManager.clientCaFromServerTlsSecret: false`. The chart's `templates/gateway-config.yaml` gates `client_ca_path` on this flag; with it false, gateway no longer demands client certs. Encryption stays (cert-manager-issued server cert).

### Controller side
- `base-apps/kagent.yaml`:
  - Add `openshell-ca` Secret-backed volume + readOnly mount at `/etc/openshell-tls/ca`.
  - Set `OPENSHELL_TLS_CA_FILE: /etc/openshell-tls/ca/ca.crt`. (Env var name derived from `--openshell-tls-ca-file` flag via `app.LoadFromEnv`'s kebab→upper-snake convention.)
  - Flip `OPENSHELL_INSECURE` from `"true"` to `"false"`. Controller now verifies the gateway's server cert.
  - Replace the previous misleading comment with an accurate description of the new posture and the upstream blocker.

### Cross-namespace CA delivery (new)
- `base-apps/eso-kubernetes-clusterstore.yaml` — ArgoCD `Application` at sync-wave `-3`.
- `base-apps/eso-kubernetes-clusterstore/` — SA + ClusterRole + RoleBinding + ClusterSecretStore using ESO's built-in `kubernetes` provider.
- `base-apps/kagent/external-secret-openshell-ca.yaml` — ExternalSecret pulling `openshell-ca-tls.tls.crt` from the `openshell` namespace into `Secret/kagent-openshell-ca` in the `kagent` namespace.

### Docs hygiene (cleanup from PR #305)
- `docs/superpowers/specs/2026-05-27-openshell-jwt-keys-fix-design.md` — failure-mode triage row updated with the precise diagnosis and pointer to this PR.
- `docs/superpowers/plans/2026-05-27-openshell-jwt-keys-fix.md` — Task 7 Step 5 footnoted with the actual post-merge outcome.
- New design spec: `docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md`.

## Key Features
- **Security posture trade-off documented:** server-TLS-only (encrypted + controller verifies server identity) is the interim posture; full mTLS blocked on upstream kagent adding `CertPEM`/`KeyPEM` config fields. Re-enable mTLS once upstream lands.
- **Narrow RBAC:** the ClusterRole is pinned by `resourceNames: ["openshell-ca-tls"]` and bound via a RoleBinding (not ClusterRoleBinding) in the `openshell` namespace. Effective grant: read one Secret in one namespace.
- **Defense-in-depth:** ClusterSecretStore `remoteNamespace: openshell` further scopes ESO's lookups.
- **Automatic rotation:** cert-manager rotates the CA per `certificateDuration` (chart default 8760h). ESO re-syncs on `refreshInterval: 1h`. No manual touch.

## Technical Implementation
- ClusterSecretStore uses the built-in ESO Kubernetes provider with `auth.serviceAccount` — ESO requests a TokenRequest for the SA on each reconcile and uses that token to make API calls as the SA.
- SA lives in `external-secrets` namespace (same as the ESO controller) so the ESO chart's existing TokenRequest RBAC covers it without modification.
- `kagent-openshell-ca` is a regular `Opaque` Secret (not `kubernetes.io/tls`) because the controller only needs `ca.crt`, not a cert+key pair.
- Sync-wave `-3` for the ClusterSecretStore Application ensures it lands before any ExternalSecret references it (kagent's ExternalSecret materializes at the default wave `0`).

## Testing
- All six new manifests pass `kubectl apply --dry-run=server` against the live cluster (validates against installed ESO, ArgoCD, and core RBAC CRDs).
- The two modified Application manifests pass `kubectl apply --dry-run=client`.
- Source-code verification of the kagent controller's TLS config struct (`v0.9.4`) confirms the diagnosis and the chosen approach.

## Test Plan
After merge, ArgoCD reconciles in wave order. Verify with:

- [ ] `kubectl get applications -n argo-cd eso-kubernetes-clusterstore openshell kagent -w` — all reach `Synced / Healthy`
- [ ] `kubectl get clustersecretstore kubernetes-cluster-reader -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` → `True`
- [ ] `kubectl get externalsecret -n kagent kagent-openshell-ca -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` → `True`
- [ ] `kubectl get secret -n kagent kagent-openshell-ca -o jsonpath='{.data}' | jq 'keys'` → `["ca.crt"]`
- [ ] Gateway pod re-rolled: `kubectl get pod -n openshell openshell-0` shows recent restart; `kubectl exec -n openshell openshell-0 -- cat /etc/openshell/gateway.toml | grep -q client_ca_path || echo "client_ca_path absent (expected)"`
- [ ] `kubectl get pods -n kagent -l app.kubernetes.io/component=controller` — exactly one Running pod on the new ReplicaSet hash, RESTARTS small
- [ ] `kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=30 | grep -iE 'openshell|sandbox'` — no `unable to build openshell sandbox backends` error
- [ ] `kubectl get agentharness -n kagent homelab-harness` — Ready/Synced

## Deployment Notes
**No manual prerequisite.** All resources land via ArgoCD on merge. cert-manager already has the `openshell-ca-tls` Secret in place (issued during PR #305's chart sync).

**Rollback:** Revert the merge commit. ArgoCD prunes the new Application + ExternalSecret + RBAC. Controller goes back to `INSECURE=true`. `openshell.yaml` reverts; gateway goes back to mTLS-required mode. Cluster returns to the pre-PR state (controller CrashLoop, old controller still serving). No data loss.

## Related
- Closes #306
- Follows PR #305 (`fix(openshell): provision openshell-jwt-keys via Vault + ESO`)
- Upstream kagent gap to track for future re-enablement of full mTLS: `Config` struct in `go/core/pkg/sandboxbackend/openshell/config.go` needs `CertPEM`/`KeyPEM` (or path) fields.

🤖 Generated with [Claude Code](https://claude.ai/code)