### PR TITLE
chore(backstage): deploy v1.4.1 (mcp-actions config fix)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.0
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.1
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Redeploys backstage with the corrected mcpActions server config (name + filter.include). Builds on the 1.52 upgrade. After merge: mcp-actions endpoint should start, platform entities ingest, RemoteMCPServer connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)