### PR TITLE
fix(kagent): remove experimental compaction + run homelab-knowledge on Sonnet 4.6

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -28,10 +28,12 @@ spec:
       - alias: builtin
         kind: ConfigMap
         name: kagent-builtin-prompts
-    context:
-      compaction:
-        compactionInterval: 5
-        overlapSize: 2
+    # No context.compaction: this agent delegates to k8s-agent/helm-agent, whose
+    # live-state replies can grow the conversation large. kagent's EXPERIMENTAL
+    # sliding-window compaction summarizer then sends a malformed request to the
+    # Anthropic API (400 "system: Input should be a valid array") and the turn
+    # fails. Every working delegation agent (k8s-agent, helm-agent, cilium-*,
+    # istio, ...) runs WITHOUT compaction on the same model — match them.
     systemMessage: |
       You are HomelabAssist, an expert assistant for this homelab Kubernetes
       cluster and its GitOps repo at github.com/arigsela/kubernetes. You answer

--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -18,7 +18,10 @@ spec:
   description: Answers questions about the homelab GitOps repo, base-apps deployments, and live cluster state by delegating to k8s and helm specialists
   type: Declarative
   declarative:
-    modelConfig: default-model-config
+    # Sonnet (not the default haiku): this agent ingests k8s-agent/helm-agent
+    # live-state replies on top of its doc reads, so it needs the larger context
+    # headroom and more reliable tool-calling for the atlas→index→app traversal.
+    modelConfig: anthropic-claude-sonnet-4-6
     memory:
       modelConfig: embedding-model-config
     runtime: python


### PR DESCRIPTION
Two related changes to make drift-detection (delegation) queries work.

## 1. Remove experimental compaction (the crash fix)

Drift queries delegate to `k8s-agent`/`helm-agent`; the live-state reply grew the conversation large, tripping kagent's **experimental** sliding-window compaction summarizer (`google/adk/apps/compaction.py:605`), which sent a malformed Anthropic request and 400'd:

```
Error code: 400 - invalid_request_error: system: Input should be a valid array
```

Docs-only queries never grew large enough to compact, so they worked. **None** of the delegation-heavy built-ins (`k8s-agent`, `helm-agent`, `cilium-*`, `istio`, `kgateway`, `observability`, `promql`) set `context.compaction` — only three light, non-delegating agents do. `homelab-knowledge` inherited the knob but has a delegation profile that grows, so it alone hit the bug. Removed the block to match the working agents.

## 2. Run on Sonnet 4.6 (the headroom fix)

The failed drift turn spiked to **~272K tokens** — over haiku's 200K. Since this agent ingests `k8s-agent`/`helm-agent` output on top of its doc reads, switch the main `modelConfig` to `anthropic-claude-sonnet-4-6` (already in-cluster, `Accepted=True`) for context headroom and more reliable tool-calling. Memory/embedding config unchanged.

## Validation

- `yamllint` clean.
- Server-side dry-run against live CRD passed for both commits.

## After merge

Argo `kagent-secrets` selfHeals → agent pod rolls onto Sonnet. Re-run the vault drift question; the `k8s-agent` delegation should complete and compose an answer (with a drift call-out if docs and live disagree) instead of 400'ing.