### PR TITLE
fix(logging): raise alloy memory limits to stop OOMKilled crashloop

### DIFF
--- a/base-apps/logging/alloy-daemonset.yaml
+++ b/base-apps/logging/alloy-daemonset.yaml
@@ -51,10 +51,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 300m
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           privileged: true
           runAsUser: 0


### PR DESCRIPTION
## Problem

The Grafana Alloy log-collector DaemonSet pods in the `logging` namespace are in a chronic **OOMKilled crashloop**:

| Pod | Reason | Lifetime restarts |
|-----|--------|-------------------|
| `alloy-cstc8` | OOMKilled (exit 137) | ~2,969 |
| `alloy-sqg6t` | OOMKilled (exit 137) | ~3,761 |

Both pods sit at **~253Mi** steady-state (`kubectl top`) against a **256Mi** memory limit — pinned to the ceiling, so the kernel OOM-kills them repeatedly. Most recent kill was minutes before this PR. This causes intermittent gaps in log shipping.

## Fix

Give Alloy headroom above observed usage:

| | Before | After |
|-|--------|-------|
| `requests.memory` | 128Mi | **256Mi** |
| `limits.memory` | 256Mi | **512Mi** |

CPU (`100m`/`300m`) left unchanged.

## Rollout

ArgoCD `logging` Application has automated sync (`prune: true`, `selfHeal: true`), so this rolls out automatically on merge to `main`. Watch the DaemonSet roll and confirm restart counts stop climbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)