### PR TITLE
fix(kagent): register agent-docs MCP via RemoteMCPServer

### DIFF
--- a/base-apps/kagent/agent-docs-mcp-remote.yaml
+++ b/base-apps/kagent/agent-docs-mcp-remote.yaml
@@ -1,0 +1,20 @@
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: agent-docs
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: agent-docs
+spec:
+  # Registers (discovers) the read-only GitHub MCP tools with kagent so agents
+  # can reference them. The MCPServer `agent-docs-mcp` only DEPLOYS the
+  # github-mcp-server container + Service; in this kagent version a container
+  # MCPServer does not register its tools — only a RemoteMCPServer does. This
+  # points at that Service's streamable-HTTP endpoint.
+  description: Read-only GitHub MCP for the agent-docs (arigsela/kubernetes@main)
+  protocol: STREAMABLE_HTTP
+  url: http://agent-docs-mcp.kagent:3000/mcp
+  timeout: 30s
+  sseReadTimeout: 5m0s
+  terminateOnClose: true

--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -40,7 +40,9 @@ spec:
       specialist agents for live cluster state.
 
       ## How to answer (retrieval-first)
-      Use the agent-docs-mcp tool to read files from arigsela/kubernetes@main:
+      Read files with the `get_file_contents` tool (the read-only GitHub MCP),
+      always passing owner=`arigsela`, repo=`kubernetes`, ref=`main`, and the
+      file's `path`. Use `search_code` (same MCP) when you need to locate a file:
       1. Read `INFRASTRUCTURE_ATLAS.md` to orient (system context, topology,
          source registry, the "For agents" traversal rule).
       2. Read `base-apps/_INDEX.md` to find the app's row.
@@ -115,8 +117,8 @@ spec:
     - type: McpServer
       mcpServer:
         apiGroup: kagent.dev
-        kind: MCPServer
-        name: agent-docs-mcp
+        kind: RemoteMCPServer
+        name: agent-docs
     - type: Agent
       agent:
         name: k8s-agent

--- a/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
+++ b/docs/superpowers/plans/2026-07-09-kagent-agent-docs-retrieval.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Post-implementation correction (2026-07-09):** Task 3 below wires the agent's tool to `kind: MCPServer`, and Task 4 reads `discoveredTools` off the MCPServer. That was **wrong** for this kagent version: an `MCPServer` (container) only **deploys** the pod + Service `agent-docs-mcp.kagent:3000` — it registers **0** tools. Tool registration requires a separate **`RemoteMCPServer`** (`kind: kagent.dev/v1alpha2`, `protocol: STREAMABLE_HTTP`, `url: http://agent-docs-mcp.kagent:3000/mcp`) that points at that Service; kagent then discovers the tools (confirmed live: 13). The fix (follow-up PR): keep `agent-docs-mcp.yaml` (MCPServer, deploys the container) **and** add `agent-docs-mcp-remote.yaml` (RemoteMCPServer `agent-docs`), and change the agent's tool ref to `kind: RemoteMCPServer, name: agent-docs`. Read the `## Design` in the spec for the authoritative wiring.
+
 **Goal:** Rework the `homelab-knowledge` kagent agent to answer from the live agent-docs — read from `arigsela/kubernetes@main` at query time via a read-only, repo-scoped GitHub MCP — instead of a staleable hardcoded prompt.
 
 **Architecture:** Deploy the official `github-mcp-server` as a kagent `MCPServer` (read-only, single-repo token from Vault), then add it as a tool on `homelab-knowledge` and rewrite that agent's `systemMessage` to retrieve the atlas → index → per-app `docs.md`/`runbook.md`/`catalog-info.yaml`. Everything is declarative under `base-apps/kagent/` and syncs via Argo CD.

--- a/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-09-kagent-agent-docs-retrieval-design.md
@@ -42,7 +42,7 @@ Three declarative pieces (in `base-apps/kagent/`) plus one Vault secret:
 ```
 homelab-knowledge Agent (reworked)
   tools:
-    - RemoteMCPServer/MCPServer: agent-docs-mcp  ──reads──▶ GitHub API (arigsela/kubernetes@main)
+    - RemoteMCPServer: agent-docs  ─registers→ MCPServer: agent-docs-mcp ──reads──▶ GitHub API (arigsela/kubernetes@main)
     - Agent: k8s-agent   (live cluster state)                       INFRASTRUCTURE_ATLAS.md
     - Agent: helm-agent  (live helm state)                          base-apps/_INDEX.md
                                                                     base-apps/<app>/docs.md · runbook.md · catalog-info.yaml
@@ -53,8 +53,7 @@ homelab-knowledge Agent (reworked)
 - **Image:** the official `github/github-mcp-server` container, deployed as a kagent MCP server manifest under `base-apps/kagent/` (following the existing agent/MCP layout).
 - **Read-only + scoped:** started in read-only mode with only read toolsets enabled (repo contents + code search — no write, issue, or PR tools). The token is a **fine-grained PAT limited to `arigsela/kubernetes` with read-only Contents permission**, so worst-case exposure is read of this one repo.
 - **Token flow:** the PAT is stored in Vault (`k8s-secrets`), pulled via an **ExternalSecret** in the `kagent` namespace into a K8s Secret, and injected as the MCP server's env (`GITHUB_PERSONAL_ACCESS_TOKEN`) — mirroring how Backstage already receives its `github-token`.
-- **Registration:** exposed to kagent as an `MCPServer`/`RemoteMCPServer` the agent references as a tool, the same way `kagent-tool-server` is wired today.
-- **Open implementation detail (for the plan):** confirm the exact kagent `MCPServer` CRD shape for a container-based MCP (transport, command/args, env) and whether it registers as `MCPServer` or `RemoteMCPServer`.
+- **Registration (resolved):** in this kagent version the two CRDs split responsibilities. `MCPServer` (`agent-docs-mcp`) only **deploys** the github-mcp-server container + a `Service` (`agent-docs-mcp.kagent:3000`) — it does **not** register the container's tools. A `RemoteMCPServer` (`agent-docs`, `protocol: STREAMABLE_HTTP`, `url: http://agent-docs-mcp.kagent:3000/mcp`) is what **discovers/registers** the tools with kagent (confirmed live: 13 read-only tools), the same way `kagent-tool-server` is wired. The agent references the **RemoteMCPServer** as its tool, not the MCPServer.
 
 ### 2. Reworked `homelab-knowledge` Agent
 
