### PR TITLE
feat(kagent): Phase 2 — homelab-knowledge retrieves live agent-docs via read-only GitHub MCP

### DIFF
--- a/base-apps/kagent/agent-docs-mcp-external-secret.yaml
+++ b/base-apps/kagent/agent-docs-mcp-external-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: agent-docs-github-mcp-token
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: agent-docs-github-mcp-token
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_PERSONAL_ACCESS_TOKEN
+      remoteRef:
+        key: kagent
+        property: agent-docs-github-token

--- a/base-apps/kagent/agent-docs-mcp.yaml
+++ b/base-apps/kagent/agent-docs-mcp.yaml
@@ -21,8 +21,14 @@ spec:
     # Injects GITHUB_PERSONAL_ACCESS_TOKEN from the K8s Secret (Task 1).
     secretRefs:
       - name: agent-docs-github-mcp-token
-    env:
-      GITHUB_TOOLSETS: repos
+    # Thin stdio proxy; bounded so it never runs BestEffort on infra nodes.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     nodeSelector:
       node.kubernetes.io/workload: infrastructure
     tolerations:

--- a/base-apps/kagent/agent-docs-mcp.yaml
+++ b/base-apps/kagent/agent-docs-mcp.yaml
@@ -1,0 +1,30 @@
+apiVersion: kagent.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: agent-docs-mcp
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: agent-docs-mcp
+spec:
+  # Read the agent-docs from arigsela/kubernetes@main over MCP. Read-only,
+  # single-repo (token scope) — see agent-docs-mcp-external-secret.yaml.
+  transportType: stdio
+  deployment:
+    image: ghcr.io/github/github-mcp-server:v1.5.0
+    cmd: ./github-mcp-server
+    args:
+      - stdio
+      - --read-only
+      - --toolsets
+      - repos
+    # Injects GITHUB_PERSONAL_ACCESS_TOKEN from the K8s Secret (Task 1).
+    secretRefs:
+      - name: agent-docs-github-mcp-token
+    env:
+      GITHUB_TOOLSETS: repos
+    nodeSelector:
+      node.kubernetes.io/workload: infrastructure
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule

--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -33,72 +33,59 @@ spec:
         compactionInterval: 5
         overlapSize: 2
     systemMessage: |
-      You are HomelabAssist, an expert on this homelab Kubernetes cluster and its
-        GitOps repository at github.com/arigsela/kubernetes. Your job is to answer
-        questions about what's deployed, why, how things are wired together, and to
-        help diagnose issues — by delegating to specialist agents for live cluster
-        queries and to your built-in knowledge for architectural context.
-      
-        ## What you know about
-      
-        - **GitOps model**: ArgoCD watches arigsela/kubernetes/base-apps. The master-app
-          pattern creates one ArgoCD Application per .yaml file in that directory.
-          All apps have prune: true and selfHeal: true.
-        - **Application layout**: each base-apps/<name>/ subdirectory holds the
-          manifests for one app; the matching base-apps/<name>.yaml is its ArgoCD
-          Application definition.
-        - **Secret management**: HashiCorp Vault (in-cluster, k8s auth method, KV v2
-          at path k8s-secrets) feeds External Secrets via per-namespace SecretStores
-          that reference vault role = <namespace-name>.
-        - **Cloud resources**: Crossplane v2 with the XApplication composition
-          provisions optional Postgres (CloudNativePG) and S3 buckets. TeraSky's
-          kubernetes-ingestor auto-registers XRs in Backstage.
-        - **TLS + ingress**: nginx-ingress + cert-manager with letsencrypt-prod
-          (Route 53 DNS-01).
-        - **IDP**: Backstage with scaffolder templates (Application, CrewAI agent,
-          Kagent agent, decommission flows). Custom actions in
-          packages/backend/src/modules/scaffolder/ for non-Crossplane work.
-        - **AI agents**: kagent.dev controller manages declarative agents in the
-          kagent namespace. Custom orchestrators (build-orchestrator, this one) live
-          alongside chart-installed agents (k8s-agent, helm-agent, etc.).
-      
-        ## Delegation rules
-      
-        - For LIVE cluster state (pod status, events, logs, resource usage, RBAC,
-          CRDs, namespaces) → delegate to k8s-agent. Always prefer this over guessing.
-        - For Helm release questions (what charts are installed, versions, values
-          diffs, release history) → delegate to helm-agent.
-        - For repo/manifest questions (what's in base-apps/<x>/, ArgoCD sync status,
-          Vault role names, ingress hostnames) → answer from your own knowledge if
-          possible, then cross-check live state via k8s-agent.
-      
-        ## Response format
-      
-        1. Brief answer first (1-3 sentences).
-        2. Then a "What I checked" section listing which delegate(s) you used.
-        3. Then specifics: file paths in arigsela/kubernetes, exact resource names,
-           kubectl commands the user could run to verify.
-      
-        ## Constraints
-      
-        {{include "builtin/safety-guardrails"}}
-        {{include "builtin/kubernetes-context"}}
-      
-        - Never invent file paths or resource names. If you don't know, delegate to
-          k8s-agent for a real lookup.
-        - Never recommend `kubectl apply` or any mutation directly — this cluster is
-          GitOps-driven. Recommend a PR to arigsela/kubernetes instead.
-        - If asked about secrets, never quote values — only the Vault path/property.
-      
+      You are HomelabAssist, an expert assistant for this homelab Kubernetes
+      cluster and its GitOps repo at github.com/arigsela/kubernetes. You answer
+      "what/why/how" and triage questions by RETRIEVING the repo's agent-docs
+      (never from memorized facts, which go stale), and by delegating to
+      specialist agents for live cluster state.
+
+      ## How to answer (retrieval-first)
+      Use the agent-docs-mcp tool to read files from arigsela/kubernetes@main:
+      1. Read `INFRASTRUCTURE_ATLAS.md` to orient (system context, topology,
+         source registry, the "For agents" traversal rule).
+      2. Read `base-apps/_INDEX.md` to find the app's row.
+      3. Read that app's `base-apps/<app>/docs.md` (architecture/config),
+         `runbook.md` (symptom → check → fix), and `catalog-info.yaml`
+         (owner, system, dependsOn) as needed.
+      4. Treat the files listed under a doc's `sources:` as authoritative —
+         read them rather than guessing. NEVER invent file paths or resource
+         names; if a doc doesn't cover it, say so and read the source.
+
+      ## Live state vs docs
+      - For LIVE cluster state (pod status, events, logs, sync status, RBAC)
+        delegate to k8s-agent. For Helm releases/values/history delegate to
+        helm-agent. Prefer these over guessing.
+      - DRIFT: if the docs and the live state disagree (e.g. runbook says X,
+        cluster shows Y), call it out explicitly as a drift finding — this is
+        valuable signal, since the docs are meant to track reality.
+
+      ## Response format
+
+      1. Brief answer first (1-3 sentences).
+      2. Then a "What I checked" section listing which delegate(s) you used.
+      3. Then specifics: file paths in arigsela/kubernetes, exact resource names,
+         kubectl commands the user could run to verify.
+
+      ## Constraints
+
+      {{include "builtin/safety-guardrails"}}
+      {{include "builtin/kubernetes-context"}}
+
+      - Never invent file paths or resource names. If you don't know, delegate to
+        k8s-agent for a real lookup.
+      - Never recommend `kubectl apply` or any mutation directly — this cluster is
+        GitOps-driven. Recommend a PR to arigsela/kubernetes instead.
+      - If asked about secrets, never quote values — only the Vault path/property.
+
     a2aConfig:
       skills:
       - id: repo-knowledge
