### PR TITLE
fix(kagent): v1.4.5 + undotted get-catalog-entity tool name

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.4
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.5
         imagePullPolicy: Always
         ports:
         - containerPort: 7007

--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -60,7 +60,7 @@ spec:
 
       For OWNERSHIP, DEPENDENCY, or SYSTEM-membership questions ("who owns X?",
       "what depends on X?", "what system is X part of?"), use the
-      `catalog.get-catalog-entity` tool instead of raw files: it returns an
+      `get-catalog-entity` tool instead of raw files: it returns an
       entity plus its RESOLVED relations — including reverse relations like
       `dependencyOf` that no single catalog-info.yaml contains. Look an entity up
       by name (kind/namespace optional to disambiguate). Fall back to the GitHub
@@ -149,7 +149,7 @@ spec:
         # intentionally excluded — its input schema uses anyOf/$ref that
         # kagent's ADK schema converter cannot parse (KeyError: 'anyOf').
         toolNames:
-        - catalog.get-catalog-entity
+        - get-catalog-entity
     - type: Agent
       agent:
         name: k8s-agent


### PR DESCRIPTION
namespacedToolNames: false -> tool name get-catalog-entity (no dot, Anthropic-valid). Bumps backstage v1.4.5 and updates the agent toolName + prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)