### PR TITLE
docs(agent-docs): onboard base-apps batch 2 (weather-kitchen +frontend, n8n, ollama)

### DIFF
--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -41,5 +41,5 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) | postgresql | docs.md | runbook.md | catalog-info.yaml |
 | vcluster-sandbox-1 | | | | | |
 | weather-kitchen-backend | Backend API for Weather Kitchen (likely FastAPI, JWT, Vault-backed DB) | weather-kitchen | docs.md | runbook.md | catalog-info.yaml |
-| weather-kitchen-frontend | | | | | |
+| weather-kitchen-frontend | Web frontend for Weather Kitchen (nginx-fronted Node build) | weather-kitchen-frontend | docs.md | runbook.md | catalog-info.yaml |
 | whoami-test | | | | | |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -40,6 +40,6 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | openshell | | | | | |
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) | postgresql | docs.md | runbook.md | catalog-info.yaml |
 | vcluster-sandbox-1 | | | | | |
-| weather-kitchen-backend | | | | | |
+| weather-kitchen-backend | Backend API for Weather Kitchen (likely FastAPI, JWT, Vault-backed DB) | weather-kitchen | docs.md | runbook.md | catalog-info.yaml |
 | weather-kitchen-frontend | | | | | |
 | whoami-test | | | | | |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -34,7 +34,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | loki-aws-infrastructure | | | | | |
 | n8n | Workflow automation platform (shared PostgreSQL, Vault, admin UI + public webhooks) | n8n | docs.md | runbook.md | catalog-info.yaml |
 | nginx-ingress | Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware) | ingress-nginx | docs.md | runbook.md | catalog-info.yaml |
-| ollama | | | | | |
+| ollama | Local LLM/embedding model server (Ollama, CPU-only, PVC-backed) | ollama | docs.md | runbook.md | catalog-info.yaml |
 | oncall-agent | AI on-call/incident-response agent (Anthropic Claude, Slack, GitOps PRs) | oncall-agent | docs.md | runbook.md | catalog-info.yaml |
 | oncall-crewai | | | | | |
 | openshell | | | | | |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -32,7 +32,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | kyverno-policies | | | | | |
 | logging | | | | | |
 | loki-aws-infrastructure | | | | | |
-| n8n | | | | | |
+| n8n | Workflow automation platform (shared PostgreSQL, Vault, admin UI + public webhooks) | n8n | docs.md | runbook.md | catalog-info.yaml |
 | nginx-ingress | Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware) | ingress-nginx | docs.md | runbook.md | catalog-info.yaml |
 | ollama | | | | | |
 | oncall-agent | AI on-call/incident-response agent (Anthropic Claude, Slack, GitOps PRs) | oncall-agent | docs.md | runbook.md | catalog-info.yaml |

--- a/base-apps/n8n.yaml
+++ b/base-apps/n8n.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/n8n
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: n8n

--- a/base-apps/n8n/catalog-info.yaml
+++ b/base-apps/n8n/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: n8n
+  namespace: n8n
+  annotations:
+    agent-docs/path: docs.md
+  tags: [automation, postgresql, webhooks]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-automation
+  dependsOn:
+    - resource:vault/vault
+    - resource:postgresql/postgresql

