### PR TITLE
fix(kagent): bind agent-docs toolNames so homelab-knowledge gets its MCP tools

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -119,6 +119,12 @@ spec:
         apiGroup: kagent.dev
         kind: RemoteMCPServer
         name: agent-docs
+        # kagent binds only the tools listed here (like every other agent);
+        # without toolNames the ref resolves to nothing → "Unknown Tool".
+        # These are the read tools the systemMessage drives.
+        toolNames:
+        - get_file_contents
+        - search_code
     - type: Agent
       agent:
         name: k8s-agent


### PR DESCRIPTION
## Why

Follow-up to #322. That PR got the `RemoteMCPServer/agent-docs` registering **13 tools** (`Accepted=True`), but the kagent UI still showed **"Unknown Tool"** and the agent had no MCP tools at runtime.

**Root cause:** the agent's tool ref omitted `toolNames`. Every working kagent agent (`k8s-agent`, `helm-agent`, `cilium-*`, …) lists explicit `toolNames` on its `RemoteMCPServer` ref (7–35 each). With none, kagent binds nothing → "Unknown Tool."

## What

Add `toolNames: [get_file_contents, search_code]` to the `agent-docs` tool ref — the exact read tools the `systemMessage` drives, using the raw names from the RemoteMCPServer's `discoveredTools`.

## Validation

- `yamllint` clean.
- Server-side dry-run against live CRD: `agent.kagent.dev/homelab-knowledge configured (server dry run)`.

## After merge

Argo `kagent-secrets` selfHeals. Then the agent's "Tools & Agents" panel should list `get_file_contents`/`search_code` (not "Unknown Tool"), and the gold questions should show real `get_file_contents` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1