### PR TITLE
feat(identity): enforce the agent-identity contract at admission with Kyverno

### DIFF
--- a/base-apps/kyverno-policies/agent-identity.yaml
+++ b/base-apps/kyverno-policies/agent-identity.yaml
@@ -1,0 +1,102 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: agent-identity
+  annotations:
+    policies.kyverno.io/title: Agent Identity Contract
+    policies.kyverno.io/category: Agent Platform
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: ExternalSecret, Agent
+    policies.kyverno.io/description: >-
+      Enforces the agent-principal contract (templates/agent-identity/README.md)
+      at admission. scripts/validate-agent-identity.py checks the same invariants
+      in CI, but CI only sees git — a direct `kubectl apply`, a Helm chart, or an
+      operator writing an Agent bypasses it entirely. This is the runtime half.
+spec:
+  # Enforce, not Audit. Every other policy in this repo is Audit, which means
+  # Kyverno currently blocks nothing and its findings are a report nobody reads.
+  # A safety control that only reports is the same failure mode that let the
+  # kagent HITL requireApproval gates go missing for days while Argo showed
+  # Synced/Healthy. These invariants are cheap to satisfy and the cluster is
+  # already compliant, so they are enforced.
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    # ---- Invariant 1: scoped credentials -----------------------------------
+    - name: credential-must-not-use-broad-secretstore
+      match:
+        any:
+          - resources:
+              kinds:
+                - external-secrets.io/v1beta1/ExternalSecret
+              namespaces:
+                - kagent
+      exclude:
+        any:
+          # Owned by the `kagent-config` Argo app, which lives outside this
+          # repo, so it cannot be scoped from here. It still reads the broad
+          # `vault-backend` store / monolithic `kagent` key. Remove this
+          # exclusion once that app is brought into this repo and scoped.
+          - resources:
+              names:
+                - kagent-anthropic-secrets
+      validate:
+        message: >-
+          ExternalSecret '{{ request.object.metadata.name }}' must not resolve through the
+          broad 'vault-backend' SecretStore. Give it a dedicated ESO ServiceAccount +
+          SecretStore backed by a Vault role that reads only its own path.
+          See templates/agent-identity/README.md (invariant 1).
+        pattern:
+          spec:
+            secretStoreRef:
+              name: "!vault-backend"
+
+    - name: credential-must-not-read-monolithic-vault-key
+      match:
+        any:
+          - resources:
+              kinds:
+                - external-secrets.io/v1beta1/ExternalSecret
+              namespaces:
+                - kagent
+      exclude:
+        any:
+          - resources:
+              names:
+                - kagent-anthropic-secrets
+      validate:
+        message: >-
+          ExternalSecret '{{ request.object.metadata.name }}' must not read the monolithic
+          Vault key 'kagent' — that key holds every consumer's credential, so any token
+          able to read it can read them all. Use a per-consumer key (k8s-secrets/<consumer>).
+          See templates/agent-identity/README.md (invariant 1).
+        foreach:
+          - list: "request.object.spec.data"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.remoteRef.key }}"
+                    operator: Equals
+                    value: kagent
+
+    # ---- Invariant 3: declared capability surface --------------------------
+    - name: agent-mcp-tools-must-list-toolnames
+      match:
+        any:
+          - resources:
+              kinds:
+                - kagent.dev/v1alpha2/Agent
+      validate:
+        message: >-
+          Agent '{{ request.object.metadata.name }}' has an McpServer tool ref with no
+          toolNames. An empty list is an implicit bind-all: the agent silently gains every
+          tool the server exposes, including any added by a future upgrade. List the tools
+          explicitly. See templates/agent-identity/README.md (invariant 3).
+        foreach:
+          - list: "request.object.spec.declarative.tools[?type=='McpServer']"
+            deny:
+              conditions:
+                any:
+                  - key: "{{ element.mcpServer.toolNames[] || `[]` | length(@) }}"
+                    operator: Equals
+                    value: 0

--- a/templates/agent-identity/README.md
+++ b/templates/agent-identity/README.md
@@ -50,13 +50,33 @@ consumer or unresolved reference is a warning (visible backlog).
    Never depend on an out-of-band, hand-applied ModelConfig.
 3. **Capability:** list explicit `toolNames` for every `McpServer` tool ref.
 