-        name:  Repo & Architecture Knowledge
+        name: Repo & Architecture Knowledge
         description: Explain what's deployed, where it lives in the GitOps repo, and how components are wired together.
         examples:
-        - What apps run in the kagent namespace?
-        - How does the Vault SecretStore for chores-tracker work?
-        - Where is the cert-manager Route 53   config?
+        - What is cert-manager and how does it issue certs here?
+        - Who owns chores-tracker-backend and what does it depend on?
+        - Where does vault store its config and how is it unsealed?
         tags:
         - gitops
         - documentation
@@ -107,9 +94,9 @@ spec:
         name: Cluster State Troubleshooting
         description: Diagnose issues by checking live pod/deployment/event state and correlating with the GitOps manifests.
         examples:
-        - Why is the backstage pod restarting?
-        - Is the kagent helm-agent ready?
-        - What's the ArgoCD sync status for external-secrets?
+        - cert-manager Certificates are stuck pending — walk me through the runbook.
+        - chores-tracker-backend is CrashLooping — what does its runbook say to check?
+        - Is the argo-cd control plane healthy?
         tags:
         - troubleshooting
         - kubernetes
@@ -119,12 +106,17 @@ spec:
         description: Recommend how to onboard a new app following the established base-apps patterns (Crossplane composition, SecretStore, ingress, ECR auth).
         examples:
         - I want to deploy a new service called billing-api. What's the right pattern?
-        - How do I add Vault secrets for a new namespace? 
+        - How do I add Vault secrets for a new namespace?
         tags:
         - onboarding
         - crossplane
         - idp
     tools:
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: MCPServer
+        name: agent-docs-mcp
     - type: Agent
       agent:
         name: k8s-agent

--- a/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
+++ b/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
@@ -157,8 +157,14 @@ spec:
     # Injects GITHUB_PERSONAL_ACCESS_TOKEN from the K8s Secret (Task 1).
     secretRefs:
       - name: agent-docs-github-mcp-token
-    env:
-      GITHUB_TOOLSETS: repos
+    # Thin stdio proxy; bounded so it never runs BestEffort on infra nodes.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     nodeSelector:
       node.kubernetes.io/workload: infrastructure
     tolerations:
@@ -166,14 +172,20 @@ spec:
         effect: NoSchedule
 ```
 
+(The `--toolsets repos` arg already restricts the toolset — no separate
+`GITHUB_TOOLSETS` env is needed, and `--read-only` enforces read-only
+regardless.)
+
 - [ ] **Step 4: Lint + validate the manifest**
 
 Run:
 ```bash
 yamllint -c .yamllint.yaml base-apps/kagent/agent-docs-mcp.yaml
 python3 -c "import yaml; d=yaml.safe_load(open('base-apps/kagent/agent-docs-mcp.yaml')); assert d['kind']=='MCPServer'; assert '--read-only' in d['spec']['deployment']['args']; assert d['spec']['deployment']['secretRefs'][0]['name']=='agent-docs-github-mcp-token'; print('ok')"
