### PR TITLE
fix(openshell): allow unauthenticated users — gateway gRPC auth gate

### DIFF
--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -45,6 +45,27 @@ spec:
         # docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md.
         server:
           disableTls: true
+          # allowUnauthenticatedUsers=true: gateway accepts requests without
+          # an Authorization: Bearer <token> header, treating the caller as a
+          # local-developer principal.
+          #
+          # Why: PR #308 disabled TLS to work around the chart's inability to
+          # express server-TLS-only. Even after that landed, the kagent v0.9.4
+          # controller's connections were rejected at the gRPC application
+          # layer with "Unauthenticated: missing authorization header" — the
+          # gateway requires bearer tokens by default unless OIDC is enabled
+          # (it isn't) or auth is explicitly opened. The kagent controller
+          # config has a Token/TokenFile field but no token source is wired
+          # in our deployment; standing up an OIDC issuer is out of scope for
+          # this homelab.
+          #
+          # Trade-off: anything that can reach the gateway gRPC port becomes
+          # an authenticated principal. NetworkPolicies + intra-cluster RBAC
+          # are the perimeter. Consistent with the disableTls=true posture.
+          # Revisit when an OIDC issuer is available OR when kagent supports
+          # mTLS client certs (then we can flip back to identity-bearing auth).
+          auth:
+            allowUnauthenticatedUsers: true
 
         # Gateway pod resource bounds. Kyverno require-resource-limits policy
         # only warns when missing, but declaring explicitly keeps events clean.

--- a/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
+++ b/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
@@ -219,6 +219,18 @@ Resolution shipped in the follow-up PR:
 
 **Future work:** re-enable encryption when either upstream lands a fix — openshell chart should gate `client_ca_path` rendering, OR kagent should add client-cert config fields to its openshell client. Both tracked in issue #306.
 
+### Second post-merge finding (after PR #308)
+
+Disabling TLS unblocked the controller's TCP dial but surfaced a third chart gate: the gateway requires app-layer bearer-token auth by default. With OIDC disabled (the chart default) and no token wired into the controller, every gRPC call from the controller was rejected with `Unauthenticated: missing authorization header`.
+
+Resolution in the next follow-up PR:
+
+- `base-apps/openshell.yaml` — add `server.auth.allowUnauthenticatedUsers: true`. The chart documents this flag as "UNSAFE: accept unauthenticated CLI/user requests as a local developer principal", intended for "trusted local Skaffold/k3d development or a fully trusted fronting proxy."
+
+**Trade-off:** anything that can reach the gateway gRPC port is now an authenticated principal. NetworkPolicies + intra-cluster RBAC become the only perimeter. Consistent with the `disableTls=true` posture from PR #308 — both choices accept that the cluster's pod-network is the trust boundary.
+
+**Future work:** re-enable identity-bearing auth when either an OIDC issuer is available in-cluster OR kagent gains a way to mint/forward auth tokens. Tracked in issue #306.
+
 ## Out of scope
 
 - **Upstream kagent client-cert support.** Not opening an upstream issue or PR. If/when kagent adds `CertPEM`/`KeyPEM` config fields, a future follow-up can swap our server-TLS-only posture back to full mTLS.


### PR DESCRIPTION
## Summary
- Final step in the controller-mTLS series. PR #308 cleared the TLS handshake; this PR clears the next gate (app-layer bearer-token auth) that surfaced immediately after.
- Sets \`server.auth.allowUnauthenticatedUsers: true\`. Consistent with the no-TLS posture PR #308 already chose.

## Diagnosis from PR #308's verification

After PR #308 merged and synced, the new kagent controller's TCP/gRPC dial succeeded — but every RPC was rejected with:

\`\`\`
openshell GetSandbox kagent-homelab-harness: rpc error: code = Unauthenticated
desc = missing authorization header
\`\`\`

The gateway requires \`Authorization: Bearer <token>\` on every gRPC call by default. With OIDC disabled (the chart default — \`server.oidc.issuer\` is empty) and no token source wired into the kagent controller, the controller has no way to satisfy this.

The chart's \`server.auth.allowUnauthenticatedUsers\` flag (default \`false\`) lets the gateway accept requests without an auth header. From the chart's own values.yaml comment:

> "UNSAFE: accept unauthenticated CLI/user requests as a local developer principal. Intended only for trusted local Skaffold/k3d development or a fully trusted fronting proxy. Leave false for shared or production clusters."

## Changes
- \`base-apps/openshell.yaml\` — add \`server.auth.allowUnauthenticatedUsers: true\` with inline explanation.
- \`docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md\` — second post-merge addendum documenting this gate and the resolution.

## Posture summary across the series

| Layer | Default | This series |
|---|---|---|
| TLS — encryption + server-cert verify | mTLS-required | Disabled (plain h2c) — PR #308 |
| TLS — client-cert verify | required | Disabled — PR #308 |
| App-layer auth | bearer token required | Allowed unauthenticated — this PR |
| Network | Cluster-internal | NetworkPolicy enforced |

Net: NetworkPolicy + intra-cluster RBAC are the trust boundary. Acceptable for a homelab; cleaner story comes back when an OIDC issuer is in place (re-enable bearer token auth) or when kagent supports mTLS client certs (re-enable identity-bearing TLS).

## Testing
- Helm-render verified: \`helm template ... -f values.yaml\` with \`server.auth.allowUnauthenticatedUsers=true\` produces a gateway.toml with \`[openshell.gateway.auth] allow_unauthenticated_users = true\`.
- All manifests pass \`kubectl apply --dry-run=client\`.

## Test Plan
After merge + sync:

- [ ] \`kubectl get configmap -n openshell openshell-config -o jsonpath='{.data.gateway\\.toml}' | grep -A1 allow_unauth\` — shows \`allow_unauthenticated_users = true\`
- [ ] \`kubectl get pod -n openshell openshell-0\` — Running, recently rolled (ConfigMap-checksum'd pod template)
- [ ] \`kubectl logs -n kagent -l app.kubernetes.io/component=controller --tail=60 | grep -iE 'Unauthenticated|missing authorization'\` — NO matches
- [ ] \`kubectl get agentharness -n kagent homelab-harness\` — Ready (no reconciliation errors)
- [ ] kagent UI: sample AgentHarness can spawn a sandbox

## Deployment Notes
**Rollback:** revert. Gateway returns to bearer-token-required, controller starts logging Unauthenticated errors again. AgentHarness reconciliation stops. Old controller stays serving. No data loss.

## Related
- Closes the kagent controller bootstrap arc started by PR #305
- Follows PR #308 (\`fix(openshell): disable TLS\`)
- Follows PR #307 (\`fix(openshell): controller mTLS\` — failed approach, superseded)
- Follows PR #305 (\`fix(openshell): provision openshell-jwt-keys via Vault + ESO\`)
- Tracks issue #306

🤖 Generated with [Claude Code](https://claude.ai/code)