### PR TITLE
chore(backstage): deploy v1.4.0 (Backstage 1.52 upgrade)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.3.0
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.0
         imagePullPolicy: Always
         ports:
         - containerPort: 7007

--- a/docs/superpowers/plans/2026-07-10-backstage-1.52-upgrade.md
+++ b/docs/superpowers/plans/2026-07-10-backstage-1.52-upgrade.md
@@ -1,0 +1,295 @@
+# Backstage 1.48 → 1.52 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade `arigsela/backstage` to Backstage 1.52.0 so `@backstage/plugin-mcp-actions-backend@0.1.14` starts, rebuild/deploy the image, confirm the IDP flows still work, and resume wiring the MCP agent tool.
+
+**Architecture:** `yarn backstage-cli versions:bump --release 1.52.0` bumps all 60 `@backstage/*` packages to the 1.52 manifest; `yarn install` resolves the four `@terasky/*` carets (compatible with 1.52); iterate `tsc`/`config:check`/`build:all` until green; rebuild image `v1.4.0`; deploy via a GitOps tag bump; smoke-test; then execute the deferred MCP agent-tool wiring.
+
+**Tech Stack:** Backstage 1.52.0 (backend-plugin-api 1.9.2, backend-defaults 0.17.3, mcp-actions 0.1.14) · `@terasky/*` plugins · Node 22 / yarn 4.4.1 · buildx → ECR · Argo CD GitOps.
+
+## Global Constraints
+
+- **Two repos.** Tasks 1–2 operate in `arigsela/backstage`. Tasks 3–4 operate in `arigsela/kubernetes` (this repo).
+- **Target is 1.52.0 exactly** (latest stable; the release that pairs mcp-actions 0.1.14 with backend-plugin-api 1.9.2 + backend-defaults 0.17.3).
+- **Stay on TeraSky `kubernetes-ingestor` 3.x** (caret `^3.14.0` → latest 3.x, declares `backend-plugin-api ^1.9.0`, compatible with 1.52). Do **not** jump to 4.0.0 unless 3.x is proven broken on 1.52 — 4.0.0 is a major with behavior changes to the load-bearing ingestor.
+- **Build (Task 2) is user-run** — local Docker+buildx, AWS creds, Node 22/yarn.
+- **Image version:** `v1.4.0` (current live is `v1.3.0`, which has the broken mcp-actions). Rollback target is `v1.2.0` (last clean pre-mcp image).
+- **Preserve IDP behavior** — catalog, kubernetes-ingestor (agent/crossplane entities), crossplane resources view, scaffolder templates, auth, TechDocs, search.
+- **Node env for all backstage commands:** prefix `export PATH="/opt/homebrew/opt/node@22/bin:$PATH"` and `corepack prepare yarn@4.4.1 --activate`.
+
+---
+
+## File Structure
+
+- `arigsela/backstage` → `backstage.json`, `packages/*/package.json`, `yarn.lock` — bumped by `versions:bump` + `install`.
+- `arigsela/backstage` → any `packages/backend/src/**`, `packages/app/src/**` that hit a breaking API change — fixed iteratively (undiscoverable until `tsc` runs).
+- `arigsela/backstage` → `app-config.yaml` — only if `config:check` flags a moved/renamed config key.
+- `arigsela/kubernetes` → `base-apps/backstage/deployments.yaml:27` — tag bump to `v1.4.0`.
+- `arigsela/kubernetes` → `base-apps/kagent/agents/homelab-knowledge.yaml` — resumed MCP tool wiring (Task 4).
+
+No new files.
+
+---
+
+## Task 1: Bump to 1.52.0 and get it building (repo: `arigsela/backstage`)
+
+**Files:** `backstage.json`, `packages/*/package.json`, `yarn.lock`, plus any source files that hit breaking changes.
+
+**Interfaces:**
+- Produces: a `main` on Backstage 1.52.0 that installs, type-checks, config-checks, and builds — the source for Task 2's image.
+
+- [ ] **Step 1: Branch and record the baseline**
+
+```bash
+cd ~/git/backstage && git checkout main && git pull
+git checkout -b chore/backstage-1.52-upgrade
+export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
+corepack prepare yarn@4.4.1 --activate
+cat backstage.json   # expect "version": "1.48.0"
+```
+
+- [ ] **Step 2: Run the version bump**
+
+```bash
+yarn backstage-cli versions:bump --release 1.52.0
+cat backstage.json   # expect "version": "1.52.0"
+```
+Expected: the CLI rewrites `@backstage/*` versions across `package.json`s and prints a summary of bumped packages (and any manual-review notes). If it reports packages it could not bump, note them for Step 4.
+
+- [ ] **Step 3: Install and verify TeraSky compatibility**
+
+```bash
+yarn install
+# Confirm the resolved ingestor is 3.x (>=3.14) and its bpa peer is satisfied by 1.9.2:
+node -e "console.log('ingestor', require('@terasky/backstage-plugin-kubernetes-ingestor/package.json').version)"
+node -e "console.log('backend-plugin-api', require('@backstage/backend-plugin-api/package.json').version)"
+```
+Expected: install completes; ingestor version is `3.x` (≥3.14), backend-plugin-api is `1.9.2`. If `yarn install` fails with an unsatisfiable `@terasky/*` peer on 1.52, bump that one package to its latest release that supports Backstage 1.52 (crossplane-backend → `^1.18.0`, crossplane-frontend → `^2.19.1`, terasky-utils → `^2.9.0`; keep ingestor on the latest **3.x**, currently `^3.17.0`, not 4.0.0) and re-run `yarn install`.
+
+- [ ] **Step 4: Type-check and fix breakages (iterate)**
+
+```bash
+yarn tsc 2>&1 | tee /tmp/tsc-1.52.txt
+```
+Expected first run: may report errors from removed/renamed `@backstage` APIs across 1.49–1.52. For each error: consult the package's `CHANGELOG.md` in `node_modules/@backstage/<pkg>/CHANGELOG.md` (or the release changelogs) for the breaking change and its migration, apply the minimal fix in the flagged source file, and re-run `yarn tsc`. Repeat until `yarn tsc` exits clean (no output). Do not suppress errors with `any`/`@ts-ignore` — apply the documented migration.
+
+- [ ] **Step 5: Config-check and fix schema breakages**
+
+```bash
+yarn backstage-cli config:check --lax 2>&1 | tail -20
+```
+Expected: `Loaded config from app-config.yaml` with no schema errors. If a config key was moved/renamed in 1.49–1.52, `config:check` flags it — update `app-config.yaml`/`app-config.production.yaml` per the changelog, re-run until clean.
+
+- [ ] **Step 6: Full build (catches bundling/runtime-shape issues tsc misses)**
+
+```bash
+yarn build:all 2>&1 | tail -25
+```
+Expected: all workspaces build successfully. If a plugin fails to build, resolve per its changelog (same loop as Step 4). This mirrors what the Docker build runs, so a green `build:all` de-risks Task 2.
+
+- [ ] **Step 7: Commit, PR, merge**
+
+```bash
+git add -A
+git commit -m "chore(deps): upgrade Backstage 1.48 -> 1.52 (unblocks mcp-actions)"
+git push -u origin chore/backstage-1.52-upgrade
+gh pr create --repo arigsela/backstage --fill
+```
+Merge to `main` (the source Task 2 builds). Record in the PR body any breaking-change fixes applied and any `@terasky/*` bumps.
+
+---
+
+## Task 2: Build & push image `v1.4.0` (repo: `arigsela/backstage`) — USER-RUN GATE
+
+**This cannot run in the agent environment** (local Docker+buildx, AWS ECR push, Node 22/yarn). Hand off to the user; resume at Task 3 once the image exists.
+
+- [ ] **Step 1: Build from merged main**
+
+```bash
+cd ~/git/backstage && git checkout main && git pull
+export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
+colima start --cpu 6 --memory 16 --disk 60   # if the Docker daemon isn't running
+./scripts/build-and-push.sh --version v1.4.0
+```
+Expected: ends with `Successfully pushed and deployed: …/backstage-portal:v1.4.0` and `:latest`.
+
+- [ ] **Step 2: Confirm the tag in ECR**
+
+```bash
+aws ecr describe-images --repository-name backstage-portal --region us-east-2 \
+  --image-ids imageTag=v1.4.0 --query 'imageDetails[0].imageTags' --output json
+```
+Expected: array containing `"v1.4.0"`. Do not proceed until this succeeds.
+
+---
+
+## Task 3: Deploy v1.4.0 and smoke-test the IDP (repo: this repo)
+
+**Files:** `base-apps/backstage/deployments.yaml:27` (tag bump).
+
+**Interfaces:**
+- Consumes: image `v1.4.0` (Task 2).
+- Produces: a running Backstage 1.52 with a healthy mcp-actions endpoint and ingested platform entities — the prerequisite for Task 4.
+
+- [ ] **Step 1: Branch and bump the tag**
+
+```bash
+cd ~/git/kubernetes && git checkout main && git pull
+git checkout -b chore/backstage-v1.4.0
+grep -nE 'image:.*backstage-portal' base-apps/backstage/deployments.yaml
+```
+Change the tag on line 27 from `:v1.3.0` to `:v1.4.0`.
+
+- [ ] **Step 2: Validate**
+
+```bash
+YL=/Users/arisela/.claude/jobs/3654b4c1/tmp/yl/bin/yamllint
+grep -q 'backstage-portal:v1.4.0' base-apps/backstage/deployments.yaml && echo "tag bumped"
+$YL -c .yamllint.yaml base-apps/backstage/deployments.yaml
+kubectl apply --dry-run=server -f base-apps/backstage/deployments.yaml 2>&1 | grep -v last-applied
+```
+Expected: `tag bumped`; yamllint clean; `deployment.apps/backstage configured (server dry run)`.
+
+- [ ] **Step 3: Commit, PR, merge**
+
+```bash
+git add base-apps/backstage/deployments.yaml
+git commit -m "chore(backstage): deploy v1.4.0 (Backstage 1.52 upgrade)"
+git push -u origin chore/backstage-v1.4.0
+gh pr create --fill
+```
+Merge (admin bypass); Argo syncs `backstage` to v1.4.0.
+
+- [ ] **Step 4: Confirm rollout + no plugin startup failures**
+
+```bash
+kubectl -n argo-cd annotate application backstage argocd.argoproj.io/refresh=hard --overwrite
+until kubectl -n backstage get deploy backstage -o jsonpath='{.spec.template.spec.containers[0].image}' | grep -q 'v1.4.0'; do sleep 10; done
+kubectl -n backstage rollout status deploy/backstage --timeout=180s
+POD=$(kubectl -n backstage get pods -o jsonpath='{.items[0].metadata.name}')
+kubectl -n backstage logs "$POD" 2>/dev/null | grep -iE 'startup failed|threw an error during startup|has not started' | tail -10 || echo "no startup failures"
+```
+Expected: rolled out; **no** `startup failed` / `mcp-actions … threw an error` lines. If mcp-actions still errors, capture the message and stop — the upgrade didn't satisfy its deps.
+
+- [ ] **Step 5: Smoke-test the IDP flows**
+
+```bash
+POD=$(kubectl -n backstage get pods -o jsonpath='{.items[0].metadata.name}')
+kubectl -n backstage exec "$POD" -- node -e '
+const http=require("http");http.get("http://localhost:7007/api/catalog/entities?limit=2000",res=>{let b="";res.on("data",d=>b+=d);res.on("end",()=>{const d=JSON.parse(b);
+const names=new Set(d.map(e=>e.kind+":"+e.metadata.namespace+"/"+e.metadata.name));
+console.log("total entities:",d.length);
+console.log("homelab-knowledge agent (ingestor):", [...names].some(n=>n.includes("homelab-knowledge")));
+console.log("Group:platform (url location):", names.has("Group:default/platform"));
+const cm=d.find(x=>x.kind==="Resource"&&x.metadata.name==="cert-manager");
+console.log("cert-manager relations:");(cm.relations||[]).forEach(r=>console.log("   ",r.type,"->",r.targetRef));
+})});'
+```
+Expected: entities present; ingestor still produces the agent Components (`homelab-knowledge agent … true`); `Group:default/platform … true`; cert-manager relations include `ownedBy -> group:default/platform` and `partOf -> system:default/platform-networking`.
+
+- [ ] **Step 6: Confirm the MCP endpoint is live**
+
+```bash
+kubectl -n kagent get remotemcpserver backstage-catalog -o json | python3 -c "
+import json,sys
+d=json.load(sys.stdin);st=d.get('status',{})
+print('accepted:',{c['type']:c['status'] for c in st.get('conditions',[])})
+for t in st.get('discoveredTools',[]): print('tool:', t.get('name') if isinstance(t,dict) else t)
+"
+```
+Expected: `accepted: {'Accepted': 'True'}` and one `tool:` line (the `catalog:entity` tool). **Record the exact tool name — Task 4 pins it.** (kagent reconciles the already-deployed RemoteMCPServer on a loop, so it connects once the endpoint is up; if still `Accepted=False` after a few minutes, hard-refresh: `kubectl -n kagent annotate remotemcpserver backstage-catalog kagent.dev/refresh=$(date +%s) --overwrite` or delete/let Argo recreate.)
+
+Also confirm auth is enforced (unauthenticated → 401, not 200):
+```bash
+POD=$(kubectl -n backstage get pods -o jsonpath='{.items[0].metadata.name}')
+kubectl -n backstage exec "$POD" -- node -e '
+const http=require("http");const r=http.request("http://localhost:7007/api/mcp-actions/v1/catalog",{method:"POST",headers:{"content-type":"application/json","accept":"application/json, text/event-stream"}},res=>{console.log("no-token status:",res.statusCode);res.resume();});r.end(JSON.stringify({jsonrpc:"2.0",id:1,method:"tools/list"}));'
+```
+Expected: `no-token status: 401` (or 403). If `200`, the endpoint is unauthenticated — stop and report.
+
+---
+
+## Task 4: Resume the MCP agent-tool wiring (repo: this repo)
+
+This is the deferred Task 5 of the v2 plan (`docs/superpowers/plans/2026-07-10-backstage-mcp-agent-tool.md`). It only runs once Task 3 confirms the tool is discovered.
+
+**Files:** `base-apps/kagent/agents/homelab-knowledge.yaml`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/git/kubernetes && git checkout main && git pull
+git checkout -b feat/homelab-knowledge-backstage-tool
+```
+
+- [ ] **Step 2: Add the tool (use the tool name from Task 3 Step 6 as `<TOOLNAME>`)**
+
+In `base-apps/kagent/agents/homelab-knowledge.yaml`, in `spec.declarative.tools`, after the `agent-docs` McpServer entry, add:
+```yaml
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: backstage-catalog
+        toolNames:
+        - <TOOLNAME>
+```
+
+- [ ] **Step 3: Update the systemMessage for relation questions**
+
+In the `## How to answer (retrieval-first)` section, after the numbered retrieval steps, add:
+```
+      For OWNERSHIP, DEPENDENCY, or SYSTEM-membership questions ("who owns X?",
+      "what depends on X?", "what system is X part of?"), use the Backstage
+      catalog tool (catalog:entity) — it returns the entity's RESOLVED relations,
+      including reverse relations like dependencyOf that are not in any single
+      catalog-info.yaml. Look the entity up by name (kind/namespace optional to
+      disambiguate). Use the agent-docs GitHub MCP for narrative docs
+      (docs.md/runbook.md) and as a fallback for catalog-info.yaml.
+```
+
+- [ ] **Step 4: Validate**
+
+```bash
+YL=/Users/arisela/.claude/jobs/3654b4c1/tmp/yl/bin/yamllint
+$YL -c .yamllint.yaml base-apps/kagent/agents/homelab-knowledge.yaml && echo "yamllint clean"
+python3 - <<'PY'
+import yaml
+a=yaml.safe_load(open('base-apps/kagent/agents/homelab-knowledge.yaml'))
+bc=[t for t in a['spec']['declarative']['tools'] if t.get('mcpServer',{}).get('name')=='backstage-catalog']
+assert bc and bc[0]['mcpServer']['kind']=='RemoteMCPServer' and bc[0]['mcpServer'].get('toolNames'), 'tool not wired with toolNames'
+print('OK: backstage-catalog tool wired', bc[0]['mcpServer']['toolNames'])
+PY
+kubectl apply --dry-run=server -f base-apps/kagent/agents/homelab-knowledge.yaml 2>&1 | grep -v last-applied
+```
+Expected: yamllint clean; `OK: backstage-catalog tool wired [...]`; `agent.kagent.dev/homelab-knowledge configured (server dry run)`.
+
+- [ ] **Step 5: Commit, PR, merge**
+
+```bash
+git add base-apps/kagent/agents/homelab-knowledge.yaml
+git commit -m "feat(kagent): give homelab-knowledge the Backstage catalog MCP tool"
+git push -u origin feat/homelab-knowledge-backstage-tool
+gh pr create --fill
+```
+Merge (admin bypass); Argo rolls the agent pod with the new tool.
+
+- [ ] **Step 6: Verify the gold questions in the kagent UI**
+
+Hard-reload the kagent UI, New Chat with `homelab-knowledge`:
+- "What depends on vault?" → **cert-manager** + **chores-tracker-backend** (reverse `dependencyOf`) via a `catalog:entity` call.
+- "Who owns cert-manager?" → **platform**.
+- "What system is chores-tracker-backend part of?" → **chores-tracker**.
+
+Confirm the Tools panel lists the Backstage catalog tool (not "Unknown Tool") and answers come from tool calls.
+
+---
+
+## Done criteria
+
+- `arigsela/backstage` on 1.52.0: `tsc`, `config:check`, `build:all` all clean; PR merged.
+- Image `v1.4.0` deployed; Argo `backstage` Synced/Healthy; no plugin startup failures.
+- IDP flows intact: catalog, kubernetes-ingestor (agents present), scaffolder, crossplane view.
+- mcp-actions endpoint live (auth enforced); `RemoteMCPServer/backstage-catalog` `Accepted=True`; platform relations resolved.
+- Gold relation questions answered from the catalog graph via tool calls.

