### PR TITLE
feat(kagent): plex-stack-diagnostics agent + plex-stack-mcp server

### DIFF
--- a/base-apps/kagent/agents/plex-stack-diagnostics.yaml
+++ b/base-apps/kagent/agents/plex-stack-diagnostics.yaml
@@ -1,0 +1,120 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: plex-stack-diagnostics
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: plex-stack-diagnostics
+    app: kagent
+    arigsela.com/idp-managed: "true"
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/plex-stack-diagnostics.yaml
+    backstage.io/owner: group:default/platform-engineering
+spec:
+  description: Diagnoses the Dockerized Plex stack on 10.0.1.200 (2 Plex instances + qBittorrent) and takes whitelisted safe recovery actions via HTTP APIs.
+  type: Declarative
+  declarative:
+    # Sonnet: correlates across two Plex instances + qBittorrent and reasons
+    # over multi-step tool calls. No context.compaction (kagent's compaction
+    # sends a malformed Anthropic request — every working agent runs without it).
+    modelConfig: anthropic-claude-sonnet-4-6
+    memory:
+      modelConfig: embedding-model-config
+    runtime: python
+    stream: true
+    promptTemplate:
+      dataSources:
+      - alias: builtin
+        kind: ConfigMap
+        name: kagent-builtin-prompts
+    systemMessage: |
+      You are PlexOps, an assistant that diagnoses and safely recovers a
+      self-hosted media stack running as Docker Compose on the host 10.0.1.200.
+      This host is OUTSIDE the Kubernetes cluster; you reach it only through the
+      plex-stack-mcp tools (HTTP APIs), never via kubectl or docker.
+
+      ## Topology
+      - Family Plex   — instance "family",  http://10.0.1.200:32401 (shared content)
+      - Private Plex  — instance "private", http://10.0.1.200:32500 (private content)
+      - qBittorrent   — http://10.0.1.200:8080, routed through a Gluetun VPN container
+
+      ## Tools (the ONLY actions you can take)
+      Read:  plex_status(instance), plex_sessions(instance), qbit_status()
+      Write (SAFE ACTIONS): plex_scan_library(instance, section_key),
+             qbit_resume(hashes|all_stalled), qbit_recheck(hashes)
+
+      ## How to answer
+      1. Call the relevant read tool(s) first; never guess state.
+      2. Brief answer (1-3 sentences), then a "What I checked" section naming the
+         tools you called, then specifics (versions, session counts, torrent
+         states, section keys).
+
+      ## Safe actions — guardrails
+      - Before any write tool, state exactly what you are about to do and why,
+        then call it. Use only the three write tools; invent nothing else.
+      - Resume/recheck operate on the hashes you name or the current stalled set.
+        Prefer all_stalled only when the user asked to fix all stalled torrents.
+
+      ## Honest limitation (critical)
+      You have NO docker/host access. If a service is unreachable (tool returns
+      reachable=false), report it as "down — needs a host-level container restart
+      (Option B, not yet available)" and recommend the operator run, on 10.0.1.200:
+      `cd ~/plex-stack && docker compose ps` / `docker compose logs <svc>` /
+      `docker compose up -d <svc>`. NEVER imply you restarted anything.
+
+      ## Note on the private Plex
+      If the private instance (32500) is reachable at the HTTP level but the user
+      cannot see its content, that is an account/claim or library-mapping issue,
+      not a down container — say so and point at the server's account/library
+      settings rather than a restart.
+
+      {{include "builtin/safety-guardrails"}}
+
+    a2aConfig:
+      skills:
+      - id: plex-health
+        name: Plex Health
+        description: Report whether each Plex instance is up, its version, libraries, and active/transcoding streams.
+        examples:
+        - Is the private Plex up, and why can't I see my content?
+        - How many people are streaming right now, and is anything transcoding?
+        tags: [plex, health, streaming]
+      - id: torrent-health
+        name: Torrent Health & Recovery
+        description: Report qBittorrent connection status and torrent states; resume or recheck stalled torrents on request.
+        examples:
+        - Are any torrents stalled? If so, resume them.
+        - What's qBittorrent's connection status and download rate?
+        tags: [qbittorrent, torrents, recovery]
+      - id: plex-recovery
+        name: Plex Library Recovery
+        description: Trigger a library scan on an instance and triage library/claim issues.
+        examples:
+        - Trigger a scan of the Movies library on the family server.
+        - The private server shows no movies — walk me through why.
+        tags: [plex, library, scan]
+    tools:
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: plex-stack-mcp
+        toolNames:
+        - plex_status
+        - plex_sessions
+        - qbit_status
+        - plex_scan_library
+        - qbit_resume
+        - qbit_recheck
+    deployment:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi

--- a/base-apps/kagent/plex-stack-mcp-external-secret.yaml
+++ b/base-apps/kagent/plex-stack-mcp-external-secret.yaml
@@ -1,0 +1,36 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: plex-stack-mcp-creds
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: plex-stack-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    # Matches the existing kagent SecretStore (base-apps/kagent/secret-store.yaml),
+    # whose object name is "vault-backend" (see agent-docs-mcp-external-secret.yaml
+    # and backstage-mcp-external-secret.yaml for the same reference).
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: plex-stack-mcp-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: PLEX_FAMILY_TOKEN
+      remoteRef:
+        key: plex-stack-mcp
+        property: plex_family_token
+    - secretKey: PLEX_PRIVATE_TOKEN
+      remoteRef:
+        key: plex-stack-mcp
+        property: plex_private_token
+    - secretKey: QBIT_USERNAME
+      remoteRef:
+        key: plex-stack-mcp
+        property: qbit_username
+    - secretKey: QBIT_PASSWORD
+      remoteRef:
+        key: plex-stack-mcp
+        property: qbit_password

