### PR TITLE
feat(kagent): Backstage catalog MCP + deploy v1.3.0 (v2 Task 4)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.2.0
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.3.0
         imagePullPolicy: Always
         ports:
         - containerPort: 7007

--- a/base-apps/backstage/external-secrets.yaml
+++ b/base-apps/backstage/external-secrets.yaml
@@ -58,3 +58,10 @@ spec:
       remoteRef:
         key: backstage
         property: vault-token
+    # Static token the MCP Actions backend (backend.auth.externalAccess) accepts
+    # on /api/mcp-actions/v1/catalog. Same raw value the kagent side sends as the
+    # Authorization: Bearer header (stored in Vault kagent/backstage-mcp-token).
+    - secretKey: MCP_TOKEN
+      remoteRef:
+        key: backstage
+        property: mcp-token

--- a/base-apps/kagent/backstage-catalog-mcp.yaml
+++ b/base-apps/kagent/backstage-catalog-mcp.yaml
@@ -1,0 +1,25 @@
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: backstage-catalog
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: backstage-catalog
+spec:
+  # Read-only Backstage catalog MCP: returns an entity plus its RESOLVED
+  # relations (ownedBy, partOf, and computed reverse relations like
+  # dependencyOf) that no single catalog-info.yaml contains. Auth header is
+  # injected from the backstage-mcp-token Secret (ExternalSecret from Vault).
+  description: Read-only Backstage catalog MCP (catalog:entity) for resolved entity relations
+  protocol: STREAMABLE_HTTP
+  url: http://backstage.backstage.svc.cluster.local/api/mcp-actions/v1/catalog
+  timeout: 30s
+  sseReadTimeout: 5m0s
+  terminateOnClose: true
+  headersFrom:
+    - name: Authorization
+      valueFrom:
+        type: Secret
+        name: backstage-mcp-token
+        key: authorization

--- a/base-apps/kagent/backstage-mcp-external-secret.yaml
+++ b/base-apps/kagent/backstage-mcp-external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: backstage-mcp-token
+  namespace: kagent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: backstage-mcp-token
+    creationPolicy: Owner
+    # Build the full header value so the RemoteMCPServer injects it verbatim.
+    template:
+      engineVersion: v2
+      data:
+        authorization: "Bearer {{ .token }}"
+  data:
+    - secretKey: token
+      remoteRef:
+        key: kagent
+        property: backstage-mcp-token


### PR DESCRIPTION
Stands up the read-only Backstage catalog MCP connection for homelab-knowledge.

## Changes
- `base-apps/backstage/external-secrets.yaml` — add `MCP_TOKEN` (Vault `backstage/mcp-token`).
- `base-apps/kagent/backstage-mcp-external-secret.yaml` (new) — templated `authorization: Bearer <token>` from Vault `kagent/backstage-mcp-token`.
- `base-apps/kagent/backstage-catalog-mcp.yaml` (new) — `RemoteMCPServer/backstage-catalog` → `http://backstage.backstage.svc.cluster.local/api/mcp-actions/v1/catalog`, auth via `headersFrom`.
- `base-apps/backstage/deployments.yaml` — bump image to `:v1.3.0` (ships the MCP backend + platform-entities location).

## ⚠️ Merge prerequisites
1. **PR #326 merged** (platform-entities.yaml + qualified refs on main — the url Location resolves it).
2. **MCP token stored in Vault** under `backstage/mcp-token` AND `kagent/backstage-mcp-token` (same value) — else backstage v1.3.0's `externalAccess` has no token and the RemoteMCPServer can't authenticate.

## Validation
- yamllint clean; server-side dry-run of all four manifests passed.

## After merge (I'll verify)
Auth enforced (unauthenticated request → 401), platform relations resolve on cert-manager, and the `RemoteMCPServer` registers the `catalog:entity` tool — then Task 5 wires it into the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1