--- a/docs/superpowers/specs/2026-07-10-backstage-1.52-upgrade-design.md
+++ b/docs/superpowers/specs/2026-07-10-backstage-1.52-upgrade-design.md
@@ -1,0 +1,96 @@
+# Backstage 1.48 → 1.52 Upgrade — Design
+
+- **Date:** 2026-07-10
+- **Status:** Approved (design); implementation plan to follow
+- **Repo:** `arigsela/backstage` (the portal image source). Deploy is a tag bump in `arigsela/kubernetes`.
+- **Depends on / unblocks:** the Backstage MCP agent tool (v2). `@backstage/plugin-mcp-actions-backend@0.1.14` requires `backend-plugin-api ^1.9.2` and alpha `metrics`/`tracing` core services that Backstage 1.48 (backend-plugin-api 1.7.0, backend-defaults 0.15.2) does not provide. The plugin fails to start on 1.48 (503 on `/api/mcp-actions/v1/catalog`), which also blocked the `platform-entities` catalog Location from ingesting.
+
+## Problem
+
+`arigsela/backstage` runs Backstage 1.48.0. The MCP Actions backend we added for the agent tool cannot start on 1.48 — it needs the newer backend service graph. The live pod is stable and serves the catalog/UI, but the mcp-actions route is dead and the platform Group/System entities are not ingested.
+
+**Goal:** upgrade `arigsela/backstage` to Backstage 1.52.0 so `mcp-actions 0.1.14` has its dependencies satisfied, rebuild and deploy the image, and confirm the existing IDP behaviors still work — then resume wiring the MCP tool onto the agent.
+
+## Why 1.52.0
+
+The release manifests (`backstage/versions`) give the exact pairing:
+
+| Backstage | backend-plugin-api | backend-defaults | mcp-actions (bundled) |
+|---|---|---|---|
+| 1.48 (current) | 1.7.0 | 0.15.2 | — |
+| 1.49 | 1.8.0 | 0.16.0 | 0.1.10 |
+| 1.50 | 1.9.0 | 0.17.0 | 0.1.12 |
+| 1.51 | 1.9.1 | 0.17.1 | 0.1.13 |
+| **1.52** | **1.9.2** | **0.17.3** | **0.1.14** |
+
+1.52.0 is both the minimum release that satisfies `mcp-actions 0.1.14` (`backend-plugin-api ^1.9.2`) **and** the latest stable — so there is no target-version trade-off. Its `backend-defaults 0.17.3` provides the alpha `metrics`/`tracing` services the plugin depends on.
+
+## Goals
+
+- Bump all `@backstage/*` packages to the 1.52.0 release manifest via `yarn backstage-cli versions:bump --release 1.52.0`.
+- Keep the mcp-actions plugin + config already in `main`; after the bump it starts cleanly.
+- Preserve every current IDP behavior: catalog, the TeraSky kubernetes-ingestor (agent/crossplane entity ingestion), the crossplane resources view, scaffolder templates, auth, TechDocs, search, kubernetes plugin.
+- Build image `v1.4.0` and deploy via a GitOps tag bump.
+
+## Non-goals
+
+- No new features beyond unblocking the MCP tool. This is a maintenance upgrade.
+- No Backstage new-frontend-system migration or other opt-in architecture changes — only what 1.52 requires.
+- The MCP agent-tool wiring itself (deferred Task 5 of the v2 plan) is resumed *after* this upgrade lands; it is not part of this spec.
+
+## Approach
+
+In-place version bump of `arigsela/backstage`, resolve breakages, rebuild, deploy. Rejected alternatives:
+- **Provide no-op metrics/tracing factories on 1.48** — the alpha service refs don't exist in backend-plugin-api 1.7.0, so they can't be imported/stubbed; infeasible without the newer API.
+- **Pin an older mcp-actions** — every stable version (0.1.10–0.1.14) tracks a Backstage ≥1.49 with backend-plugin-api ≥1.8.0; none work on 1.48.
+- **Drop the Backstage MCP entirely** — rejected by the user in favor of upgrading.
+
+## Design / steps
+
+### 1. Version bump
+On a branch in `arigsela/backstage`: `yarn backstage-cli versions:bump --release 1.52.0`. This rewrites the 60 `@backstage/*` pins to the 1.52 manifest (backend-plugin-api 1.9.2, backend-defaults 0.17.3, mcp-actions 0.1.14) and updates `backstage.json` to 1.52.0.
+
+### 2. Third-party (TeraSky) compatibility — the top risk
+Four `@terasky/*` plugins are not managed by `versions:bump`:
+- `@terasky/backstage-plugin-kubernetes-ingestor` (`^3.14.0`) — **load-bearing** (ingests kagent agents + Crossplane claims).
+- `@terasky/backstage-plugin-crossplane-resources-backend` (`^1.15.0`) and `-frontend` (`^2.17.0`).
+- `@terasky/backstage-plugin-scaffolder-backend-module-terasky-utils` (`^2.7.0`).
+
+`yarn install` after the bump may resolve their caret ranges to 1.52-compatible builds; if not, bump each `@terasky/*` to a release that supports Backstage 1.52 (per their release notes). If a required plugin has no 1.52-compatible release, that is a hard blocker to escalate — do not force-resolve an incompatible tree.
+
+### 3. Resolve breaking changes
+`yarn install` → `yarn tsc` → `yarn backstage-cli config:check --lax` surface removed/renamed APIs and config-schema changes across 1.49–1.52. Fix each (deprecations removed, moved exports, changed service/extension-point signatures). Consult the per-release changelogs / the upgrade helper for the 1.49→1.52 span.
+
+### 4. Build & smoke-test
+Build `backstage-portal:v1.4.0` (`./scripts/build-and-push.sh --version v1.4.0`, user-run). Deploy by bumping `base-apps/backstage/deployments.yaml` to `:v1.4.0`. Post-deploy smoke test:
+- Pod healthy; no plugin startup errors in logs.
+- Catalog UI loads; the four pilot entities + agents present.
+- **kubernetes-ingestor** still ingests (agents show `cluster origin: homelab`).
+- Scaffolder templates list; the crossplane resources view renders.
+- **mcp-actions endpoint starts** — `/api/mcp-actions/v1/catalog` returns 200 (not 503) to an authenticated `tools/list`, exposing `catalog:entity`.
+- `platform-entities` Location now ingests: `Group:platform` + Systems present; cert-manager relations resolve to `group:default/platform` / `system:default/platform-networking`.
+
+### 5. Resume MCP wiring
+The already-deployed `backstage-catalog` RemoteMCPServer connects once the endpoint is live (`Accepted=True`, `catalog:entity` discovered). Then execute the deferred Task 5 of the v2 plan: add the tool to `homelab-knowledge` + prompt, and drive the gold relation questions.
+
+## Success criteria
+
+1. `arigsela/backstage` builds and type-checks on 1.52.0; `config:check` clean.
+2. Image `v1.4.0` deployed; Argo `backstage` Synced/Healthy.
+3. No plugin startup failures; catalog, ingestor, scaffolder, crossplane view all functional.
+4. mcp-actions endpoint live; `RemoteMCPServer/backstage-catalog` `Accepted=True`; platform relations resolved.
+
+## Testing
+
+Build-time gates (`tsc`, `config:check`, image build) plus the post-deploy smoke test above. No unit-test harness for the app; validation is behavioral, matching prior backstage work.
+
+## Safety, blast radius & rollback
+
+- **Whole-app upgrade** — blast radius is all of Backstage. Mitigated by: building on a branch, gating on tsc/config:check/build, and smoke-testing the critical flows before trusting it.
+- **Ingestor risk** — the IDP depends on the TeraSky ingestor; verify it early (step 4) before considering the upgrade done.
+- **Rollback:** revert the `base-apps/backstage/deployments.yaml` tag to `:v1.2.0` (last clean pre-mcp image); Argo redeploys it. The 1.52 code stays in `arigsela/backstage` history.
+
+## Open questions
+
+- **TeraSky 1.52 compatibility** — unknown until `yarn install` + build. Resolved during implementation; if a required `@terasky/*` plugin has no 1.52-compatible release, escalate before proceeding.
+- **Breaking-change surface** — the exact set of `@backstage` API changes across 1.49–1.52 is discovered by `tsc`/runtime during implementation, not enumerable up front.


### PR DESCRIPTION
Deploys the Backstage 1.52 image (arigsela/backstage#31 merged) so the mcp-actions endpoint starts and the platform entities ingest. Includes the upgrade spec + plan.

## Change
- `base-apps/backstage/deployments.yaml` — image `:v1.3.0` → `:v1.4.0`.

## Validation
- yamllint clean; server-side dry-run `deployment.apps/backstage configured`.

## After merge (I verify)
- Rollout to v1.4.0, no plugin startup failures.
- IDP smoke test: catalog, kubernetes-ingestor (agents present), scaffolder, crossplane view.
- mcp-actions endpoint live (auth enforced); `RemoteMCPServer/backstage-catalog` Accepted; platform relations resolved.

Rollback = revert to `:v1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1