### PR TITLE
fix(kagent): stop kagent-secrets reporting OutOfSync forever

### DIFF
--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -7,6 +7,32 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   project: default
+  # The External Secrets admission webhook stamps schema defaults onto every
+  # ExternalSecret it admits (conversionStrategy=Default, decodingStrategy=None,
+  # metadataPolicy=None, deletionPolicy=Retain, template.mergePolicy=Replace).
+  # Git does not spell those out, so Argo saw fields present live but absent from
+  # the desired state and reported this app OutOfSync forever — even though no
+  # field's VALUE ever differed and every ExternalSecret was SecretSynced.
+  #
+  # A permanently-OutOfSync app is worse than cosmetic: it trains you to ignore
+  # sync status, which is how a real regression (the kagent HITL approval gates
+  # being silently stripped) went unnoticed. Ignore only the defaulted paths so
+  # that OutOfSync means something again.
+  #
+  # NOTE: ignoreDifferences suppresses drift DETECTION, not overwrites — see
+  # argoproj/argo-cd#8970. That is fine here and only here: these values are
+  # re-applied by the ESO webhook after every sync, so there is nothing of ours
+  # for a sync to clobber. Do NOT reach for this pattern to protect
+  # hand-applied values; own the resource in Git instead.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
+        - .spec.target.deletionPolicy
+        - .spec.target.template.mergePolicy
   source:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main


### PR DESCRIPTION
Follow-up to #344. Small, cosmetic-but-worth-it.

## The problem

`kagent-secrets` has been reporting `OutOfSync` permanently — while `Healthy`, and with every ExternalSecret `SecretSynced`. Nothing was broken.

The External Secrets admission webhook stamps schema defaults onto every ExternalSecret it admits:

| path | default |
|---|---|
| `.spec.data[].remoteRef.conversionStrategy` | `Default` |
| `.spec.data[].remoteRef.decodingStrategy` | `None` |
| `.spec.data[].remoteRef.metadataPolicy` | `None` |
| `.spec.target.deletionPolicy` | `Retain` |
| `.spec.target.template.mergePolicy` | `Replace` |

Git doesn't spell these out, so Argo sees fields present live but absent from desired state and flags drift. I diffed all four Git-managed ExternalSecrets: **no field's value ever differed.** It's purely the defaults, and it predates the recent kagent work.

## Why bother fixing something cosmetic

Because a permanently-`OutOfSync` app isn't just noise — **it trains you to ignore sync status.** That's precisely how the real regression in #344 went unnoticed: the kagent HITL `requireApproval` gates were being silently stripped on every sync while Argo cheerfully reported `Synced / Healthy`. A red light that's always red isn't a signal.

Ignoring only the defaulted paths makes `OutOfSync` mean something again.

## Note on the pattern (please read before copying this)

`ignoreDifferences` suppresses drift **detection**, not overwrites ([argo-cd#8970](https://github.com/argoproj/argo-cd/issues/8970)). That's acceptable **here and only here**, because ESO's webhook re-applies these defaults after every sync — there is nothing of ours for a sync to clobber.

It is *not* a way to protect hand-applied values. That's exactly what bit us in #344, where the fix was to own the resources in Git instead. The manifest carries a comment saying so, so the next reader doesn't copy this into a case where it silently fails.

## Validation

- `yamllint` passes.
- The jq expressions were **executed against all four live ExternalSecrets** and select only webhook-supplied values (`Default`/`None`/`Retain`/`Replace`) — no real configuration is masked.
- `jqPathExpressions` rather than `jsonPointers` because the defaults land on every element of the `.spec.data[]` array.

I'll confirm `kagent-secrets` goes `Synced/Healthy` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKWrvPotdM7yW122vJFrGC