--- a/base-apps/kagent/plex-stack-mcp-remote.yaml
+++ b/base-apps/kagent/plex-stack-mcp-remote.yaml
@@ -1,0 +1,21 @@
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: plex-stack-mcp
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: plex-stack-mcp
+spec:
+  # Registers (discovers) the plex-stack-mcp tools with kagent so agents can
+  # reference them. The MCPServer/plex-stack-mcp only DEPLOYS the container +
+  # Service; in this kagent version a container MCPServer does not register
+  # its tools — only a RemoteMCPServer does (same pattern as
+  # agent-docs-mcp.yaml / agent-docs-mcp-remote.yaml). This points at that
+  # Service's streamable-HTTP endpoint.
+  description: HTTP-API diagnostics + safe actions for the Plex stack on 10.0.1.200
+  protocol: STREAMABLE_HTTP
+  url: http://plex-stack-mcp.kagent:3000/mcp
+  timeout: 30s
+  sseReadTimeout: 5m0s
+  terminateOnClose: true

--- a/base-apps/kagent/plex-stack-mcp.yaml
+++ b/base-apps/kagent/plex-stack-mcp.yaml
@@ -1,0 +1,39 @@
+apiVersion: kagent.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: plex-stack-mcp
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: plex-stack-mcp
+spec:
+  # This MCPServer kind/apiVersion comes from the kmcp CRDs bundled by the
+  # kagent-crds chart (kmcp v0.3.0, pinned via kagent v0.9.4's go.mod) — the
+  # same CRD used by agent-docs-mcp.yaml. Unlike that stdio example, this
+  # server IS the long-running HTTP process (FastMCP, streamable-http on
+  # :3000, mounted at /mcp by fastmcp's default), so transportType is "http"
+  # with httpTransport.targetPort/path instead of stdioTransport.
+  transportType: http
+  httpTransport:
+    targetPort: 3000
+    path: /mcp
+  deployment:
+    # TODO(handoff): replace with the real ECR repo once plex-stack-mcp is
+    # pushed (Task 10). Using this repo's existing ECR account/region
+    # convention (see base-apps/kagent/build/build.sh) and the image version
+    # pinned in plex-stack-mcp/pyproject.toml.
+    image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/plex-stack-mcp:0.1.0
+    port: 3000
+    # spec.deployment.secretRefs -> the kmcp controller injects each
+    # referenced Secret's keys via envFrom on the MCP server container (see
+    # transportadapter_translator.go's createSecretEnvFrom). This is the same
+    # mechanism agent-docs-mcp.yaml uses for its GitHub token secret.
+    secretRefs:
+      - name: plex-stack-mcp-creds
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/base-apps/kagent/plex-stack-mcp/.gitignore
+++ b/base-apps/kagent/plex-stack-mcp/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.egg-info/