+# Real CRD schema validation against the live cluster (validates only — applies nothing):
+kubectl apply --dry-run=server -f base-apps/kagent/agent-docs-mcp.yaml
 ```
-Expected: yamllint clean and `ok`. (kubeconform will `-ignore-missing-schemas` the kagent CRD in CI — that's fine.)
+Expected: yamllint clean, `ok`, and `mcpserver.kagent.dev/agent-docs-mcp created (server dry run)` (proves the manifest is valid against the actual `mcpservers.kagent.dev` CRD — kubeconform in CI `-ignore-missing-schemas` the kagent CRD, so the server dry-run is the authoritative schema check). **Validated on 2026-07-09:** all three manifests passed server-side dry-run (`externalsecret … created`, `mcpserver … created`, `agent … configured`).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
+++ b/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
@@ -1,0 +1,355 @@
+# Phase 2 — kagent Agent-Docs Retrieval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the `homelab-knowledge` kagent agent to answer from the live agent-docs — read from `arigsela/kubernetes@main` at query time via a read-only, repo-scoped GitHub MCP — instead of a staleable hardcoded prompt.
+
+**Architecture:** Deploy the official `github-mcp-server` as a kagent `MCPServer` (read-only, single-repo token from Vault), then add it as a tool on `homelab-knowledge` and rewrite that agent's `systemMessage` to retrieve the atlas → index → per-app `docs.md`/`runbook.md`/`catalog-info.yaml`. Everything is declarative under `base-apps/kagent/` and syncs via Argo CD.
+
+**Tech Stack:** kagent CRDs (`MCPServer` v1alpha1, `Agent` v1alpha2) · `github/github-mcp-server` container · External Secrets Operator + Vault (`k8s-secrets`, role `kagent`) · Argo CD (GitOps) · yamllint/kubeconform (CI, from `.github/workflows/validate.yaml`).
+
+## Global Constraints
+
+- **Additive & advisory only.** This adds one MCP server + one ExternalSecret and reworks one agent's prompt/tools. No workload, IAM, or other-agent changes. The agent only reads and recommends.
+- **Read-only, single-repo MCP.** The GitHub MCP runs with `--read-only`; the token is a **fine-grained PAT limited to `arigsela/kubernetes` with read-only Contents**. No write/issue/PR tools.
+- **Namespace:** everything in `kagent`. Secrets via the existing `SecretStore/vault-backend` (Vault `k8s-secrets`, role `kagent`).
+- **GitOps:** manifests live under `base-apps/kagent/`; Argo CD (app `kagent`) syncs the directory. Do not `kubectl apply` — commit and let Argo sync. Work on branch `docs/phase2-kagent-agent-docs` (already checked out; the design spec is already committed there). Do not commit to `main`.
+- **Ordering prerequisite:** the GitHub PAT must exist in Vault **before** merge, or the MCP pod crashloops waiting for its secret.
+- **Commit style:** Conventional Commits, imperative subject (e.g. `feat(kagent): ...`).
+- **v2 (out of scope):** a Backstage MCP for structured catalog relations — deferred, noted in the spec.
+
+---
+
+## File Structure
+
+**Created:**
+- `base-apps/kagent/agent-docs-mcp-external-secret.yaml` — ExternalSecret syncing the read-only GitHub PAT from Vault into a K8s Secret.
+- `base-apps/kagent/agent-docs-mcp.yaml` — the `MCPServer` running `github-mcp-server` (read-only, repos toolset).
+
+**Modified:**
+- `base-apps/kagent/agents/homelab-knowledge.yaml` — add the MCP tool; rewrite `systemMessage` for retrieval; refresh `a2aConfig` examples.
+
+**Manual (documented, not a repo file):** create the fine-grained PAT and store it in Vault.
+
+---
+
+## Task 1: GitHub PAT → Vault → ExternalSecret
+
+**Files:**
+- Create: `base-apps/kagent/agent-docs-mcp-external-secret.yaml`
+
+**Interfaces:**
+- Consumes: the existing `SecretStore` `vault-backend` in `kagent` (`base-apps/kagent/secret-store.yaml`), Vault path `k8s-secrets`.
+- Produces: a K8s Secret `agent-docs-github-mcp-token` in `kagent` with key `GITHUB_PERSONAL_ACCESS_TOKEN`, consumed by Task 2's MCPServer.
+
+- [ ] **Step 1: (Manual) Mint the fine-grained PAT and store it in Vault**
+
+In GitHub → Settings → Developer settings → **Fine-grained tokens** → Generate:
+- **Resource owner:** `arigsela`; **Repository access:** only `arigsela/kubernetes`.
+- **Repository permissions:** `Contents: Read-only` (and `Metadata: Read-only`, which is mandatory). Nothing else.
+
+Then store it in Vault under the `kagent` KV path (the value the ExternalSecret reads):
+
+```bash
+# You must run this (interactive Vault login). Replace <PAT>.
+vault kv patch k8s-secrets/kagent agent-docs-github-token="<PAT>"
+```
+
+Verify the property exists:
+
+```bash
+vault kv get -field=agent-docs-github-token k8s-secrets/kagent | head -c 8; echo "…(present)"
+```
+
+- [ ] **Step 2: Create the ExternalSecret manifest**
+
+Create `base-apps/kagent/agent-docs-mcp-external-secret.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: agent-docs-github-mcp-token
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: agent-docs-github-mcp-token
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_PERSONAL_ACCESS_TOKEN
+      remoteRef:
+        key: kagent
+        property: agent-docs-github-token
+```
+
+- [ ] **Step 3: Lint the manifest**
+
+Run: `yamllint -c .yamllint.yaml base-apps/kagent/agent-docs-mcp-external-secret.yaml`
+Expected: no errors. (If `yamllint` isn't installed: `python3 -m venv /tmp/yl && /tmp/yl/bin/pip install -q yamllint==1.35.1 && /tmp/yl/bin/yamllint -c .yamllint.yaml base-apps/kagent/agent-docs-mcp-external-secret.yaml`.)
+
+- [ ] **Step 4: Confirm it parses as a valid ExternalSecret**
+
+Run:
+```bash
+python3 -c "import yaml,sys; d=yaml.safe_load(open('base-apps/kagent/agent-docs-mcp-external-secret.yaml')); assert d['kind']=='ExternalSecret'; assert d['spec']['data'][0]['secretKey']=='GITHUB_PERSONAL_ACCESS_TOKEN'; assert d['spec']['data'][0]['remoteRef']['property']=='agent-docs-github-token'; print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/kagent/agent-docs-mcp-external-secret.yaml
+git commit -m "feat(kagent): ExternalSecret for read-only agent-docs GitHub MCP token"
+```
+
+---
+
+## Task 2: The `agent-docs-mcp` MCPServer (github-mcp-server, read-only)
+
+**Files:**
+- Create: `base-apps/kagent/agent-docs-mcp.yaml`
+
+**Interfaces:**
+- Consumes: the K8s Secret `agent-docs-github-mcp-token` (Task 1) — injected as env via `deployment.secretRefs`.
+- Produces: an `MCPServer` named `agent-docs-mcp` in `kagent` exposing read-only GitHub repo tools (e.g. `get_file_contents`, `search_code`) that Task 3's agent references by name.
+
+- [ ] **Step 1: (Confirmed CRD shape — for reference)**
+
+Verified against the live CRD: `spec.deployment.secretRefs` is a list of `{name: <k8s-secret>}` (its keys become container env vars); `spec.stdioTransport` has no required fields (so `transportType: stdio` alone is enough); `spec.deployment` also has `image`, `cmd`, `args`, `env` (`map[string]string`), `port`, `nodeSelector`, `tolerations`. This will be the cluster's **first** `MCPServer` (only `RemoteMCPServer`s exist today), so there's no in-repo example to copy — the manifest below is complete. Optional sanity check: `kubectl explain mcpserver.spec.deployment.secretRefs`.
+
+- [ ] **Step 2: Pin the current github-mcp-server image tag**
+
+Run:
+```bash
+curl -fsSL https://api.github.com/repos/github/github-mcp-server/releases/latest | python3 -c "import sys,json; print('ghcr.io/github/github-mcp-server:' + json.load(sys.stdin)['tag_name'])"
+```
+Use the printed `ghcr.io/github/github-mcp-server:<tag>` value in Step 3 (do not use `:latest`).
+
+- [ ] **Step 3: Create the MCPServer manifest**
+
+Create `base-apps/kagent/agent-docs-mcp.yaml` (replace `IMAGE_FROM_STEP_2`; keep node placement consistent with other kagent workloads):
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: agent-docs-mcp
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: agent-docs-mcp
+spec:
+  # Read the agent-docs from arigsela/kubernetes@main over MCP. Read-only,
+  # single-repo (token scope) — see agent-docs-mcp-external-secret.yaml.
+  transportType: stdio
+  deployment:
+    image: IMAGE_FROM_STEP_2
+    cmd: ./github-mcp-server
+    args:
+      - stdio
+      - --read-only
+      - --toolsets
+      - repos
+    # Injects GITHUB_PERSONAL_ACCESS_TOKEN from the K8s Secret (Task 1).
+    secretRefs:
+      - name: agent-docs-github-mcp-token
+    env:
+      GITHUB_TOOLSETS: repos
+    nodeSelector:
+      node.kubernetes.io/workload: infrastructure
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+```
+
+- [ ] **Step 4: Lint + validate the manifest**
+
+Run:
+```bash
+yamllint -c .yamllint.yaml base-apps/kagent/agent-docs-mcp.yaml
+python3 -c "import yaml; d=yaml.safe_load(open('base-apps/kagent/agent-docs-mcp.yaml')); assert d['kind']=='MCPServer'; assert '--read-only' in d['spec']['deployment']['args']; assert d['spec']['deployment']['secretRefs'][0]['name']=='agent-docs-github-mcp-token'; print('ok')"
+```
+Expected: yamllint clean and `ok`. (kubeconform will `-ignore-missing-schemas` the kagent CRD in CI — that's fine.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/kagent/agent-docs-mcp.yaml
+git commit -m "feat(kagent): deploy read-only github-mcp-server as agent-docs-mcp"
+```
+
+---
+
+## Task 3: Rework the `homelab-knowledge` agent
+
+**Files:**
+- Modify: `base-apps/kagent/agents/homelab-knowledge.yaml`
+
+**Interfaces:**
+- Consumes: the `agent-docs-mcp` MCPServer (Task 2); the existing `k8s-agent` and `helm-agent` Agents; the agent-docs contract (`INFRASTRUCTURE_ATLAS.md`, `base-apps/_INDEX.md`, `base-apps/<app>/docs.md|runbook.md|catalog-info.yaml`).
+- Produces: the reworked agent (no downstream consumers).
+
+- [ ] **Step 1: Add the MCP tool to `spec.declarative.tools`**
+
+In `base-apps/kagent/agents/homelab-knowledge.yaml`, the `tools:` list currently holds two `type: Agent` entries (`k8s-agent`, `helm-agent`). Add an MCP tool entry referencing `agent-docs-mcp`. The tool shape is verified against the live CRD: `tools[].type` ∈ {`McpServer`, `Agent`}; the `mcpServer` object takes `name` (required), `kind`, `apiGroup`, and optional `toolNames`. Set `tools:` to:
+
+```yaml
+    tools:
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: MCPServer
+        name: agent-docs-mcp
+    - type: Agent
+      agent:
+        name: k8s-agent
+    - type: Agent
+      agent:
+        name: helm-agent
+```
+
+- [ ] **Step 2: Replace the hardcoded architectural block in `systemMessage`**
+
+Replace the entire `## What you know about` section (the hardcoded GitOps/master-app/secret-management/Crossplane/TLS/IDP/AI-agents bullet list — the stale part) with a retrieval instruction. The new `systemMessage` opening becomes:
+
+```yaml
+    systemMessage: |
+      You are HomelabAssist, an expert assistant for this homelab Kubernetes
+      cluster and its GitOps repo at github.com/arigsela/kubernetes. You answer
+      "what/why/how" and triage questions by RETRIEVING the repo's agent-docs
+      (never from memorized facts, which go stale), and by delegating to
+      specialist agents for live cluster state.
+
+      ## How to answer (retrieval-first)
+      Use the agent-docs-mcp tool to read files from arigsela/kubernetes@main:
+      1. Read `INFRASTRUCTURE_ATLAS.md` to orient (system context, topology,
+         source registry, the "For agents" traversal rule).
+      2. Read `base-apps/_INDEX.md` to find the app's row.
+      3. Read that app's `base-apps/<app>/docs.md` (architecture/config),
+         `runbook.md` (symptom → check → fix), and `catalog-info.yaml`
+         (owner, system, dependsOn) as needed.
+      4. Treat the files listed under a doc's `sources:` as authoritative —
+         read them rather than guessing. NEVER invent file paths or resource
+         names; if a doc doesn't cover it, say so and read the source.
+
+      ## Live state vs docs
+      - For LIVE cluster state (pod status, events, logs, sync status, RBAC)
+        delegate to k8s-agent. For Helm releases/values/history delegate to
+        helm-agent. Prefer these over guessing.
+      - DRIFT: if the docs and the live state disagree (e.g. runbook says X,
+        cluster shows Y), call it out explicitly as a drift finding — this is
+        valuable signal, since the docs are meant to track reality.
+```
+
+Keep the existing `## Response format` and `## Constraints` sections (the `{{include "builtin/…"}}` lines, the GitOps-not-`kubectl` rule, the never-quote-secrets rule, the "answer → what I checked → specifics" format). Just remove the stale `## What you know about` block and swap the opening two paragraphs as above.
+
+- [ ] **Step 3: Refresh the `a2aConfig` skill examples**
+
+Update the `examples:` under the three skills to reflect retrieval and correct facts. In `repo-knowledge` replace the examples with:
+```yaml
+        examples:
+        - What is cert-manager and how does it issue certs here?
+        - Who owns chores-tracker-backend and what does it depend on?
+        - Where does vault store its config and how is it unsealed?
+```
+In `cluster-troubleshooting`:
+```yaml
+        examples:
+        - cert-manager Certificates are stuck pending — walk me through the runbook.
+        - chores-tracker-backend is CrashLooping — what does its runbook say to check?
+        - Is the argo-cd control plane healthy?
+```
+Leave `deployment-guidance` examples as-is (still valid).
+
+- [ ] **Step 4: Lint + validate the agent manifest**
+
+Run:
+```bash
+yamllint -c .yamllint.yaml base-apps/kagent/agents/homelab-knowledge.yaml
+python3 -c "
+import yaml
+d=yaml.safe_load(open('base-apps/kagent/agents/homelab-knowledge.yaml'))
+t=d['spec']['declarative']['tools']
+names=[ (x.get('mcpServer') or x.get('agent') or {}).get('name') for x in t ]
+assert 'agent-docs-mcp' in names, names
+assert 'k8s-agent' in names and 'helm-agent' in names, names
+sm=d['spec']['declarative']['systemMessage']
+assert 'agent-docs-mcp' in sm and 'INFRASTRUCTURE_ATLAS.md' in sm
+assert 'What you know about' not in sm, 'stale hardcoded block still present'
+print('ok')
+"
+```
+Expected: yamllint clean and `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/kagent/agents/homelab-knowledge.yaml
+git commit -m "feat(kagent): rework homelab-knowledge to retrieve live agent-docs via MCP"
+```
+
+---
+
+## Task 4: Deploy + post-merge behavioral validation
+
+**Files:** none (validation only).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3, live in the cluster after Argo CD syncs the merged PR.
+
+> This task runs **after** the PR is merged (so Argo CD syncs `base-apps/kagent/`) and **after** the PAT is in Vault (Task 1 Step 1). It is a checklist, not code.
+
+- [ ] **Step 1: Confirm the MCP server is up and its token synced**
+
+```bash
+kubectl -n kagent get externalsecret agent-docs-github-mcp-token
+kubectl -n kagent get mcpserver agent-docs-mcp -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}{"\n"}'
+kubectl -n kagent get pods -l app.kubernetes.io/name=agent-docs-mcp
+```
+Expected: ExternalSecret `SecretSynced`, MCPServer `Accepted=True`, the pod `Running`. If the pod crashloops, check it isn't missing the token (`kubectl -n kagent describe externalsecret agent-docs-github-mcp-token`).
+
+- [ ] **Step 2: Confirm the agent picked up the tool**
+
+```bash
+kubectl -n kagent get agent homelab-knowledge -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}{"\n"}'
+kubectl -n kagent get mcpserver agent-docs-mcp -o jsonpath='{range .status.discoveredTools[*]}{.name}{"\n"}{end}' | head
+```
+Expected: agent `Accepted=True`; discovered tools include a file-read tool (e.g. `get_file_contents`).
+
+- [ ] **Step 3: Drive the gold questions (kagent UI / A2A)**
+
+Ask the reworked `homelab-knowledge` agent each of these and confirm it (a) calls the `agent-docs-mcp` tool, (b) answers with correct current facts, (c) cites real `base-apps/...` paths:
+1. "What is cert-manager and how does it issue certificates here?" → expects HTTP-01 prod/staging + a separate Route 53 DNS-01 issuer (from `cert-manager/docs.md`), NOT "DNS-01 for all".
+2. "chores-tracker-backend keeps CrashLooping — what does its runbook say to check?" → expects the ExternalSecret/Postgres checks from `chores-tracker-backend/runbook.md`; datastore is **PostgreSQL/CloudNativePG** (not MySQL), workload is a **Rollout**.
+3. "Who owns vault and what depends on it?" → reads `vault/catalog-info.yaml` + notes chores-tracker/cert-manager `dependsOn: resource:vault/vault`.
+4. "How is the argo-cd control plane structured?" → reads `argo-cd/docs.md`; app-of-apps via `terraform/modules/application-sets/`, no `base-apps/master-app.yaml`.
+5. "Is the cert-manager Route 53 ExternalSecret healthy?" → delegates to `k8s-agent` for live state (not answered from docs alone).
+
+- [ ] **Step 4: Drift-detection spot check**
+
+Ask a question whose doc fact you can compare to live state (e.g. "Does the vault runbook's unseal description match how vault is actually configured?"). Confirm the agent cross-checks docs vs `k8s-agent` and, if they differ, explicitly flags the drift.
+
+- [ ] **Step 5: Record the result**
+
+Note pass/fail per gold question in the PR. If the agent answered from memory instead of retrieving (no `agent-docs-mcp` tool call), tighten the `systemMessage` retrieval instruction and re-test.
+
+---
+
+## Final verification
+
+- [ ] `yamllint -c .yamllint.yaml base-apps/kagent/agent-docs-mcp-external-secret.yaml base-apps/kagent/agent-docs-mcp.yaml base-apps/kagent/agents/homelab-knowledge.yaml` → clean.
+- [ ] The reworked `homelab-knowledge.yaml` still has `k8s-agent` and `helm-agent` tools and no longer contains the stale `## What you know about` block.
+- [ ] `git log --oneline` shows one commit per task (1–3), all on `docs/phase2-kagent-agent-docs` (none on `main`).
+- [ ] Post-merge (Task 4): MCPServer `Accepted`, agent `Accepted`, and ≥4/5 gold questions answered from retrieved docs with correct current facts.
+
+## Success criteria (from the spec)
+
+- Agent reads the right doc files (atlas → index → app), visible in tool calls. ✅ Task 4 Step 3.
+- Answers with correct current facts (Postgres/Rollout/HTTP-01). ✅ Task 4 Step 3.
+- Cites real `file_path`s, no invented paths. ✅ Task 3 Step 2 (prompt) + Task 4 Step 3.
+- Flags doc-vs-live drift. ✅ Task 3 Step 2 + Task 4 Step 4.
+- Additive/advisory, read-only single-repo MCP. ✅ Tasks 1–2 (token scope + `--read-only`).

--- a/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
@@ -42,13 +42,13 @@ Three declarative pieces (in `base-apps/kagent/`) plus one Vault secret:
 ```
 homelab-knowledge Agent (reworked)
   tools:
-    - RemoteMCPServer/MCPServer: agent-docs-github-mcp  ──reads──▶ GitHub API (arigsela/kubernetes@main)
+    - RemoteMCPServer/MCPServer: agent-docs-mcp  ──reads──▶ GitHub API (arigsela/kubernetes@main)
     - Agent: k8s-agent   (live cluster state)                       INFRASTRUCTURE_ATLAS.md
     - Agent: helm-agent  (live helm state)                          base-apps/_INDEX.md
                                                                     base-apps/<app>/docs.md · runbook.md · catalog-info.yaml
 ```
 
-### 1. `agent-docs-github-mcp` (the repo MCP)
+### 1. `agent-docs-mcp` (the repo MCP)
 
 - **Image:** the official `github/github-mcp-server` container, deployed as a kagent MCP server manifest under `base-apps/kagent/` (following the existing agent/MCP layout).
 - **Read-only + scoped:** started in read-only mode with only read toolsets enabled (repo contents + code search — no write, issue, or PR tools). The token is a **fine-grained PAT limited to `arigsela/kubernetes` with read-only Contents permission**, so worst-case exposure is read of this one repo.
@@ -58,7 +58,7 @@ homelab-knowledge Agent (reworked)
 
 ### 2. Reworked `homelab-knowledge` Agent
 
-- **Tools:** add `agent-docs-github-mcp` alongside the existing `k8s-agent` and `helm-agent` delegates.
+- **Tools:** add `agent-docs-mcp` alongside the existing `k8s-agent` and `helm-agent` delegates.
 - **`systemMessage` rewrite (retrieval, not recall):**
   - **Remove** the large hardcoded architectural block (stale GitOps/master-app/MySQL/Crossplane facts).
   - **Add** the framework navigation: *"For any question about an app or the platform, first read `INFRASTRUCTURE_ATLAS.md`, then `base-apps/_INDEX.md`, then the app's `docs.md`/`runbook.md`/`catalog-info.yaml` via the GitHub MCP. The `sources:` files listed in a doc are authoritative; never invent file paths or resource names — read them."*

--- a/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
@@ -1,0 +1,109 @@
+# Phase 2 — kagent Agent-Docs Retrieval — Design
+
+- **Date:** 2026-07-09
+- **Status:** Approved (design); implementation plan to follow
+- **Depends on:** the agent-ready docs framework (`docs/superpowers/specs/2026-07-08-agent-ready-docs-framework-design.md`) — the atlas, per-directory `_INDEX.md`, and the per-app `catalog-info.yaml`/`docs.md`/`runbook.md` contract.
+
+## Problem
+
+The framework put an always-fresh, agent-navigable knowledge layer in git. Nothing consumes it yet. Meanwhile the existing `homelab-knowledge` kagent agent answers "what/why/how" questions from a **large hardcoded `systemMessage`** that is already stale (it describes the master-app as creating one Application per `.yaml`, MySQL persistence, etc. — the exact drift the framework exists to kill). It has no connection to the `docs.md`/`runbook.md`/`catalog-info.yaml` files.
+
+**Goal:** rework `homelab-knowledge` to answer from the **live agent-docs** (read from git at query time) instead of a staleable prompt — killing the staleness, exercising the framework's atlas → index → app navigation, and turning the agent into a drift detector.
+
+## Goals
+
+- Give the agent a **read-only** tool that reads the agent-docs from `arigsela/kubernetes@main` on demand.
+- Replace the agent's hardcoded architectural facts with **retrieval** (atlas → index → per-app docs), keeping its stable behavioral guardrails and its live-state delegation.
+- Validate on the 4 pilot apps: the agent answers with correct current facts, cites real file paths, and flags doc-vs-live drift.
+
+## Non-goals
+
+- No Backstage integration in v1 (the agent reads `catalog-info.yaml` structured facts from git directly). **v2: Backstage MCP** — see Future Work.
+- No RAG/vector indexing of docs (read-fresh-from-git was chosen over eventual-consistency indexing).
+- No changes to the docs framework itself, the other kagent agents, or `k8s-agent`/`helm-agent`.
+- No write/mutation capability for the new MCP (read-only, single repo).
+
+## Chosen approach
+
+Read the agent-docs **from git at query time** via the **official GitHub MCP server**, deployed read-only and scoped to a single repo, and wire it as a tool on the reworked `homelab-knowledge` agent. Everything is declarative in the repo (GitOps).
+
+Rejected alternatives (from brainstorming):
+- **RAG into kagent memory** — scales to fuzzy questions but adds an ingestion/re-index pipeline and carries staleness between doc changes and re-index.
+- **Docs embedded in the prompt via a synced ConfigMap** — simplest wiring, but re-introduces staleness and bloats context; undermines the freshness goal.
+- **Filesystem MCP over a synced clone** — no token needed but you own the clone-sync infra and it lags `main`.
+- **Purpose-built agent-docs MCP** — most ergonomic navigation but you build/maintain a custom server; the official GitHub MCP + a navigation prompt gets there with no custom code.
+
+## Design
+
+### Components
+
+Three declarative pieces (in `base-apps/kagent/`) plus one Vault secret:
+
+```
+homelab-knowledge Agent (reworked)
+  tools:
+    - RemoteMCPServer/MCPServer: agent-docs-github-mcp  ──reads──▶ GitHub API (arigsela/kubernetes@main)
+    - Agent: k8s-agent   (live cluster state)                       INFRASTRUCTURE_ATLAS.md
+    - Agent: helm-agent  (live helm state)                          base-apps/_INDEX.md
+                                                                    base-apps/<app>/docs.md · runbook.md · catalog-info.yaml
+```
+
+### 1. `agent-docs-github-mcp` (the repo MCP)
+
+- **Image:** the official `github/github-mcp-server` container, deployed as a kagent MCP server manifest under `base-apps/kagent/` (following the existing agent/MCP layout).
+- **Read-only + scoped:** started in read-only mode with only read toolsets enabled (repo contents + code search — no write, issue, or PR tools). The token is a **fine-grained PAT limited to `arigsela/kubernetes` with read-only Contents permission**, so worst-case exposure is read of this one repo.
+- **Token flow:** the PAT is stored in Vault (`k8s-secrets`), pulled via an **ExternalSecret** in the `kagent` namespace into a K8s Secret, and injected as the MCP server's env (`GITHUB_PERSONAL_ACCESS_TOKEN`) — mirroring how Backstage already receives its `github-token`.
+- **Registration:** exposed to kagent as an `MCPServer`/`RemoteMCPServer` the agent references as a tool, the same way `kagent-tool-server` is wired today.
+- **Open implementation detail (for the plan):** confirm the exact kagent `MCPServer` CRD shape for a container-based MCP (transport, command/args, env) and whether it registers as `MCPServer` or `RemoteMCPServer`.
+
+### 2. Reworked `homelab-knowledge` Agent
+
+- **Tools:** add `agent-docs-github-mcp` alongside the existing `k8s-agent` and `helm-agent` delegates.
+- **`systemMessage` rewrite (retrieval, not recall):**
+  - **Remove** the large hardcoded architectural block (stale GitOps/master-app/MySQL/Crossplane facts).
+  - **Add** the framework navigation: *"For any question about an app or the platform, first read `INFRASTRUCTURE_ATLAS.md`, then `base-apps/_INDEX.md`, then the app's `docs.md`/`runbook.md`/`catalog-info.yaml` via the GitHub MCP. The `sources:` files listed in a doc are authoritative; never invent file paths or resource names — read them."*
+  - **Keep** the stable guardrails: delegate to `k8s-agent`/`helm-agent` for **live** state; GitOps-not-`kubectl` (recommend a PR, never a direct mutation); never quote secret values, only the Vault path/property; the "brief answer → what I checked → specifics" response format.
+  - **New capability:** when docs and live state disagree, **flag the drift** ("runbook says X, cluster shows Y") — makes the agent a drift detector.
+- **`a2aConfig` skills:** keep repo-knowledge / cluster-troubleshooting / deployment-guidance; refresh examples to reflect retrieval (e.g., "What breaks cert-manager and how do I fix it?" pulls `cert-manager/runbook.md`).
+
+Net effect: the prompt gets **shorter and stops going stale** — the atlas is the agent's always-fresh architectural base.
+
+### 3. The Vault secret
+
+A read-only, single-repo fine-grained GitHub PAT stored at a Vault path under `k8s-secrets`, surfaced to the `kagent` namespace via ExternalSecret + SecretStore (the established per-namespace pattern).
+
+## Data flow (worked example)
+
+Query: *"What breaks cert-manager and how do I fix it?"*
+
+1. Agent reads `INFRASTRUCTURE_ATLAS.md` (MCP) → orient.
+2. Reads `base-apps/_INDEX.md` → finds the `cert-manager` row.
+3. Reads `base-apps/cert-manager/runbook.md` (symptom → check → fix) and `catalog-info.yaml` (`dependsOn: vault`).
+4. For live state, delegates to `k8s-agent` (e.g., "is the Route 53 `ExternalSecret` Ready?").
+5. Composes: brief answer → "what I checked" (docs read + delegates used) → specifics (exact file paths, `kubectl` verify commands, the Vault path for the creds).
+
+## Success criteria
+
+For ~5 gold questions across the 4 pilot apps (`chores-tracker-backend`, `vault`, `argo-cd`, `cert-manager`), the reworked agent:
+1. Reads the *right* doc files (atlas → index → app), visible in its tool calls.
+2. Answers with correct **current** facts (PostgreSQL not MySQL; Argo `Rollout` not Deployment; cert-manager prod/staging HTTP-01 with a separate Route 53 DNS-01 issuer).
+3. Cites real `file_path`s (no invented paths).
+4. Flags an injected doc-vs-live drift when asked about it.
+
+## Testing
+
+Drive the agent via the kagent UI / A2A with the gold questions after deploy; eyeball that it navigates atlas → index → app and cites real paths. This is a prompt + tool change, so there's no unit-test harness; validation is behavioral.
+
+## Safety, blast radius & rollback
+
+- **Additive and advisory.** A read-only, single-repo MCP + a prompt rewrite on one agent. The agent only reads and recommends — no workload impact, no mutation path.
+- **Rollback:** GitOps revert of the agent CRD + removal of the MCP manifest and ExternalSecret. The old hardcoded prompt remains in git history.
+
+## Future work — v2: Backstage MCP
+
+Once v1 proves out, add the **Backstage MCP** (Backstage's MCP Actions backend) as a second tool so the agent can query **structured catalog relations** — ownership, `dependsOn`/`dependencyOf` graphs, systems, and cross-entity questions — from the Backstage catalog rather than reconstructing them from individual `catalog-info.yaml` files. This is the natural evolution of the framework's two-layer design (structured facts → Backstage; narrative → git) and is intentionally deferred so v1 stays small.
+
+## Open questions
+
+- Exact kagent `MCPServer` CRD shape for a container-based GitHub MCP (transport + env) — pin during the plan by inspecting the live CRD and an existing MCP manifest.
+- Whether to reuse Backstage's existing `github-token` (broader scope) or mint a dedicated read-only single-repo PAT — the plan defaults to a **dedicated** read-only PAT for least privilege.


### PR DESCRIPTION
Phase 2 of the agent-docs framework: rework the `homelab-knowledge` kagent agent to answer from the **live agent-docs** (read from git at query time via a read-only, repo-scoped GitHub MCP) instead of a hardcoded, staleable prompt.

Produced via the full superpowers **brainstorm → spec → plan → subagent-driven execution → whole-branch review** flow. Spec + plan are included.

## What's in it (3 declarative pieces, `base-apps/kagent/`)
1. **`agent-docs-mcp-external-secret.yaml`** — ExternalSecret syncing a read-only GitHub PAT from Vault (`k8s-secrets/kagent` property `agent-docs-github-token`) into K8s Secret `agent-docs-github-mcp-token`.
2. **`agent-docs-mcp.yaml`** — a kagent `MCPServer` running `github-mcp-server:v1.5.0` in **`stdio`, `--read-only`, `repos` toolset**, token injected via `deployment.secretRefs`, with bounded `resources`. (This is the cluster's first `MCPServer`.)
3. **`agents/homelab-knowledge.yaml`** — reworked: adds the `agent-docs-mcp` tool, **replaces the stale hardcoded architectural block** with an atlas → index → per-app retrieval instruction, keeps `k8s-agent`/`helm-agent` delegation + guardrails, and adds **drift detection** (flags when docs and live state disagree).

Docs: design spec + implementation plan under `docs/superpowers/`.

## Quality
- Subagent-driven: each task got a fresh implementer + independent reviewer (Sonnet). Whole-branch review verified CRD shapes and the token-injection mechanism against the upstream kagent/kmcp + github-mcp-server sources.
- Fixes applied from that review: added `resources` to the MCPServer (avoid BestEffort QoS on infra nodes), dropped a redundant `GITHUB_TOOLSETS` env, aligned spec naming.
- yamllint clean; manifest parse/assert checks pass. Additive/advisory — the agent only reads and recommends.

## ⚠️ Before you merge — two manual steps (by design)
1. **Mint the PAT + store in Vault** (Task 1 Step 1): a GitHub **fine-grained** token limited to `arigsela/kubernetes` with **Contents: Read-only**, then:
   ```
   vault kv patch k8s-secrets/kagent agent-docs-github-token="<PAT>"
   ```
   Do this **before** merge, or the MCP pod crash-loops on the missing secret.
2. **Post-merge validation** (Task 4): after Argo CD syncs, confirm the MCPServer + agent are `Accepted`, then drive the 5 gold questions in the kagent UI (cert-manager HTTP-01, chores-tracker Postgres/Rollout, vault owners/deps, argo-cd app-of-apps, a live-state delegation) + a drift spot-check. The plan lists exact `kubectl` checks and questions.

## v2 (future, noted in spec)
A Backstage MCP for structured catalog relations (ownership/dependency graphs) — deferred so v1 stays small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
