### PR TITLE
docs(agent-docs): onboard kagent (AI agent platform)

### DIFF
--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -27,7 +27,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | ecr-auth | | | | | |
 | istio-ambient-config | | | | | |
 | k8s-monitor | | | | | |
-| kagent | | | | | |
+| kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | docs.md | runbook.md | catalog-info.yaml |
 | kube-system | | | | | |
 | kyverno-policies | | | | | |
 | logging | | | | | |

--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -13,6 +13,7 @@ spec:
     path: base-apps/kagent
     directory:
       recurse: true
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: kagent

--- a/base-apps/kagent/catalog-info.yaml
+++ b/base-apps/kagent/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kagent
+  namespace: kagent
+  annotations:
+    agent-docs/path: docs.md
+  tags: [ai-agent, kagent, mcp, anthropic]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-ai
+  dependsOn:
+    - component:ollama/ollama
+    - resource:vault/vault
+    - resource:postgresql/postgresql

--- a/base-apps/kagent/docs.md
+++ b/base-apps/kagent/docs.md
@@ -13,6 +13,7 @@ sources:
   - base-apps/kagent/embedding-model-config.yaml
   - base-apps/kagent/secret-store.yaml
   - base-apps/kagent/external-secrets.yaml
+  - base-apps/kagent/mcp-basic-auth-external-secret.yaml
   - base-apps/kagent/agents/homelab-knowledge.yaml
   - base-apps/kagent/agent-docs-mcp.yaml
   - base-apps/kagent/agent-docs-mcp-remote.yaml

