### PR TITLE
fix(openshell): inject AppArmor unconfined annotation on sandbox pods

### DIFF
--- a/base-apps/kyverno-policies/openshell-sandbox-apparmor-unconfined.yaml
+++ b/base-apps/kyverno-policies/openshell-sandbox-apparmor-unconfined.yaml
@@ -1,0 +1,62 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: openshell-sandbox-apparmor-unconfined
+  annotations:
+    policies.kyverno.io/title: OpenShell Sandbox AppArmor Unconfined
+    policies.kyverno.io/category: Workaround
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Adds the AppArmor "unconfined" annotation to OpenShell sandbox pods
+      (Pods in the openshell namespace owned by a Sandbox CR) so their
+      `agent` container can call mount(2) with MS_SHARED to set up its
+      own network namespace via `ip netns`.
+
+      Background: the sandbox agent's startup runs `ip netns add ...`,
+      which internally does `mount --make-shared /run/netns`. The default
+      containerd AppArmor profile (`cri-containerd.apparmor.d`) denies
+      `mount` outright — capabilities like CAP_SYS_ADMIN don't help
+      because AppArmor blocks the syscall before the kernel's capability
+      check. Without this annotation the pod CrashLoops with
+      "mount --make-shared /run/netns failed: Permission denied".
+
+      The Pod-spec `securityContext.appArmorProfile.type: Unconfined`
+      field SHOULD work but doesn't always propagate through containerd
+      — see https://github.com/kubernetes/kubernetes/issues/125069. The
+      legacy annotation form does.
+
+      Remove this policy once one of these upstream changes lands:
+        - openshell ships `NetworkMode::Platform` (skips netns creation
+          entirely) — tracked at https://github.com/NVIDIA/OpenShell/issues/899
+        - sigs.k8s.io/agent-sandbox propagates `runtimeClassName` from
+          the Sandbox CR, allowing us to pin sandbox pods to `crun`
+        - kubelet/containerd honor pod-level `appArmorProfile.Unconfined`
+spec:
+  # mutateExistingOnPolicyUpdate: false — only mutate new admissions.
+  rules:
+    - name: annotate-agent-apparmor-unconfined
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - openshell
+      preconditions:
+        all:
+          # Only sandbox pods (owned by a Sandbox CR). The gateway pod
+          # itself is owned by a StatefulSet, so it's excluded.
+          - key: "{{ request.object.metadata.ownerReferences[?kind=='Sandbox'] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+          # And only when the pod has an `agent` container — defends against
+          # future Sandbox CR variants that might use a different container name.
+          - key: "{{ request.object.spec.containers[?name=='agent'] | length(@) }}"
+            operator: GreaterThanOrEquals
+            value: 1
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              container.apparmor.security.beta.kubernetes.io/agent: unconfined