--- a/base-apps/kagent/plex-stack-mcp/DEPLOY-HANDOFF.md
+++ b/base-apps/kagent/plex-stack-mcp/DEPLOY-HANDOFF.md
@@ -1,0 +1,84 @@
+# plex-stack-diagnostics — Deploy Handoff
+
+The code + manifests are complete, tested (26/26), and all four manifests pass
+`kubectl apply --dry-run=server` against the live cluster CRDs. What remains
+needs your credentials / cloud access. **Do the steps in this order** — merging
+before the image and Vault secret exist will leave the ArgoCD app Degraded
+(ImagePullBackOff → RemoteMCPServer never ACCEPTED → Agent degraded), because
+`kagent-secrets` auto-syncs with `prune: true`/`selfHeal: true`.
+
+Branch: `feat/plex-stack-diagnostics-kagent` (worktree under the session scratchpad).
+
+## 1. Build & push the MCP image to ECR
+Registry/app/tag are already wired into `plex-stack-mcp.yaml`:
+`852893458518.dkr.ecr.us-east-2.amazonaws.com/plex-stack-mcp:0.1.0`
+
+```bash
+cd base-apps/kagent/plex-stack-mcp
+aws ecr get-login-password --region us-east-2 \
+  | docker login --username AWS --password-stdin 852893458518.dkr.ecr.us-east-2.amazonaws.com
+# create the repo once, if it doesn't exist:
+aws ecr create-repository --repository-name plex-stack-mcp --region us-east-2 || true
+docker build -t 852893458518.dkr.ecr.us-east-2.amazonaws.com/plex-stack-mcp:0.1.0 .
+docker push 852893458518.dkr.ecr.us-east-2.amazonaws.com/plex-stack-mcp:0.1.0
+```
+
+## 2. Get the credentials
+- **Family Plex token** (32401) and **Private Plex token** (32500): from each
+  server — `Settings → Account`, or copy the `X-Plex-Token` from an authenticated
+  request in the Plex web app. The two servers have distinct tokens.
+- **qBittorrent API user**: in the qBittorrent WebUI → `Options → Web UI`, create
+  a dedicated non-admin account for the agent (don't reuse your personal login).
+
+## 3. Write the Vault secret
+The ExternalSecret reads Vault KV `k8s-secrets` at key `plex-stack-mcp` via the
+`vault-backend` SecretStore. The `vault` CLI isn't installed on the workstation —
+either run it where you have Vault access, or exec into the in-cluster Vault pod:
+
+```bash
+# Option A — your vault CLI:
+vault kv put k8s-secrets/plex-stack-mcp \
+  plex_family_token='<FAMILY_TOKEN>' \
+  plex_private_token='<PRIVATE_TOKEN>' \
+  qbit_username='<BOT_USER>' \
+  qbit_password='<BOT_PASS>'
+
+# Option B — via the cluster (vault-0 in the vault namespace; needs VAULT_TOKEN set in the pod/env):
+kubectl exec -n vault vault-0 -- vault kv put k8s-secrets/plex-stack-mcp \
+  plex_family_token='<FAMILY_TOKEN>' plex_private_token='<PRIVATE_TOKEN>' \
+  qbit_username='<BOT_USER>' qbit_password='<BOT_PASS>'
+```
+
+## 4. Open the PR and merge
+```bash
+git push -u origin feat/plex-stack-diagnostics-kagent
+gh pr create --fill
+```
+Merge only after steps 1–3 are done.
+
+## 5. Verify after ArgoCD syncs
+```bash
+kubectl get externalsecret plex-stack-mcp-creds -n kagent      # SecretSynced=True
+kubectl get pods -n kagent -l app.kubernetes.io/name=plex-stack-mcp   # Running/Ready
+kubectl get remotemcpserver plex-stack-mcp -n kagent           # ACCEPTED=True
+kubectl get agent plex-stack-diagnostics -n kagent             # ACCEPTED=True, READY=True
+```
+
+## 6. Smoke-test the agent
+Chat at `https://kagent.arigsela.com/agents/kagent/plex-stack-diagnostics/chat`:
+1. "Is the private Plex up, and why can't I see my content?" → should call
+   `plex_status("private")`, report reachable + version, and explain the
+   account/claim-vs-down distinction (the real 32500 symptom).
+2. "Any stalled torrents? Resume them." → `qbit_status()` then, after stating
+   intent, `qbit_resume(all_stalled=True)`.
+3. Point it at a service you've stopped → confirm it uses the honest-limitation
+   phrasing and recommends the `docker compose` commands rather than claiming a restart.
+
+## Notes / optional follow-ups (non-blocking)
+- Live smoke-test is where CSRF `Referer` and the qBittorrent session behavior get
+  their first real exercise (mocks can't cover those).
+- Minor test-hardening left for later: an explicit test for the `all_stalled=True`
+  happy path (auth required + stalled torrents present); an `Accept`-header
+  assertion in `test_plex_client.py`.
+- VPN/Gluetun diagnosis and container-restart (Option B) are intentionally out of
+  scope — see the design spec's roadmap (phases 1.5 and 2).

--- a/base-apps/kagent/plex-stack-mcp/Dockerfile
+++ b/base-apps/kagent/plex-stack-mcp/Dockerfile
@@ -1,0 +1,8 @@
+# base-apps/kagent/plex-stack-mcp/Dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml ./
+COPY plex_stack_mcp ./plex_stack_mcp
+RUN pip install --no-cache-dir .
+EXPOSE 3000
+CMD ["python", "-m", "plex_stack_mcp.server"]

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/config.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    plex_family_url: str
+    plex_private_url: str
+    qbit_url: str
+    plex_family_token: str
+    plex_private_token: str
+    qbit_username: str
+    qbit_password: str
+
+    @staticmethod
+    def from_env() -> "Settings":
+        def required(name: str) -> str:
+            val = os.environ.get(name)
+            if not val:
+                raise RuntimeError(f"missing required env var: {name}")
+            return val
+
+        return Settings(
+            plex_family_url=os.environ.get("PLEX_FAMILY_URL", "http://10.0.1.200:32401"),
+            plex_private_url=os.environ.get("PLEX_PRIVATE_URL", "http://10.0.1.200:32500"),
+            qbit_url=os.environ.get("QBIT_URL", "http://10.0.1.200:8080"),
+            plex_family_token=required("PLEX_FAMILY_TOKEN"),
+            plex_private_token=required("PLEX_PRIVATE_TOKEN"),
+            qbit_username=required("QBIT_USERNAME"),
+            qbit_password=required("QBIT_PASSWORD"),
+        )

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/plex_client.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/plex_client.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import httpx
+
+
+class PlexClient:
+    def __init__(self, base_url: str, token: str, client: httpx.Client):
+        self._base = base_url.rstrip("/")
+        self._client = client
+        self._headers = {"X-Plex-Token": token, "Accept": "application/json"}
+
+    def _get(self, path: str) -> dict:
+        resp = self._client.get(self._base + path, headers=self._headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def identity(self) -> dict:
+        try:
+            mc = self._get("/identity").get("MediaContainer", {})
+            return {"reachable": True, "version": mc.get("version"),
+                    "machine_identifier": mc.get("machineIdentifier"), "error": None}
+        except Exception as e:  # noqa: BLE001 - report, never raise to the tool layer
+            return {"reachable": False, "version": None,
+                    "machine_identifier": None, "error": str(e)}
+
+    def libraries(self) -> list[dict]:
+        mc = self._get("/library/sections").get("MediaContainer", {})
+        return [{"key": d.get("key"), "title": d.get("title"), "type": d.get("type")}
+                for d in mc.get("Directory", [])]
+
+    def sessions(self) -> list[dict]:
+        mc = self._get("/status/sessions").get("MediaContainer", {})
+        out = []
+        for m in mc.get("Metadata", []):
+            out.append({
+                "user": (m.get("User") or {}).get("title"),
+                "title": m.get("title"),
+                "transcode": "TranscodeSession" in m,
+            })
+        return out
+
+    def scan(self, section_key: str) -> None:
+        resp = self._client.get(
+            f"{self._base}/library/sections/{section_key}/refresh",
+            headers=self._headers)
+        resp.raise_for_status()

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/qbit_client.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/qbit_client.py
@@ -19,7 +19,8 @@ class QbitClient:
             raise RuntimeError("qBittorrent login failed (bad credentials or IP-banned)")
 
     def transfer_info(self) -> dict:
-        resp = self._client.get(f"{self._base}/api/v2/transfer/info")
+        resp = self._client.get(f"{self._base}/api/v2/transfer/info",
+                                headers={"Referer": self._base})
         resp.raise_for_status()
         d = resp.json()
         return {"connection_status": d.get("connection_status"),
@@ -27,17 +28,20 @@ class QbitClient:
                 "up_info_speed": d.get("up_info_speed")}
 
     def torrents(self) -> list[dict]:
-        resp = self._client.get(f"{self._base}/api/v2/torrents/info")
+        resp = self._client.get(f"{self._base}/api/v2/torrents/info",
+                                headers={"Referer": self._base})
         resp.raise_for_status()
         return [{"hash": t.get("hash"), "name": t.get("name"), "state": t.get("state")}
                 for t in resp.json()]
 
     def resume(self, hashes: list[str]) -> None:
         resp = self._client.post(f"{self._base}/api/v2/torrents/resume",
-                                 data={"hashes": "|".join(hashes)})
+                                 data={"hashes": "|".join(hashes)},
+                                 headers={"Referer": self._base})
         resp.raise_for_status()
 
     def recheck(self, hashes: list[str]) -> None:
         resp = self._client.post(f"{self._base}/api/v2/torrents/recheck",
-                                 data={"hashes": "|".join(hashes)})
+                                 data={"hashes": "|".join(hashes)},
+                                 headers={"Referer": self._base})
         resp.raise_for_status()

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/qbit_client.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/qbit_client.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import httpx
+
+
+class QbitClient:
+    def __init__(self, base_url: str, username: str, password: str, client: httpx.Client):
+        self._base = base_url.rstrip("/")
+        self._client = client
+        self._username = username
+        self._password = password
+
+    def login(self) -> None:
+        resp = self._client.post(
+            f"{self._base}/api/v2/auth/login",
+            data={"username": self._username, "password": self._password},
+            headers={"Referer": self._base})
+        resp.raise_for_status()
+        if resp.text.strip() != "Ok.":
+            raise RuntimeError("qBittorrent login failed (bad credentials or IP-banned)")
+
+    def transfer_info(self) -> dict:
+        resp = self._client.get(f"{self._base}/api/v2/transfer/info")
+        resp.raise_for_status()
+        d = resp.json()
+        return {"connection_status": d.get("connection_status"),
+                "dl_info_speed": d.get("dl_info_speed"),
+                "up_info_speed": d.get("up_info_speed")}
+
+    def torrents(self) -> list[dict]:
+        resp = self._client.get(f"{self._base}/api/v2/torrents/info")
+        resp.raise_for_status()
+        return [{"hash": t.get("hash"), "name": t.get("name"), "state": t.get("state")}
+                for t in resp.json()]
+
+    def resume(self, hashes: list[str]) -> None:
+        resp = self._client.post(f"{self._base}/api/v2/torrents/resume",
+                                 data={"hashes": "|".join(hashes)})
+        resp.raise_for_status()
+
+    def recheck(self, hashes: list[str]) -> None:
+        resp = self._client.post(f"{self._base}/api/v2/torrents/recheck",
+                                 data={"hashes": "|".join(hashes)})
+        resp.raise_for_status()

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/server.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/server.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import httpx
+from fastmcp import FastMCP
+from plex_stack_mcp.config import Settings
+from plex_stack_mcp.plex_client import PlexClient
+from plex_stack_mcp.qbit_client import QbitClient
+from plex_stack_mcp import tools
+
+TIMEOUT = httpx.Timeout(6.0)
+
+
+def build_registry(
+    settings: Settings,
+    *,
+    plex_client_factory=PlexClient,
+    qbit_client_factory=QbitClient,
+) -> tools.Registry:
+    return tools.Registry(
+        family=plex_client_factory(
+            settings.plex_family_url, settings.plex_family_token,
+            httpx.Client(timeout=TIMEOUT)),
+        private=plex_client_factory(
+            settings.plex_private_url, settings.plex_private_token,
+            httpx.Client(timeout=TIMEOUT)),
+        qbit=qbit_client_factory(
+            settings.qbit_url, settings.qbit_username, settings.qbit_password,
+            httpx.Client(timeout=TIMEOUT)),
+    )
+
+
+def build_mcp(reg: tools.Registry) -> FastMCP:
+    mcp = FastMCP("plex-stack")
+
+    @mcp.tool
+    def plex_status(instance: str) -> dict:
+        """Health of a Plex instance ('family' or 'private'): reachability,
+        version, libraries, active/transcode session counts."""
+        return tools.tool_plex_status(reg, instance)
+
+    @mcp.tool
+    def plex_sessions(instance: str) -> dict:
+        """Current streams on a Plex instance ('family' or 'private')."""
+        return tools.tool_plex_sessions(reg, instance)
+
+    @mcp.tool
+    def qbit_status() -> dict:
+        """qBittorrent connection status, transfer rates, torrent list, and the
+        set of stalled/errored torrent hashes."""
+        return tools.tool_qbit_status(reg)
+
+    @mcp.tool
+    def plex_scan_library(instance: str, section_key: str) -> dict:
+        """SAFE ACTION: trigger a library scan on a Plex instance."""
+        return tools.tool_plex_scan_library(reg, instance, section_key)
+
+    @mcp.tool
+    def qbit_resume(hashes: list[str] | None = None, all_stalled: bool = False) -> dict:
+        """SAFE ACTION: resume specific torrent hashes, or all stalled ones."""
+        return tools.tool_qbit_resume(reg, hashes, all_stalled)
+
+    @mcp.tool
+    def qbit_recheck(hashes: list[str]) -> dict:
+        """SAFE ACTION: force-recheck specific torrent hashes."""
+        return tools.tool_qbit_recheck(reg, hashes)
+
+    return mcp
+
+
+def main() -> None:
+    reg = build_registry(Settings.from_env())
+    build_mcp(reg).run(transport="streamable-http", host="0.0.0.0", port=3000)
+
+
+if __name__ == "__main__":
+    main()

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
@@ -56,3 +56,30 @@ def tool_qbit_status(reg: Registry) -> dict:
     return {"reachable": True, "connection_status": info["connection_status"],
             "dl_info_speed": info["dl_info_speed"], "up_info_speed": info["up_info_speed"],
             "torrents": torrents, "stalled": stalled}
+
+
+def tool_qbit_resume(reg: Registry, hashes: list[str] | None,
+                     all_stalled: bool = False) -> dict:
+    if all_stalled:
+        status = tool_qbit_status(reg)
+        target = status.get("stalled", [])
+    elif hashes:
+        target = hashes
+    else:
+        raise ValueError("provide hashes=[...] or all_stalled=True")
+    if target:
+        reg.qbit.resume(target)
+    return {"resumed": target, "count": len(target)}
+
+
+def tool_qbit_recheck(reg: Registry, hashes: list[str]) -> dict:
+    if not hashes:
+        raise ValueError("hashes must be a non-empty list")
+    reg.qbit.recheck(hashes)
+    return {"rechecked": hashes, "count": len(hashes)}
+
+
+def tool_plex_scan_library(reg: Registry, instance: str, section_key: str) -> dict:
+    plex = resolve_plex(reg, instance)
+    plex.scan(section_key)
+    return {"instance": instance, "section_key": section_key, "scan_triggered": True}

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from plex_stack_mcp.plex_client import PlexClient
+from plex_stack_mcp.qbit_client import QbitClient
+
+DOWN_NOTE = "down — needs a host-level container restart (Option B, not yet available)"
+STALLED_STATES = {"stalledDL", "stalledUP", "error", "missingFiles"}
+
+
+@dataclass
+class Registry:
+    family: PlexClient | None
+    private: PlexClient | None
+    qbit: QbitClient | None
+
+
+def resolve_plex(reg: Registry, instance: str) -> PlexClient:
+    if instance == "family":
+        return reg.family
+    if instance == "private":
+        return reg.private
+    raise ValueError(f"unknown plex instance: {instance!r} (use 'family' or 'private')")
+
+
+def tool_plex_status(reg: Registry, instance: str) -> dict:
+    plex = resolve_plex(reg, instance)
+    ident = plex.identity()
+    if not ident["reachable"]:
+        return {"instance": instance, "reachable": False, "version": None,
+                "libraries": [], "session_count": 0, "transcode_count": 0,
+                "error": ident["error"], "note": DOWN_NOTE}
+    sessions = plex.sessions()
+    return {"instance": instance, "reachable": True, "version": ident["version"],
+            "libraries": plex.libraries(),
+            "session_count": len(sessions),
+            "transcode_count": sum(1 for s in sessions if s["transcode"])}
+
+
+def tool_plex_sessions(reg: Registry, instance: str) -> dict:
+    plex = resolve_plex(reg, instance)
+    ident = plex.identity()
+    if not ident["reachable"]:
+        return {"instance": instance, "reachable": False, "sessions": [],
+                "error": ident["error"], "note": DOWN_NOTE}
+    return {"instance": instance, "reachable": True, "sessions": plex.sessions()}
+
+
+def tool_qbit_status(reg: Registry) -> dict:
+    try:
+        reg.qbit.login()
+        info = reg.qbit.transfer_info()
+        torrents = reg.qbit.torrents()
+    except Exception as e:  # noqa: BLE001
+        return {"reachable": False, "error": str(e), "note": DOWN_NOTE}
+    stalled = [t["hash"] for t in torrents if t["state"] in STALLED_STATES]
+    return {"reachable": True, "connection_status": info["connection_status"],
+            "dl_info_speed": info["dl_info_speed"], "up_info_speed": info["up_info_speed"],
+            "torrents": torrents, "stalled": stalled}

--- a/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
+++ b/base-apps/kagent/plex-stack-mcp/plex_stack_mcp/tools.py
@@ -62,8 +62,11 @@ def tool_qbit_resume(reg: Registry, hashes: list[str] | None,
                      all_stalled: bool = False) -> dict:
     if all_stalled:
         status = tool_qbit_status(reg)
+        if status.get("reachable") is False:
+            return {"reachable": False, "error": status.get("error"), "note": DOWN_NOTE}
         target = status.get("stalled", [])
     elif hashes:
+        reg.qbit.login()
         target = hashes
     else:
         raise ValueError("provide hashes=[...] or all_stalled=True")
@@ -75,11 +78,17 @@ def tool_qbit_resume(reg: Registry, hashes: list[str] | None,
 def tool_qbit_recheck(reg: Registry, hashes: list[str]) -> dict:
     if not hashes:
         raise ValueError("hashes must be a non-empty list")
+    reg.qbit.login()
     reg.qbit.recheck(hashes)
     return {"rechecked": hashes, "count": len(hashes)}
 
 
 def tool_plex_scan_library(reg: Registry, instance: str, section_key: str) -> dict:
     plex = resolve_plex(reg, instance)
+    ident = plex.identity()
+    if not ident["reachable"]:
+        return {"instance": instance, "reachable": False,
+                "error": ident["error"], "note": DOWN_NOTE}
     plex.scan(section_key)
-    return {"instance": instance, "section_key": section_key, "scan_triggered": True}
+    return {"instance": instance, "section_key": section_key,
+            "scan_triggered": True, "reachable": True}

--- a/base-apps/kagent/plex-stack-mcp/pyproject.toml
+++ b/base-apps/kagent/plex-stack-mcp/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "plex-stack-mcp"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastmcp>=2.3.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/base-apps/kagent/plex-stack-mcp/tests/test_config.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_config.py
@@ -1,0 +1,24 @@
+import pytest
+from plex_stack_mcp.config import Settings
+
+
+def test_from_env_uses_defaults_and_secrets(monkeypatch):
+    monkeypatch.setenv("PLEX_FAMILY_TOKEN", "ftok")
+    monkeypatch.setenv("PLEX_PRIVATE_TOKEN", "ptok")
+    monkeypatch.setenv("QBIT_USERNAME", "botuser")
+    monkeypatch.setenv("QBIT_PASSWORD", "botpass")
+    s = Settings.from_env()
+    assert s.plex_family_url == "http://10.0.1.200:32401"
+    assert s.plex_private_url == "http://10.0.1.200:32500"
+    assert s.qbit_url == "http://10.0.1.200:8080"
+    assert s.plex_family_token == "ftok"
+    assert s.qbit_username == "botuser"
+
+
+def test_from_env_missing_secret_raises(monkeypatch):
+    monkeypatch.delenv("PLEX_FAMILY_TOKEN", raising=False)
+    monkeypatch.setenv("PLEX_PRIVATE_TOKEN", "ptok")
+    monkeypatch.setenv("QBIT_USERNAME", "botuser")
+    monkeypatch.setenv("QBIT_PASSWORD", "botpass")
+    with pytest.raises(RuntimeError):
+        Settings.from_env()

--- a/base-apps/kagent/plex-stack-mcp/tests/test_plex_client.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_plex_client.py
@@ -1,0 +1,51 @@
+import httpx
+from plex_stack_mcp.plex_client import PlexClient
+
+
+def _client(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler), base_url="http://plex")
+
+
+def test_identity_reachable():
+    def handler(req):
+        assert req.headers["X-Plex-Token"] == "tok"
+        assert req.url.path == "/identity"
+        return httpx.Response(200, json={"MediaContainer": {
+            "version": "1.40.0", "machineIdentifier": "abc"}})
+    c = PlexClient("http://plex", "tok", _client(handler))
+    out = c.identity()
+    assert out == {"reachable": True, "version": "1.40.0",
+                   "machine_identifier": "abc", "error": None}
+
+
+def test_identity_unreachable():
+    def handler(req):
+        raise httpx.ConnectError("refused")
+    c = PlexClient("http://plex", "tok", _client(handler))
+    out = c.identity()
+    assert out["reachable"] is False and "refused" in out["error"]
+
+
+def test_sessions_parsed():
+    def handler(req):
+        assert req.url.path == "/status/sessions"
+        return httpx.Response(200, json={"MediaContainer": {"Metadata": [
+            {"title": "Drive", "User": {"title": "asela"},
+             "TranscodeSession": {"key": "x"}},
+            {"title": "Tombstone", "User": {"title": "guest"}}]}})
+    c = PlexClient("http://plex", "tok", _client(handler))
+    assert c.sessions() == [
+        {"user": "asela", "title": "Drive", "transcode": True},
+        {"user": "guest", "title": "Tombstone", "transcode": False}]
+
+
+def test_libraries_parsed():
+    def handler(req):
+        assert req.url.path == "/library/sections"
+        return httpx.Response(200, json={"MediaContainer": {"Directory": [
+            {"key": "1", "title": "Movies", "type": "movie"},
+            {"key": "2", "title": "TV Shows", "type": "show"}]}})
+    c = PlexClient("http://plex", "tok", _client(handler))
+    assert c.libraries() == [
+        {"key": "1", "title": "Movies", "type": "movie"},
+        {"key": "2", "title": "TV Shows", "type": "show"}]

--- a/base-apps/kagent/plex-stack-mcp/tests/test_qbit_client.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_qbit_client.py
@@ -42,3 +42,11 @@ def test_torrents():
     assert out == [
         {"hash": "aaa", "name": "ubuntu.iso", "state": "stalledDL"},
         {"hash": "bbb", "name": "debian.iso", "state": "uploading"}]
+
+
+def test_resume_sends_referer_for_csrf():
+    def handler(req):
+        assert req.url.path == "/api/v2/torrents/resume"
+        assert req.headers["Referer"] == "http://qbit"
+        return httpx.Response(200, text="Ok.")
+    QbitClient("http://qbit", "b", "p", _client(handler)).resume(["aaa"])

--- a/base-apps/kagent/plex-stack-mcp/tests/test_qbit_client.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_qbit_client.py
@@ -1,0 +1,44 @@
+import httpx
+import pytest
+from plex_stack_mcp.qbit_client import QbitClient
+
+
+def _client(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler), base_url="http://qbit")
+
+
+def test_login_ok():
+    def handler(req):
+        assert req.url.path == "/api/v2/auth/login"
+        assert b"username=bot" in req.content
+        return httpx.Response(200, text="Ok.")
+    QbitClient("http://qbit", "bot", "pw", _client(handler)).login()
+
+
+def test_login_failure_raises():
+    def handler(req):
+        return httpx.Response(200, text="Fails.")
+    with pytest.raises(RuntimeError):
+        QbitClient("http://qbit", "bot", "pw", _client(handler)).login()
+
+
+def test_transfer_info():
+    def handler(req):
+        assert req.url.path == "/api/v2/transfer/info"
+        return httpx.Response(200, json={"connection_status": "connected",
+                                         "dl_info_speed": 1000, "up_info_speed": 20})
+    out = QbitClient("http://qbit", "b", "p", _client(handler)).transfer_info()
+    assert out == {"connection_status": "connected",
+                   "dl_info_speed": 1000, "up_info_speed": 20}
+
+
+def test_torrents():
+    def handler(req):
+        assert req.url.path == "/api/v2/torrents/info"
+        return httpx.Response(200, json=[
+            {"hash": "aaa", "name": "ubuntu.iso", "state": "stalledDL"},
+            {"hash": "bbb", "name": "debian.iso", "state": "uploading"}])
+    out = QbitClient("http://qbit", "b", "p", _client(handler)).torrents()
+    assert out == [
+        {"hash": "aaa", "name": "ubuntu.iso", "state": "stalledDL"},
+        {"hash": "bbb", "name": "debian.iso", "state": "uploading"}]