--- a/base-apps/kagent/docs.md
+++ b/base-apps/kagent/docs.md
@@ -1,0 +1,54 @@
+---
+app: kagent
+catalog_entity: kagent
+kind: docs
+namespace: kagent
+last_reviewed: 2026-07-10
+status: current
+tags: [ai-agent, kagent, mcp, anthropic]
+sources:
+  - base-apps/kagent.yaml
+  - base-apps/kagent-secrets.yaml
+  - base-apps/kagent-crds.yaml
+  - base-apps/kagent/embedding-model-config.yaml
+  - base-apps/kagent/secret-store.yaml
+  - base-apps/kagent/external-secrets.yaml
+  - base-apps/kagent/agents/homelab-knowledge.yaml
+  - base-apps/kagent/agent-docs-mcp.yaml
+  - base-apps/kagent/agent-docs-mcp-remote.yaml
+  - base-apps/kagent/backstage-catalog-mcp.yaml
+  - base-apps/kagent/plex-stack-mcp.yaml
+  - base-apps/kagent/plex-stack-mcp-remote.yaml
+  - base-apps/kagent/mcp-ingress.yaml
+  - base-apps/kagent/nginx-ingress.yaml
+---
+
+# kagent
+
+## What it is
+kagent is a Kubernetes-native AI agent platform: a controller (installed via Helm, `base-apps/kagent.yaml`, `chart: kagent`, `repoURL: ghcr.io/kagent-dev/kagent/helm`, `targetRevision: 0.9.4`) that reconciles declarative CRDs — `Agent`, `ModelConfig`, `MCPServer`, `RemoteMCPServer` — into running agent workloads. The CRDs themselves come from a sibling Helm install, `base-apps/kagent-crds.yaml` (`chart: kagent-crds`, same repo/version). Both are deployed into the `kagent` namespace.
+
+## Two Argo CD apps, one namespace
+- **`base-apps/kagent.yaml`** installs the controller/UI/bundled agents via Helm `valuesObject` (no `path: base-apps/kagent`, so it has no directory-exclude concern). Notable values: the LLM provider (`providers.default: anthropic`, model `claude-haiku-4-5-20251001`, key from `apiKeySecretRef: kagent-anthropic`), the database wiring (`database.postgres.bundled.enabled: false`, `urlFile: /etc/kagent/secrets/db-url`, `vectorEnabled: true`, sourced from a mounted `kagent-db-credentials` Secret), per-agent enable/resource overrides for the chart's bundled agents (`k8s-agent`, `helm-agent`, `observability-agent`, `argo-rollouts-agent`, `istio-agent`, `kgateway-agent`; several others disabled), OpenTelemetry export to Coroot, and a custom UI image (Node 20 build, ECR) to work around a SIGILL on older host CPUs.
+- **`base-apps/kagent-secrets.yaml`** (`path: base-apps/kagent`, `directory: {recurse: true}`) syncs everything in this directory: the declarative `Agent`, `ModelConfig`, `MCPServer`/`RemoteMCPServer` manifests, and the `SecretStore`/`ExternalSecret`s that back them. This is the Application whose `directory.exclude` covers `catalog-info.yaml`.
+
+## Model configs
+- **`default-model-config`** — the chart's default `ModelConfig`, generated from the `providers` block in `kagent.yaml` (Anthropic, `claude-haiku-4-5-20251001`). Used by simple/low-context agents (e.g. `agents/dungeon-crawler-carl-agent.yaml`, `agents/skill-suggester.yaml`, `build-orchestrator.yaml`).
+- **`anthropic-claude-sonnet-4-6`** — a sonnet-tier `ModelConfig` referenced by `agents/homelab-knowledge.yaml` and `agents/plex-stack-diagnostics.yaml` (both need larger context/more reliable tool-calling for multi-step delegation); its manifest is not present in this directory, so it is managed out-of-band from GitOps.
+- **`embedding-model-config`** (`embedding-model-config.yaml`) — points at **Ollama** (`http://ollama.ollama.svc.cluster.local:11434`, model `nomic-embed-text`), used as every declarative agent's `memory.modelConfig` for RAG/embedding recall. This is why the `kagent` component depends on `ollama`.
+
+## Tools via MCP servers
+Agents get tools by referencing `MCPServer`/`RemoteMCPServer` objects in their `spec.declarative.tools`. Two patterns exist side by side:
+- **stdio proxy**: `agent-docs-mcp.yaml` deploys the read-only GitHub MCP server (`ghcr.io/github/github-mcp-server`, `--read-only --toolsets repos`) as a container; `agent-docs-mcp-remote.yaml` is the `RemoteMCPServer` that registers its tools (`get_file_contents`, `search_code`) with kagent — a container-only `MCPServer` does not register tools in this kagent version, only a `RemoteMCPServer` does.
+- **HTTP server**: `plex-stack-mcp.yaml` runs a FastMCP HTTP process directly (streamable-HTTP on `:3000`, path `/mcp`); `plex-stack-mcp-remote.yaml` registers its tools (`plex_status`, `plex_sessions`, `qbit_status`, `plex_scan_library`, `qbit_resume`, `qbit_recheck`) for `agents/plex-stack-diagnostics.yaml`.
+- **In-cluster remote**: `backstage-catalog-mcp.yaml` points at Backstage's own MCP endpoint (`http://backstage.backstage.svc.cluster.local/api/mcp-actions/v1/catalog`) for resolved-entity/dependency lookups (`get-catalog-entity`), with the `Authorization` header injected from the `backstage-mcp-token` Secret.
+
+Agents only get the `toolNames` they explicitly list (e.g. `agents/homelab-knowledge.yaml` binds `get_file_contents`/`search_code` from `agent-docs` plus `get-catalog-entity` from `backstage-catalog`, and delegates to the bundled `k8s-agent`/`helm-agent` via `type: Agent` tool entries) — an unlisted tool resolves to nothing and the agent reports "Unknown Tool".
+
+## Secrets & database
+All Secrets in `base-apps/kagent/` flow through Vault: `secret-store.yaml` defines the `vault-backend` `SecretStore` (`http://vault.vault.svc.cluster.local:8200`, KV v2 path `k8s-secrets`, Kubernetes-auth role `kagent`). `ExternalSecret`s pull from Vault key `kagent` (DB creds, GitHub token, Backstage MCP token) and key `plex-stack-mcp` (Plex/qBittorrent creds); `mcp-basic-auth-external-secret.yaml` pulls the `/mcp` ingress basic-auth htpasswd blob.
+
+kagent uses the **shared PostgreSQL** instance (`base-apps/postgresql/`) rather than the chart's bundled DB (`database.postgres.bundled.enabled: false` in `kagent.yaml`): `external-secrets.yaml` here syncs `kagent-db-credentials` (`db-url`, `db-user`, `db-password`, `db-name`) from Vault key `kagent`, matching the `kagent` role/database that `postgresql`'s `init-kagent-db` Job provisions with the `vector` extension enabled (see `base-apps/postgresql/docs.md`). The controller mounts that Secret's `db-url` at `/etc/kagent/secrets/db-url` (`kagent.yaml`'s `controller.volumes`/`volumeMounts`).
+
+## Exposure
+The UI is at `kagent.arigsela.com` (`nginx-ingress.yaml`, IP-whitelisted). Agents are also invocable over **A2A**: each agent's Backstage annotations (e.g. `agents.platform.ai/a2a-endpoint` in `agents/dungeon-crawler-carl-agent.yaml`) point at `http://<agent>.kagent.svc.cluster.local:8080`. External MCP clients (e.g. Claude Code CLI) reach the controller's `/mcp` endpoint (`invoke_agent`/`list_agents`) via `mcp-ingress.yaml`, which fronts `kagent-controller:8083` at `kagent.arigsela.com/mcp`, gated by the same IP whitelist plus HTTP basic auth (`kagent-mcp-basic-auth`, since `/mcp` has no auth of its own).

