### PR TITLE
fix(atlantis): use OpenTofu to bypass expired HashiCorp GPG key

### DIFF
--- a/base-apps/atlantis.yaml
+++ b/base-apps/atlantis.yaml
@@ -16,6 +16,16 @@ spec:
           repository: infracost/infracost-atlantis
           tag: atlantis0.40-infracost0.10
 
+        # Use OpenTofu instead of Terraform. Atlantis verifies Terraform
+        # release signatures against HashiCorp's GPG key, which has expired —
+        # breaking `terraform` binary downloads with
+        # "unable to verify checksums signature: openpgp: key expired".
+        # OpenTofu uses its own signing, sidestepping the expired key.
+        # providers.tf requires >= 1.11.0; OpenTofu 1.12.3 satisfies it.
+        environment:
+          ATLANTIS_TF_DISTRIBUTION: tofu
+          ATLANTIS_DEFAULT_TF_VERSION: "1.12.3"
+
         orgAllowlist: github.com/arigsela/*
 
         github:


### PR DESCRIPTION
## Problem

Atlantis plans are failing before Terraform runs:

```
error downloading terraform version 1.15.7: unable to verify checksums signature: openpgp: key expired
```

Atlantis (image `infracost/infracost-atlantis:atlantis0.40`) downloads the Terraform binary via `hc-install`, which verifies the release's checksum signature against **HashiCorp's GPG signing key — which has expired**. This breaks the download for *every* Terraform version (it's the verification key, not the version), so it blocks all Terraform PRs in this repo. There is no `1.15.7` pin in the repo; `providers.tf` only requires `>= 1.11.0`, and Atlantis resolves the latest satisfying release.

## Fix

Switch Atlantis to the **OpenTofu** distribution:

```yaml
environment:
  ATLANTIS_TF_DISTRIBUTION: tofu
  ATLANTIS_DEFAULT_TF_VERSION: "1.12.3"
```

OpenTofu is a drop-in for the Terraform version range this repo uses and is signed independently of HashiCorp, so it sidesteps the expired key entirely. `providers.tf` requires `>= 1.11.0`; OpenTofu 1.12.3 satisfies it, and the same config already validates locally under `tofu validate`.

## Why this is safe / self-consistent

- This is a **GitOps/Argo CD-synced change** (a Helm values edit on the `atlantis` Application), **not** applied via Atlantis — so it is unaffected by the failure it fixes. Merging updates the Atlantis Helm release and restarts the pod on the OpenTofu distribution.
- Fixes **all** Terraform PRs in the repo, not just any single one.

## Verification

- `yamllint -c .yamllint.yaml base-apps/atlantis.yaml` → clean.
- Helm `values` block parses; `environment` renders the two `ATLANTIS_*` vars.
- Local `tofu fmt`/`init -backend=false`/`validate` on `terraform/roots/asela-cluster` → "Success! The configuration is valid."

## After merge

Re-run the Atlantis plan on any open Terraform PR (e.g. `atlantis plan`) — it will now fetch OpenTofu and succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