--- a/base-apps/kagent/plex-stack-mcp/tests/test_server_registration.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_server_registration.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from plex_stack_mcp import server, tools
+
+
+def test_build_mcp_registers_exactly_six_named_tools():
+    reg = tools.Registry(family=None, private=None, qbit=None)
+    mcp = server.build_mcp(reg)
+
+    # FastMCP 3.x has no public `_tool_manager` (a private, version-specific
+    # attribute the brief flagged as possibly stale). The public, documented
+    # accessor in this installed version (fastmcp 3.4.4) is the async
+    # `FastMCP.list_tools()`, which returns a list of Tool objects with a
+    # `.name` attribute. Drive it synchronously via asyncio.run since no
+    # pytest-asyncio plugin is installed in this project.
+    registered = asyncio.run(mcp.list_tools())
+    names = {t.name for t in registered}
+
+    assert names == {
+        "plex_status",
+        "plex_sessions",
+        "qbit_status",
+        "plex_scan_library",
+        "qbit_resume",
+        "qbit_recheck",
+    }

--- a/base-apps/kagent/plex-stack-mcp/tests/test_tools_read.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_tools_read.py
@@ -1,0 +1,79 @@
+import httpx
+import pytest
+from plex_stack_mcp.plex_client import PlexClient
+from plex_stack_mcp.qbit_client import QbitClient
+from plex_stack_mcp import tools
+
+
+def plex_ok():
+    def h(req):
+        if req.url.path == "/identity":
+            return httpx.Response(200, json={"MediaContainer": {"version": "1.40"}})
+        if req.url.path == "/library/sections":
+            return httpx.Response(200, json={"MediaContainer": {"Directory": [
+                {"key": "1", "title": "Movies", "type": "movie"}]}})
+        if req.url.path == "/status/sessions":
+            return httpx.Response(200, json={"MediaContainer": {"Metadata": [
+                {"title": "Drive", "User": {"title": "a"},
+                 "TranscodeSession": {"k": 1}}]}})
+        return httpx.Response(404)
+    return PlexClient("http://p", "t", httpx.Client(transport=httpx.MockTransport(h)))
+
+
+def plex_down():
+    def h(req):
+        raise httpx.ConnectError("refused")
+    return PlexClient("http://p", "t", httpx.Client(transport=httpx.MockTransport(h)))
+
+
+def test_resolve_plex_rejects_unknown():
+    reg = tools.Registry(family=plex_ok(), private=plex_ok(), qbit=None)
+    with pytest.raises(ValueError):
+        tools.resolve_plex(reg, "public")
+
+
+def test_plex_status_up():
+    reg = tools.Registry(family=plex_ok(), private=plex_ok(), qbit=None)
+    out = tools.tool_plex_status(reg, "family")
+    assert out["reachable"] is True
+    assert out["version"] == "1.40"
+    assert out["session_count"] == 1
+    assert out["transcode_count"] == 1
+    assert out["libraries"] == [{"key": "1", "title": "Movies", "type": "movie"}]
+
+
+def test_plex_status_down_has_note():
+    reg = tools.Registry(family=plex_down(), private=plex_down(), qbit=None)
+    out = tools.tool_plex_status(reg, "private")
+    assert out["reachable"] is False
+    assert out["libraries"] == [] and out["session_count"] == 0
+    assert out["note"] == tools.DOWN_NOTE
+
+
+def test_qbit_status_up_flags_stalled():
+    def h(req):
+        if req.url.path == "/api/v2/auth/login":
+            return httpx.Response(200, text="Ok.")
+        if req.url.path == "/api/v2/transfer/info":
+            return httpx.Response(200, json={"connection_status": "connected",
+                                             "dl_info_speed": 1, "up_info_speed": 2})
+        if req.url.path == "/api/v2/torrents/info":
+            return httpx.Response(200, json=[
+                {"hash": "aaa", "name": "x", "state": "stalledDL"},
+                {"hash": "bbb", "name": "y", "state": "uploading"}])
+        return httpx.Response(404)
+    q = QbitClient("http://q", "b", "p", httpx.Client(transport=httpx.MockTransport(h)))
+    reg = tools.Registry(family=None, private=None, qbit=q)
+    out = tools.tool_qbit_status(reg)
+    assert out["reachable"] is True
+    assert out["connection_status"] == "connected"
+    assert out["stalled"] == ["aaa"]
+
+
+def test_qbit_status_down_has_note():
+    def h(req):
+        raise httpx.ConnectError("refused")
+    q = QbitClient("http://q", "b", "p", httpx.Client(transport=httpx.MockTransport(h)))
+    reg = tools.Registry(family=None, private=None, qbit=q)
+    out = tools.tool_qbit_status(reg)
+    assert out["reachable"] is False and out["note"] == tools.DOWN_NOTE