--- a/base-apps/kagent/runbook.md
+++ b/base-apps/kagent/runbook.md
@@ -1,0 +1,44 @@
+---
+app: kagent
+catalog_entity: kagent
+kind: runbook
+namespace: kagent
+last_reviewed: 2026-07-10
+status: current
+tags: [ai-agent, kagent, mcp, anthropic]
+sources:
+  - base-apps/kagent.yaml
+  - base-apps/kagent-secrets.yaml
+  - base-apps/kagent/embedding-model-config.yaml
+  - base-apps/kagent/agents/homelab-knowledge.yaml
+  - base-apps/kagent/agent-docs-mcp-remote.yaml
+  - base-apps/kagent/plex-stack-mcp-remote.yaml
+  - base-apps/kagent/external-secrets.yaml
+---
+
+# kagent — Runbook
+
+## Failure modes
+
+### Symptom: an `Agent` is not `Ready` (chat/A2A calls fail)
+- **Check:** `kubectl -n kagent get agents` for the `Ready` column, then `kubectl -n kagent describe agent <name>` for the condition/reason. Also confirm the `ModelConfig` it references exists: `kubectl -n kagent get modelconfigs` — every declarative agent sets `spec.declarative.modelConfig` (e.g. `default-model-config`, `anthropic-claude-sonnet-4-6`) and `spec.declarative.memory.modelConfig: embedding-model-config` (`agents/homelab-knowledge.yaml`); a missing or misnamed `ModelConfig` leaves the agent unable to reconcile. Check the controller logs for the underlying error: `kubectl -n kagent logs deploy/kagent-controller --tail=100`.
+- **Fix:** if a `ModelConfig` reference is wrong or the Anthropic API key rotated, open a PR fixing the `modelConfig` name in the agent's manifest (or, for `default-model-config`, the `providers` block in `base-apps/kagent.yaml`) — Argo CD self-heals on merge. If the Anthropic API key itself needs rotating, update the `kagent-anthropic` Vault secret (referenced by `apiKeySecretRef: kagent-anthropic` in `kagent.yaml`) rather than the manifest.
+
+### Symptom: an agent reports "Unknown Tool", or a `RemoteMCPServer` shows `toolCount: 0`
+- **Check:** `kubectl -n kagent get remotemcpservers` for `toolCount`/status, and `kubectl -n kagent describe remotemcpserver <name>` (e.g. `agent-docs`, `backstage-catalog`, `plex-stack-mcp`) for connection errors. If it's a container-backed server (`agent-docs-mcp`, `plex-stack-mcp`), also check the backing pod: `kubectl -n kagent get pods -l app.kubernetes.io/name=agent-docs-mcp` / `plex-stack-mcp` and its logs. This is a common gap: a container `MCPServer` only *deploys* the server — the matching `RemoteMCPServer` is what *registers* its tools with kagent (see `agent-docs-mcp-remote.yaml`), and an agent only gets the specific `toolNames` it lists in `spec.declarative.tools[].mcpServer.toolNames` — anything not listed there resolves to nothing at agent-invocation time.
+- **Fix:** if the `RemoteMCPServer` itself can't reach its target (`url:` in `agent-docs-mcp-remote.yaml`/`plex-stack-mcp-remote.yaml`), check the target Service/pod is healthy first. If tools are missing because an agent's `toolNames` list is stale (a new tool was added upstream, or a typo), open a PR updating the agent's `spec.declarative.tools[].mcpServer.toolNames`.
+
+### Symptom: agents fail on memory/embedding calls (RAG lookups error or time out)
+- **Check:** every declarative agent's `memory.modelConfig: embedding-model-config` (`embedding-model-config.yaml`) points at `http://ollama.ollama.svc.cluster.local:11434` (model `nomic-embed-text`). Confirm Ollama is up: `kubectl -n ollama get pods` and `kubectl -n ollama logs deploy/ollama --tail=50`; confirm the `ModelConfig` resolved correctly in kagent: `kubectl -n kagent describe modelconfig embedding-model-config`.
+- **Fix:** this is a dependency on the `ollama` component, not a kagent config problem — see `base-apps/ollama/runbook.md` for Ollama-specific recovery. If Ollama is healthy but kagent still can't reach it, restart the controller so it re-resolves the endpoint: `kubectl -n kagent rollout restart deploy/kagent-controller`.
+
+## How-to
+
+### Deploy / update
+Edit the Helm `valuesObject` in `base-apps/kagent.yaml` (controller/UI/bundled-agent config) or the declarative CRDs under `base-apps/kagent/` (custom agents, MCP servers, model configs, secrets) and open a PR; Argo CD (`kagent` and `kagent-secrets` Applications, both `prune`/`selfHeal`) syncs on merge into `main`.
+
+### Rotate a Vault-backed secret
+All Secrets here (`kagent-db-credentials`, `agent-docs-github-mcp-token`, `backstage-mcp-token`, `plex-stack-mcp-creds`, `kagent-mcp-basic-auth`) are `ExternalSecret`s resolving from the `vault-backend` `SecretStore` (`secret-store.yaml`, Vault key `kagent` or `plex-stack-mcp`, `refreshInterval: 1h`). Update the value at the corresponding Vault path directly (never in Git) — External Secrets Operator picks it up within the refresh interval, or force it immediately: `kubectl -n kagent annotate externalsecret <name> force-sync=$(date +%s) --overwrite`.
+
+### Restart the controller
+`kubectl -n kagent rollout restart deploy/kagent-controller` — safe; agents reconcile again once the controller is back. Verify with `kubectl -n kagent get pods -l app.kubernetes.io/name=kagent` and `kubectl -n kagent get agents`.

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -10,3 +10,4 @@ weather-kitchen-backend
 weather-kitchen-frontend
 n8n
 ollama
