### PR TITLE
fix(kagent): drop query-catalog-entities tool (unparseable schema)

### DIFF
--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -59,11 +59,10 @@ spec:
          names; if a doc doesn't cover it, say so and read the source.
 
       For OWNERSHIP, DEPENDENCY, or SYSTEM-membership questions ("who owns X?",
-      "what depends on X?", "what system is X part of?"), use the Backstage
-      catalog tools instead of raw files: `catalog.get-catalog-entity` returns an
+      "what depends on X?", "what system is X part of?"), use the
+      `catalog.get-catalog-entity` tool instead of raw files: it returns an
       entity plus its RESOLVED relations — including reverse relations like
-      `dependencyOf` that no single catalog-info.yaml contains — and
-      `catalog.query-catalog-entities` lists/filters entities. Look an entity up
+      `dependencyOf` that no single catalog-info.yaml contains. Look an entity up
       by name (kind/namespace optional to disambiguate). Fall back to the GitHub
       MCP's `catalog-info.yaml` only if the catalog tool is unavailable.
 
@@ -144,12 +143,13 @@ spec:
         apiGroup: kagent.dev
         kind: RemoteMCPServer
         name: backstage-catalog
-        # Read-only Backstage catalog actions: get one entity + its resolved
-        # relations, or query/list entities. Use for ownership/dependency/system
-        # questions where reverse relations (dependencyOf) matter.
+        # Read-only: get one entity + its resolved relations. Use for
+        # ownership/dependency/system questions where reverse relations
+        # (dependencyOf) matter. NOTE: catalog.query-catalog-entities is
+        # intentionally excluded — its input schema uses anyOf/$ref that
+        # kagent's ADK schema converter cannot parse (KeyError: 'anyOf').
         toolNames:
         - catalog.get-catalog-entity
-        - catalog.query-catalog-entities
     - type: Agent
       agent:
         name: k8s-agent


### PR DESCRIPTION
catalog.query-catalog-entities' input schema uses anyOf/$ref that kagent's ADK converter can't parse (KeyError: 'anyOf'), which crashed the agent's whole toolset ('anyOf' response). Bind only catalog.get-catalog-entity (clean schema) — it answers all the gold questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)