--- a/base-apps/kagent/plex-stack-mcp/tests/test_tools_write.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_tools_write.py
@@ -1,0 +1,58 @@
+import httpx
+import pytest
+from plex_stack_mcp.plex_client import PlexClient
+from plex_stack_mcp.qbit_client import QbitClient
+from plex_stack_mcp import tools
+
+
+def qbit_recorder(records):
+    def h(req):
+        records.append((req.url.path, req.content.decode()))
+        if req.url.path == "/api/v2/auth/login":
+            return httpx.Response(200, text="Ok.")
+        if req.url.path == "/api/v2/transfer/info":
+            return httpx.Response(200, json={"connection_status": "connected",
+                                             "dl_info_speed": 0, "up_info_speed": 0})
+        if req.url.path == "/api/v2/torrents/info":
+            return httpx.Response(200, json=[
+                {"hash": "aaa", "name": "x", "state": "stalledDL"}])
+        return httpx.Response(200, text="Ok.")
+    return QbitClient("http://q", "b", "p", httpx.Client(transport=httpx.MockTransport(h)))
+
+
+def test_resume_explicit_hashes():
+    recs = []
+    reg = tools.Registry(family=None, private=None, qbit=qbit_recorder(recs))
+    out = tools.tool_qbit_resume(reg, hashes=["h1", "h2"])
+    assert out == {"resumed": ["h1", "h2"], "count": 2}
+    assert any(p == "/api/v2/torrents/resume" and "h1%7Ch2" in c for p, c in recs)
+
+
+def test_resume_all_stalled():
+    reg = tools.Registry(family=None, private=None, qbit=qbit_recorder([]))
+    out = tools.tool_qbit_resume(reg, hashes=None, all_stalled=True)
+    assert out == {"resumed": ["aaa"], "count": 1}
+
+
+def test_resume_requires_input():
+    reg = tools.Registry(family=None, private=None, qbit=qbit_recorder([]))
+    with pytest.raises(ValueError):
+        tools.tool_qbit_resume(reg, hashes=None, all_stalled=False)
+
+
+def test_recheck_empty_raises():
+    reg = tools.Registry(family=None, private=None, qbit=qbit_recorder([]))
+    with pytest.raises(ValueError):
+        tools.tool_qbit_recheck(reg, hashes=[])
+
+
+def test_plex_scan():
+    recs = []
+    def h(req):
+        recs.append(req.url.path)
+        return httpx.Response(200, text="")
+    plex = PlexClient("http://p", "t", httpx.Client(transport=httpx.MockTransport(h)))
+    reg = tools.Registry(family=plex, private=plex, qbit=None)
+    out = tools.tool_plex_scan_library(reg, "family", "1")
+    assert out == {"instance": "family", "section_key": "1", "scan_triggered": True}
+    assert "/library/sections/1/refresh" in recs