+## Two gates, deliberately
+
+- **CI** (`scripts/validate-agent-identity.py`, `agent-identity-validate` job)
+  checks all three invariants against **git**. It is the only gate that can see
+  the "exists in git" half of invariants 2 and 3.
+- **Admission** (`base-apps/kyverno-policies/agent-identity.yaml`, Kyverno
+  ClusterPolicy, `Enforce`) checks the structural invariants against **anything
+  applied to the cluster** — including a hand-run `kubectl apply`, a Helm chart,
+  or an operator writing an `Agent`. CI never sees those.
+
+Neither subsumes the other. CI catches what git says; admission catches what the
+cluster is actually asked to run.
+
+The Kyverno policy denies: an `ExternalSecret` in `kagent` using the broad
+`vault-backend` store, one reading the monolithic `kagent` Vault key, and an
+`Agent` whose `McpServer` tool ref lists no `toolNames` (implicit bind-all).
+It carries one documented exclusion: `kagent-anthropic-secrets`, owned by the
+`kagent-config` Argo app outside this repo, which still reads the broad store.
+Remove that exclusion once that app is brought in and scoped.
+
 ## Follow-ons (not yet enforced)
 
-- Kyverno admission policy enforcing invariants 1 & 2 at deploy time. Until this
-  lands, the invariants are checked only in CI — a direct `kubectl apply` can
-  still violate them.
 - Onboarding the remaining declarative agents.
 - Dedicated per-agent Anthropic keys / budget caps; egress control.
+- Invariant 2 has no admission-time equivalent (Kyverno cannot read git). A
+  cluster-existence check on the referenced `ModelConfig` would be the closest
+  analogue if it proves worth the moving parts.
 
 ## Done
 


### PR DESCRIPTION
Closes follow-on C of the Identity pillar. **Stacked on #348 — merge that first.** (GitHub will retarget this to `main` automatically once #348 lands.)

## Why this exists

Until now the three identity invariants were checked **only by `scripts/validate-agent-identity.py` in CI — which sees git and nothing else.** A hand-run `kubectl apply`, a Helm chart, or an operator writing an `Agent` bypassed them completely. This is the runtime half of the gate.

The two gates are complementary, not redundant: CI catches what git *says*; admission catches what the cluster is actually asked to *run*.

## Rules (ClusterPolicy `agent-identity`)

| rule | denies |
|---|---|
| `credential-must-not-use-broad-secretstore` | an `ExternalSecret` in `kagent` resolving through `vault-backend` |
| `credential-must-not-read-monolithic-vault-key` | …or reading Vault key `kagent`, which holds *every* consumer's credential |
| `agent-mcp-tools-must-list-toolnames` | an `Agent` whose `McpServer` ref lists no `toolNames` |

That last one matters more than it looks: an empty `toolNames` is an **implicit bind-all** — the agent silently gains every tool the server exposes, *including any added by a future chart upgrade*. That's how an agent quietly acquires `k8s_delete_resource`.

## Enforce, not Audit — deliberately

**All 5 existing policies in this repo are `validationFailureAction: Audit`**, which means Kyverno currently blocks nothing and its findings are a report nobody reads.

That is the same failure mode that let the kagent HITL `requireApproval` gates go missing for days while Argo cheerfully reported `Synced / Healthy`. A safety control that only reports is not a safety control. These invariants are cheap to satisfy and the cluster is already compliant, so they are **enforced**.

## One documented exclusion

`kagent-anthropic-secrets` — owned by the `kagent-config` Argo app, which lives **outside this repo** and still reads the broad store. Without the exclusion, an `Enforce` policy would permanently break that app's sync. Remove it once that app is brought in and scoped.

## Verified with the Kyverno CLI, not by inspection

Installed `kyverno` v1.18.2 and ran the policy against real objects:

- **Synthetic fixtures:** broad-store ES, monolithic-key ES and a bind-all Agent are each **DENIED**; a scoped ES, the excluded ES and a well-formed Agent **PASS**.
- **Every real manifest in `base-apps/kagent/`** (post-scoping): **11 pass, 0 fail**.
- **Every live Agent + ExternalSecret in the cluster:** all **7 agents pass**, and the only failures are *exactly* the 3 ExternalSecrets that #348 scopes.

## ⚠️ Ordering

That last result is the reason for the stack. **On the pre-#348 cluster this policy would deny `backstage-mcp-token`, `kagent-db-credentials` and `kagent-mcp-basic-auth` — blocking the `kagent-secrets` Argo app from syncing.**

Merge #348, let it sync, then merge this. I'll re-verify against the live cluster before it goes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKWrvPotdM7yW122vJFrGC