### PR DESCRIPTION
## Summary
- Closes #310. The openshell sandbox pod's \`agent\` container was CrashLooping with \`mount --make-shared /run/netns: Permission denied\` even after PR #311 set \`hostUsers: false\`.
- Root cause is containerd's default AppArmor profile (\`cri-containerd.apparmor.d\`) — it denies \`mount\` outright, regardless of \`CAP_SYS_ADMIN\` or user namespace mode. AppArmor blocks the syscall before the kernel ever checks capabilities.
- Adds a Kyverno ClusterPolicy that injects the legacy AppArmor annotation \`container.apparmor.security.beta.kubernetes.io/agent: unconfined\` on sandbox pods at admission time.

## Why a Kyverno policy and not a chart-values fix

The openshell chart v0.0.49 doesn't expose any way to set AppArmor profile on the sandbox pods it provisions through the agent-sandbox controller. The fix has to land on the Pod via admission.

The Kubernetes \`securityContext.appArmorProfile.type: Unconfined\` field SHOULD work but doesn't always propagate through containerd — see [kubernetes/kubernetes#125069](https://github.com/kubernetes/kubernetes/issues/125069). The legacy annotation form (\`container.apparmor.security.beta.kubernetes.io/<container>\`) is the proven workaround.

Kyverno is already deployed in this cluster with several mutating ClusterPolicies (\`inject-ecr-pull-secret\`, etc.), so the pattern is established.

## Live-tested before commit

After applying the policy:

\`\`\`
=== New pod state ===
NAME                     STATUS    READY   RESTARTS
kagent-homelab-harness   Running   true    0

=== AppArmor annotation applied? ===
{ \"container.apparmor.security.beta.kubernetes.io/agent\": \"unconfined\" }

=== AgentHarness final status ===
NAME              BACKEND    READY   ID                       AGE
homelab-harness   openclaw   True    kagent-homelab-harness   28h
{
  \"reason\": \"SandboxReady\",
  \"status\": \"True\",
  \"type\": \"Ready\",
  \"message\": \"Ready=True: Pod is Ready\"
}
\`\`\`

End-to-end working. The kagent → openshell → sandbox path is now fully functional.

## Selector scope (narrow)

The policy only mutates pods that meet ALL of:
- Namespace: \`openshell\`
- \`ownerReferences\` contains \`kind=Sandbox\` (so the gateway StatefulSet pod and any unrelated namespace pods are excluded)
- The pod has a container literally named \`agent\` (defends against future Sandbox CR variants)

## Security trade-off

The sandbox \`agent\` container loses AppArmor confinement. It still has:
- Seccomp filter (containerd default) — most dangerous syscalls still blocked
- Kernel network namespace isolation (created by the agent itself once it can mount)
- Capability bounding set (only what the openshell driver explicitly grants)
- runAsUser bounded to UID 0 in a user namespace (PR #311's hostUsers=false)
- OpenShell's own Landlock + cgroups + eBPF policy enforcement after startup
- Kubernetes NetworkPolicies (\`openshell-sandbox-ssh\` from the chart)

This is the same security posture upstream OpenShell expects for sandbox pods on a Kubernetes platform — there's no way to set up an isolated netns from inside a container without privileged mount access. The chart's restricted-SCC support ([NVIDIA/OpenShell#899](https://github.com/NVIDIA/OpenShell/issues/899)) is the planned upstream solution: it adds a \`NetworkMode::Platform\` variant that skips netns creation entirely and uses K8s NetworkPolicies for egress control.

## When to remove this policy

Remove when ANY of these upstream changes lands:
1. \`NetworkMode::Platform\` in openshell ([NVIDIA/OpenShell#899](https://github.com/NVIDIA/OpenShell/issues/899)) — preferred long-term
2. \`runtimeClassName\` propagation in \`sigs.k8s.io/agent-sandbox\` — allows pinning sandbox pods to \`crun\` (already registered in this cluster)
3. Containerd properly honors pod-level \`appArmorProfile.Unconfined\` ([kubernetes/kubernetes#125069](https://github.com/kubernetes/kubernetes/issues/125069))

## Files
- \`base-apps/kyverno-policies/openshell-sandbox-apparmor-unconfined.yaml\` — single new ClusterPolicy

## Test Plan
After merge + sync:

- [ ] \`kubectl get clusterpolicy openshell-sandbox-apparmor-unconfined\` — exists
- [ ] \`kubectl get pod -n openshell kagent-homelab-harness -o jsonpath='{.metadata.annotations}'\` — contains \`container.apparmor.security.beta.kubernetes.io/agent: unconfined\`
- [ ] \`kubectl get pod -n openshell kagent-homelab-harness\` — \`1/1 Running\`, low restart count
- [ ] \`kubectl get agentharness -n kagent homelab-harness\` — \`Ready: True\`

## Rollback
Revert. Sandbox pods stop getting the annotation; on next pod recreate they CrashLoop again. No data loss; AgentHarness goes back to Ready=False.

## Related
- Closes #310
- Final fix in the controller-mTLS arc (#306, PRs #305 → #307 → #308 → #309 → #311 → this)
- Upstream tracking: [NVIDIA/OpenShell#899](https://github.com/NVIDIA/OpenShell/issues/899), [kubernetes/kubernetes#125069](https://github.com/kubernetes/kubernetes/issues/125069)

🤖 Generated with [Claude Code](https://claude.ai/code)