--- a/base-apps/kagent/plex-stack-mcp/tests/test_tools_write.py
+++ b/base-apps/kagent/plex-stack-mcp/tests/test_tools_write.py
@@ -50,9 +50,74 @@ def test_plex_scan():
     recs = []
     def h(req):
         recs.append(req.url.path)
+        if req.url.path == "/identity":
+            return httpx.Response(200, json={"MediaContainer": {"version": "1.40"}})
         return httpx.Response(200, text="")
     plex = PlexClient("http://p", "t", httpx.Client(transport=httpx.MockTransport(h)))
     reg = tools.Registry(family=plex, private=plex, qbit=None)
     out = tools.tool_plex_scan_library(reg, "family", "1")
-    assert out == {"instance": "family", "section_key": "1", "scan_triggered": True}
+    assert out == {"instance": "family", "section_key": "1", "scan_triggered": True, "reachable": True}
     assert "/library/sections/1/refresh" in recs
+
+
+def test_plex_scan_down_returns_note_no_raise():
+    def h(req):
+        raise httpx.ConnectError("refused")
+    plex = PlexClient("http://p", "t", httpx.Client(transport=httpx.MockTransport(h)))
+    reg = tools.Registry(family=plex, private=plex, qbit=None)
+    out = tools.tool_plex_scan_library(reg, "family", "1")
+    assert out["reachable"] is False
+    assert out["note"] == tools.DOWN_NOTE
+    assert out["instance"] == "family"
+
+
+def _qbit_requires_login(records, calls):
+    """qBittorrent-like handler: resume/recheck 403 unless login happened first."""
+    def h(req):
+        calls.append(req.url.path)
+        records.append((req.url.path, req.content.decode()))
+        if req.url.path == "/api/v2/auth/login":
+            return httpx.Response(200, text="Ok.")
+        if req.url.path in ("/api/v2/torrents/resume", "/api/v2/torrents/recheck"):
+            if "/api/v2/auth/login" not in calls:
+                return httpx.Response(403, text="Forbidden")
+            return httpx.Response(200, text="Ok.")
+        if req.url.path == "/api/v2/transfer/info":
+            return httpx.Response(200, json={"connection_status": "connected",
+                                             "dl_info_speed": 0, "up_info_speed": 0})
+        if req.url.path == "/api/v2/torrents/info":
+            return httpx.Response(200, json=[
+                {"hash": "aaa", "name": "x", "state": "stalledDL"}])
+        return httpx.Response(200, text="Ok.")
+    return QbitClient("http://q", "b", "p", httpx.Client(transport=httpx.MockTransport(h)))
+
+
+def test_resume_explicit_hashes_authenticates_first():
+    recs = []
+    calls = []
+    reg = tools.Registry(family=None, private=None, qbit=_qbit_requires_login(recs, calls))
+    out = tools.tool_qbit_resume(reg, hashes=["h1", "h2"])
+    assert out == {"resumed": ["h1", "h2"], "count": 2}
+    assert "/api/v2/auth/login" in calls
+    assert calls.index("/api/v2/auth/login") < calls.index("/api/v2/torrents/resume")
+
+
+def test_recheck_authenticates_first():
+    recs = []
+    calls = []
+    reg = tools.Registry(family=None, private=None, qbit=_qbit_requires_login(recs, calls))
+    out = tools.tool_qbit_recheck(reg, hashes=["h1"])
+    assert out == {"rechecked": ["h1"], "count": 1}
+    assert "/api/v2/auth/login" in calls
+    assert calls.index("/api/v2/auth/login") < calls.index("/api/v2/torrents/recheck")
+
+
+def test_resume_all_stalled_when_qbit_down_reports_down_not_fake_success():
+    def h(req):
+        raise httpx.ConnectError("refused")
+    q = QbitClient("http://q", "b", "p", httpx.Client(transport=httpx.MockTransport(h)))
+    reg = tools.Registry(family=None, private=None, qbit=q)
+    out = tools.tool_qbit_resume(reg, hashes=None, all_stalled=True)
+    assert out["reachable"] is False
+    assert out["note"] == tools.DOWN_NOTE
+    assert out != {"resumed": [], "count": 0}


