### PR TITLE
chore(kagent): bump chart 0.9.4 -> 0.9.11

### DIFF
--- a/base-apps/kagent-crds.yaml
+++ b/base-apps/kagent-crds.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     chart: kagent-crds
     repoURL: ghcr.io/kagent-dev/kagent/helm
-    targetRevision: 0.9.4
+    targetRevision: 0.9.11
   destination:
     server: https://kubernetes.default.svc
     namespace: kagent

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: kagent
     repoURL: ghcr.io/kagent-dev/kagent/helm
-    targetRevision: 0.9.4
+    targetRevision: 0.9.11
     helm:
       valuesObject:
         # Database: use existing PostgreSQL with pgvector
@@ -46,7 +46,9 @@ spec:
           # "server-TLS-only" — its gateway-config.yaml unconditionally
           # renders client_ca_path inside [openshell.gateway.tls], forcing
           # mTLS-required posture whenever TLS is enabled. And the kagent
-          # v0.9.4 controller has no client-cert config fields. So we drop
+          # controller still has no client-cert config fields as of v0.9.11
+          # (sandboxbackend/openshell/config.go exposes only TLSCAPEM +
+          # Insecure — no client keypair). So we drop
           # TLS entirely on the openshell side (server.disableTls=true in
           # base-apps/openshell.yaml) and dial insecure here.
           # Re-evaluate when either upstream fix lands.
@@ -67,16 +69,21 @@ spec:
             apiKeySecretKey: ANTHROPIC_API_KEY
 
         # UI image override: custom Node-20 build for older HP server CPUs.
-        # Upstream cr.kagent.dev/kagent-dev/kagent/ui:0.9.4 ships Node 24 with
-        # x86-64-v2 baseline → SIGILL on this hardware.
-        # Track upstream: https://github.com/kagent-dev/kagent/issues/1505
+        # Upstream cr.kagent.dev/kagent-dev/kagent/ui ships Node 24, which needs
+        # the x86-64-v2 instruction baseline → SIGILL on this hardware.
+        #
+        # This is a PERMANENT fork, not temporary scaffolding: upstream closed
+        # https://github.com/kagent-dev/kagent/issues/1505 as `not_planned`
+        # (2026-05-23), and v0.9.11 still builds on Node 24. Every chart bump
+        # therefore requires a matching image rebuild.
+        #
         # NOTE: Image must be built via base-apps/kagent/build/build.sh BEFORE
         # this PR merges to main, otherwise the kagent-ui pod will ImagePullBackOff.
         ui:
           image:
             registry: "852893458518.dkr.ecr.us-east-2.amazonaws.com"
             repository: "kagent-ui"
-            tag: "0.9.4-node20"
+            tag: "0.9.11-node20"
             pullPolicy: IfNotPresent
 
         # Right-sized agent resources (Task 3.3)

--- a/base-apps/kagent/build/Dockerfile
+++ b/base-apps/kagent/build/Dockerfile
@@ -70,7 +70,7 @@ RUN chown -R nextjs:nginx /app/ui \
 EXPOSE 8080
 
 LABEL org.opencontainers.image.source=https://github.com/arigsela/kubernetes
-LABEL org.opencontainers.image.description="Patched kagent UI v0.9.4 — Node 20 LTS for older x86-64 CPUs"
+LABEL org.opencontainers.image.description="Patched kagent UI v0.9.11 — Node 20 LTS for older x86-64 CPUs"
 
 USER 1001
 CMD ["/usr/local/bin/init.sh"]

--- a/base-apps/kagent/build/README.md
+++ b/base-apps/kagent/build/README.md
@@ -1,6 +1,8 @@
 # kagent UI custom image build
 
-Builds a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.9.4` so the Next.js process doesn't `SIGILL` on the HP server's older x86-64 CPU.
+Builds a Node-20-on-Debian replacement for `cr.kagent.dev/kagent-dev/kagent/ui:0.9.11` so the Next.js process doesn't `SIGILL` on the HP server's older x86-64 CPU.
+
+**This is a permanent fork.** Upstream closed [#1505](https://github.com/kagent-dev/kagent/issues/1505) as `not_planned` on 2026-05-23 and still ships Node 24 as of v0.9.11, so this image will not go away. **Every kagent chart bump requires a matching rebuild here** — see "Bumping `KAGENT_VERSION`" below.
 
 **Background:** [Design spec](../../../docs/superpowers/specs/2026-05-09-kagent-ui-custom-image-design.md) · [Upstream issue #1505](https://github.com/kagent-dev/kagent/issues/1505)
 
@@ -25,21 +27,30 @@ From the repo root:
 ```
 
 This will:
