### PR TITLE
fix(kagent,ci): stop syncs from stripping HITL gates; lint top-level app manifests

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,10 +21,18 @@ jobs:
         run: |
           # --diff-filter=d excludes deleted files so downstream lint/validate
           # steps don't try to read paths that no longer exist on disk.
+          #
+          # Both pathspecs are required: 'base-apps/**/*.yaml' has a literal '/'
+          # after the '**', so it only matches files at least one directory deep
+          # and silently misses the top-level Argo CD Application manifests
+          # (base-apps/<app>.yaml). Without 'base-apps/*.yaml' those files are
+          # never linted or schema-validated, and the jobs below skip while
+          # reporting green.
+          PATHSPEC=('base-apps/*.yaml' 'base-apps/**/*.yaml')
           if [ "${{ github.event_name }}" = "push" ]; then
-            FILES=$(git diff --name-only --diff-filter=d HEAD~1 HEAD -- 'base-apps/**/*.yaml' | tr '\n' ' ')
+            FILES=$(git diff --name-only --diff-filter=d HEAD~1 HEAD -- "${PATHSPEC[@]}" | tr '\n' ' ')
           else
-            FILES=$(git diff --name-only --diff-filter=d origin/main...HEAD -- 'base-apps/**/*.yaml' | tr '\n' ' ')
+            FILES=$(git diff --name-only --diff-filter=d origin/main...HEAD -- "${PATHSPEC[@]}" | tr '\n' ' ')
           fi
           echo "yaml_files=$FILES" >> "$GITHUB_OUTPUT"
           if [ -n "$FILES" ]; then

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -7,7 +7,19 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   project: default
-  # Ignore diffs on Agent CRD tools and memory fields - managed separately via agent-patches
+  # Ignore diffs on Agent CRD tools and memory fields - managed separately via
+  # base-apps/kagent/post-deploy-patches.sh (HITL requireApproval + memory config).
+  #
+  # ignoreDifferences alone only suppresses drift *detection*. It does NOT stop a
+  # sync from overwriting these fields, so any sync of this app (a chart bump, a
+  # manual sync) silently strips the requireApproval gates off the write-capable
+  # agents — verified live during the 0.9.4 -> 0.9.11 bump. RespectIgnoreDifferences
+  # pre-patches the ignored paths out of the desired state before apply, so the live
+  # (patched) values survive.
+  #
+  # Safe on a fresh install: the option is only effective when the resource already
+  # exists. With no live state, Argo applies the desired state as-is, so the chart's
+  # tools/memory land normally on first create.
   ignoreDifferences:
     - group: kagent.dev
       kind: Agent
@@ -179,3 +191,4 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
Follow-up to #342. Two safety nets that weren't actually catching anything — both found while verifying that upgrade.

## 1. Argo syncs were silently stripping the HITL approval gates

`base-apps/kagent.yaml` ignores `/spec/declarative/{tools,memory}` because `post-deploy-patches.sh` manages them out-of-band (HITL `requireApproval` + memory config). But **`ignoreDifferences` only suppresses drift _detection_ — it does not stop a sync from overwriting those fields.**

**Observed live during the 0.9.4 → 0.9.11 sync:** Argo re-applied the chart's rendered Agent specs and stripped `requireApproval` from all five write-capable agents. For a few minutes `k8s-agent` could call `k8s_delete_resource`, `k8s_apply_manifest` and `k8s_execute_command` with **no human approval gate**. Nothing alerted — the app cheerfully reported `Synced / Healthy`.

This is not a bump-only hazard. It would recur on **every** sync of this app, including a routine manual one.

`RespectIgnoreDifferences=true` pre-patches the ignored paths out of the desired state before apply, so the live (patched) values survive.

**Why this is safe on a fresh install** — I checked this specifically, because the obvious worry is that bundled agents get created with no tools. Per the Argo CD docs:

> the `RespectIgnoreDifferences` sync option is only effective when the resource is already created in the cluster. If the Application is being created and no live state exists, the desired state is applied as-is.

So on first create the chart's `tools`/`memory` land normally. No toolless agents, no broken DR path.

## 2. CI has never linted a single Argo CD Application manifest

The `changed-files` gate in `.github/workflows/validate.yaml` used the pathspec `'base-apps/**/*.yaml'`. The literal `/` after `**` means it only matches files **at least one directory deep** — so top-level `base-apps/<app>.yaml` never matched. Every Application manifest in the repo has been skipping `yaml-lint`, `kubernetes-validate` and `ingress-policy`, while CI reported green.

That's why the checks on #342 showed `skipping` rather than `pass`.

Verified against the kagent bump commit (`1696d05`), which touched only `base-apps/kagent.yaml` and `base-apps/kagent-crds.yaml`:

| pathspec | files matched | result |
|---|---|---|
| `base-apps/**/*.yaml` (old) | **0** | all three jobs skipped |
| `+ base-apps/*.yaml` (new) | **2** | jobs run |

## Validation

- `yamllint` 1.35.1 passes on `base-apps/kagent.yaml`, `base-apps/kagent-crds.yaml`, and `.github/workflows/validate.yaml`.
- The new `changed-files` logic was simulated against `1696d05` and correctly selects both files.
- This PR touches `.github/workflows/`, so it should be the first PR whose own manifest changes actually get linted by the fixed gate — worth watching that `yaml-lint` reports `pass` and not `skipping`.

## Deployment impact

`RespectIgnoreDifferences=true` changes sync behavior for the `kagent` app only. No DNS, IAM, or secret-management impact. The currently-applied gates (restored by hand after the 0.9.11 sync) will now persist across future syncs instead of being clobbered.

## Still open (not in this PR)

- `plex-stack-mcp` has been down ~18h on a Vault `SecretSyncedError` for `plex-stack-mcp-creds` — unrelated to kagent, needs its own fix.
- `post-deploy-patches.sh` still references `dnd-agent`, which no longer exists (error swallowed by `|| true`).
- `promql-agent` and the `cilium-*` agents run despite `enabled: false` — orphaned Agent CRs.
- kagent 0.9.10 added native Helm memory config, which can retire the memory half of `post-deploy-patches.sh` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKWrvPotdM7yW122vJFrGC