### PR TITLE
feat(ci): gated terraform-apply action + reconcile Atlantis IAM to AWS

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -1,0 +1,56 @@
+name: Terraform Apply (gated)
+
+# Manually-triggered, approval-gated Terraform apply.
+#
+# GitHub-hosted runners cannot reach the private cluster API or AWS, so this
+# workflow does NOT run `tofu apply` itself. Instead it posts an
+# `atlantis apply` comment on the target PR, and the in-cluster Atlantis (which
+# has the AWS creds + cluster reachability) performs the apply.
+#
+# The gate is the `terraform-apply` GitHub Environment: configure it in
+# repo Settings > Environments with yourself as a Required reviewer. The job
+# below will pause until you approve the deployment before it posts the comment.
+# (Atlantis still enforces its own apply_requirements: [approved, mergeable].)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Open PR number to run 'atlantis apply' on"
+        required: true
+        type: string
+      project:
+        description: "Atlantis project to apply"
+        required: false
+        default: "asela-cluster"
+        type: string
+
+permissions:
+  pull-requests: write
+
+jobs:
+  apply:
+    name: Trigger gated Atlantis apply
+    runs-on: ubuntu-latest
+    environment: terraform-apply
+    steps:
+      - name: Validate PR is open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=$(gh pr view "${{ inputs.pr_number }}" \
+            --repo "${{ github.repository }}" --json state --jq '.state')
+          echo "PR #${{ inputs.pr_number }} state: $state"
+          if [ "$state" != "OPEN" ]; then
+            echo "::error::PR #${{ inputs.pr_number }} is not OPEN (state=$state). Atlantis apply requires an open PR."
+            exit 1
+          fi
+      - name: Post 'atlantis apply' comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ inputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --body "atlantis apply -p ${{ inputs.project }}"
+          echo "Requested 'atlantis apply -p ${{ inputs.project }}' on PR #${{ inputs.pr_number }}."
+          echo "Watch the PR for Atlantis's apply result."

--- a/terraform/roots/asela-cluster/atlantis-iam.tf
+++ b/terraform/roots/asela-cluster/atlantis-iam.tf
@@ -25,16 +25,15 @@ resource "aws_iam_user" "atlantis" {
   name = "atlantis-terraform"
   path = "/system/"
 
+  # Tags match the live AWS state (extra Environment/Team/CostCenter/Owner tags
+  # were added in code during e2e testing but never applied). Reconcile any
+  # tag additions via a deliberate, gated apply.
   tags = {
     Name        = "atlantis-terraform"
     Purpose     = "Atlantis-Terraform-Automation"
     ManagedBy   = "Terraform"
     Service     = "Platform-Engineering"
-    Environment = "Prod"
-    Team        = "Platform"
     Description = "IAM user for Atlantis to run terraform plan/apply via PR workflow"
-    CostCenter  = "Platform"
-    Owner       = "Platform-Engineering"
   }
 }
 
@@ -49,12 +48,7 @@ resource "aws_iam_policy" "atlantis" {
   path        = "/system/"
   description = "Scoped policy for Atlantis to run terraform plan/apply"
 
-  tags = {
-    ManagedBy   = "Terraform"
-    Service     = "Platform-Engineering"
-    Environment = "Prod"
-    Team        = "Platform"
-  }
+  # AWS has no tags on this policy (tags_all = {}); keep it tag-free to avoid drift.
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -193,6 +187,8 @@ resource "aws_iam_policy" "atlantis" {
           "kms:DisableKey",
           "kms:GetKeyPolicy",
           "kms:GetKeyRotationStatus",
+          "kms:ListKeys",
+          "kms:ListAliases",
           "kms:ListResourceTags",
           "kms:PutKeyPolicy",
           "kms:UpdateKeyDescription",
@@ -204,16 +200,6 @@ resource "aws_iam_policy" "atlantis" {
         Resource = [
           "arn:aws:kms:us-east-2:${data.aws_caller_identity.current.account_id}:key/*"
         ]
-      },
-      # kms:ListAliases and kms:ListKeys require * resource (AWS limitation)
-      {
-        Sid    = "KMSListActions"
-        Effect = "Allow"
-        Action = [
-          "kms:ListAliases",
-          "kms:ListKeys"
-        ]
-        Resource = ["*"]
       },
       {
         Sid    = "KMSAliasManagement"


### PR DESCRIPTION
Two changes, as requested.

## 1) Gated `terraform apply` GitHub Action

`.github/workflows/terraform-apply.yaml` — a manually-dispatched, approval-gated apply.

**Why it triggers Atlantis instead of running `tofu apply` itself:** GitHub-hosted runners can't reach the private cluster API (`192.168.0.100:6443`) or AWS, and there are no self-hosted runners. So the workflow posts `atlantis apply -p <project>` on a target PR, and the in-cluster Atlantis (which has the creds + reachability) does the apply.

**The gate is a GitHub Environment.** The `apply` job uses `environment: terraform-apply`, so it pauses for your approval before posting the comment. **One-time setup required** (I can't set repo settings from a PR):

> Settings → Environments → **New environment** `terraform-apply` → enable **Required reviewers** → add yourself.

Or I can run it for you:
```
gh api -X PUT repos/arigsela/kubernetes/environments/terraform-apply \
  -f "reviewers[][type]=User" -F "reviewers[][id]=$(gh api user --jq .id)"
```

Usage: **Actions → Terraform Apply (gated) → Run workflow**, enter the open PR number → approve the environment prompt → Atlantis applies. (Atlantis still enforces its own `apply_requirements: [approved, mergeable]`, so it's double-gated.)

## 2) Reconcile `atlantis-iam.tf` to live AWS (kill the drift)

I read the **live** policy/users from Terraform state (in the Atlantis pod, read-only) and matched the code to them. Changes:

- **`aws_iam_policy.atlantis`** — folded `kms:ListKeys`/`kms:ListAliases` back into `KMSKeyManagement` (on `key/*`) and dropped the separate `KMSListActions` (`*`) statement; removed the 4 policy tags (AWS has none).
- **`aws_iam_user.atlantis`** — dropped the `Environment`/`Team`/`CostCenter`/`Owner` tags (added in code during e2e testing, never applied).

**Verified:** a targeted `tofu plan` against live state shows **0 changes** for `aws_iam_policy.atlantis` and `aws_iam_user.atlantis` after these edits.

### ⚠️ One anomaly surfaced

The same plan shows a single remaining delta on **`aws_iam_user.crossplane_admin`**: AWS has an accidental tag — **key `AKIA4NFDJMBLB…`-shaped (an access-key-ID), value `terraform-sa`**. That's junk (looks like a mis-tagging accident), so I deliberately did **not** encode it in IaC. The result: a reconcile apply will *remove* it (cleanup). If you'd rather preserve it exactly, tell me and I'll add it back.

## What this PR's own Atlantis plan will show

Since #315's `resource.exclusions` change is in `main`'s code but not yet applied, this PR's plan will show: the **backstage.io exclusion** (still pending) + the **crossplane_admin junk-tag removal**. The IAM policy and `atlantis` user show **no** changes. Applying this PR (via the new gated action, or a normal `atlantis apply`) cleanly lands all of it and leaves the root drift-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