+kagent


### PR DESCRIPTION
Onboards **kagent** — the Kubernetes-native AI agent platform — into the agent-docs framework (standalone, from the deferred tier; requested to close the `dependsOn: ollama` catalog gap the agent itself flagged).

## What
- `base-apps/kagent/catalog-info.yaml` (`Component`, system `platform-ai`) with **grounded `dependsOn`**: `component:ollama/ollama` (embeddings), `resource:vault/vault` (secrets), `resource:postgresql/postgresql` (kagent DB — `init-kagent-db` Job provisions it with pgvector; bundled postgres disabled).
- `docs.md` + `runbook.md` covering the controller (Helm), declarative Agents/ModelConfigs/MCP servers, secret flow, and the real failure modes we've actually hit (Agent not Ready; `RemoteMCPServer toolCount:0` / "Unknown Tool"; ollama-down embeddings).
- `_INDEX.md` row + `scope.txt` entry.
- `directory.exclude: catalog-info.yaml` added to **`kagent-secrets.yaml`** (the Application that syncs `base-apps/kagent`, preserving its `recurse: true`) — NOT the Helm-chart `kagent.yaml`.

## Review
Reviewer subagent: spec compliance ✅; quality approved; every `dependsOn` ref hand-verified against the target entities; out-of-band sonnet ModelConfig correctly hedged (not invented). One Minor nit fixed (added `mcp-basic-auth-external-secret.yaml` to `sources:`). Validator: **13 apps in scope, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1