--- a/base-apps/n8n/docs.md
+++ b/base-apps/n8n/docs.md
@@ -1,0 +1,40 @@
+---
+app: n8n
+catalog_entity: n8n
+kind: docs
+namespace: n8n
+last_reviewed: 2026-07-10
+status: current
+tags: [automation, postgresql, webhooks]
+sources:
+  - base-apps/n8n/deployments.yaml
+  - base-apps/n8n/external-secrets.yaml
+  - base-apps/n8n/secret-store.yaml
+  - base-apps/n8n/pvc.yaml
+  - base-apps/n8n/services.yaml
+  - base-apps/n8n/nginx-ingress-admin.yaml
+  - base-apps/n8n/nginx-ingress-webhook.yaml
+---
+
+# n8n
+
+## What it is
+n8n (`n8nio/n8n:latest`) is a workflow-automation platform, deployed as a single-replica `Deployment` (`deployments.yaml`) in the `n8n` namespace, listening on container port `5678`.
+
+## Architecture & data flow
+The `Deployment` runs one pod on nodes labeled `node.kubernetes.io/workload: application`, with `fsGroup`/`runAsUser`/`runAsGroup` all set to `1000` so it can write to its mounted volume. A `n8n-pvc` `PersistentVolumeClaim` (`pvc.yaml`, `5Gi`, `storageClassName: local-path`) is mounted at `/home/node/.n8n` — this holds n8n's local state directory (settings file, etc.), **not** workflow/execution data: `DB_TYPE` is set to `postgresdb` (`deployments.yaml`), so n8n persists workflows, credentials, and execution history in the shared PostgreSQL instance (`base-apps/postgresql`) via `DB_POSTGRESDB_HOST/PORT/DATABASE/USER/PASSWORD` env vars sourced from the `n8n-secrets` Secret. The `n8n` `Service` (`services.yaml`, ClusterIP, port `5678`) fronts the pod for both ingresses below.
+
+## Secrets
+`secret-store.yaml` defines a `SecretStore` named `vault-backend` pointing at `http://vault.vault.svc.cluster.local:8200`, KV v2 path `k8s-secrets`, Kubernetes auth with role `n8n`. `external-secrets.yaml`'s `n8n-secrets` `ExternalSecret` resolves most keys (`encryption-key`, `db-host`, `db-port`, `db-name`, `db-user`, `webhook-url`, `basic-auth-user`, `basic-auth-password`) from Vault path `n8n`, but `db-password` is resolved from Vault path `postgresql` property `n8n-password` — the same credential the shared PostgreSQL app provisions for n8n (see `base-apps/postgresql/external-secrets.yaml`'s `n8n-user`/`n8n-password` keys), confirming n8n's database is the shared in-cluster PostgreSQL instance, not an app-local database. `N8N_ENCRYPTION_KEY` (also Vault-sourced) encrypts stored credentials at rest — losing or rotating it without care makes existing workflow credentials unreadable. Admin UI access also requires HTTP Basic Auth (`N8N_BASIC_AUTH_ACTIVE=true`, `N8N_BASIC_AUTH_USER`/`PASSWORD` from Vault).
+
+## Networking — two ingress endpoints
+- **Admin UI** (`nginx-ingress-admin.yaml`, `n8n-admin`): host `n8n.arigsela.com`, path `/`, TLS via `letsencrypt-prod`. Restricted by `nginx.ingress.kubernetes.io/whitelist-source-range` to a small set of home/office IPs plus `10.0.0.0/8` — the workflow editor and admin UI are not publicly reachable.
+- **Webhook endpoint** (`nginx-ingress-webhook.yaml`, `n8n-webhook`): same host `n8n.arigsela.com`, paths `/webhook`, `/webhook-test`, and `/mcp-server` — deliberately **not** IP-restricted, since external services (Slack, etc.) and n8n's MCP server integration need to reach it. Security here relies on n8n's per-workflow unique webhook URLs/tokens rather than network restriction.
+
+Both ingresses route to the same `n8n` Service/port `5678`; they exist only to apply different rate-limit and IP-whitelist annotations to different paths of the same app.
+
+## Where config lives
+- Workload: `deployments.yaml` (env, probes on `/healthz`, resources, volume mount).
+- Persistence: `pvc.yaml` (local `/home/node/.n8n` state) + the shared PostgreSQL instance for workflow/execution data.
+- Secrets: `secret-store.yaml` + `external-secrets.yaml` (Vault-backed, path `n8n` plus the shared `postgresql` path for `n8n-password`).
+- Networking: `services.yaml` (ClusterIP :5678) + `nginx-ingress-admin.yaml` (IP-restricted UI) + `nginx-ingress-webhook.yaml` (public webhook/MCP paths).

