### PR TITLE
fix(openshell): enable user namespaces for sandbox pods

### DIFF
--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -66,6 +66,23 @@ spec:
           # mTLS client certs (then we can flip back to identity-bearing auth).
           auth:
             allowUnauthenticatedUsers: true
+          # enableUserNamespaces=true: gateway emits
+          # `enable_user_namespaces = true` in gateway.toml; the kubernetes
+          # driver then creates sandbox pods with hostUsers=false. The agent
+          # container inside the sandbox runs in its own user namespace, so
+          # CAP_SYS_ADMIN/CAP_NET_ADMIN are namespaced and the agent can
+          # create network namespaces without host-level privileges.
+          #
+          # Why: post-PR #309 verification surfaced that sandbox pods crash
+          # at startup with `mount --make-shared /run/netns: Permission
+          # denied` even with SYS_ADMIN granted, because containerd's
+          # seccomp/AppArmor profile blocks the underlying syscall at the
+          # host level. User namespaces give the agent its own namespace
+          # where the capabilities are real. See issue #310.
+          #
+          # Prereqs in this cluster: kernel 6.8 (chart requires 5.12+),
+          # k8s 1.33 (hostUsers field went GA in 1.30).
+          enableUserNamespaces: true
 
         # Gateway pod resource bounds. Kyverno require-resource-limits policy
         # only warns when missing, but declaring explicitly keeps events clean.

--- a/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
+++ b/docs/superpowers/specs/2026-05-28-openshell-controller-mtls-design.md
@@ -231,6 +231,26 @@ Resolution in the next follow-up PR:
 
 **Future work:** re-enable identity-bearing auth when either an OIDC issuer is available in-cluster OR kagent gains a way to mint/forward auth tokens. Tracked in issue #306.
 
+### Third post-merge finding (after PR #309)
+
+The controller-to-gateway path was fully working after PR #309 — `AgentHarness` reached `Accepted=True` and the gateway successfully created sandbox pods via its kubernetes driver. But the sandbox pod itself (e.g. `kagent-homelab-harness`) crashed at startup with:
+
+```
+mount --make-shared /run/netns failed: Permission denied
+```
+
+The pod is granted `CAP_SYS_ADMIN` + `CAP_NET_ADMIN` in its securityContext, but containerd's default seccomp/AppArmor profile blocks the `mount` syscall at the host level regardless of the granted capabilities.
+
+Resolution in the follow-up PR (`fix/openshell-user-namespaces`):
+
+- `base-apps/openshell.yaml` — add `server.enableUserNamespaces: true`. The gateway-config emits `enable_user_namespaces = true` and the gateway's kubernetes driver creates sandbox pods with `pod.spec.hostUsers: false`. The agent container then runs in its own user namespace where `CAP_SYS_ADMIN`/`CAP_NET_ADMIN` are namespaced — it can manipulate netns within its own user namespace without host-level privileges.
+
+Cluster prereqs satisfied:
+- Kernel 6.8.0 — well above the 5.12 floor that the chart documents.
+- Kubernetes 1.33 — well above 1.30 where `pod.spec.hostUsers` went GA.
+
+This is also a real **security improvement** vs. the previous state (sandbox container UID 0 = host UID 0 with elevated caps).
+
 ## Out of scope
 
 - **Upstream kagent client-cert support.** Not opening an upstream issue or PR. If/when kagent adds `CertPEM`/`KeyPEM` config fields, a future follow-up can swap our server-TLS-only posture back to full mTLS.


### PR DESCRIPTION
## Summary
- Closes #310. The sandbox pod's \`agent\` container was CrashLooping with \`mount --make-shared /run/netns: Permission denied\` because containerd's default seccomp profile blocks the mount syscall even with \`CAP_SYS_ADMIN\` granted.
- Enables user namespaces on sandbox pods so the agent's capabilities become namespaced and the netns operation succeeds within the pod's own user namespace.

## Change

Single one-liner: \`server.enableUserNamespaces: true\` in \`base-apps/openshell.yaml\`.

The chart emits \`enable_user_namespaces = true\` in \`gateway.toml\`. The gateway's kubernetes driver then creates sandbox pods with \`pod.spec.hostUsers: false\`, putting each sandbox in its own user namespace.

## How this fixes the netns problem

- Sandbox container UID 0 maps to an unprivileged host UID.
- \`CAP_SYS_ADMIN\` and \`CAP_NET_ADMIN\` granted to the container are real within the user namespace, not at the host level.
- The kernel allows the user-namespace-confined process to create network namespaces inside its own user namespace — no seccomp/AppArmor restriction applies because the mount target is namespaced.

## Cluster prereqs (satisfied)
- Kernel \`6.8.0-117-generic\` — well above the chart-documented \`5.12+\` floor for user namespaces.
- Kubernetes \`v1.33.5+k3s1\` — well above \`1.30\` where \`pod.spec.hostUsers\` went GA.

## Security note

This is also a **net security improvement** vs. the prior state. Before: sandbox container UID 0 was host UID 0 with elevated capabilities. After: UID 0 inside the sandbox is an unprivileged UID on the host, and the elevated caps are confined to the user namespace.

## Test Plan
After merge + sync:

- [ ] \`kubectl get configmap -n openshell openshell-config -o jsonpath='{.data.gateway\\.toml}' | grep enable_user_namespaces\` — \`true\`
- [ ] \`kubectl get pod -n openshell openshell-0\` — Running, recently rolled
- [ ] Delete the old failing sandbox pod: \`kubectl delete pod -n openshell kagent-homelab-harness\`
- [ ] After kagent controller reconciles, a new sandbox pod appears with \`pod.spec.hostUsers: false\`
- [ ] \`kubectl get pod -n openshell -l openshell.ai/managed-by=openshell -o jsonpath='{.items[*].spec.hostUsers}'\` — \`false\`
- [ ] Sandbox pod's \`agent\` container reaches Running 1/1 (no \`Permission denied\` errors)
- [ ] \`kubectl get agentharness -n kagent homelab-harness\` — \`Ready=True\`

## Rollback
Revert the commit. Sandbox pods go back to running on the host user namespace and the netns error returns. No data loss; the gateway pod and existing AgentHarness CR are unaffected.

## Related
- Closes #310
- Follows PR #309 (\`fix(openshell): allow unauthenticated users\`) — that PR completed the controller-mTLS arc; this PR fixes the next downstream layer that surfaced during verification.

🤖 Generated with [Claude Code](https://claude.ai/code)