### PR TITLE
chore(backstage): deploy v1.4.2 (catalog MCP action ids)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.1
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.2
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Deploys backstage with the corrected 1.52 catalog action ids so the MCP catalog server exposes tools. After merge: RemoteMCPServer should discover get-catalog-entity/query-catalog-entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)