--- a/base-apps/n8n/runbook.md
+++ b/base-apps/n8n/runbook.md
@@ -1,0 +1,39 @@
+---
+app: n8n
+catalog_entity: n8n
+kind: runbook
+namespace: n8n
+last_reviewed: 2026-07-10
+status: current
+tags: [automation, postgresql, webhooks]
+sources:
+  - base-apps/n8n/deployments.yaml
+  - base-apps/n8n/external-secrets.yaml
+  - base-apps/n8n/nginx-ingress-admin.yaml
+  - base-apps/n8n/nginx-ingress-webhook.yaml
+  - base-apps/n8n/pvc.yaml
+---
+
+# n8n runbook
+
+## Failure modes
+
+### Symptom: admin UI (`https://n8n.arigsela.com/`) times out or returns connection-refused from a normal browser, but works from the office/VPN
+- **Check:** `nginx.ingress.kubernetes.io/whitelist-source-range` in `nginx-ingress-admin.yaml` only allows a fixed set of `/32` IPs plus `10.0.0.0/8`. Confirm the caller's current public IP isn't in that list: `curl -s ifconfig.me` from the affected machine, and compare against the annotation.
+- **Fix:** this is IP allowlisting working as designed, not an outage. If a legitimate IP changed (e.g. new home/office egress IP), open a PR adding the new `/32` to `nginx.ingress.kubernetes.io/whitelist-source-range` in `base-apps/n8n/nginx-ingress-admin.yaml`. Do not widen the range to `0.0.0.0/0` — the admin UI is deliberately restricted while `/webhook*` and `/mcp-server` on `nginx-ingress-webhook.yaml` remain public.
+
+### Symptom: webhook calls to `https://n8n.arigsela.com/webhook/...` (or `/webhook-test/...`, `/mcp-server/...`) return 404
+- **Check:** `kubectl -n n8n get ingress` to confirm both `n8n-admin` and `n8n-webhook` exist and are pointed at the `n8n` Service/port `5678`; `kubectl -n n8n logs deploy/n8n --tail=100` for n8n-side routing errors. Also confirm from the n8n UI (once reachable) that the target workflow is **Active** — n8n only registers a webhook path once its workflow is activated, and production webhooks (`/webhook/...`) vs. test webhooks (`/webhook-test/...`) use different URLs by design.
+- **Fix:** if the workflow is inactive, activate it in the editor (operational action, not a manifest change). If the ingress path itself is missing or misrouted, PR a fix to `base-apps/n8n/nginx-ingress-webhook.yaml`'s `rules[].http.paths`.
+
+### Symptom: pod CrashLoopBackOff, or n8n runs but reports it cannot decrypt existing credentials/workflows
+- **Check:** `kubectl -n n8n get pods` and `kubectl -n n8n logs deploy/n8n --tail=200`. First rule out normal slow startup — `livenessProbe`/`readinessProbe` in `deployments.yaml` use `initialDelaySeconds: 240`, so the pod is expected to take up to 4 minutes before probes even begin. If logs show Postgres connection errors, check the shared PostgreSQL instance is healthy: `kubectl -n postgresql get pods`. If logs show credential/decryption errors instead, check whether `N8N_ENCRYPTION_KEY` (`external-secrets.yaml`, Vault key `n8n`/`encryption-key`) was rotated in Vault — n8n cannot decrypt previously stored credentials/workflow secrets with a different encryption key than the one used to save them.
+- **Fix:** for DB issues, resolve the shared `postgresql` app first (see its runbook) — n8n has no local fallback DB since `DB_TYPE=postgresdb`. For an encryption-key mismatch, restore the original Vault value at `n8n`/`encryption-key` rather than rotating it in place; rotating `N8N_ENCRYPTION_KEY` requires n8n's own credential re-encryption process, not a plain secret swap.
+
+### Symptom: pod healthy but new workflow executions fail to write data / pod evicted for disk pressure
+- **Check:** `kubectl -n n8n exec deploy/n8n -- df -h /home/node/.n8n` against the `n8n-pvc` (`pvc.yaml`, `5Gi`, `local-path`). This volume holds n8n's local `.n8n` state directory, not workflow execution history (that's in Postgres per `EXECUTIONS_DATA_SAVE_*` settings in `deployments.yaml`), but it can still fill from logs/binary temp files.
+- **Fix:** PR a size increase to `spec.resources.requests.storage` in `base-apps/n8n/pvc.yaml` (note: `local-path` PVCs are not trivially resizable in-place — check the storage class's expansion support before relying on a live resize).
+
+## How-to
+### Deploy / update
+Edit manifests here and PR; Argo CD auto-syncs on merge (`prune: true`, `selfHeal: true`).

--- a/base-apps/ollama.yaml
+++ b/base-apps/ollama.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/ollama
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: ollama

--- a/base-apps/ollama/catalog-info.yaml
+++ b/base-apps/ollama/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ollama
+  namespace: ollama
+  annotations:
+    agent-docs/path: docs.md
+  tags: [llm, embeddings, gpu-optional]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-ai

--- a/base-apps/ollama/docs.md
+++ b/base-apps/ollama/docs.md
@@ -1,0 +1,36 @@
+---
+app: ollama
+catalog_entity: ollama
+kind: docs
+namespace: ollama
+last_reviewed: 2026-07-10
+status: current
+tags: [llm, embeddings, gpu-optional]
+sources:
+  - base-apps/ollama/deployments.yaml
+  - base-apps/ollama/pvc.yaml
+  - base-apps/ollama/services.yaml
+---
+
+# ollama
+
+## What it is
+Self-hosted [Ollama](https://ollama.com) model server (`ollama/ollama:0.20.5`) providing local LLM/embedding inference in-cluster. It is a base provider — other apps call it over HTTP; it does not itself depend on any other catalogued app.
+
+## Architecture & data flow
+Single-replica `Deployment` (`deployments.yaml`, `strategy: Recreate`) scheduled onto nodes labeled `node.kubernetes.io/workload: application` via `nodeSelector`. There is no GPU `nodeSelector`/resource request anywhere in the spec, so this runs **CPU-only inference** — expect slower token/embedding throughput than a GPU-backed deployment.
+
+An `initContainer` (`pull-model`, same `ollama/ollama:0.20.5` image) starts `ollama serve` in the background, runs `ollama pull nomic-embed-text`, then stops the server before the main container starts — so the `nomic-embed-text` embedding model is pre-pulled onto the PVC at deploy/restart time rather than lazily on first request.
+
+The main container exposes port `11434` (`services.yaml`, Service `ollama`, `ClusterIP`) with HTTP `readinessProbe`/`livenessProbe` on `/`. Other in-cluster apps reach it at `http://ollama.ollama.svc.cluster.local:11434` — for example kagent's `embedding-model-config.yaml` configures `nomic-embed-text` against exactly that address.
+
+## Where config lives
+- Workload, image, model-pull init step, resource requests/limits: `deployments.yaml`.
+- Model storage: `pvc.yaml` — a 2Gi `ReadWriteOnce` PVC (`ollama-pvc`) mounted at `/root/.ollama` in both the init container and the main container. 2Gi is sized for a small embedding model only; it is not enough headroom for large general-purpose LLMs.
+- Network exposure: `services.yaml` — ClusterIP Service `ollama` on port `11434`.
+
+## Resources
+Main container: requests `cpu: 100m` / `memory: 512Mi`, limits `cpu: 1000m` / `memory: 1Gi`. Init container (model pull): requests `cpu: 200m` / `memory: 512Mi`, limits `cpu: 2000m` / `memory: 1Gi`. No GPU is requested.
+
+## Who consumes it
+kagent's embedding model config (`base-apps/kagent/embedding-model-config.yaml`) points at `ollama` for the `nomic-embed-text` embedding model via `http://ollama.ollama.svc.cluster.local:11434`.

--- a/base-apps/ollama/runbook.md
+++ b/base-apps/ollama/runbook.md
@@ -1,0 +1,40 @@
+---
+app: ollama
+catalog_entity: ollama
+kind: runbook
+namespace: ollama
+last_reviewed: 2026-07-10
+status: current
+tags: [llm, embeddings, gpu-optional]
+sources:
+  - base-apps/ollama/deployments.yaml
+  - base-apps/ollama/pvc.yaml
+  - base-apps/ollama/services.yaml
+---
+
+# ollama runbook
+
+## Failure modes
+
+### Symptom: pod stuck in `Init` / model requests fail with "model not found"
+- **Check:** `kubectl -n ollama logs deploy/ollama -c pull-model` (the `pull-model` init container runs `ollama pull nomic-embed-text` before the main container starts — a slow/failed pull blocks readiness). Also check `kubectl -n ollama get pods` for `Init:` status and `kubectl -n ollama exec deploy/ollama -c ollama -- ollama list` once running, to confirm `nomic-embed-text` is present.
+- **Fix:** if the pull fails due to network/registry issues, restart the pod (`kubectl -n ollama delete pod <pod>`) to retry the init container. If a different/larger model is needed, PR a change to the `pull-model` command in `deployments.yaml` and raise the PVC size in `pvc.yaml` accordingly (see PVC-full mode below).
+
+### Symptom: OOMKilled or CrashLoopBackOff on the `ollama` container
+- **Check:** `kubectl -n ollama describe pod -l app=ollama` for `OOMKilled`/`Last State`, and `kubectl -n ollama top pod -l app=ollama`. The main container is limited to `memory: 1Gi` (`deployments.yaml`), which can be tight if a larger model than `nomic-embed-text` is loaded or concurrent requests are high.
+- **Fix:** PR to raise `resources.limits.memory` (and `requests.memory`) for the `ollama` container in `deployments.yaml`.
+
+### Symptom: `PersistentVolumeClaim` full / model pull fails with no space left on device
+- **Check:** `kubectl -n ollama exec deploy/ollama -c ollama -- df -h /root/.ollama` and `kubectl -n ollama get pvc ollama-pvc`. The PVC is only `2Gi` (`pvc.yaml`), sized for the small `nomic-embed-text` embedding model — pulling additional or larger models can exhaust it.
+- **Fix:** PR to increase `spec.resources.requests.storage` in `pvc.yaml` (note: expanding a bound PVC requires the underlying StorageClass to support volume expansion).
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge. The Deployment uses `strategy: Recreate` (not `RollingUpdate`), so updates cause a brief full outage while the old pod terminates and the new one (including the `pull-model` init container) starts.
+
+### Check current model inventory
+`kubectl -n ollama exec deploy/ollama -c ollama -- ollama list`
+
+### Note on performance
+No GPU `nodeSelector` or GPU resource request is configured (`deployments.yaml`) — inference runs on CPU only. Expect materially slower embedding/generation latency than a GPU-backed node pool; this is expected behavior, not a bug.

--- a/base-apps/weather-kitchen-backend.yaml
+++ b/base-apps/weather-kitchen-backend.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/weather-kitchen-backend
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: weather-kitchen

--- a/base-apps/weather-kitchen-backend/catalog-info.yaml
+++ b/base-apps/weather-kitchen-backend/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: weather-kitchen-backend
+  namespace: weather-kitchen
+  annotations:
+    agent-docs/path: docs.md
+  tags: [fastapi, jwt, postgresql]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/weather-kitchen
+  dependsOn:
+    - resource:vault/vault

--- a/base-apps/weather-kitchen-backend/docs.md
+++ b/base-apps/weather-kitchen-backend/docs.md
@@ -1,0 +1,32 @@
+---
+app: weather-kitchen-backend
+catalog_entity: weather-kitchen-backend
+kind: docs
+namespace: weather-kitchen
+last_reviewed: 2026-07-10
+status: current
+tags: [fastapi, jwt, postgresql]
+sources:
+  - base-apps/weather-kitchen-backend/deployments.yaml
+  - base-apps/weather-kitchen-backend/configmaps.yaml
+  - base-apps/weather-kitchen-backend/external_secrets.yaml
+  - base-apps/weather-kitchen-backend/secret-store.yaml
+  - base-apps/weather-kitchen-backend/nginx-ingress.yaml
+  - base-apps/weather-kitchen-backend/services.yaml
+---
+
+# weather-kitchen-backend
+
+## What it is
+Backend API for the Weather Kitchen app, image `852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-backend:latest` (`deployments.yaml`). The env var names in `configmaps.yaml` (`BACKEND_CORS_ORIGINS`, `DEBUG`, `ENVIRONMENT`) and the Vault-sourced `JWT_SECRET_KEY`/`DATABASE_URL` secrets follow the common FastAPI backend-template convention, so this is very likely a FastAPI/Python service with JWT auth and a Postgres-style database, listening on port `8000` (`/health` used for both liveness and readiness probes).
+
+## Architecture & data flow
+Deployed as a `Deployment` (`deployments.yaml`, `replicas: 2`) on nodes labeled `node.kubernetes.io/workload: application`. Config comes from two sources wired via `envFrom`: the `weather-kitchen-backend-config` ConfigMap (`configmaps.yaml` — `ENVIRONMENT`, `DEBUG`, `BACKEND_CORS_ORIGINS: https://weather-kitchen.arigsela.com`) and the `weather-kitchen-backend-secrets` Secret populated by an `ExternalSecret`. The `weather-kitchen-backend` `Service` (`services.yaml`, ClusterIP, port `80` → container port `8000`) is fronted by an nginx `Ingress` (`nginx-ingress.yaml`) at host `weather-kitchen.arigsela.com`, TLS via `cert-manager.io/cluster-issuer: letsencrypt-prod`, restricted by an IP whitelist annotation, and rewriting `/api/(?!docs|openapi\.json)(.*)` to `/api/$1` on the backend. The companion `weather-kitchen-frontend` app (separate namespace `weather-kitchen-frontend`) points its `API_URL` at this same host.
+
+## Secrets
+`secret-store.yaml` defines a `SecretStore` named `vault-backend` pointing at `http://vault.vault.svc.cluster.local:8200`, KV v2 path `k8s-secrets`, using Vault's Kubernetes auth method with role `weather-kitchen`. `external_secrets.yaml` resolves three keys under Vault path `weather-kitchen-backend` into the `weather-kitchen-backend-secrets` Secret: `JWT_SECRET_KEY` (`jwt-secret-key`), `DATABASE_URL` (`database-url`), and `BETA_ACCESS_CODE` (`beta-access-code`). The `DATABASE_URL` is an opaque connection string from Vault — these manifests don't reference an in-cluster Postgres service host directly, so the database target (shared `postgresql` app vs. something external) isn't verifiable from this directory alone.
+
+## Where config lives
+- Runtime config: `configmaps.yaml`.
+- Secrets: `secret-store.yaml` + `external_secrets.yaml` (Vault-backed).
+- Networking: `services.yaml` (ClusterIP :80 → :8000), `nginx-ingress.yaml` (TLS host `weather-kitchen.arigsela.com`, IP whitelist, `/api` rewrite).

--- a/base-apps/weather-kitchen-backend/runbook.md
+++ b/base-apps/weather-kitchen-backend/runbook.md
@@ -1,0 +1,30 @@
+---
+app: weather-kitchen-backend
+catalog_entity: weather-kitchen-backend
+kind: runbook
+namespace: weather-kitchen
+last_reviewed: 2026-07-10
+status: current
+tags: [fastapi, jwt, postgresql]
+sources:
+  - base-apps/weather-kitchen-backend/deployments.yaml
+  - base-apps/weather-kitchen-backend/external_secrets.yaml
+  - base-apps/weather-kitchen-backend/secret-store.yaml
+  - base-apps/weather-kitchen-backend/nginx-ingress.yaml
+---
+
+# weather-kitchen-backend runbook
+
+## Failure modes
+
+### Symptom: pods stuck in `CreateContainerConfigError` / `CrashLoopBackOff` on deploy
+- **Check:** `kubectl -n weather-kitchen get externalsecret weather-kitchen-backend-secrets` (look for `SecretSynced` / `Ready` status) and `kubectl -n weather-kitchen get secret weather-kitchen-backend-secrets`. The `Deployment` (`deployments.yaml`) pulls `JWT_SECRET_KEY`, `DATABASE_URL`, `BETA_ACCESS_CODE` via `envFrom.secretRef: weather-kitchen-backend-secrets` — if the `ExternalSecret` hasn't synced from Vault (`secret-store.yaml`, role `weather-kitchen`, path `k8s-secrets/weather-kitchen-backend`), the Secret is missing or stale and every pod fails at container-create time, not at request time.
+- **Fix:** confirm Vault is unsealed and reachable (`vault.vault.svc.cluster.local:8200`) and that the `weather-kitchen` Vault role/policy grants read on `k8s-secrets/weather-kitchen-backend` with the `jwt-secret-key`/`database-url`/`beta-access-code` properties populated. If the SecretStore role or Vault path needs to change, open a PR updating `secret-store.yaml`/`external_secrets.yaml`.
+
+### Symptom: clients get `403 Forbidden` from `https://weather-kitchen.arigsela.com`
+- **Check:** `kubectl -n weather-kitchen get ingress weather-kitchen-backend-nginx -o yaml` and look at the `nginx.ingress.kubernetes.io/whitelist-source-range` annotation — it hard-codes a small allow-list of IPs (plus `10.0.0.0/8`). A legitimate client whose public IP isn't in that list is blocked at the ingress before it reaches the pod.
+- **Fix:** open a PR adding the new IP/CIDR to `whitelist-source-range` in `base-apps/weather-kitchen-backend/nginx-ingress.yaml`; do not edit the Ingress live (Argo CD `selfHeal` will revert it).
+
+### Symptom: pods never become `Ready`, rolling deploys stall
+- **Check:** `kubectl -n weather-kitchen get pods -l app=weather-kitchen-backend` and `kubectl -n weather-kitchen logs deploy/weather-kitchen-backend`. The readiness probe hits `/health` on port `8000` with a 60s initial delay and the liveness probe a 90s initial delay (`deployments.yaml`); a backend that can't reach its database (bad/rotated `DATABASE_URL`) or is still starting up past those windows will fail both probes and never go Ready, blocking the rollout.
+- **Fix:** check the app logs for a DB connection error first (points back to the Vault-sourced `DATABASE_URL`); if it's just slow startup under load, a PR increasing `initialDelaySeconds`/`failureThreshold` in `deployments.yaml` is the durable fix.

--- a/base-apps/weather-kitchen-frontend.yaml
+++ b/base-apps/weather-kitchen-frontend.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/weather-kitchen-frontend
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: weather-kitchen-frontend

--- a/base-apps/weather-kitchen-frontend/catalog-info.yaml
+++ b/base-apps/weather-kitchen-frontend/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: weather-kitchen-frontend
+  namespace: weather-kitchen-frontend
+  annotations:
+    agent-docs/path: docs.md
+  tags: [nginx, node, frontend]
+spec:
+  type: website
+  lifecycle: production
+  owner: group:default/platform
+  system: default/weather-kitchen
+  dependsOn:
+    - component:weather-kitchen/weather-kitchen-backend

--- a/base-apps/weather-kitchen-frontend/docs.md
+++ b/base-apps/weather-kitchen-frontend/docs.md
@@ -1,0 +1,32 @@
+---
+app: weather-kitchen-frontend
+catalog_entity: weather-kitchen-frontend
+kind: docs
+namespace: weather-kitchen-frontend
+last_reviewed: 2026-07-10
+status: current
+tags: [nginx, node, frontend]
+sources:
+  - base-apps/weather-kitchen-frontend/deployments.yaml
+  - base-apps/weather-kitchen-frontend/nginx-ingress.yaml
+  - base-apps/weather-kitchen-frontend/services.yaml
+---
+
+# weather-kitchen-frontend
+
+## What it is
+The web frontend for the Weather Kitchen app, image `852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-frontend:latest`, listening on container port `3000` (`deployments.yaml`). The pod mounts writable `emptyDir` volumes for `/tmp`, `/var/cache/nginx`, and `/var/run` under `readOnlyRootFilesystem: true` (non-root, `runAsUser: 1001`) — the same nginx-cache/nginx-run pattern used by the `chores-tracker-frontend` sibling app — so this is very likely an nginx-fronted Node build serving the UI.
+
+## How it's deployed
+A `Deployment` (`deployments.yaml`) in namespace `weather-kitchen-frontend` runs 2 replicas, scheduled onto `node.kubernetes.io/workload: application` nodes. Liveness (30s initial delay) and readiness (5s initial delay) probes both hit `GET /health` on port `3000`. Resources are modest (128Mi/100m request, 256Mi/200m limit). A `Service` (`services.yaml`, ClusterIP) exposes port `80` → container port `3000`.
+
+## How it reaches the backend
+The container sets `API_URL=https://weather-kitchen.arigsela.com` (`deployments.yaml`) — the frontend calls the backend over the **public ingress host**, not an in-cluster Service reference. Routing between the two apps is split at the `Ingress` layer on that same shared host:
+- This app's `Ingress` (`nginx-ingress.yaml`, name `weather-kitchen-frontend-nginx`) matches path `/` (`pathType: Prefix`) and is annotated `nginx.ingress.kubernetes.io/priority: "50"`.
+- `weather-kitchen-backend`'s `Ingress` (`base-apps/weather-kitchen-backend/nginx-ingress.yaml`, namespace `weather-kitchen`) matches `/api/(?!docs|openapi\.json)(.*)` with `priority: "100"` (higher priority, evaluated first on the shared host) and rewrites to `/api/$1`.
+
+Both Ingresses request TLS for host `weather-kitchen.arigsela.com` via the same `weather-kitchen-tls` secret name and `cert-manager.io/cluster-issuer: letsencrypt-prod`, and carry an identical IP `whitelist-source-range` annotation — so requests to `weather-kitchen.arigsela.com/api/*` route to `weather-kitchen-backend` (namespace `weather-kitchen`) and everything else routes to this frontend.
+
+## Where config lives
+- Runtime config: env vars in `deployments.yaml` (`NODE_ENV`, `API_URL`) — no `ConfigMap`/`ExternalSecret` exists in this directory, so the frontend holds no secrets of its own.
+- Networking: `services.yaml` (ClusterIP `:80` → `:3000`), `nginx-ingress.yaml` (TLS host `weather-kitchen.arigsela.com`, IP whitelist, path `/`, priority `50`).

--- a/base-apps/weather-kitchen-frontend/runbook.md
+++ b/base-apps/weather-kitchen-frontend/runbook.md
@@ -1,0 +1,32 @@
+---
+app: weather-kitchen-frontend
+catalog_entity: weather-kitchen-frontend
+kind: runbook
+namespace: weather-kitchen-frontend
+last_reviewed: 2026-07-10
+status: current
+tags: [nginx, node, frontend]
+sources:
+  - base-apps/weather-kitchen-frontend/deployments.yaml
+  - base-apps/weather-kitchen-frontend/nginx-ingress.yaml
+  - base-apps/weather-kitchen-frontend/services.yaml
+---
+
+# weather-kitchen-frontend runbook
+
+## Failure modes
+
+### Symptom: `weather-kitchen.arigsela.com/api/*` calls return the frontend UI (or 404) instead of backend responses
+Routing between the two apps is split purely by `nginx.ingress.kubernetes.io/priority` annotations on two separate `Ingress` objects sharing the same host: this app's `weather-kitchen-frontend-nginx` matches `/` at priority `"50"`, while `weather-kitchen-backend-nginx` (`base-apps/weather-kitchen-backend/nginx-ingress.yaml`, namespace `weather-kitchen`) matches `/api/(?!docs|openapi\.json)(.*)` at priority `"100"`. If either annotation is dropped or this app's path is broadened past `/`, the frontend's catch-all rule can shadow the backend's `/api` routes.
+- **Check:** `kubectl -n weather-kitchen-frontend get ingress weather-kitchen-frontend-nginx -o yaml` and `kubectl -n weather-kitchen get ingress weather-kitchen-backend-nginx -o yaml` — confirm both `nginx.ingress.kubernetes.io/priority` annotations are present (`50` vs `100`) and this app's path is still `/` with `pathType: Prefix`.
+- **Fix:** open a PR restoring the priority annotation / path scoping in `base-apps/weather-kitchen-frontend/nginx-ingress.yaml` rather than editing the live `Ingress` (Argo CD `selfHeal` will revert direct edits anyway).
+
+### Symptom: clients get `403 Forbidden` from `https://weather-kitchen.arigsela.com`
+The `Ingress` (`nginx-ingress.yaml`) hard-codes `nginx.ingress.kubernetes.io/whitelist-source-range` to a small allow-list of public IPs plus `10.0.0.0/8`. A legitimate client whose public IP isn't in that list is blocked at the ingress before it ever reaches a pod.
+- **Check:** `kubectl -n weather-kitchen-frontend get ingress weather-kitchen-frontend-nginx -o yaml` and inspect the `whitelist-source-range` annotation.
+- **Fix:** open a PR adding the new IP/CIDR to `whitelist-source-range` in `base-apps/weather-kitchen-frontend/nginx-ingress.yaml` (the backend's ingress carries the same list and typically needs the matching update).
+
+### Symptom: Pods stuck in `ImagePullBackOff`/`ErrImagePull`
+The image (`852893458518.dkr.ecr.us-east-2.amazonaws.com/weather-kitchen-frontend:latest`, `deployments.yaml`) is pulled from a private ECR repo, and this `Deployment` declares no `imagePullSecrets`. Cluster-wide ECR auth is refreshed into namespaces by `base-apps/ecr-auth/cronjobs.yaml` (an `ecr-registry` docker-registry `Secret`).
+- **Check:** `kubectl -n weather-kitchen-frontend describe pod -l app=weather-kitchen-frontend` (look for `ErrImagePull`/`ImagePullBackOff` in Events) and `kubectl -n weather-kitchen-frontend get secret ecr-registry`.
+- **Fix:** confirm the `ecr-credentials-sync` CronJob (`base-apps/ecr-auth/cronjobs.yaml`, namespace `kube-system`) is running successfully (`kubectl -n kube-system get cronjob ecr-credentials-sync` and check its latest job's logs); if the secret is missing here, open a PR adding an explicit `imagePullSecrets: [{name: ecr-registry}]` to `base-apps/weather-kitchen-frontend/deployments.yaml`.

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -8,3 +8,4 @@ chores-tracker-frontend
 oncall-agent
 weather-kitchen-backend
 weather-kitchen-frontend
+n8n

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -9,3 +9,4 @@ oncall-agent
 weather-kitchen-backend
 weather-kitchen-frontend
 n8n
+ollama

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -7,3 +7,4 @@ postgresql
 chores-tracker-frontend
 oncall-agent
 weather-kitchen-backend
+weather-kitchen-frontend

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -6,3 +6,4 @@ nginx-ingress
 postgresql
 chores-tracker-frontend
 oncall-agent
+weather-kitchen-backend


### PR DESCRIPTION
Batch 2 of 3 onboarding prioritized base-apps into the agent-docs framework.

## Apps onboarded (4, all Components)
- **weather-kitchen-backend** (`service`, system `weather-kitchen`) — `dependsOn: resource:vault/vault` (DB target hedged, not asserted — no cross-ref evidence).
- **weather-kitchen-frontend** (`website`, system `weather-kitchen`) — `dependsOn: component:weather-kitchen/weather-kitchen-backend` (grounded in shared ingress host + `API_URL` + complementary ingress priorities).
- **n8n** (`service`, system `platform-automation`) — `dependsOn: resource:vault/vault` + `resource:postgresql/postgresql` (genuine cross-referenced shared Vault secret `postgresql/n8n-password`).
- **ollama** (`service`, system `platform-ai`) — CPU-only LLM server; no deps (base provider; kagent consumes it for embeddings).

## Each got
`catalog-info.yaml` + `docs.md` + `runbook.md` (grounded in real manifests) + `_INDEX.md` row + `scope.txt` entry + `directory.exclude`.

## Review
Reviewer subagent: spec compliance ✅ all 4; **zero findings** — every dependsOn ref and runbook check hand-verified against the manifests; unverifiable facts correctly hedged. Validator: **12 apps in scope, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1