-1. `git clone --depth 1 --branch v0.9.4 https://github.com/kagent-dev/kagent.git` into a tmp dir
+1. `git clone --depth 1 --branch v${KAGENT_VERSION} https://github.com/kagent-dev/kagent.git` into a tmp dir
 2. Copy our patched `Dockerfile` into `ui/`
-3. `docker buildx build --platform linux/amd64 --push` to `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.9.4-node20`
+3. `docker buildx build --platform linux/amd64 --push` to `852893458518.dkr.ecr.us-east-2.amazonaws.com/kagent-ui:0.9.11-node20`
 4. Clean up the tmp dir on exit
 
 Expected runtime: 3–5 min.
 
 ## Bumping `KAGENT_VERSION`
 
-If you need to rebuild this patch against a newer kagent release (because upstream issue #1505 still isn't fixed):
+Required on every kagent chart bump. The image tag and the chart `targetRevision` must always match.
 
 1. Edit `KAGENT_VERSION` at the top of `build.sh`
-2. Update `IMAGE_TAG` if you want a different suffix
-3. Re-run `./build.sh`
-4. Verify upstream's `ui/Dockerfile` hasn't changed in ways our patch is incompatible with — if it has, re-merge the upstream changes into our `Dockerfile` here
+2. Diff upstream's `ui/Dockerfile` between the old and new tags and re-merge anything that affects our patch:
+   ```bash
+   gh api "repos/kagent-dev/kagent/contents/ui/Dockerfile?ref=v<old>" -q .content | base64 -d > /tmp/old
+   gh api "repos/kagent-dev/kagent/contents/ui/Dockerfile?ref=v<new>" -q .content | base64 -d > /tmp/new
+   diff -u /tmp/old /tmp/new
+   ```
+   Our Dockerfile hardcodes upstream's layout: `ui/package*.json`, `npm run build`, `.next/standalone`, `.next/static`, `next.config.ts`, `scripts/init.sh`, uid 1001 `nextjs` / 1002 `nginx`, `EXPOSE 8080`. A restructure upstream breaks the build.
+3. Update the `LABEL org.opencontainers.image.description` version in our `Dockerfile`
+4. Re-run `./build.sh` — **before** the chart bump merges to main, or `kagent-ui` will `ImagePullBackOff`
+5. Update `ui.image.tag` in `base-apps/kagent.yaml` to match
+
+Note: nginx/supervisord config is supplied by the chart (ConfigMap), not baked into this image — chart-side settings like `ui.nginx.proxyReadTimeout` apply to our custom image too.
 
 ## Risk A/B contingency: nginx / supervisord path patches
 
@@ -50,10 +61,11 @@ If the `kagent-ui` pod fails to start because Debian's nginx or supervisord path
 
 Then uncomment the matching block in `build.sh` and re-run.
 
-## Cleanup
+## Retiring this fork
 
-When upstream fixes [#1505](https://github.com/kagent-dev/kagent/issues/1505):
+Upstream closed #1505 as `not_planned`, so there is no fix coming. This directory goes away only if one of these becomes true:
 
-1. Remove the `ui:` block from `base-apps/kagent.yaml`
-2. Bump `targetRevision` in `base-apps/kagent.yaml` and `base-apps/kagent-crds.yaml` to the fixed version
-3. Delete this directory
+- Upstream moves the UI image off Node 24 (check `ARG TOOLS_NODE_VERSION` in their `ui/Dockerfile` on each bump), **or**
+- The cluster's nodes are replaced with CPUs that support the x86-64-v2 baseline.
+
+If either happens: remove the `ui:` block from `base-apps/kagent.yaml`, confirm the stock image starts, then delete this directory.

--- a/base-apps/kagent/build/build.sh
+++ b/base-apps/kagent/build/build.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # --- config ---
-KAGENT_VERSION="0.9.4"
+KAGENT_VERSION="0.9.11"
 ECR_REGISTRY="852893458518.dkr.ecr.us-east-2.amazonaws.com"
 ECR_REGION="us-east-2"
 IMAGE_NAME="kagent-ui"


### PR DESCRIPTION
## What

Bumps `kagent` and `kagent-crds` from **0.9.4 → 0.9.11** (latest stable, released 2026-07-01) and rebuilds the custom Node-20 UI image at the matching tag.

`0.10.0` is still at beta6 and deprecates `controller.streaming`, so it is deliberately not targeted.

## Affected app

`base-apps/kagent.yaml`, `base-apps/kagent-crds.yaml`, `base-apps/kagent/build/*`. No Terraform root is touched.

## ⚠️ Pre-merge requirements

**Do not merge until both are done:**

1. **Build and push the UI image**, or `kagent-ui` will `ImagePullBackOff` the moment Argo syncs:
   ```bash
   ./base-apps/kagent/build/build.sh   # pushes kagent-ui:0.9.11-node20 to ECR
   ```
2. **Back up the kagent PostgreSQL database.** The controller runs schema migrations on first start. (0.9.9 added "skip migration when schema is ahead of binary," which makes a downgrade safer than the 0.8.6→0.9.4 jump was, but the data migration is still one-way.)

## The custom UI image is a permanent fork now

This PR also corrects a stale assumption in our docs. Upstream **closed [#1505](https://github.com/kagent-dev/kagent/issues/1505) as `not_planned`** on 2026-05-23, and v0.9.11 still builds the UI on Node 24 (`ARG TOOLS_NODE_VERSION=24`), which SIGILLs on this hardware's pre-x86-64-v2 CPU.

So the README's "when upstream fixes #1505, delete this directory" cleanup path was dead. It's been replaced with the real exit criteria (upstream drops Node 24, or the nodes get newer CPUs) and a hard note that **every chart bump requires a matching image rebuild**.

Good news: upstream's `ui/Dockerfile` is otherwise byte-identical between 0.9.4 and 0.9.11, so no re-merge of our patch was needed.

## Compatibility — verified, not assumed

| Risk | Verdict |
|---|---|
| CRD breaking changes | **Safe.** Additive only. `Agent`/`RemoteMCPServer`/`AgentHarness`/`ModelConfig` keep `v1alpha2` as storage version; nothing we use was removed. `AgentHarness` grew 697 lines, all additions. Agent skill `required: [id, tags]` was *relaxed*. |
| `MCPServer` on `v1alpha1` (kmcp) | **Safe.** kmcp still pinned at `v0.3.0` in upstream go.mod — CRD untouched. `agent-docs-mcp` + `plex-stack-mcp` unaffected. |
| New `substrate-crds` subchart dep | **No-op.** Defaults to `substrate.enabled: false`. |
| `ui.image` override | **Safe.** Chart image templating is unchanged across versions. |
| `ignoreDifferences` jsonPointers | **Safe.** `/spec/declarative/{tools,memory}` still resolve. |
| OpenShell env contract | **Safe, and now blessed.** `OPENSHELL_GATEWAY_URL`/`OPENSHELL_INSECURE` are the documented examples in upstream's values.yaml. Controller still has no client-cert fields at 0.9.11, so the `disableTls` posture stands — comment updated to say so. |

## What we gain

- **OTEL env var panic fix** (#2029) — we run `otel.tracing` + `otel.logging` into Coroot, so this is directly in our path.
- **Anthropic config fields now forwarded to ModelConfig** (#1962) — we're an Anthropic deployment.
- **MCP null `tools` field handling** (#1960).
- **UI: "new chat hangs on Thinking…" fix** (#2010), chat viewport overflow fix, reconnect to in-progress tasks.
- **Controller `/metrics` endpoint** with RBAC for authenticated scrapes (new `controller.metrics` values, off by default).
- **Configurable streaming timeouts** (`ui.streamTimeoutSeconds`, `ui.nginx.proxyReadTimeout`) — chart-side, so they apply to our custom image too.
- **PSS-restricted hardening** + CVE remediation in app images.

## ⚠️ Post-sync action

**Re-run `base-apps/kagent/post-deploy-patches.sh` and verify the HITL gates landed.** It JSON-patches the *index-based* path `/spec/declarative/tools/0/mcpServer/requireApproval`. If bundled-agent tool ordering shifted, the human-approval gate on destructive tools (`k8s_delete_resource`, `k8s_apply_manifest`, `helm_uninstall`, …) silently lands in the wrong place or no-ops. Bundled agent *names* are unchanged in the chart values, which is reassuring but not sufficient — verify.

## Follow-up (not in this PR)

0.9.10 adds native Helm memory config (`memory.{enabled,modelConfigRef,ttlDays}`) for bundled agents. That can retire the **memory half of `post-deploy-patches.sh`**, shrinking our most fragile artifact to just the `requireApproval` patches. Worth doing next.

## Validation

`yamllint` and `kubeconform` aren't installed locally — relying on CI for those. YAML changes are confined to two `targetRevision` values, one image tag, and comment blocks; `bash -n` passes on `build.sh`.

## Deployment / secret impact

No DNS, IAM, or secret-management changes. Requires the ECR push above and a DB backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKWrvPotdM7yW122vJFrGC