### PR TITLE
docs(agent-docs): onboard base-apps batch 3 (backstage, atlantis, coroot, logging)

### DIFF
--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -30,7 +30,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | docs.md | runbook.md | catalog-info.yaml |
 | kube-system | | | | | |
 | kyverno-policies | | | | | |
-| logging | | | | | |
+| logging | Observability stack (Alloy collector, Loki logs on S3, Prometheus metrics, Grafana) | logging | docs.md | runbook.md | catalog-info.yaml |
 | loki-aws-infrastructure | | | | | |
 | n8n | Workflow automation platform (shared PostgreSQL, Vault, admin UI + public webhooks) | n8n | docs.md | runbook.md | catalog-info.yaml |
 | nginx-ingress | Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware) | ingress-nginx | docs.md | runbook.md | catalog-info.yaml |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -19,7 +19,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | chores-tracker | | | | | |
 | chores-tracker-frontend | HTMX/nginx web frontend for Chores Tracker | chores-tracker-frontend | docs.md | runbook.md | catalog-info.yaml |
 | cluster-scanner | | | | | |
-| coroot | | | | | |
+| coroot | eBPF-based observability/APM (Coroot operator + instance, node/cluster agents, ClickHouse) | coroot | docs.md | runbook.md | catalog-info.yaml |
 | crossplane-aws-provider | | | | | |
 | crossplane-compositions | | | | | |
 | crossplane-functions | | | | | |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -14,7 +14,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | argo-workflow-tasks | | | | | |
 | argo-workflows | | | | | |
 | argo-workflows-aws-infrastructure | | | | | |
-| atlantis | | | | | |
+| atlantis | Terraform/OpenTofu PR automation (Atlantis, GitHub + AWS auth via Vault, Infracost) | atlantis | docs.md | runbook.md | catalog-info.yaml |
 | backstage | Internal developer portal / software catalog (Backstage, shared PostgreSQL, Vault, kubernetes-ingestor) | backstage | docs.md | runbook.md | catalog-info.yaml |
 | chores-tracker | | | | | |
 | chores-tracker-frontend | HTMX/nginx web frontend for Chores Tracker | chores-tracker-frontend | docs.md | runbook.md | catalog-info.yaml |

--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -15,7 +15,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | argo-workflows | | | | | |
 | argo-workflows-aws-infrastructure | | | | | |
 | atlantis | | | | | |
-| backstage | | | | | |
+| backstage | Internal developer portal / software catalog (Backstage, shared PostgreSQL, Vault, kubernetes-ingestor) | backstage | docs.md | runbook.md | catalog-info.yaml |
 | chores-tracker | | | | | |
 | chores-tracker-frontend | HTMX/nginx web frontend for Chores Tracker | chores-tracker-frontend | docs.md | runbook.md | catalog-info.yaml |
 | cluster-scanner | | | | | |

--- a/base-apps/atlantis-config.yaml
+++ b/base-apps/atlantis-config.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/atlantis
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: atlantis

--- a/base-apps/atlantis/catalog-info.yaml
+++ b/base-apps/atlantis/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: atlantis
+  namespace: atlantis
+  annotations:
+    agent-docs/path: docs.md
+  tags: [terraform, opentofu, gitops, ci-cd]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-gitops
+  dependsOn:
+    - resource:vault/vault