### PR DESCRIPTION
## What

Adds `plex-stack-diagnostics`, a kagent (Sonnet) that diagnoses the Dockerized Plex stack on `10.0.1.200` (two Plex instances + qBittorrent) and takes whitelisted safe recovery actions — via a new `plex-stack-mcp` HTTP-API server. HTTP-only ("Option A"): **full detection, API-level recovery, no container-restart** (that's a future Option B). Credentials are injected server-side from Vault; the agent never sees a secret.

## ⚠️ Do NOT merge until deploy preconditions are met

This repo auto-syncs (`prune`+`selfHeal`). Merging before the image + secret exist leaves the app Degraded (ImagePullBackOff → RemoteMCPServer never ACCEPTED → agent degraded). **Before merge**, complete steps 1–3 of `base-apps/kagent/plex-stack-mcp/DEPLOY-HANDOFF.md`:
1. Build & push `plex-stack-mcp:0.1.0` to ECR (`852893458518.dkr.ecr.us-east-2...`).
2. Get the two Plex tokens + create a dedicated qBittorrent API user.
3. `vault kv put k8s-secrets/plex-stack-mcp ...` (4 keys).

## Contents

- **`base-apps/kagent/plex-stack-mcp/`** — Python/FastMCP server. 6 tools: `plex_status`, `plex_sessions`, `qbit_status` (read) + `plex_scan_library`, `qbit_resume`, `qbit_recheck` (safe-action write). Read/write split enforced in code. **26/26 unit tests** (TDD, mocked httpx).
- **`base-apps/kagent/plex-stack-mcp.yaml`** (MCPServer), **`plex-stack-mcp-remote.yaml`** (RemoteMCPServer), **`plex-stack-mcp-external-secret.yaml`** (Vault → `vault-backend` SecretStore), **`agents/plex-stack-diagnostics.yaml`** (Agent CRD, Sonnet, no compaction, honest-limitation prompt).

## Validation

- 26/26 tests pass.
- All 4 manifests pass `kubectl apply --dry-run=server` against the live cluster CRDs.
- Per-task + final whole-branch review completed; two write-path auth bugs found in review and fixed with regression tests.

## Out of scope (roadmap)

VPN/Gluetun diagnosis (phase 1.5, needs Gluetun control server exposed) and container-restart/Option B (phase 2). See `docs/superpowers/specs/2026-07-10-plex-diagnostic-kagent-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoeBYvcd86rwAAb56q7FEu