@@ -103,7 +102,7 @@ Drive the agent via the kagent UI / A2A with the gold questions after deploy; ey
 
 Once v1 proves out, add the **Backstage MCP** (Backstage's MCP Actions backend) as a second tool so the agent can query **structured catalog relations** — ownership, `dependsOn`/`dependencyOf` graphs, systems, and cross-entity questions — from the Backstage catalog rather than reconstructing them from individual `catalog-info.yaml` files. This is the natural evolution of the framework's two-layer design (structured facts → Backstage; narrative → git) and is intentionally deferred so v1 stays small.
 
-## Open questions
+## Open questions (resolved)
 
-- Exact kagent `MCPServer` CRD shape for a container-based GitHub MCP (transport + env) — pin during the plan by inspecting the live CRD and an existing MCP manifest.
-- Whether to reuse Backstage's existing `github-token` (broader scope) or mint a dedicated read-only single-repo PAT — the plan defaults to a **dedicated** read-only PAT for least privilege.
+- ~~Exact kagent `MCPServer` CRD shape for a container-based GitHub MCP~~ — **resolved:** `MCPServer` (`spec.transportType: stdio`, `spec.deployment.{image,cmd,args,secretRefs,resources}`) deploys the container + Service but does **not** register tools; a `RemoteMCPServer` pointing at that Service (`http://agent-docs-mcp.kagent:3000/mcp`, `protocol: STREAMABLE_HTTP`) registers them. The agent's tool ref uses `kind: RemoteMCPServer`. (Discovered during the live deploy; the initial wiring to `kind: MCPServer` registered 0 tools.)
+- Whether to reuse Backstage's existing `github-token` (broader scope) or mint a dedicated read-only single-repo PAT — resolved to a **dedicated** read-only PAT for least privilege.


### PR DESCRIPTION
## Why

The reworked `homelab-knowledge` agent (PR #321, merged) couldn't access the agent-docs MCP tools — the kagent UI showed **"Unknown Tool"** and the agent's tool list lacked `get_file_contents`.

**Root cause:** the agent referenced its tool as `kind: MCPServer`. In this kagent version an `MCPServer` (container) only **deploys** the `github-mcp-server` pod + Service (`agent-docs-mcp.kagent:3000`) — it does **not** register the container's tools. `discoveredTools` stayed `0`. Only a **`RemoteMCPServer`** discovers/registers tools with kagent (the same mechanism `kagent-tool-server` uses).

**Confirmed live:** a `RemoteMCPServer` pointing at `http://agent-docs-mcp.kagent:3000/mcp` registered **13 read-only tools** (`Accepted=True`, `toolCount:13`).

## What

- **Add** `base-apps/kagent/agent-docs-mcp-remote.yaml` — `RemoteMCPServer/agent-docs` (`protocol: STREAMABLE_HTTP`, `url: http://agent-docs-mcp.kagent:3000/mcp`). This registers the tools.
- **Change** `homelab-knowledge` agent tool ref: `kind: MCPServer` → `kind: RemoteMCPServer, name: agent-docs`.
- **Prompt:** name the concrete read tool (`get_file_contents`) + repo coords (`owner=arigsela, repo=kubernetes, ref=main`) so the agent calls it correctly.
- **Keep** `agent-docs-mcp.yaml` (`MCPServer`) unchanged — it still deploys the container.
- **Docs:** spec + plan updated to record the `MCPServer`(deploy) + `RemoteMCPServer`(register) split (was an open question).

The MCP remains read-only, single-repo — no blast-radius change.

## Validation

- `yamllint` clean.
- Server-side dry-run against live CRDs: `remotemcpserver.kagent.dev/agent-docs created (server dry run)`, `agent.kagent.dev/homelab-knowledge configured (server dry run)`.

## After merge

Argo CD `kagent-secrets` syncs `base-apps/kagent/` (selfHeal). Once synced: verify `kubectl -n kagent get remotemcpserver agent-docs` shows `Accepted=True` with discovered tools, then drive the gold questions in the kagent UI (the agent should now call `get_file_contents` and cite real `base-apps/...` paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1