--- a/base-apps/atlantis/docs.md
+++ b/base-apps/atlantis/docs.md
@@ -1,0 +1,83 @@
+---
+app: atlantis
+catalog_entity: atlantis
+kind: docs
+namespace: atlantis
+last_reviewed: 2026-07-10
+status: current
+tags: [terraform, opentofu, gitops, ci-cd]
+sources:
+  - base-apps/atlantis.yaml
+  - base-apps/atlantis-config.yaml
+  - base-apps/atlantis/external-secrets.yaml
+  - base-apps/atlantis/secret-store.yaml
+  - base-apps/atlantis/network-policy.yaml
+  - base-apps/atlantis/nginx-ingress.yaml
+---
+
+# atlantis
+
+## What it is
+[Atlantis](https://www.runatlantis.io/) runs Terraform/OpenTofu `plan`/`apply`
+as PR comments/checks against `github.com/arigsela/kubernetes`
+(`orgAllowlist: github.com/arigsela/*`, `base-apps/atlantis.yaml`), covering
+the `terraform/roots/asela-cluster` root described elsewhere in this repo.
+It is deployed by **two** Argo CD Applications: `base-apps/atlantis.yaml`
+installs the upstream Helm chart (`runatlantis/atlantis` 6.1.0, the server
+itself — image `infracost/infracost-atlantis:atlantis0.40-infracost0.10`,
+which bundles Infracost cost estimation), and
+`base-apps/atlantis-config.yaml` syncs `base-apps/atlantis/` (its
+`ExternalSecret`s, `SecretStore`, `NetworkPolicy`, and `Ingress`).
+
+## OpenTofu distribution
+The chart values set `defaultTFDistribution: opentofu` /
+`defaultTFVersion: "1.12.3"` (`base-apps/atlantis.yaml`). This is a deliberate
+workaround: Atlantis's Terraform-binary downloads verify HashiCorp's GPG
+release signature, which expired, breaking `terraform` binary downloads with
+`unable to verify checksums signature: openpgp: key expired`. OpenTofu is
+signed independently, so switching the default distribution sidesteps the
+issue. `providers.tf` requires `>= 1.11.0`; OpenTofu `1.12.3` satisfies that.
+
+## Auth: GitHub + AWS via Vault
+Two `ExternalSecret`s (`base-apps/atlantis/external-secrets.yaml`) resolve
+from Vault through the `vault-backend` `SecretStore`
+(`base-apps/atlantis/secret-store.yaml`, Kubernetes auth role `atlantis`,
+`k8s-secrets` KV v2 mount at `http://vault.vault.svc.cluster.local:8200`):
+- `atlantis-vcs` (Vault key `atlantis/github`, `atlantis/webhook`) — the
+  GitHub token and webhook secret, wired into the chart via
+  `vcsSecretName: atlantis-vcs`.
+- `atlantis-env` (Vault keys `atlantis/aws`, `atlantis/infracost`,
+  `atlantis/k8s`) — AWS access key/secret (for the AWS provider Atlantis
+  plans/applies against), the Infracost API key, and `TF_VAR_host` /
+  `TF_VAR_client_certificate` / `TF_VAR_client_key` /
+  `TF_VAR_cluster_ca_certificate` (Kubernetes provider credentials for the TF
+  root), injected as env vars via the chart's `environmentSecrets`.
+
+## Repo config and apply gating
+`repoConfig` (`base-apps/atlantis.yaml`) allows custom workflows for
+`github.com/arigsela/kubernetes` and sets server-side
+`apply_requirements: [approved, mergeable]` — `apply` only runs once the PR
+is approved and mergeable (`allowed_overrides` lets a PR override `workflow`
+or `apply_requirements` locally).
+
+## Network policy and ingress
+`base-apps/atlantis/network-policy.yaml` restricts the `atlantis` pod to:
+ingress from the `nginx-ingress` namespace on port `4141` only; egress for
+DNS (53), Vault in the `vault` namespace (8200), the Kubernetes API server on
+443/6443 (excluding RFC1918 ranges), and HTTPS (443) generally (GitHub API +
+AWS APIs). `base-apps/atlantis/nginx-ingress.yaml` fronts the chart's
+`atlantis` Service (port 4141) at `atlantis.arigsela.com` (TLS via
+`letsencrypt-prod`), with `whitelist-source-range` limited to the operator's
+IPs plus GitHub's published webhook-delivery CIDRs.
+
+## Where config lives
+- Server/chart values (image, OpenTofu distribution, `repoConfig`, secret
+  wiring, resources, volume): `base-apps/atlantis.yaml`.
+- Config-only sync path (no `path:` change needed for chart upgrades):
+  `base-apps/atlantis-config.yaml` → `base-apps/atlantis/`.
+- Secrets: `base-apps/atlantis/external-secrets.yaml` +
+  `base-apps/atlantis/secret-store.yaml`.
+- Network: `base-apps/atlantis/network-policy.yaml`.
+- Exposure: `base-apps/atlantis/nginx-ingress.yaml`.
+- Working directory persistence: `volumeClaim` (5Gi, `local-path`,
+  `ReadWriteOnce`) in `base-apps/atlantis.yaml`.

--- a/base-apps/atlantis/runbook.md
+++ b/base-apps/atlantis/runbook.md
@@ -1,0 +1,61 @@
+---
+app: atlantis
+catalog_entity: atlantis
+kind: runbook
+namespace: atlantis
+last_reviewed: 2026-07-10
+status: current
+tags: [terraform, opentofu, gitops, ci-cd]
+sources:
+  - base-apps/atlantis.yaml
+  - base-apps/atlantis-config.yaml
+  - base-apps/atlantis/external-secrets.yaml
+  - base-apps/atlantis/secret-store.yaml
+---
+
+# atlantis runbook
+
+## Failure modes
+
+### Symptom: `plan`/`apply` fails with `unable to verify checksums signature: openpgp: key expired`
+This is the well-known HashiCorp release-signing-key expiry breaking
+Terraform binary downloads. It's why `base-apps/atlantis.yaml` already sets
+`defaultTFDistribution: opentofu` / `defaultTFVersion: "1.12.3"` instead of
+downloading `terraform`.
+- **Check:** `kubectl -n atlantis logs deploy/atlantis | grep -i "distribution\|checksums signature"` — confirm the pod actually rendered
+  `ATLANTIS_DEFAULT_TF_DISTRIBUTION=opentofu` (the older `--tf-distribution`
+  flag/env is deprecated and silently ignored by Atlantis 0.40, so a stale
+  value here is the usual regression). Also check the PR's `atlantis plan`
+  comment for the specific error.
+- **Fix:** PR a change to `base-apps/atlantis.yaml`'s Helm `values` —
+  confirm `defaultTFDistribution: opentofu` (not `tofu`) and bump
+  `defaultTFVersion` only to an OpenTofu release that still satisfies
+  `providers.tf`'s `>= 1.11.0` constraint.
+
+### Symptom: `apply` never runs even though `plan` succeeded
+`repoConfig` in `base-apps/atlantis.yaml` sets server-side
+`apply_requirements: [approved, mergeable]` for
+`github.com/arigsela/kubernetes` — Atlantis refuses `apply` until the PR is
+both approved and mergeable (no failing checks, no conflicts).
+- **Check:** the PR's review/mergeable status on GitHub, and
+  `kubectl -n atlantis logs deploy/atlantis | grep -i "apply_requirements\|not mergeable\|not approved"`.
+- **Fix:** get the PR approved and green, or PR a change to `repoConfig` if
+  the requirement itself needs adjusting (it's in `allowed_overrides`, so a
+  PR can locally override `apply_requirements` in its own `atlantis.yaml` if
+  that's genuinely warranted).
+
+### Symptom: `plan`/`apply` fails on GitHub auth, AWS auth, or a `TF_VAR_*` value
+The chart sources GitHub (`vcsSecretName: atlantis-vcs`) and
+AWS/Infracost/Kubernetes-provider credentials
+(`environmentSecrets` → `atlantis-env`) entirely from Vault via
+`base-apps/atlantis/external-secrets.yaml` / `secret-store.yaml`.
+- **Check:** `kubectl -n atlantis get externalsecret atlantis-vcs atlantis-env` (look for `SecretSynced` status) and
+  `kubectl -n atlantis get secretstore vault-backend -o yaml`. A `SecretSyncedError` here means Vault (role `atlantis`,
+  `k8s-secrets` KV v2 path) doesn't have current values at `atlantis/github`,
+  `atlantis/webhook`, `atlantis/aws`, `atlantis/infracost`, or `atlantis/k8s`.
+- **Fix:** rotate/update the relevant value in Vault at the affected
+  `remoteRef.key`/`property` (see `external-secrets.yaml` for the exact
+  mapping); ExternalSecrets Operator re-syncs on its `refreshInterval: 1h` or
+  can be forced sooner. If the `SecretStore` itself is failing, verify
+  Vault's `atlantis` Kubernetes-auth role/policy grants `k8s-secrets` read
+  (see `base-apps/vault` runbook for Vault-side auth checks).

--- a/base-apps/backstage.yaml
+++ b/base-apps/backstage.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/backstage
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: backstage

--- a/base-apps/backstage/catalog-info.yaml
+++ b/base-apps/backstage/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  namespace: backstage
+  annotations:
+    agent-docs/path: docs.md
+  tags: [backstage, developer-portal, catalog, kubernetes-ingestor]
+spec:
+  type: website
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-tooling
+  dependsOn:
+    - resource:postgresql/postgresql
+    - resource:vault/vault

--- a/base-apps/backstage/docs.md
+++ b/base-apps/backstage/docs.md
@@ -1,0 +1,86 @@
+---
+app: backstage
+catalog_entity: backstage
+kind: docs
+namespace: backstage
+last_reviewed: 2026-07-10
+status: current
+tags: [backstage, developer-portal, catalog, kubernetes-ingestor]
+sources:
+  - base-apps/backstage/deployments.yaml
+  - base-apps/backstage/configmaps.yaml
+  - base-apps/backstage/external-secrets.yaml
+  - base-apps/backstage/secret-store.yaml
+  - base-apps/backstage/rbac.yaml
+  - base-apps/backstage/nginx-ingress.yaml
+  - base-apps/backstage/services.yaml
+---
+
+# backstage
+
+## What it is
+The internal developer portal / software catalog (Backstage), running a custom
+image `852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.5`
+(`deployments.yaml`). It is the platform's software catalog UI and scaffolder,
+and (per the RBAC below) also ingests live cluster/Crossplane resources and
+renders kagent agent detail cards. Note: Backstage's `app-config.yaml` (catalog
+providers, the TeraSky `kubernetes-ingestor` plugin config, MCP Actions
+backend) is baked into the container image, not present as a manifest in this
+directory — this doc only covers what the Kubernetes manifests and env
+actually show.
+
+## Architecture & data flow
+A single-replica `Deployment` (`deployments.yaml`, port `7007`) fronted by a
+ClusterIP `Service` (`services.yaml`, port `80` -> `7007`) and an nginx
+`Ingress` (`nginx-ingress.yaml`) terminating TLS at `backstage.arigsela.com`
+(cert via `letsencrypt-prod`, source IPs restricted by
+`nginx.ingress.kubernetes.io/whitelist-source-range`).
+
+Config is split between a `ConfigMap` (`backstage-config`, `configmaps.yaml`)
+and a Vault-backed `Secret` (`backstage-secrets`, `external-secrets.yaml`),
+both wired in via `envFrom`:
+- **Database**: `POSTGRES_HOST=postgresql.postgresql.svc.cluster.local`,
+  `POSTGRES_PORT=5432` (`configmaps.yaml`) — the shared PostgreSQL instance
+  (see `base-apps/postgresql`). Credentials (`POSTGRES_USER`,
+  `POSTGRES_PASSWORD`) come from Vault.
+- **Vault**: `VAULT_ADDR=http://vault.vault.svc.cluster.local:8200`
+  (`configmaps.yaml`) is used by the `vault:setup` scaffolder action; the
+  `SecretStore` `vault-backend` (`secret-store.yaml`) resolves the
+  `backstage-secrets` `ExternalSecret` from the `k8s-secrets` KV v2 mount
+  using the Kubernetes auth method (role `backstage`).
+- **Secrets from Vault** (`external-secrets.yaml`, key `backstage`): Postgres
+  creds, a GitHub token + GitHub OAuth client id/secret (catalog
+  ingestion/auth), a Kubernetes cluster URL + service account token (for the
+  Kubernetes/kubernetes-ingestor plugins), AWS access keys (ECR scaffolder
+  actions `aws:ecr:create`/`aws:ecr:build-push`, region `us-east-2` per
+  `AWS_DEFAULT_REGION`), a Vault token (the `vault:setup` scaffolder action),
+  and an `MCP_TOKEN` (static bearer token the MCP Actions backend accepts on
+  `/api/mcp-actions/v1/catalog`, shared with kagent).
+
+## RBAC / cluster ingestion
+The `backstage` `ServiceAccount` (`rbac.yaml`) is bound to three
+`ClusterRole`s:
+- `backstage-read-only` — read-only on core workload/network objects (pods,
+  services, deployments, ingresses, jobs, HPAs, etc.) for the Kubernetes
+  plugin.
+- `backstage-crossplane-read` — read on CRDs, Crossplane core APIs (XRDs,
+  Compositions, Functions), this platform's own `platform.arigsela.com` XRs,
+  managed resources (`postgresql.cnpg.io`, `s3.aws.upbound.io`,
+  `iam.aws.upbound.io`), and External Secrets Operator objects
+  (`secretstores`/`pushsecrets`/`externalsecrets`) — this is what the TeraSky
+  `kubernetes-ingestor` plugin needs to discover XRDs/Compositions and walk
+  composed resources into catalog entities.
+- `backstage-kagent-read` — read on `kagent.dev` `agents`/`modelconfigs`/
+  `remotemcpservers`, used by the Backstage entity-page card that fetches the
+  live kagent `Agent` CRD through the Kubernetes plugin proxy.
+
+## Where config lives
+- Runtime env: `configmaps.yaml` (Postgres host/port, AWS region, Vault addr).
+- Secrets: `external-secrets.yaml` + `secret-store.yaml` (Vault, key
+  `backstage`, `k8s-secrets` KV v2 path).
+- RBAC for cluster/Crossplane/kagent ingestion: `rbac.yaml`.
+- Exposure: `services.yaml` (ClusterIP `80`->`7007`) + `nginx-ingress.yaml`
+  (`backstage.arigsela.com`).
+- Catalog wiring for other apps: each `base-apps/<app>/catalog-info.yaml` is
+  the entity Backstage's catalog providers ingest — see
+  `templates/agent-docs/README.md` for the contract.

--- a/base-apps/backstage/runbook.md
+++ b/base-apps/backstage/runbook.md
@@ -1,0 +1,36 @@
+---
+app: backstage
+catalog_entity: backstage
+kind: runbook
+namespace: backstage
+last_reviewed: 2026-07-10
+status: current
+tags: [backstage, developer-portal, catalog, kubernetes-ingestor]
+sources:
+  - base-apps/backstage/deployments.yaml
+  - base-apps/backstage/external-secrets.yaml
+  - base-apps/backstage/secret-store.yaml
+  - base-apps/backstage/rbac.yaml
+---
+
+# backstage — Runbook
+
+## Failure modes
+### Symptom: pod CrashLoopBackOff / fails readiness on startup
+- **Check:** `kubectl -n backstage get pods` and `kubectl -n backstage logs deploy/backstage`; also `kubectl -n backstage get externalsecret,secret backstage-secrets` to confirm the `ExternalSecret` synced (the `Deployment` uses `envFrom.secretRef: backstage-secrets`, so a missing/stale Secret means Postgres, GitHub, AWS, Vault, and MCP env vars are all absent).
+- **Fix:** if the `ExternalSecret` is not Ready, check the `vault-backend` `SecretStore` (`secret-store.yaml`) — role `backstage` against Vault at `vault.vault.svc.cluster.local:8200`, key `backstage`. If Vault itself is sealed/unreachable, see `base-apps/vault/runbook.md`. Once Vault resolves, ESO recreates the Secret (`refreshInterval: 1h`); the pod will still need a restart to pick up new env values (`kubectl -n backstage rollout restart deploy/backstage`).
+
+### Symptom: Crossplane/XR resources tab shows nothing, or kubernetes-ingestor logs 403 Forbidden
+- **Check:** `kubectl -n backstage logs deploy/backstage | grep -i forbidden` and confirm the RBAC bindings exist: `kubectl get clusterrolebinding backstage-crossplane-read backstage-read-only backstage-kagent-read -o wide` (all three bind the `backstage` ServiceAccount, `rbac.yaml`).
+- **Fix:** if a binding or its `ClusterRole` is missing/out of date for a new resource type the ingestor now needs to walk (e.g. a new managed-resource API group), open a PR adding the `apiGroups`/`resources` to the relevant `ClusterRole` in `base-apps/backstage/rbac.yaml`.
+
+### Symptom: catalog entity page 404s / new `base-apps/<app>/catalog-info.yaml` doesn't show up
+- **Check:** confirm the entity's `catalog-info.yaml` is valid and its Argo CD Application excludes it from sync (`spec.source.directory.exclude` covering `catalog-info.yaml`, per `templates/agent-docs/README.md`) — the file must exist in the repo but not be applied as a Kubernetes manifest.
+- **Fix:** the catalog provider config lives in the baked-in `app-config.yaml` (inside the `backstage-portal` image), not in this directory — if the provider itself needs reconfiguring, that requires a new image build/tag bump in `deployments.yaml`, not a manifest change here.
+
+## How-to
+### Deploy / update
+Edit manifests in this directory (or bump the `image:` tag in `deployments.yaml`) and open a PR; Argo CD syncs on merge to `main`.
+
+### Rotate a Vault secret (e.g. GitHub token, AWS keys, MCP token)
+Update the value under Vault key `backstage` (property matching the field in `external-secrets.yaml`, e.g. `github-token`, `aws-access-key-id`, `mcp-token`); ESO re-syncs the `backstage-secrets` Secret within the 1h `refreshInterval`. Restart the Deployment to pick up the new env values immediately: `kubectl -n backstage rollout restart deploy/backstage`.

--- a/base-apps/coroot.yaml
+++ b/base-apps/coroot.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/coroot
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: coroot

--- a/base-apps/coroot/catalog-info.yaml
+++ b/base-apps/coroot/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: coroot
+  namespace: coroot
+  annotations:
+    agent-docs/path: docs.md
+  tags: [observability, ebpf, apm, clickhouse]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-observability

--- a/base-apps/coroot/catalog-info.yaml
+++ b/base-apps/coroot/catalog-info.yaml
@@ -11,3 +11,6 @@ spec:
   lifecycle: production
   owner: group:default/platform
   system: default/platform-observability
+  dependsOn:
+    # coroot-instance.yaml externalPrometheus.url points at the logging stack's Prometheus.
+    - component:logging/logging

--- a/base-apps/coroot/docs.md
+++ b/base-apps/coroot/docs.md
@@ -1,0 +1,60 @@
+---
+app: coroot
+catalog_entity: coroot
+kind: docs
+namespace: coroot
+last_reviewed: 2026-07-10
+status: current
+tags: [observability, ebpf, apm, clickhouse]
+sources:
+  - base-apps/coroot/coroot-operator.yaml
+  - base-apps/coroot/coroot-instance.yaml
+  - base-apps/coroot/ingress.yaml
+  - base-apps/coroot/namespace-config.yaml
+---
+
+# coroot
+
+## What it is
+[Coroot](https://coroot.com) is an eBPF-based observability/APM platform: it auto-instruments
+services at the node level (no code changes) to collect metrics, distributed traces, logs, and
+continuous CPU/memory profiles, and correlates them into a service map and root-cause views.
+
+## Architecture & deploy model: operator + instance split
+This app is deployed in two layers, both sourced from `base-apps/coroot/`:
+
+1. **Operator** (`coroot-operator.yaml`) — a *nested* Argo CD `Application` named `coroot-operator`
+   that installs the `coroot-operator` Helm chart (`coroot.github.io/helm-charts`, version `0.6.0`)
+   into the `coroot` namespace. Unlike every other app in this repo, this Application manifest is
+   not a top-level `base-apps/*.yaml` file — it lives inside `base-apps/coroot/` and is applied as
+   part of the `coroot` app's own sync, which is what bootstraps the second, independently-synced
+   `coroot-operator` Application (visible in Argo CD as its own app).
+2. **Instance** (`coroot-instance.yaml`) — a `Coroot` custom resource (`coroot.com/v1`) that the
+   operator (once installed) reconciles into the actual Coroot workloads: the Coroot server,
+   a bundled ClickHouse, a per-node eBPF agent, and a cluster agent.
+
+## What it observes and how
+The `Coroot` CR (`coroot-instance.yaml`) configures:
+- **Node Agent** (`nodeAgent`): eBPF-based tracer and profiler (`ebpfTracer.enabled: true`,
+  `ebpfProfiler.enabled: true`) plus log collection (`logCollector`), tolerating all taints
+  (`tolerations: [{operator: Exists}]`) so it runs on every node — hence
+  `namespace-config.yaml` labels the `coroot` namespace `pod-security.kubernetes.io/enforce: privileged`,
+  required for the agent's privileged access.
+- **Cluster Agent** (`clusterAgent`): collects Kubernetes object metadata.
+- **Metrics refresh**: `metricsRefreshInterval: 15s`, `cacheTTL: 30d`.
+
+## Storage: external Prometheus, bundled ClickHouse
+- **Metrics**: Coroot does **not** bundle its own Prometheus — it points at the cluster's existing
+  one via `externalPrometheus.url: http://prometheus.logging.svc.cluster.local:9090` (the
+  `logging` app's Prometheus, `base-apps/logging/prometheus-statefulset.yaml`).
+- **Traces / logs / profiles**: Coroot bundles its own single-shard, single-replica **ClickHouse**
+  (`clickhouse: {shards: 1, replicas: 1}`), backed by a 20Gi `local-path` PVC. Retention is
+  `tracesTTL`/`logsTTL`/`profilesTTL`: `7d` each.
+- **Coroot server data**: a separate 10Gi `local-path` PVC (`storage.size: 10Gi`).
+- Single replica for both the Coroot server and ClickHouse (`replicas: 1` at each level) — no HA.
+
+## Ingress
+`ingress.yaml` exposes the `coroot-coroot` Service (port `8080`) at `coroot.arigsela.com` via the
+shared `nginx` IngressClass, TLS from `letsencrypt-prod` (`cert-manager.io/cluster-issuer`), with a
+`nginx.ingress.kubernetes.io/whitelist-source-range` restricting access to a short list of home/LAN
+IPs, and long (`600s`) read/send timeouts for dashboard loading.

--- a/base-apps/coroot/runbook.md
+++ b/base-apps/coroot/runbook.md
@@ -1,0 +1,64 @@
+---
+app: coroot
+catalog_entity: coroot
+kind: runbook
+namespace: coroot
+last_reviewed: 2026-07-10
+status: current
+tags: [observability, ebpf, apm, clickhouse]
+sources:
+  - base-apps/coroot/coroot-operator.yaml
+  - base-apps/coroot/coroot-instance.yaml
+  - base-apps/coroot/ingress.yaml
+  - base-apps/coroot/namespace-config.yaml
+---
+
+# coroot runbook
+
+## Failure modes
+
+### Symptom: `Coroot` CR exists but no coroot-server/ClickHouse pods come up
+This app has an operator/instance split: `coroot-operator.yaml` is a nested Argo CD `Application`
+(named `coroot-operator`) that installs the operator chart; only once that operator is
+Synced/Healthy does it reconcile the `Coroot` CR (`coroot-instance.yaml`) into real workloads.
+- **Check:** `kubectl -n argo-cd get application coroot-operator` for sync/health status, then
+  `kubectl -n coroot get pods -l app.kubernetes.io/name=coroot-operator` and its logs
+  (`kubectl -n coroot logs -l app.kubernetes.io/name=coroot-operator`) for reconcile errors against
+  the `Coroot` object (`kubectl -n coroot get coroot coroot -o yaml`).
+- **Fix:** if the `coroot-operator` Application is out of sync (e.g. Helm chart version `0.6.0`
+  pinned in `coroot-operator.yaml` no longer resolves), PR a version bump or values fix there. If
+  the operator is healthy but the CR won't reconcile, PR a fix to `coroot-instance.yaml` (e.g. a
+  malformed field) rather than editing the CR live.
+
+### Symptom: eBPF node agent CrashLoopBackOff on some/all nodes
+`nodeAgent` runs with `ebpfTracer.enabled: true` / `ebpfProfiler.enabled: true` and
+`tolerations: [{operator: Exists}]` so it schedules on every node; it needs the privileged access
+granted by `namespace-config.yaml`'s `pod-security.kubernetes.io/enforce: privileged` label.
+- **Check:** `kubectl -n coroot get pods -l app.kubernetes.io/component=node-agent -o wide` and
+  `kubectl -n coroot describe pod <pod>` for PodSecurity admission denials or eBPF/kernel errors;
+  confirm the label is still present with `kubectl get ns coroot -o yaml`.
+- **Fix:** PR restoring the `pod-security.kubernetes.io/enforce: privileged` label in
+  `namespace-config.yaml` if it was changed, or adjust `nodeAgent.resources` in
+  `coroot-instance.yaml` if pods are being OOMKilled (current limit is `memory: 1Gi`).
+
+### Symptom: dashboard loads but shows no/incomplete metrics
+Coroot has no bundled Prometheus — metrics come from `externalPrometheus.url:
+http://prometheus.logging.svc.cluster.local:9090` (the `logging` app's Prometheus). Traces/logs/
+profiles are unaffected since those go to Coroot's own bundled ClickHouse.
+- **Check:** `kubectl -n coroot exec deploy/coroot -- wget -qO- http://prometheus.logging.svc.cluster.local:9090/-/healthy`
+  (or check from any pod in-cluster), and `kubectl -n logging get pods -l app=prometheus` for the
+  Prometheus StatefulSet's health.
+- **Fix:** this is a `logging`-namespace problem, not a coroot-config problem — resolve Prometheus
+  there. Only PR `coroot-instance.yaml` if the `externalPrometheus.url` itself needs to change
+  (e.g. Prometheus moved namespace/service name).
+
+## How-to
+
+### Access the dashboard
+`https://coroot.arigsela.com` — restricted by `nginx.ingress.kubernetes.io/whitelist-source-range`
+in `ingress.yaml` to a fixed list of home/LAN CIDRs. A `403`/connection refusal from an otherwise
+allowed network usually means that IP list is stale — PR an update to `ingress.yaml`.
+
+### Deploy / update
+Edit manifests under `base-apps/coroot/` and PR; Argo CD syncs `coroot` (and, via
+`coroot-operator.yaml`, the separate `coroot-operator` Application) on merge.

--- a/base-apps/logging.yaml
+++ b/base-apps/logging.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/logging
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: catalog-info.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: logging

--- a/base-apps/logging/catalog-info.yaml
+++ b/base-apps/logging/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: logging
+  namespace: logging
+  annotations:
+    agent-docs/path: docs.md
+  tags: [loki, grafana, prometheus, alloy]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-observability
+  dependsOn:
+    - resource:vault/vault

--- a/base-apps/logging/docs.md
+++ b/base-apps/logging/docs.md
@@ -1,0 +1,79 @@
+---
+app: logging
+catalog_entity: logging
+kind: docs
+namespace: logging
+last_reviewed: 2026-07-10
+status: current
+tags: [loki, grafana, prometheus, alloy]
+sources:
+  - base-apps/logging/alloy-config.yaml
+  - base-apps/logging/alloy-daemonset.yaml
+  - base-apps/logging/alloy-rbac.yaml
+  - base-apps/logging/loki-config.yaml
+  - base-apps/logging/loki-deployment.yaml
+  - base-apps/logging/loki-s3-external-secret.yaml
+  - base-apps/logging/secret-store.yaml
+  - base-apps/logging/grafana-deployment.yaml
+  - base-apps/logging/grafana-ingress.yaml
+  - base-apps/logging/grafana-dashboard-configmap.yaml
+  - base-apps/logging/istio-ambient-dashboard.yaml
+  - base-apps/logging/prometheus-config.yaml
+  - base-apps/logging/prometheus-statefulset.yaml
+---
+
+# logging
+
+## What it is
+The cluster's observability stack: four components deployed together in the `logging`
+namespace — Grafana Alloy (collector), Loki (log store), Prometheus (metrics store), and
+Grafana (visualization). There is no Helm chart; everything is plain Kubernetes manifests
+under `base-apps/logging/`.
+
+## Pipeline
+1. **Alloy** (`alloy-daemonset.yaml`, image `grafana/alloy:v1.4.3`) runs as a DaemonSet on
+   every `node.kubernetes.io/workload: application` node, using a cluster-wide RBAC
+   ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods/nodes. Its pipeline
+   config (`alloy-config.yaml`) does two things in parallel:
+   - **Logs**: discovers running pods, tails `/var/log/pods/...` (mounted `hostPath`
+     `varlog`/`varlibdockercontainers`), parses JSON fields, drops nginx health-check and
+     non-`development` `[DEBUG]` lines, and pushes to
+     `http://loki.logging.svc.cluster.local:3100/loki/api/v1/push`.
+   - **Metrics**: scrapes pods annotated `prometheus.io/scrape: "true"`, plus node and
+     cAdvisor metrics (via the node's kubelet on port 10250), and remote-writes to
+     `http://prometheus.logging.svc.cluster.local:9090/api/v1/write`.
+2. **Loki** (`loki-deployment.yaml`, single-replica Deployment, image `grafana/loki:3.2.1`,
+   `-target=all` monolithic mode) receives log pushes and stores chunks/index in **S3**
+   (`loki-config.yaml`: `common.storage.s3` and `storage_config.aws.s3` both point at bucket
+   `asela-chores-loki-logs-20251017` in `us-east-1`, created by Crossplane). Retention is 30
+   days (`limits_config.retention_period: 720h`) with the compactor handling delete requests
+   against S3. Loki has no local index/chunk PVC — S3 is the only durable store (the pod's
+   `/loki` mount is an `emptyDir`).
+3. **Prometheus** (`prometheus-statefulset.yaml`, single-replica StatefulSet, image
+   `prom/prometheus:v3.0.1`) stores metrics on a 50Gi `local-path` PVC with 15-day retention
+   (`--storage.tsdb.retention.time=15d`) and has `--web.enable-remote-write-receiver` on so it
+   can accept Alloy's remote-write pushes. `prometheus-config.yaml` also has it self-scrape
+   the Kubernetes API server, nodes, cAdvisor, and any pod/service annotated for scraping —
+   so it collects both from its own service discovery and from Alloy's forwarded metrics.
+4. **Grafana** (`grafana-deployment.yaml`, single-replica Deployment, image
+   `grafana/grafana:11.3.1`, 10Gi `local-path` PVC) is provisioned with two datasources
+   (`grafana-datasources` ConfigMap): `Loki` at `http://loki.logging.svc.cluster.local:3100`
+   and `Prometheus` (default) at `http://prometheus.logging.svc.cluster.local:9090`.
+   Dashboards are file-provisioned (`grafana-dashboard-provider` ConfigMap) from two folders:
+   `Kubernetes` (`grafana-dashboard-configmap.yaml`, a basic cluster dashboard) and `Istio`
+   (`istio-ambient-dashboard.yaml`, the Istio ambient mesh dashboard).
+
+## External access
+Grafana is exposed via `grafana-ingress.yaml`: nginx `Ingress` at host `grafana.arigsela.com`,
+TLS via `cert-manager.io/cluster-issuer: letsencrypt-prod` into secret `grafana-tls`. Loki and
+Prometheus are ClusterIP-only (no ingress) — accessed from inside the cluster (Alloy, Grafana)
+or via port-forward.
+
+## How it wires to other apps
+Loki's S3 credentials come from Vault: `loki-s3-external-secret.yaml` is an `ExternalSecret`
+resolving `loki-s3` (`aws_access_key_id`/`aws_secret_access_key`) through the `vault-backend`
+`SecretStore` (`secret-store.yaml`, Vault KV v2 at `k8s-secrets`, Kubernetes auth role
+`logging`) into the `loki-s3-credentials` Secret that `loki-deployment.yaml` mounts as
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Grafana's admin credentials
+(`GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD`) are plain env vars in
+`grafana-deployment.yaml`, not Vault-sourced.

--- a/base-apps/logging/runbook.md
+++ b/base-apps/logging/runbook.md
@@ -1,0 +1,67 @@
+---
+app: logging
+catalog_entity: logging
+kind: runbook
+namespace: logging
+last_reviewed: 2026-07-10
+status: current
+tags: [loki, grafana, prometheus, alloy]
+sources:
+  - base-apps/logging/alloy-daemonset.yaml
+  - base-apps/logging/loki-config.yaml
+  - base-apps/logging/loki-deployment.yaml
+  - base-apps/logging/loki-s3-external-secret.yaml
+  - base-apps/logging/secret-store.yaml
+  - base-apps/logging/grafana-deployment.yaml
+  - base-apps/logging/grafana-ingress.yaml
+---
+
+# logging runbook
+
+## Failure modes
+
+### Symptom: Alloy DaemonSet pods CrashLooping / OOMKilled
+- **Check:** `kubectl -n logging get pods -l app=alloy` — look for `OOMKilled` (exit code
+  137) in `kubectl -n logging describe pod <alloy-pod>`, and restart counts. Compare against
+  current limits in `alloy-daemonset.yaml` (`requests.memory: 256Mi`, `limits.memory: 512Mi`
+  — these were raised from 128Mi/256Mi after pods sitting at ~253Mi steady-state caused a
+  real OOMKilled crashloop and log-shipping gaps).
+- **Fix:** if pods are again running close to the current 512Mi limit,
+  PR a further increase to `alloy-daemonset.yaml`'s `resources.requests/limits.memory`. Since
+  Alloy is a DaemonSet, an OOMKilled pod only breaks log/metric collection on that one node,
+  but if it's cluster-wide, check whether a recent change to `alloy-config.yaml` (e.g. a new
+  scrape target or log volume spike) is driving memory up rather than assuming the limit
+  alone is at fault.
+
+### Symptom: Loki can't write logs / storage errors ("AccessDenied", "NoSuchBucket")
+- **Check:** `kubectl -n logging get pods -l app=loki` and `kubectl -n logging logs
+  deploy/loki` for S3 errors. Then confirm the credentials chain: `kubectl -n logging get
+  externalsecret loki-s3-credentials -o yaml` (status/conditions should show `SecretSynced`),
+  `kubectl -n logging get secret loki-s3-credentials` (should have `username`/`password`
+  keys per `loki-s3-external-secret.yaml`'s template), and that Vault (`vault-backend`
+  SecretStore, `secret-store.yaml`) is reachable and unsealed — Loki's S3 target is bucket
+  `asela-chores-loki-logs-20251017` in `us-east-1` (`loki-config.yaml`).
+- **Fix:** if the `ExternalSecret` isn't syncing, check Vault health first (a sealed/down
+  Vault stops this and every other namespace's secret sync at once). If Vault is healthy but
+  this secret specifically fails, verify the `logging` Vault role/policy grants read on the
+  `loki-s3` KV v2 entry. If the bucket/region itself changed, PR the update to
+  `loki-config.yaml`'s `common.storage.s3` and `storage_config.aws.s3` (both must match).
+
+### Symptom: Grafana unreachable or dashboards missing
+- **Check:** `kubectl -n logging get pods -l app=grafana` and
+  `kubectl -n logging get ingress grafana-nginx` — confirm the `grafana-tls` cert is issued
+  (`kubectl -n logging get certificate grafana-tls`) and the ingress host
+  `grafana.arigsela.com` resolves. For missing dashboards/data, check the Loki/Prometheus
+  datasources are reachable from inside the Grafana pod (`http://loki.logging.svc.cluster
+  .local:3100`, `http://prometheus.logging.svc.cluster.local:9090` — both ClusterIP-only, no
+  ingress) and that the `grafana-dashboard-provider` ConfigMap's folders (`Kubernetes`,
+  `Istio`) still match the mounted dashboard ConfigMaps.
+- **Fix:** PR any datasource URL or dashboard-provider path changes; a stuck cert-manager
+  challenge for `grafana-tls` is a cert-manager issue, not this app.
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge (`prune`/`selfHeal` enabled). All four
+components are single-replica (Deployment or StatefulSet) — expect a brief gap in
+collection/storage/visualization during a rolling update of any one of them.

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -11,3 +11,4 @@ weather-kitchen-frontend
 n8n
 ollama
 kagent
+backstage

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -13,3 +13,4 @@ ollama
 kagent
 backstage
 atlantis
+coroot

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -12,3 +12,4 @@ n8n
 ollama
 kagent
 backstage
+atlantis

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -14,3 +14,4 @@ kagent
 backstage
 atlantis
 coroot
+logging


### PR DESCRIPTION
Final batch (3 of 3) onboarding prioritized base-apps into the agent-docs framework.

## Apps onboarded (4, all Components)
- **backstage** (`website`, system `platform-tooling`) — the IDP; `dependsOn: postgresql + vault`.
- **atlantis** (`service`, system `platform-gitops`) — Terraform/OpenTofu PR automation; `dependsOn: vault`. `directory.exclude` correctly on `atlantis-config.yaml` (the Application that syncs `base-apps/atlantis`), not the Helm-chart `atlantis.yaml`.
- **coroot** (`service`, system `platform-observability`) — eBPF APM; `dependsOn: component:logging/logging` (its `externalPrometheus.url` targets the logging stack's Prometheus).
- **logging** (`service`, system `platform-observability`) — Alloy + Loki(+S3) + Grafana + Prometheus stack; `dependsOn: vault` (S3 creds).

## Review
Reviewer subagent: spec compliance ✅ all 4; quality approved, zero blocking findings. Every `dependsOn` ref hand-verified; the atlantis-config exclude placement and the coroot→logging relation confirmed grounded; unverifiable facts (backstage's baked-in app-config) correctly hedged. Validator: **17 apps in scope, 0 warnings**.

## Completes the onboarding effort
With this, the prioritized subset (12) + kagent bonus is done — **17 apps in scope** total (4 pilots + 13 onboarded this effort). The remaining ~21 dirs are the deferred long tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1