### PR TITLE
fix(atlantis): use chart-native defaultTFDistribution=opentofu (correct flag/value)

### DIFF
--- a/base-apps/atlantis.yaml
+++ b/base-apps/atlantis.yaml
@@ -20,11 +20,14 @@ spec:
         # release signatures against HashiCorp's GPG key, which has expired —
         # breaking `terraform` binary downloads with
         # "unable to verify checksums signature: openpgp: key expired".
-        # OpenTofu uses its own signing, sidestepping the expired key.
+        # OpenTofu is signed independently, sidestepping the expired key.
+        # These chart-native values render ATLANTIS_DEFAULT_TF_DISTRIBUTION /
+        # ATLANTIS_DEFAULT_TF_VERSION — the flags Atlantis 0.40 actually uses
+        # (the older --tf-distribution env var is deprecated and ignored).
+        # The value must be "opentofu" (not "tofu").
         # providers.tf requires >= 1.11.0; OpenTofu 1.12.3 satisfies it.
-        environment:
-          ATLANTIS_TF_DISTRIBUTION: tofu
-          ATLANTIS_DEFAULT_TF_VERSION: "1.12.3"
+        defaultTFDistribution: opentofu
+        defaultTFVersion: "1.12.3"
 
         orgAllowlist: github.com/arigsela/*
 


### PR DESCRIPTION
## Problem

Follow-up to #316. That PR set `ATLANTIS_TF_DISTRIBUTION=tofu` via the chart's `environment` block, but Atlantis plans **kept failing** with the same expired-GPG error. Diagnosing the running pod showed why:

```
ATLANTIS_TF_DISTRIBUTION=tofu             ← from #316 (the DEPRECATED flag)
ATLANTIS_DEFAULT_TF_DISTRIBUTION=terraform ← chart-rendered (the flag Atlantis 0.40 uses) — wins
```

Atlantis 0.40 uses `--default-tf-distribution` (env `ATLANTIS_DEFAULT_TF_DISTRIBUTION`), rendered from the chart's `defaultTFDistribution` value (default `terraform`). The deprecated `ATLANTIS_TF_DISTRIBUTION` I set was ignored, so Atlantis kept using Terraform and hitting the expired HashiCorp key. The chart also documents the accepted value as **`opentofu`**, not `tofu`.

## Fix

Use the chart-native values instead of a raw env var:

```yaml
defaultTFDistribution: opentofu
defaultTFVersion: "1.12.3"
```

Verified against the chart 6.1.0 `statefulset.yaml` template (renders `ATLANTIS_DEFAULT_TF_DISTRIBUTION` / `ATLANTIS_DEFAULT_TF_VERSION` from these values) and the live StatefulSet env.

## After merge

Argo CD syncs `base-apps/atlantis.yaml` → the StatefulSet's `ATLANTIS_DEFAULT_TF_DISTRIBUTION` becomes `opentofu` → the `atlantis-0` pod rolls → Atlantis fetches OpenTofu 1.12.3 (signed independently of HashiCorp) instead of Terraform. Then re-plan any open Terraform PR (`atlantis plan`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
