### PR TITLE
feat(security): enforce agent capability classes at admission

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -121,3 +121,41 @@ jobs:
         run: python -m pytest tests/agent-identity/ -q
       - name: Validate agent-identity contract
         run: python scripts/validate-agent-identity.py --repo-root .
+
+  # The agent-capability contract (L03 Security guardrails). This is the
+  # AUTHORITATIVE gate for all four invariants — in particular "delegation does
+  # not escalate", which Kyverno cannot check at admission because it needs a
+  # transitive closure over the whole agent graph. That graph lives in git, so
+  # this is where it is decided.
+  # Spec: docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md
+  agent-capability-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: pip install pyyaml==6.0.2 pytest==8.3.3
+      - name: Run agent-capability validator tests
+        run: python -m pytest tests/agent-capability/ -q
+      - name: Validate agent-capability contract
+        run: python scripts/validate-agent-capability.py --repo-root .
+      # ClusterPolicy/agent-capability is GENERATED from the taxonomy. If someone
+      # edits the taxonomy without regenerating (or hand-edits the policy), the
+      # admission gate and the CI gate would silently disagree about what a tool
+      # is allowed to do. Fail loudly instead.
+      - name: Check the Kyverno policy is in sync with the taxonomy
+        run: python scripts/gen-agent-capability-policy.py --check --repo-root .
+      # Verify the SHIPPED policy file verbatim: every real Agent passes (a false
+      # positive would wedge the kagent app on next sync), and every violating
+      # fixture is denied (a false negative is a hole). One fixture per rule.
+      - name: Install Kyverno CLI
+        run: |
+          curl -sSL -o kyverno.tar.gz \
+            https://github.com/kyverno/kyverno/releases/download/v1.13.4/kyverno-cli_v1.13.4_linux_x86_64.tar.gz
+          tar -xzf kyverno.tar.gz kyverno
+          sudo install -m 0755 kyverno /usr/local/bin/kyverno
+      - name: Verify agent-capability Kyverno policy
+        run: ./tests/agent-capability/kyverno/run.sh

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -103,8 +103,13 @@ spec:
         # argoproj/argo-cd#8970 / #9678, reproduced on this cluster. Owning the
         # CRs makes both fields declarative and self-healed by Argo.
         #
-        # observability-agent stays chart-managed: it is read-only, so it needs
-        # no approval gates, and chart 0.9.10+ sets memory natively.
+        # observability-agent WAS left chart-managed on the belief that it is
+        # "read-only, so it needs no approval gates". That was wrong. It binds 34
+        # kagent-grafana-mcp tools, three of which mutate (update_dashboard,
+        # create_incident, add_activity_to_incident), with no requireApproval at
+        # all — and it delegated to promql-agent, which is disabled below and does
+        # not exist. It is now owned in git like the other two, gated, and declared
+        # class `write`. See base-apps/kagent/agents/observability-agent.yaml.
         k8s-agent:
           enabled: false
         istio-agent:
@@ -129,17 +134,7 @@ spec:
         cilium-policy-agent:
           enabled: false
         observability-agent:
-          enabled: true
-          memory:
-            enabled: true
-            modelConfigRef: embedding-model-config
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
+          enabled: false
 
         # OpenTelemetry tracing → Coroot OTLP receiver
         otel:

--- a/base-apps/kagent/agents/dungeon-crawler-carl-agent.yaml
+++ b/base-apps/kagent/agents/dungeon-crawler-carl-agent.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/name: dungeon-crawler-carl-agent
     app: kagent
     arigsela.com/idp-managed: "true"
+    # Pure LLM, tools: []. Nothing to gate.
+    capability.homelab/class: read
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent

--- a/base-apps/kagent/agents/homelab-knowledge.yaml
+++ b/base-apps/kagent/agents/homelab-knowledge.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/name: homelab-knowledge
     app: kagent
     arigsela.com/idp-managed: "true"
+    # Read-only, and now genuinely so end-to-end: its own three tools are reads
+    # backed by a --read-only MCP binary, and it delegates to k8s-reader rather
+    # than k8s-agent. It previously delegated to k8s-agent, which made its
+    # EFFECTIVE capability admin — it could reach delete/apply/exec by asking.
+    capability.homelab/class: read
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent
@@ -150,9 +155,16 @@ spec:
         # kagent's ADK schema converter cannot parse (KeyError: 'anyOf').
         toolNames:
         - get-catalog-entity
+    # Delegation is capability-transitive: this agent's effective capability is
+    # its own tools UNION everything it can reach by delegating. It used to
+    # delegate to k8s-agent (admin), which silently made this read-only agent
+    # able to reach k8s_delete_resource / k8s_apply_manifest / k8s_execute_command
+    # by simply asking. It now delegates to k8s-reader, which binds only read
+    # tools — the live-cluster investigation ability is kept, the escalation
+    # path is gone.
     - type: Agent
       agent:
-        name: k8s-agent
+        name: k8s-reader
     deployment:
       resources:
         requests:

--- a/base-apps/kagent/agents/istio-agent.yaml
+++ b/base-apps/kagent/agents/istio-agent.yaml
@@ -17,6 +17,9 @@ kind: Agent
 metadata:
   name: istio-agent
   namespace: kagent
+  labels:
+    # Binds k8s_delete_resource and istio_delete_waypoint.
+    capability.homelab/class: admin
 spec:
   declarative:
     a2aConfig:

--- a/base-apps/kagent/agents/k8s-agent.yaml
+++ b/base-apps/kagent/agents/k8s-agent.yaml
@@ -17,6 +17,11 @@ kind: Agent
 metadata:
   name: k8s-agent
   namespace: kagent
+  labels:
+    # Binds k8s_delete_resource and k8s_execute_command — the operator agent a
+    # human drives when something actually needs changing. Everything mutating
+    # it holds is gated by requireApproval below.
+    capability.homelab/class: admin
 spec:
   declarative:
     a2aConfig:
@@ -146,6 +151,9 @@ spec:
         apiGroup: kagent.dev
         kind: RemoteMCPServer
         name: kagent-tool-server
+        # Every mutating tool bound below must appear here — the capability
+        # contract enforces it in CI and at admission, so this list can no
+        # longer be silently stripped or fall behind toolNames.
         requireApproval:
         - k8s_patch_resource
         - k8s_create_resource
@@ -153,6 +161,14 @@ spec:
         - k8s_delete_resource
         - k8s_apply_manifest
         - k8s_execute_command
+        # The four label/annotation mutators were bound but UNGATED until the
+        # capability increment. They are not cosmetic: Argo CD sync behaviour
+        # and Kyverno matching are both label/annotation-driven, so an agent
+        # holding these can disable the controls that hold it in.
+        - k8s_annotate_resource
+        - k8s_remove_annotation
+        - k8s_label_resource
+        - k8s_remove_label
         toolNames:
         - k8s_check_service_connectivity
         - k8s_patch_resource

--- a/base-apps/kagent/agents/k8s-reader.yaml
+++ b/base-apps/kagent/agents/k8s-reader.yaml
@@ -1,0 +1,119 @@
+---
+# k8s-reader — the read-only half of the Kubernetes capability.
+#
+# Why this agent exists: homelab-knowledge is a read-only documentation agent,
+# but it delegated to k8s-agent so it could answer live-cluster questions ("why
+# is this pod crashlooping"). Delegation is capability-transitive, so that made
+# its EFFECTIVE capability admin — it could reach k8s_delete_resource,
+# k8s_apply_manifest and k8s_execute_command just by asking another agent.
+#
+# Splitting the capability keeps the useful half and drops the dangerous half:
+# homelab-knowledge now delegates here, and this agent binds ONLY tools the
+# capability taxonomy classifies `read`. There is no mutating tool to reach.
+#
+# k8s-agent remains the `admin` operator agent for humans who need to act.
+#
+# Contract: templates/agent-identity/README.md (identity) and the capability
+# taxonomy at base-apps/kyverno-policies/agent-capability-taxonomy.yaml.
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: k8s-reader
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: k8s-reader
+    app: kagent
+    arigsela.com/idp-managed: "true"
+    # Binds only read-classified k8s tools. No requireApproval needed because
+    # there is nothing mutating to gate.
+    capability.homelab/class: read
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/k8s-reader.yaml
+    backstage.io/owner: group:default/platform-engineering
+    agents.platform.ai/version: "v1"
+    agents.platform.ai/runtime: kagent
+    agents.platform.ai/description: |-
+      Read-only Kubernetes cluster investigator. Observes state; cannot change it.
+    agents.platform.ai/a2a-endpoint: http://k8s-reader.kagent.svc.cluster.local:8080
+    agents.platform.ai/skills: |-
+      [{"id":"cluster-inspection","name":"Cluster Inspection","description":"Reads Kubernetes resource state, events, logs and cluster configuration to answer questions and diagnose problems."}]
+    agents.platform.ai/delegates: |-
+      []
+    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
+spec:
+  type: Declarative
+  description: A read-only Kubernetes investigator. Inspects cluster state, events and
+    logs to diagnose problems. Cannot create, modify, or delete anything.
+  declarative:
+    modelConfig: default-model-config
+    a2aConfig:
+      skills:
+      - id: cluster-inspection
+        name: Cluster Inspection
+        description: Reads Kubernetes resource state, events, logs and cluster
+          configuration to answer questions and diagnose problems.
+        examples:
+        - Why is the pod X in namespace Y crashlooping?
+        - Show me recent events for the deployment Z.
+        - What are the resource requests and limits on this StatefulSet?
+        - Which pods are not Running right now?
+        tags:
+        - kubernetes
+        - diagnostics
+        - read-only
+    systemMessage: |-
+      You are a read-only Kubernetes investigator.
+
+      ## What you can do
+
+      You inspect cluster state: resources, events, pod logs, cluster
+      configuration, and service connectivity. You diagnose problems and explain
+      what you find, clearly and with evidence.
+
+      ## What you cannot do
+
+      You hold NO mutating tools. You cannot create, patch, apply, label,
+      annotate, delete, or exec. This is enforced by the capability contract,
+      not by your own restraint — the tools are simply not bound to you.
+
+      When a question requires a change to the cluster, do not attempt it and do
+      not pretend you have. Say plainly what change you believe is needed and
+      why, and tell the user that acting on it requires the `k8s-agent` operator
+      agent, which gates every mutating call behind human approval.
+
+      ## How to work
+
+      Gather evidence before concluding. Prefer describing a resource and reading
+      its events and logs over guessing from names. Quote what you actually saw —
+      the status, the event message, the log line — rather than paraphrasing it.
+      If the evidence does not support a conclusion, say so.
+    tools:
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: kagent-tool-server
+        # Every tool here is classified `read` in the capability taxonomy.
+        # Adding a mutating tool to this list fails CI and is denied at
+        # admission — a `read` agent may not bind `write` or `destructive`.
+        toolNames:
+        - k8s_get_resources
+        - k8s_get_resource_yaml
+        - k8s_get_pod_logs
+        - k8s_describe_resource
+        - k8s_get_events
+        - k8s_get_cluster_configuration
+        - k8s_get_available_api_resources
+        - k8s_check_service_connectivity
+    deployment:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi

--- a/base-apps/kagent/agents/observability-agent.yaml
+++ b/base-apps/kagent/agents/observability-agent.yaml
@@ -1,0 +1,210 @@
+---
+# observability-agent — adopted into git by the agent-capability increment.
+#
+# The chart's bundled copy is disabled via agents.observability-agent.enabled=false
+# in base-apps/kagent.yaml, following the k8s-agent / istio-agent precedent. We own
+# it here so its capability class and HITL requireApproval gates are declarative
+# and self-healed by Argo CD rather than living only in a chart's rendered output.
+#
+# Why it had to be adopted, and what was wrong with it:
+#
+#   * It was described in this repo as "read-only". It was not. It binds 34 tools
+#     from kagent-grafana-mcp, three of which MUTATE — update_dashboard,
+#     create_incident, add_activity_to_incident — with NO requireApproval at all.
+#     It could rewrite dashboards and open incidents, ungated.
+#
+#   * It carried a `type: Agent` delegation to `promql-agent`, an agent that does
+#     not exist in the cluster and is explicitly disabled in base-apps/kagent.yaml.
+#     The reference was dangling. It is removed here: it pointed at nothing, so
+#     removing it restores no behaviour and breaks none. The systemMessage never
+#     referenced promql-agent, so nothing else depended on it.
+#
+# This escaped review because kagent-grafana-mcp is exempt by name from the
+# identity contract's "MCP server must exist in git" invariant, so its 34 tools
+# were never scrutinised. The capability taxonomy's fail-closed rule is what
+# surfaced it: every bound tool must now be classified to be bindable at all.
+#
+# Class is `write`, not `read`: it holds mutating tools, and the contract requires
+# an agent to declare its true capability. The three mutating tools are gated.
+#
+# systemMessage and a2aConfig below are upstream's, captured from chart 0.9.11.
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: observability-agent
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: observability-agent
+    app: kagent
+    arigsela.com/idp-managed: 'true'
+    capability.homelab/class: write
+  annotations:
+    terasky.backstage.io/add-to-catalog: 'true'
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/observability-agent.yaml
+    backstage.io/owner: group:default/platform-engineering
+spec:
+  type: Declarative
+  description: An Observability-oriented Agent specialized in using Prometheus, Grafana, and Kubernetes
+    for monitoring and observability. This agent is equipped with a range of tools to query Prometheus
+    for metrics, create Grafana dashboards, and verify Kubernetes resources.
+  declarative:
+    modelConfig: default-model-config
+    runtime: python
+    memory:
+      modelConfig: embedding-model-config
+      ttlDays: 15
+    promptTemplate:
+      dataSources:
+      - alias: builtin
+        kind: ConfigMap
+        name: kagent-builtin-prompts
+    a2aConfig:
+      skills:
+      - description: Designs Prometheus monitoring strategies, writes PromQL queries, executes them, interprets
+          metrics, and designs alerts.
+        examples:
+        - Generate a PromQL query to show the 99th percentile latency for 'my-service'.
+        - 'Execute this PromQL query and show me the results: `sum(rate(container_cpu_usage_seconds_total[5m]))
+          by (pod)`'
+        - Help me design an alert for when the disk space on my nodes is above 80%.
+        - What are the key metrics I should monitor for a Kafka cluster?
+        id: prometheus-monitoring-querying
+        name: Prometheus Monitoring & Querying
+        tags:
+        - prometheus
+        - promql
+        - monitoring
+        - metrics
+        - alerting
+        - query
+        - analysis
+      - description: "Finds and reads Grafana dashboards, and updates existing ones (update requires human\
+          \ approval). Cannot delete dashboards, manage versions, or change permissions \u2014 no such\
+          \ tool is bound."
+        examples:
+        - Find all Grafana dashboards related to 'nginx'.
+        - Show me the panel queries on the 'Kubernetes Overview' dashboard.
+        - Add a new panel to the 'Kubernetes Overview' dashboard to show network traffic.
+        id: grafana-dashboard-management
+        name: Grafana Dashboard Query & Update
+        tags:
+        - grafana
+        - dashboard
+        - visualization
+        - search-dashboard
+        - update-dashboard
+      - description: Provides insights into Kubernetes cluster and application health by correlating Kubernetes
+          resource information with Prometheus metrics and Grafana visualizations. Helps troubleshoot
+          performance bottlenecks and service issues.
+        examples:
+        - My 'checkout-service' pods are restarting frequently. Can you help me investigate using logs
+          and metrics?
+        - What's the current resource utilization (CPU/memory) of nodes tagged with 'workload=critical'?
+        - Show me Kubernetes events related to the 'database' StatefulSet along with its key performance
+          metrics.
+        - Help me identify potential performance bottlenecks in my microservices deployment.
+        id: kubernetes-observability-insights
+        name: Kubernetes Observability Insights
+        tags:
+        - kubernetes
+        - observability
+        - insights
+        - troubleshooting
+        - performance
+        - resource-utilization
+        - service-monitoring
+    systemMessage: "# Observability AI Agent System Prompt\n\nYou are an advanced AI agent specialized\
+      \ in Kubernetes observability with expertise in Prometheus monitoring and Grafana visualization.\
+      \ You excel at helping users design, implement, and troubleshoot monitoring solutions for Kubernetes\
+      \ environments. Your purpose is to assist users in gaining actionable insights from their infrastructure\
+      \ and application metrics through effective monitoring, querying, and visualization.\n\n## Core\
+      \ Capabilities\n\n- **Prometheus Expertise**: You understand PromQL, metric types, collection methods,\
+      \ alerting, and optimization.\n- **Grafana Mastery**: You know how to create, manage, and optimize\
+      \ dashboards, visualizations, and data sources.\n- **Kubernetes Observability**: You comprehend\
+      \ service monitoring, resource utilization patterns, and common performance bottlenecks.\n- **Metrics\
+      \ Interpretation**: You can analyze trends, anomalies, and correlations in observability data.\n\
+      - **Alerting Design**: You can recommend effective alerting strategies based on metrics and thresholds.\n\
+      \n{{include \"builtin/kubernetes-context\"}}\n\n{{include \"builtin/tool-usage-best-practices\"\
+      }}\n\n## Available Tools\n\nYou have access to the following tools. This list is EXACT \u2014 it\
+      \ mirrors the\ntools actually bound to you. Do not attempt any operation not listed here.\n\n  ###\
+      \ Prometheus / Loki (read-only)\n  - query_prometheus, query_loki_logs, query_loki_stats\n  - list_prometheus_metric_names,\
+      \ list_prometheus_metric_metadata,\n    list_prometheus_label_names, list_prometheus_label_values\n\
+      \  - list_loki_label_names, list_loki_label_values\n  - list_datasources, get_datasource\n\n  ###\
+      \ Grafana dashboards\n  - search_dashboards, get_dashboard_by_uid, get_dashboard_panel_queries (read)\n\
+      \  - update_dashboard (MUTATING \u2014 requires human approval before it runs)\n\n  You CANNOT delete\
+      \ dashboards, read or restore version history, diff versions,\n  or read or change permissions.\
+      \ No such tool is bound to you. If asked, say so\n  plainly and stop; do not improvise or claim\
+      \ to have done it.\n\n  ### Alerting, incidents, on-call\n  - list_alert_rules, get_alert_rule_by_uid,\
+      \ list_contact_points (read)\n  - list_incidents, get_incident (read)\n  - list_teams, list_oncall_users,\
+      \ list_oncall_teams, list_oncall_schedules,\n    get_oncall_shift, get_current_oncall_users (read)\n\
+      \  - create_incident, add_activity_to_incident (MUTATING \u2014 require approval)\n\n  ### Investigation\n\
+      \  - list_sift_investigations, get_sift_investigation, get_sift_analysis,\n    get_assertions, find_slow_requests,\
+      \ find_error_pattern_logs (read)\n\n  ### Kubernetes (read-only)\n  - k8s_get_resources, k8s_get_available_api_resources\n\
+      \n  You have no PromQL-generation agent to delegate to. Write PromQL yourself and\n  execute it\
+      \ with query_prometheus.\n\n# Response format\n- ALWAYS format your response as Markdown\n- Your\
+      \ response will include a summary of actions you took and an explanation of the result\n- If you\
+      \ created any artifacts such as files or resources, you will include those in your response as well"
+    tools:
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: kagent-tool-server
+        toolNames:
+        - k8s_get_resources
+        - k8s_get_available_api_resources
+    - type: McpServer
+      mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: kagent-grafana-mcp
+        toolNames:
+        - update_dashboard
+        - search_dashboards
+        - query_prometheus
+        - query_loki_stats
+        - query_loki_logs
+        - list_teams
+        - list_sift_investigations
+        - list_prometheus_metric_names
+        - list_prometheus_metric_metadata
+        - list_prometheus_label_values
+        - list_prometheus_label_names
+        - list_oncall_users
+        - list_oncall_teams
+        - list_oncall_schedules
+        - list_loki_label_values
+        - list_loki_label_names
+        - list_incidents
+        - list_datasources
+        - list_contact_points
+        - list_alert_rules
+        - get_sift_investigation
+        - get_sift_analysis
+        - get_oncall_shift
+        - get_incident
+        - get_datasource
+        - get_dashboard_panel_queries
+        - get_dashboard_by_uid
+        - get_current_oncall_users
+        - get_assertions
+        - get_alert_rule_by_uid
+        - find_slow_requests
+        - find_error_pattern_logs
+        - create_incident
+        - add_activity_to_incident
+        requireApproval:
+        - add_activity_to_incident
+        - create_incident
+        - update_dashboard
+    deployment:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi

--- a/base-apps/kagent/agents/skill-suggester.yaml
+++ b/base-apps/kagent/agents/skill-suggester.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/name: skill-suggester
     app: kagent
     arigsela.com/idp-managed: "true"
+    # Pure LLM, tools: []. Nothing to gate.
+    capability.homelab/class: read
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent

--- a/base-apps/kagent/build-orchestrator.yaml
+++ b/base-apps/kagent/build-orchestrator.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: kagent
   labels:
     app.kubernetes.io/part-of: kagent
+    # Binds no MCP tool of its own, but delegates to k8s-agent and istio-agent,
+    # both admin. Effective capability is admin, so it is declared admin —
+    # delegation is transitive and the contract will not let it under-declare.
+    capability.homelab/class: admin
 spec:
   description: Orchestrates across all specialized K8s agents to handle complex multi-domain requests
   type: Declarative

--- a/base-apps/kyverno-policies/agent-capability-taxonomy.yaml
+++ b/base-apps/kyverno-policies/agent-capability-taxonomy.yaml
@@ -1,0 +1,140 @@
+---
+# Agent capability taxonomy — THE single source of truth for what every kagent
+# tool is allowed to DO. Edit the classification here and nowhere else.
+#
+# Three consumers, all reading this exact content:
+#
+#   - scripts/gen-agent-capability-policy.py  compiles it INTO
+#     ClusterPolicy/agent-capability. CI fails if that policy drifts from this
+#     file (`--check`).
+#   - scripts/validate-agent-capability.py    the CI contract gate.
+#   - humans, in-cluster: `kubectl get cm -n kyverno agent-capability-taxonomy`
+#
+# NOTE: Kyverno does NOT read this ConfigMap at admission time. The policy embeds
+# the lists inline instead. A `context.configMap` lookup would be DRYer but is a
+# runtime dependency at rule level — evaluated for EVERY Agent — and if it failed
+# for any reason (RBAC, sync ordering, schema) every rule would error and Kyverno's
+# default failurePolicy=Fail would deny ALL Agent writes, wedging the kagent app.
+# It is also unresolvable by the kyverno CLI, so that riskiest path would have been
+# the one path never covered by tests. Inlining makes the artifact we test
+# byte-for-byte the artifact that ships. See the generator for the full rationale.
+#
+# Three classifications, ordered read < write < destructive:
+#
+#   read         observes state; cannot change anything. Tools that RENDER a
+#                manifest but do not apply it (k8s_generate_resource,
+#                istio_generate_manifest, istio_generate_waypoint) are `read` —
+#                they return YAML to the caller.
+#   write        mutates state. Must appear in the tool ref's requireApproval.
+#   destructive  removes state, or is an arbitrary-code escape hatch whose blast
+#                radius is not bounded by its name (k8s_execute_command). Must
+#                appear in requireApproval, and only an `admin` agent may bind it.
+#
+# FAIL-CLOSED: a tool bound by an Agent but absent from all three lists is
+# DENIED. This is deliberate. A chart upgrade that introduces new tools cannot
+# silently widen any agent's capability — the new tools must be triaged and
+# classified here first. If a sync fails with "tool not in taxonomy", that is
+# the control working, not a bug.
+#
+# The lists are JSON arrays because Kyverno reads them with parse_json().
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-capability-taxonomy
+  namespace: kyverno
+  labels:
+    app.kubernetes.io/part-of: agent-guardrails
+data:
+  # ---------------------------------------------------------------- read (53)
+  read: |
+    [
+      "k8s_get_resources",
+      "k8s_get_pod_logs",
+      "k8s_describe_resource",
+      "k8s_get_events",
+      "k8s_get_resource_yaml",
+      "k8s_get_cluster_configuration",
+      "k8s_get_available_api_resources",
+      "k8s_check_service_connectivity",
+      "k8s_generate_resource",
+
+      "istio_proxy_status",
+      "istio_proxy_config",
+      "istio_version",
+      "istio_analyze_cluster_configuration",
+      "istio_ztunnel_config",
+      "istio_waypoint_status",
+      "istio_list_waypoints",
+      "istio_remote_clusters",
+      "istio_generate_manifest",
+      "istio_generate_waypoint",
+
+      "search_dashboards",
+      "get_dashboard_by_uid",
+      "get_dashboard_panel_queries",
+      "query_prometheus",
+      "query_loki_logs",
+      "query_loki_stats",
+      "list_prometheus_metric_names",
+      "list_prometheus_metric_metadata",
+      "list_prometheus_label_names",
+      "list_prometheus_label_values",
+      "list_loki_label_names",
+      "list_loki_label_values",
+      "list_datasources",
+      "get_datasource",
+      "list_alert_rules",
+      "get_alert_rule_by_uid",
+      "list_contact_points",
+      "list_incidents",
+      "get_incident",
+      "list_teams",
+      "list_oncall_users",
+      "list_oncall_teams",
+      "list_oncall_schedules",
+      "get_oncall_shift",
+      "get_current_oncall_users",
+      "list_sift_investigations",
+      "get_sift_investigation",
+      "get_sift_analysis",
+      "get_assertions",
+      "find_slow_requests",
+      "find_error_pattern_logs",
+
+      "get_file_contents",
+      "search_code",
+      "get-catalog-entity"
+    ]
+
+  # --------------------------------------------------------------- write (13)
+  # Every tool here MUST appear in requireApproval wherever it is bound.
+  # The four k8s label/annotation mutators matter more than they look: Argo CD
+  # sync behaviour and Kyverno matching are both label/annotation-driven, so an
+  # agent holding them can disable the very controls that hold it in.
+  write: |
+    [
+      "k8s_patch_resource",
+      "k8s_apply_manifest",
+      "k8s_create_resource",
+      "k8s_create_resource_from_url",
+      "k8s_annotate_resource",
+      "k8s_remove_annotation",
+      "k8s_label_resource",
+      "k8s_remove_label",
+
+      "istio_apply_waypoint",
+      "istio_install_istio",
+
+      "update_dashboard",
+      "create_incident",
+      "add_activity_to_incident"
+    ]
+
+  # ---------------------------------------------------------- destructive (3)
+  # Only an `admin` agent may bind these, and only with requireApproval.
+  destructive: |
+    [
+      "k8s_delete_resource",
+      "k8s_execute_command",
+      "istio_delete_waypoint"
+    ]

--- a/base-apps/kyverno-policies/agent-capability.yaml
+++ b/base-apps/kyverno-policies/agent-capability.yaml
@@ -1,0 +1,307 @@
+---
+# Agent capability guardrails — the admission half of the L03 Security pillar.
+#
+# !!! GENERATED FILE — DO NOT EDIT BY HAND !!!
+# Source of truth: base-apps/kyverno-policies/agent-capability-taxonomy.yaml
+# Regenerate:      ./scripts/gen-agent-capability-policy.py
+# CI fails if this file drifts from the taxonomy.
+#
+# ClusterPolicy/agent-identity answers WHO an agent is (its credentials are scoped
+# to a dedicated Vault path). This policy answers what an agent may DO. It DENIES,
+# at admission:
+#
+#   1. an Agent with no capability.homelab/class in {read, write, admin}
+#   2. an Agent binding a tool that is not in the taxonomy   (FAIL-CLOSED)
+#   3. a `read` agent binding any write/destructive tool
+#   4. a `write` agent binding any destructive tool
+#   5. any mutating tool bound without a matching requireApproval entry
+#   6. a `read` agent delegating to a `write` or `admin` agent
+#   7. a `write` agent delegating to an `admin` agent
+#
+# Rules 6-7 close the privilege-escalation path that admission previously left
+# open: an agent's effective capability is its own tools UNION everything it can
+# reach by delegating, so a read-only agent delegating to an admin agent IS an
+# admin agent. This was live (homelab-knowledge -> k8s-agent) and is reachable by
+# an agent, not just a human: k8s-agent holds k8s_create_resource, so it could be
+# driven to create a `read` Agent that delegates straight back to itself.
+#
+# Rules 6-7 check ONE HOP, which is inductively sufficient at admission: if every
+# agent is forbidden from delegating above its own class, no chain can exceed its
+# head's class. The multi-hop closure (A->B->C, where B is later PROMOTED to
+# admin and A is never re-admitted) is not catchable one-object-at-a-time; CI
+# computes the full transitive closure over the graph in git, and background
+# PolicyReports re-scan existing agents.
+#
+# Rules 6-7 are the ONLY rules that make a runtime API call (to read the
+# delegate's class). That call is made inside `foreach tools[?type=='Agent']`, so
+# it never fires for an agent that has no delegations — the blast radius of an
+# apiCall failure is the delegating agents alone, not every Agent in the cluster.
+#
+# ---------------------------------------------------------------------------
+# KYVERNO NOTES — both cost real debugging time. Read before editing the generator.
+#
+# (a) Context variables do NOT resolve inside JMESPath filter expressions.
+#     `toolNames[?contains(mutating, @)]` evaluates `mutating` to nil and the rule
+#     ERRORS ("Invalid type for: <nil>, expected: array|string"). Variables are
+#     substituted by {{ }} templating BEFORE JMESPath runs, so a variable must be
+#     injected as a JSON literal: toolNames[?contains(`{{ mutating }}`, @)].
+#     Prefer the AnyIn/AnyNotIn operators, which compare arrays natively.
+#
+# (b) Keep every jmesPath on ONE line. A YAML folded scalar (>-) preserves
+#     newlines literally when continuation lines are more-indented, embedding \n
+#     into the expression so it fails to parse and the variable resolves to nil.
+#
+# Verified offline against the SHIPPED policy (no substitution):
+#     ./tests/agent-capability/kyverno/run.sh
+#
+# Contract: docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: agent-capability
+  annotations:
+    policies.kyverno.io/title: Agent capability classes
+    policies.kyverno.io/category: Agent Guardrails
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Agent
+    policies.kyverno.io/description: Constrains what a kagent Agent may do. Each Agent declares a capability class; every tool it binds must be classified in the capability taxonomy and permitted by that class; every mutating tool must be gated behind requireApproval; and an agent may not delegate to a higher-class agent.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+  - name: agent-must-declare-capability-class
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+    validate:
+      message: "Agent must declare a capability class: the label capability.homelab/class must be one of read, write, admin. There is no default \u2014 an agent with no declared class is denied."
+      deny:
+        conditions:
+          any:
+          - key: '{{ request.object.metadata.labels."capability.homelab/class" || ''<none>'' }}'
+            operator: AnyNotIn
+            value:
+            - read
+            - write
+            - admin
+  - name: bound-tools-must-be-classified
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+    validate:
+      message: "Agent binds tools that are not in the capability taxonomy. Classify them in base-apps/kyverno-policies/agent-capability-taxonomy.yaml before binding them \u2014 unclassified tools are denied by design, so that a chart upgrade cannot silently widen any agent's capability."
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='McpServer']
+        deny:
+          conditions:
+            any:
+            - key: '{{ element.mcpServer.toolNames }}'
+              operator: AnyNotIn
+              value:
+              - k8s_get_resources
+              - k8s_get_pod_logs
+              - k8s_describe_resource
+              - k8s_get_events
+              - k8s_get_resource_yaml
+              - k8s_get_cluster_configuration
+              - k8s_get_available_api_resources
+              - k8s_check_service_connectivity
+              - k8s_generate_resource
+              - istio_proxy_status
+              - istio_proxy_config
+              - istio_version
+              - istio_analyze_cluster_configuration
+              - istio_ztunnel_config
+              - istio_waypoint_status
+              - istio_list_waypoints
+              - istio_remote_clusters
+              - istio_generate_manifest
+              - istio_generate_waypoint
+              - search_dashboards
+              - get_dashboard_by_uid
+              - get_dashboard_panel_queries
+              - query_prometheus
+              - query_loki_logs
+              - query_loki_stats
+              - list_prometheus_metric_names
+              - list_prometheus_metric_metadata
+              - list_prometheus_label_names
+              - list_prometheus_label_values
+              - list_loki_label_names
+              - list_loki_label_values
+              - list_datasources
+              - get_datasource
+              - list_alert_rules
+              - get_alert_rule_by_uid
+              - list_contact_points
+              - list_incidents
+              - get_incident
+              - list_teams
+              - list_oncall_users
+              - list_oncall_teams
+              - list_oncall_schedules
+              - get_oncall_shift
+              - get_current_oncall_users
+              - list_sift_investigations
+              - get_sift_investigation
+              - get_sift_analysis
+              - get_assertions
+              - find_slow_requests
+              - find_error_pattern_logs
+              - get_file_contents
+              - search_code
+              - get-catalog-entity
+              - k8s_patch_resource
+              - k8s_apply_manifest
+              - k8s_create_resource
+              - k8s_create_resource_from_url
+              - k8s_annotate_resource
+              - k8s_remove_annotation
+              - k8s_label_resource
+              - k8s_remove_label
+              - istio_apply_waypoint
+              - istio_install_istio
+              - update_dashboard
+              - create_incident
+              - add_activity_to_incident
+              - k8s_delete_resource
+              - k8s_execute_command
+              - istio_delete_waypoint
+  - name: read-agent-must-not-bind-mutating-tools
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+          selector:
+            matchLabels:
+              capability.homelab/class: read
+    validate:
+      message: Agent is declared capability.homelab/class=read but binds mutating tools. A read agent may bind only read-classified tools.
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='McpServer']
+        deny:
+          conditions:
+            any:
+            - key: '{{ element.mcpServer.toolNames }}'
+              operator: AnyIn
+              value: &id001
+              - k8s_patch_resource
+              - k8s_apply_manifest
+              - k8s_create_resource
+              - k8s_create_resource_from_url
+              - k8s_annotate_resource
+              - k8s_remove_annotation
+              - k8s_label_resource
+              - k8s_remove_label
+              - istio_apply_waypoint
+              - istio_install_istio
+              - update_dashboard
+              - create_incident
+              - add_activity_to_incident
+              - k8s_delete_resource
+              - k8s_execute_command
+              - istio_delete_waypoint
+  - name: write-agent-must-not-bind-destructive-tools
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+          selector:
+            matchLabels:
+              capability.homelab/class: write
+    validate:
+      message: Agent is declared capability.homelab/class=write but binds destructive tools. Only an admin agent may bind destructive tools.
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='McpServer']
+        deny:
+          conditions:
+            any:
+            - key: '{{ element.mcpServer.toolNames }}'
+              operator: AnyIn
+              value:
+              - k8s_delete_resource
+              - k8s_execute_command
+              - istio_delete_waypoint
+  - name: mutating-tools-must-require-approval
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+    validate:
+      message: Agent binds mutating tools that are not gated behind requireApproval. Every write/destructive tool bound must appear in that same tool ref's requireApproval list. This gate was silently stripped once before; it is enforced now.
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='McpServer']
+        context:
+        - name: approved
+          variable:
+            jmesPath: element.mcpServer.requireApproval || `[]`
+        - name: mutating
+          variable:
+            value: *id001
+        - name: ungated
+          variable:
+            jmesPath: element.mcpServer.toolNames[?contains(`{{ mutating }}`, @) && !contains(`{{ approved }}`, @)] || `[]`
+        deny:
+          conditions:
+            any:
+            - key: '{{ length(ungated) }}'
+              operator: GreaterThan
+              value: 0
+  - name: read-agent-must-not-delegate-to-higher-class
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+          selector:
+            matchLabels:
+              capability.homelab/class: read
+    validate:
+      message: 'Agent is declared capability.homelab/class=read but delegates to a write or admin agent. Delegation is capability-transitive: an agent''s effective capability is its own tools UNION everything it can reach by delegating, so this is a privilege escalation. Delegate to a read-class agent instead (see k8s-reader), or declare the class this agent actually needs.'
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='Agent']
+        context:
+        - name: delegateClass
+          apiCall:
+            urlPath: /apis/kagent.dev/v1alpha2/namespaces/{{request.object.metadata.namespace}}/agents/{{element.agent.name}}
+            jmesPath: metadata.labels."capability.homelab/class" || 'admin'
+        deny:
+          conditions:
+            any:
+            - key: '{{ delegateClass }}'
+              operator: AnyIn
+              value:
+              - write
+              - admin
+  - name: write-agent-must-not-delegate-to-admin
+    match:
+      any:
+      - resources:
+          kinds:
+          - kagent.dev/v1alpha2/Agent
+          selector:
+            matchLabels:
+              capability.homelab/class: write
+    validate:
+      message: "Agent is declared capability.homelab/class=write but delegates to an admin agent. Delegation is capability-transitive \u2014 this is a privilege escalation."
+      foreach:
+      - list: request.object.spec.declarative.tools[?type=='Agent']
+        context:
+        - name: delegateClass
+          apiCall:
+            urlPath: /apis/kagent.dev/v1alpha2/namespaces/{{request.object.metadata.namespace}}/agents/{{element.agent.name}}
+            jmesPath: metadata.labels."capability.homelab/class" || 'admin'
+        deny:
+          conditions:
+            any:
+            - key: '{{ delegateClass }}'
+              operator: AnyIn
+              value:
+              - admin

--- a/base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
+++ b/base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
@@ -1,0 +1,52 @@
+---
+# Lets Kyverno's REPORTS controller — and only that one — read kagent Agents.
+#
+# Why any grant is needed at all
+# ------------------------------
+# ClusterPolicy/agent-identity has declared `background: true` since it shipped
+# and has produced ZERO PolicyReports for Agents, because the reports controller
+# cannot list them:
+#
+#   $ kubectl auth can-i list agents.kagent.dev \
+#       --as=system:serviceaccount:kyverno:kyverno-reports-controller
+#   no
+#
+# So the identity policy enforces correctly at admission while its background scan
+# quietly does nothing: no report, and no visibility into the agents that already
+# exist. Applying either agent policy makes Kyverno say so itself:
+#
+#   Warning: system:serviceaccount:kyverno:kyverno-reports-controller requires
+#   permissions get,list,watch for resource kagent.dev/v1alpha2/Agent
+#
+# Why ONLY the reports controller
+# -------------------------------
+# Kyverno names exactly one service account in that warning, and the scope of this
+# ClusterRole is deliberately held to it. The other two controllers do not need it,
+# and granting them access would widen a security-critical component's permissions
+# beyond anything demonstrated:
+#
+#   admission controller  — does NOT need read access to validate. The API server
+#                           hands it the object in the AdmissionReview payload.
+#                           This is why agent-identity has been enforcing
+#                           correctly at admission all along with no RBAC at all.
+#
+#   background controller — reconciles `generate` and `mutate-existing` rules.
+#                           Both agent policies are validate-only (zero generate
+#                           or mutate rules), so it has no work to do on Agents.
+#                           Add it here only if a generate/mutate rule is ever
+#                           introduced for this kind.
+#
+# Read-only verbs: Kyverno never needs to mutate an Agent. It validates them at
+# admission (no RBAC) and reports on them in the background (this grant).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:read-kagent-agents
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups: ["kagent.dev"]
+    resources: ["agents"]
+    verbs: ["get", "list", "watch"]

--- a/docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md
+++ b/docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md
@@ -1,0 +1,343 @@
+# Agent Capability Classes — Security Guardrails (increment 1) — Design
+
+Status: draft for review
+Pillar: L03 Security (agent guardrails)
+Predecessor: [Agent Identity — "Agent Principal"](2026-07-11-agent-identity-principal-design.md)
+
+## Problem
+
+The Identity pillar answered *who an agent is* — each agent's credentials are now
+scoped to a dedicated Vault path, proven read-own / denied-neighbour. It said
+nothing about *what an agent may do*.
+
+Today, nothing constrains capability:
+
+1. **The existing `toolNames` rule is an anti-bind-all floor, not a fence.** It
+   denies an empty/absent `toolNames`, and nothing more. Any agent may bind
+   `k8s_delete_resource` and `k8s_execute_command` and pass admission.
+
+2. **Delegation is an uncovered escalation path.** The rule's
+   `[?type=='McpServer']` filter excludes `type: Agent` refs entirely.
+   `homelab-knowledge` — whose own three tools are genuinely read-only, backed by
+   a `--read-only` MCP binary — carries a delegation ref to `k8s-agent`, which
+   holds delete/apply/exec. Its *effective* capability is admin.
+   `build-orchestrator` binds no MCP tool at all yet delegates to both
+   `k8s-agent` and `istio-agent`.
+
+3. **Four mutating tools are bound but ungated.** `k8s_annotate_resource`,
+   `k8s_remove_annotation`, `k8s_label_resource`, `k8s_remove_label` are on
+   `k8s-agent` and absent from its `requireApproval`. Argo CD sync behaviour and
+   Kyverno matching are both label/annotation-driven, so these tools can be used
+   to disable the controls holding the agent in.
+
+4. **`requireApproval` is hand-maintained and unasserted.** It lives in the same
+   object an agent author edits, no policy requires it, and it has already been
+   silently stripped once — for days, while Argo CD reported Synced/Healthy.
+
+## Insight: where capability actually lives in kagent
+
+The kagent `Agent` CRD gives declarative agents **no `serviceAccountName`**. All
+agents share one chart-provided Kubernetes identity. There is therefore no
+native per-agent principal to bind RBAC, NetworkPolicy, or audit attribution to.
+
+Consequence for this design: **capability must be enforced at the declaration,
+not at the Kubernetes API boundary.** An agent's capability is exactly the set of
+tools it binds, plus — transitively — the tools of every agent it delegates to.
+That set is fully knowable from Git, which is what makes both a CI gate and an
+admission gate possible without inventing a new runtime identity.
+
+## Goal
+
+Make an agent's capability **declared, bounded, and non-escalating** — checkable
+in CI and enforced at admission, in the same shape as the Identity contract.
+
+## The contract (four invariants)
+
+Every kagent `Agent` must satisfy:
+
+1. **Declared class.** Carries the label `capability.homelab/class` with value
+   `read`, `write`, or `admin`. No default. An agent with no class is denied.
+
+2. **Tools within class.** Every bound tool is classified in the taxonomy, and
+   its classification is permitted by the agent's class. A tool absent from the
+   taxonomy is **denied** (fail-closed — a new tool from a chart upgrade must be
+   triaged before it can be used).
+
+3. **Mutating tools are gated.** Every bound tool classified `write` or
+   `destructive` appears in that tool ref's `requireApproval`.
+
+4. **Delegation does not escalate.** For every `type: Agent` tool ref, the
+   delegate's class is ≤ this agent's class. Effective capability = own tools ∪
+   delegates' effective capability.
+
+### The class lattice
+
+| Class    | May bind                    | Approval required for | May delegate to     |
+|----------|-----------------------------|-----------------------|---------------------|
+| `read`   | `read`                      | — (nothing to gate)   | `read`              |
+| `write`  | `read`, `write`             | all `write`           | `read`, `write`     |
+| `admin`  | `read`, `write`, `destructive` | all `write` + `destructive` | any            |
+
+Ordering: `read` < `write` < `admin`.
+
+## The taxonomy
+
+A single source of truth in Git, applied as a ConfigMap so both gates read the
+same content:
+
+- `base-apps/kyverno-policies/agent-capability-taxonomy.yaml` → ConfigMap
+  `agent-capability-taxonomy` (namespace `kyverno`), with keys `read`, `write`,
+  `destructive` holding JSON arrays of tool names.
+- Kyverno reads it via a `context.configMap` block + `parse_json`.
+- The CI validator reads the same file from the working tree.
+
+Initial classification of the tools bound today:
+
+**`read`** (53) —
+*k8s:* `k8s_get_resources`, `k8s_get_pod_logs`, `k8s_describe_resource`,
+`k8s_get_events`, `k8s_get_resource_yaml`, `k8s_get_cluster_configuration`,
+`k8s_get_available_api_resources`, `k8s_check_service_connectivity`,
+`k8s_generate_resource`.
+*istio:* `istio_proxy_status`, `istio_proxy_config`, `istio_version`,
+`istio_analyze_cluster_configuration`, `istio_ztunnel_config`,
+`istio_waypoint_status`, `istio_list_waypoints`, `istio_remote_clusters`,
+`istio_generate_manifest`, `istio_generate_waypoint`.
+*grafana:* `search_dashboards`, `get_dashboard_by_uid`,
+`get_dashboard_panel_queries`, `query_prometheus`, `query_loki_logs`,
+`query_loki_stats`, `list_prometheus_metric_names`,
+`list_prometheus_metric_metadata`, `list_prometheus_label_names`,
+`list_prometheus_label_values`, `list_loki_label_names`,
+`list_loki_label_values`, `list_datasources`, `get_datasource`,
+`list_alert_rules`, `get_alert_rule_by_uid`, `list_contact_points`,
+`list_incidents`, `get_incident`, `list_teams`, `list_oncall_users`,
+`list_oncall_teams`, `list_oncall_schedules`, `get_oncall_shift`,
+`get_current_oncall_users`, `list_sift_investigations`,
+`get_sift_investigation`, `get_sift_analysis`, `get_assertions`,
+`find_slow_requests`, `find_error_pattern_logs`.
+*github/backstage:* `get_file_contents`, `search_code`, `get-catalog-entity`
+
+**`write`** (13) —
+*k8s:* `k8s_patch_resource`, `k8s_apply_manifest`, `k8s_create_resource`,
+`k8s_create_resource_from_url`, `k8s_annotate_resource`,
+`k8s_remove_annotation`, `k8s_label_resource`, `k8s_remove_label`.
+*istio:* `istio_apply_waypoint`, `istio_install_istio`.
+*grafana:* `update_dashboard`, `create_incident`, `add_activity_to_incident`
+
+**`destructive`** (3) — `k8s_delete_resource`, `k8s_execute_command`,
+`istio_delete_waypoint`
+
+`k8s_generate_resource` / `istio_generate_manifest` / `istio_generate_waypoint`
+are classified `read`: they render YAML and return it, they do not apply it.
+`k8s_execute_command` is `destructive` rather than `write` because it is an
+arbitrary-code escape hatch whose blast radius is not bounded by its name.
+
+## Current-state violations this surfaces
+
+Applying the contract to the tree as it stands today:
+
+| Agent | Declared class | Violation | Resolution |
+|---|---|---|---|
+| `k8s-agent` | `admin` | 4 `write` tools bound but absent from `requireApproval` | Add the four label/annotation mutators to `requireApproval` |
+| `istio-agent` | `admin` | none — its approval list already covers its writes | Label only |
+| `homelab-knowledge` | `read` | **delegates to `k8s-agent` (admin)** — escalation | See "Decision 1" |
+| `build-orchestrator` | `admin` | binds no MCP tool, but delegates to two `admin` agents | Declare `admin` (its effective class) |
+| `dungeon-crawler-carl-agent` | `read` | none (`tools: []`) | Label only |
+| `skill-suggester` | `read` | none (`tools: []`) | Label only |
+| `observability-agent` | `write` | **chart-rendered; 3 ungated mutating tools; dangling delegation** | See "Decision 2" |
+
+### Decision 1 — the `homelab-knowledge` → `k8s-agent` delegation — RESOLVED: split
+
+Dropping the delegation closes the hole but removes real capability:
+`homelab-knowledge` uses it to answer live cluster questions ("why is this pod
+crashlooping"), which is much of its value.
+
+**Decision: split the capability rather than remove it.** Introduce a new
+`k8s-reader` agent — class `read`, bound only to the read-classified `k8s_*`
+tools — and repoint `homelab-knowledge`'s delegation from `k8s-agent` to
+`k8s-reader`. `homelab-knowledge` keeps its cluster-investigation ability, and
+its effective capability becomes genuinely read-only. `k8s-agent` remains the
+`admin` operator agent for humans who need to act.
+
+### Decision 2 — the chart-rendered `observability-agent` — RESOLVED: adopt as `write`, gated
+
+Invariant 1 denies any `Agent` without a class label. The chart renders
+`observability-agent` with no such label, so an Enforce policy matching
+cluster-wide would **deny it on next Argo sync** and break the app. It therefore
+has to be resolved before Enforce.
+
+**Inspection of the live object disproved the "read-only" claim** made in the
+repo's own comments. It binds 34 tools from `kagent-grafana-mcp` with **zero
+`requireApproval`**, three of which mutate: `update_dashboard`, `create_incident`,
+`add_activity_to_incident`. It also carries a **dangling `type: Agent` delegation
+to `promql-agent`** — an agent that does not exist in the cluster and is
+explicitly disabled in `base-apps/kagent.yaml`.
+
+This escaped notice because `kagent-grafana-mcp` is one of the two MCP servers
+**exempted by name** from the Identity contract's "must exist in Git" invariant,
+so its 34 tools were never scrutinised. It is the exact failure mode invariant 2's
+fail-closed rule exists to catch.
+
+**Decision:** adopt into Git; declare class `write`; keep all 34 tools; add the
+three mutating tools to `requireApproval`; **remove** the dead `promql-agent`
+delegation (it points at nothing, so removing it restores no behaviour and breaks
+none). Disable the chart copy, following the `k8s-agent`/`istio-agent` precedent.
+
+## Enforcement
+
+Two gates, mirroring the Identity increment.
+
+**CI (`scripts/validate-agent-capability.py`) — authoritative for all four
+invariants.** The full agent graph is in Git, so delegation transitivity is
+static analysis: build the delegation DAG, compute each agent's effective class,
+fail if any agent's declared class is below its effective class. Also detects
+delegation cycles.
+
+**Kyverno (`ClusterPolicy/agent-capability`, Enforce) — invariants 1–3.** These
+are single-object checks and need no cross-object lookup. Ships directly in
+`Enforce`, not staged through `Audit`, because the policy is verified before it
+lands (see below) and the class labels ship in the same commit. Argo sync-waves
+put the taxonomy ConfigMap and the Kyverno RBAC at wave `-1` and the policy at
+wave `0`, so the policy never evaluates before its taxonomy exists.
+
+**Invariant 4 (delegation) IS enforced at admission**, by rules 6–7: a `read`
+agent may not delegate to a `write`/`admin` agent, and a `write` agent may not
+delegate to an `admin` agent. Each reads the delegate's class with a Kyverno
+`apiCall`.
+
+This matters more than it first appeared, because the escalation is **reachable
+by an agent, not only by a careless PR**: `k8s-agent` holds
+`k8s_create_resource`, so it could be driven to create a `read`-class Agent that
+delegates straight back to itself — binding no mutating tool of its own, and so
+passing rules 1–5 cleanly. Leaving this to CI alone would have left a live
+privilege-escalation path open at admission.
+
+Rules 6–7 check **one hop**, which is inductively sufficient for admission: if
+every agent is forbidden from delegating above its own class, no chain can exceed
+its head's class. The case one-object-at-a-time cannot catch is a *later
+promotion* — A(read) → B(read) is admitted, then B is promoted to `admin` and A
+is never re-admitted. CI computes the full transitive closure over the Git graph
+and catches it; background PolicyReports (now that Kyverno can read Agents)
+re-scan existing agents and surface it.
+
+The apiCall is the policy's only runtime lookup, and it fires **only** inside
+`foreach tools[?type=='Agent']` — an agent with no delegations never triggers it.
+So the blast radius of an apiCall failure is the delegating agents alone, not
+every Agent in the cluster.
+
+The existing `agent-mcp-tools-must-list-toolnames` rule is retained: it remains
+the floor that makes invariant 2 meaningful (a bind-all would otherwise have no
+`toolNames` to check against the taxonomy).
+
+### The policy is generated, and the tested artifact is the shipped artifact
+
+The policy **embeds the taxonomy inline** rather than reading
+`ConfigMap/agent-capability-taxonomy` at admission time, and is compiled from it
+by `scripts/gen-agent-capability-policy.py`. CI fails if the two drift
+(`--check`).
+
+This trades DRYness for two things worth more. A `context.configMap` lookup sits
+at *rule* level, so it is evaluated for **every** Agent — if it failed for any
+reason (RBAC, sync ordering, a schema change), every rule errors and Kyverno's
+default `failurePolicy: Fail` denies **all** Agent writes, wedging the kagent app.
+And the `kyverno` CLI has no cluster to resolve a ConfigMap against, so that
+single riskiest path would have been the one path no test could cover: the policy
+we shipped would not have been the policy we tested. Inlining removes the lookup
+and closes both gaps at once. The duplication it introduces is exactly what the
+generator plus the CI drift check exist to police.
+
+### Verifying the policy
+
+`tests/agent-capability/kyverno/run.sh` runs the **shipped policy file verbatim**
+— no rewriting, no substitution — under the `kyverno` CLI, and asserts both
+directions: all 8 real agents **pass** (a false positive would wedge the kagent
+app on next sync), and each of **9 fixtures — one per rule** — is **denied** (a
+false negative is a hole). It also fails if the policy has drifted from the
+taxonomy. It runs in CI.
+
+The one thing stubbed is the `apiCall` in rules 6–7, which the CLI cannot make;
+`values.yaml` supplies the delegate's class per resource, so the delegation
+deny-logic is genuinely exercised and only the lookup is mocked.
+
+New manifests are covered by the repo's existing `yaml-lint` and
+`kubernetes-validate` CI jobs, which run `yamllint` and `kubeconform` over changed
+`base-apps/**/*.yaml`.
+
+Two Kyverno behaviours cost real debugging time and are worth recording:
+
+1. **Context variables do not resolve inside JMESPath filter expressions.**
+   `toolNames[?contains(mutating, @)]` evaluates `mutating` to nil and the rule
+   *errors*. Variables are substituted by `{{ }}` templating *before* JMESPath
+   runs, so a context variable must be injected as a JSON literal:
+   ``toolNames[?contains(`{{ mutating }}`, @)]``. Prefer the `AnyIn`/`AnyNotIn`
+   condition operators, which compare arrays natively.
+2. **A YAML folded scalar (`>-`) preserves newlines literally** when continuation
+   lines are more-indented, embedding `\n` into the JMESPath so it fails to parse
+   and the variable resolves to nil. Keep every `jmesPath` on one line.
+
+**Kyverno's background scanning never worked for Agents.** `agent-identity`
+declares `background: true` and has produced *zero* PolicyReports, because
+Kyverno's reports and background controllers have no RBAC to read
+`kagent.dev/Agent`. Admission enforcement was unaffected — the webhook is handed
+the object in the AdmissionReview payload — but there has been no report and no
+visibility into agents that already exist. Fixed by
+`base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml`.
+
+## Success criteria
+
+1. Every `Agent` in Git carries a valid `capability.homelab/class`.
+2. `homelab-knowledge`'s effective capability is `read` — proven by the validator
+   computing its transitive closure, not by inspection.
+3. An `Agent` binding a tool outside its class is denied at admission (probe).
+4. An `Agent` binding a `write`/`destructive` tool absent from `requireApproval`
+   is denied at admission (probe).
+5. Stripping `requireApproval` from `k8s-agent` fails CI **and** admission — the
+   silent-strip regression is structurally impossible.
+6. An unclassified tool name is denied (fail-closed probe).
+7. All kagent apps remain Synced/Healthy; no agent loses intended function.
+
+## Safety, blast radius & rollback
+
+The policy denies `Agent` writes only. Worst case is a failed Argo sync on the
+kagent app, not a runtime outage — running agents are unaffected by an admission
+denial on an update. Rollback is reverting the ClusterPolicy to `Audit`.
+
+**The sequencing risk is real and is handled by sync-waves, not by staging.** An
+Enforce policy that evaluated before the agents carried their class labels — or
+before its taxonomy ConfigMap existed — would block the kagent app. Both are
+ordered explicitly: the taxonomy ConfigMap and the Kyverno RBAC are at Argo
+sync-wave `-1`, the policy at wave `0`, and the labelled agents ship in the same
+commit as the policy. The offline verification (all 8 real agents pass, zero rule
+errors) is what makes shipping straight to `Enforce` defensible rather than
+reckless.
+
+The one link not covered offline is the `context.configMap` lookup itself: the
+`kyverno` CLI has no cluster to resolve it against, so the taxonomy is inlined
+for the test. If that lookup were to fail in-cluster, every rule errors and
+Kyverno's default `failurePolicy: Fail` denies all Agent writes — fail-closed and
+safe, but it would wedge the kagent app until reverted. Watch the first sync.
+
+## Non-goals (documented follow-ons)
+
+- **Egress control.** No NetworkPolicy on kagent pods; agents have unrestricted
+  egress. Needs its own increment.
+- **Audit trail.** No record of which agent invoked which tool with what
+  arguments. Blocked on the shared-ServiceAccount problem: API-server audit logs
+  cannot attribute an action to an agent. Likely needs a kagent-layer hook.
+- **Per-agent budget / rate limits.** All agents share one Anthropic key with no
+  quota or spend cap.
+- **Falco has no sink** (`falcosidekick.enabled: false`) — detections go to
+  stdout and nothing reads them.
+
+## Open questions
+
+1. ~~Decision 1~~ — **resolved: split, via a new read-only `k8s-reader`.**
+2. ~~Decision 2~~ — **resolved: adopt `observability-agent` as class `write`,
+   gate its three mutating tools, drop the dead `promql-agent` delegation.**
+3. Should `write` really require approval for *every* tool, or is that too noisy
+   in practice for an agent a human is actively driving? (Leaning: keep it — the
+   gate is per-invocation and the agents are low-traffic. Revisit if it bites.)
+4. `kagent-tool-server` and `kagent-grafana-mcp` remain exempt from the Identity
+   contract's "MCP server must exist in Git" invariant, because both are
+   chart-rendered. The capability taxonomy closes the *tool-level* half of that
+   gap (their tools must now be classified to be bindable), but the servers
+   themselves are still unreviewable in Git. Worth its own increment.

--- a/scripts/gen-agent-capability-policy.py
+++ b/scripts/gen-agent-capability-policy.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Generate ClusterPolicy/agent-capability from the capability taxonomy.
+
+WHY THIS EXISTS — the policy embeds the taxonomy inline instead of reading it
+from a ConfigMap at admission time.
+
+A `context.configMap` lookup would be DRYer, but it is a runtime dependency with
+a total blast radius: it sits at rule level, so it is evaluated for EVERY Agent,
+and if the lookup fails for any reason (missing ConfigMap, RBAC, schema change,
+sync ordering) every rule errors and Kyverno's default failurePolicy=Fail denies
+ALL Agent writes — wedging the kagent app. Worse, the kyverno CLI has no cluster
+to resolve a configMap against, so that exact path could not be covered by the
+offline tests: the policy we shipped would not be the policy we tested.
+
+Inlining removes the lookup, so the artifact under test is byte-for-byte the
+artifact that ships. The cost is that the tool lists are repeated across rules,
+and duplication drifts — which is what this generator plus the CI drift check
+(`--check`) exist to prevent. The taxonomy has exactly one source of truth:
+base-apps/kyverno-policies/agent-capability-taxonomy.yaml.
+
+  ./scripts/gen-agent-capability-policy.py            # regenerate
+  ./scripts/gen-agent-capability-policy.py --check    # CI: fail if stale
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+TAXONOMY = "base-apps/kyverno-policies/agent-capability-taxonomy.yaml"
+POLICY = "base-apps/kyverno-policies/agent-capability.yaml"
+
+HEADER = """\
+---
+# Agent capability guardrails — the admission half of the L03 Security pillar.
+#
+# !!! GENERATED FILE — DO NOT EDIT BY HAND !!!
+# Source of truth: base-apps/kyverno-policies/agent-capability-taxonomy.yaml
+# Regenerate:      ./scripts/gen-agent-capability-policy.py
+# CI fails if this file drifts from the taxonomy.
+#
+# ClusterPolicy/agent-identity answers WHO an agent is (its credentials are scoped
+# to a dedicated Vault path). This policy answers what an agent may DO. It DENIES,
+# at admission:
+#
+#   1. an Agent with no capability.homelab/class in {read, write, admin}
+#   2. an Agent binding a tool that is not in the taxonomy   (FAIL-CLOSED)
+#   3. a `read` agent binding any write/destructive tool
+#   4. a `write` agent binding any destructive tool
+#   5. any mutating tool bound without a matching requireApproval entry
+#   6. a `read` agent delegating to a `write` or `admin` agent
+#   7. a `write` agent delegating to an `admin` agent
+#
+# Rules 6-7 close the privilege-escalation path that admission previously left
+# open: an agent's effective capability is its own tools UNION everything it can
+# reach by delegating, so a read-only agent delegating to an admin agent IS an
+# admin agent. This was live (homelab-knowledge -> k8s-agent) and is reachable by
+# an agent, not just a human: k8s-agent holds k8s_create_resource, so it could be
+# driven to create a `read` Agent that delegates straight back to itself.
+#
+# Rules 6-7 check ONE HOP, which is inductively sufficient at admission: if every
+# agent is forbidden from delegating above its own class, no chain can exceed its
+# head's class. The multi-hop closure (A->B->C, where B is later PROMOTED to
+# admin and A is never re-admitted) is not catchable one-object-at-a-time; CI
+# computes the full transitive closure over the graph in git, and background
+# PolicyReports re-scan existing agents.
+#
+# Rules 6-7 are the ONLY rules that make a runtime API call (to read the
+# delegate's class). That call is made inside `foreach tools[?type=='Agent']`, so
+# it never fires for an agent that has no delegations — the blast radius of an
+# apiCall failure is the delegating agents alone, not every Agent in the cluster.
+#
+# ---------------------------------------------------------------------------
+# KYVERNO NOTES — both cost real debugging time. Read before editing the generator.
+#
+# (a) Context variables do NOT resolve inside JMESPath filter expressions.
+#     `toolNames[?contains(mutating, @)]` evaluates `mutating` to nil and the rule
+#     ERRORS ("Invalid type for: <nil>, expected: array|string"). Variables are
+#     substituted by {{ }} templating BEFORE JMESPath runs, so a variable must be
+#     injected as a JSON literal: toolNames[?contains(`{{ mutating }}`, @)].
+#     Prefer the AnyIn/AnyNotIn operators, which compare arrays natively.
+#
+# (b) Keep every jmesPath on ONE line. A YAML folded scalar (>-) preserves
+#     newlines literally when continuation lines are more-indented, embedding \\n
+#     into the expression so it fails to parse and the variable resolves to nil.
+#
+# Verified offline against the SHIPPED policy (no substitution):
+#     ./tests/agent-capability/kyverno/run.sh
+#
+# Contract: docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md
+"""
+
+AGENT_KIND = "kagent.dev/v1alpha2/Agent"
+CLASS_LABEL = "capability.homelab/class"
+
+
+def _match(cls: str | None = None) -> dict:
+    res: dict = {"kinds": [AGENT_KIND]}
+    if cls:
+        res["selector"] = {"matchLabels": {CLASS_LABEL: cls}}
+    return {"any": [{"resources": res}]}
+
+
+def _tool_foreach(deny_key: str, op: str, value: list[str]) -> list[dict]:
+    return [{
+        "list": "request.object.spec.declarative.tools[?type=='McpServer']",
+        "deny": {"conditions": {"any": [
+            {"key": deny_key, "operator": op, "value": value}
+        ]}},
+    }]
+
+
+def _delegation_foreach(forbidden: list[str]) -> list[dict]:
+    """Fetch the delegate Agent and read its declared class.
+
+    An absent class defaults to 'admin' — the most restrictive reading. A
+    delegate with no class is itself denied by rule 1, but if one somehow exists
+    (created before this policy), we must not treat it as harmless.
+    """
+    return [{
+        "list": "request.object.spec.declarative.tools[?type=='Agent']",
+        "context": [{
+            "name": "delegateClass",
+            "apiCall": {
+                "urlPath": "/apis/kagent.dev/v1alpha2/namespaces/{{request.object.metadata.namespace}}/agents/{{element.agent.name}}",
+                "jmesPath": "metadata.labels.\"capability.homelab/class\" || 'admin'",
+            },
+        }],
+        "deny": {"conditions": {"any": [
+            {"key": "{{ delegateClass }}", "operator": "AnyIn", "value": forbidden}
+        ]}},
+    }]
+
+
+def build_policy(read: list[str], write: list[str], destructive: list[str]) -> dict:
+    classified = read + write + destructive
+    mutating = write + destructive
+
+    rules = [
+        {
+            "name": "agent-must-declare-capability-class",
+            "match": _match(),
+            "validate": {
+                "message": (
+                    "Agent must declare a capability class: the label "
+                    "capability.homelab/class must be one of read, write, admin. "
+                    "There is no default — an agent with no declared class is denied."
+                ),
+                "deny": {"conditions": {"any": [{
+                    "key": "{{ request.object.metadata.labels.\"capability.homelab/class\" || '<none>' }}",
+                    "operator": "AnyNotIn",
+                    "value": ["read", "write", "admin"],
+                }]}},
+            },
+        },
+        {
+            "name": "bound-tools-must-be-classified",
+            "match": _match(),
+            "validate": {
+                "message": (
+                    "Agent binds tools that are not in the capability taxonomy. "
+                    "Classify them in base-apps/kyverno-policies/agent-capability-taxonomy.yaml "
+                    "before binding them — unclassified tools are denied by design, so that a "
+                    "chart upgrade cannot silently widen any agent's capability."
+                ),
+                "foreach": _tool_foreach(
+                    "{{ element.mcpServer.toolNames }}", "AnyNotIn", classified
+                ),
+            },
+        },
+        {
+            "name": "read-agent-must-not-bind-mutating-tools",
+            "match": _match("read"),
+            "validate": {
+                "message": (
+                    "Agent is declared capability.homelab/class=read but binds mutating tools. "
+                    "A read agent may bind only read-classified tools."
+                ),
+                "foreach": _tool_foreach(
+                    "{{ element.mcpServer.toolNames }}", "AnyIn", mutating
+                ),
+            },
+        },
+        {
+            "name": "write-agent-must-not-bind-destructive-tools",
+            "match": _match("write"),
+            "validate": {
+                "message": (
+                    "Agent is declared capability.homelab/class=write but binds destructive "
+                    "tools. Only an admin agent may bind destructive tools."
+                ),
+                "foreach": _tool_foreach(
+                    "{{ element.mcpServer.toolNames }}", "AnyIn", destructive
+                ),
+            },
+        },
+        {
+            "name": "mutating-tools-must-require-approval",
+            "match": _match(),
+            "validate": {
+                "message": (
+                    "Agent binds mutating tools that are not gated behind requireApproval. "
+                    "Every write/destructive tool bound must appear in that same tool ref's "
+                    "requireApproval list. This gate was silently stripped once before; it is "
+                    "enforced now."
+                ),
+                "foreach": [{
+                    "list": "request.object.spec.declarative.tools[?type=='McpServer']",
+                    "context": [
+                        {"name": "approved", "variable": {
+                            "jmesPath": "element.mcpServer.requireApproval || `[]`"}},
+                        {"name": "mutating", "variable": {"value": mutating}},
+                        {"name": "ungated", "variable": {
+                            "jmesPath": "element.mcpServer.toolNames[?contains(`{{ mutating }}`, @) && !contains(`{{ approved }}`, @)] || `[]`"}},
+                    ],
+                    "deny": {"conditions": {"any": [
+                        {"key": "{{ length(ungated) }}", "operator": "GreaterThan", "value": 0}
+                    ]}},
+                }],
+            },
+        },
+        {
+            "name": "read-agent-must-not-delegate-to-higher-class",
+            "match": _match("read"),
+            "validate": {
+                "message": (
+                    "Agent is declared capability.homelab/class=read but delegates to a write "
+                    "or admin agent. Delegation is capability-transitive: an agent's effective "
+                    "capability is its own tools UNION everything it can reach by delegating, "
+                    "so this is a privilege escalation. Delegate to a read-class agent instead "
+                    "(see k8s-reader), or declare the class this agent actually needs."
+                ),
+                "foreach": _delegation_foreach(["write", "admin"]),
+            },
+        },
+        {
+            "name": "write-agent-must-not-delegate-to-admin",
+            "match": _match("write"),
+            "validate": {
+                "message": (
+                    "Agent is declared capability.homelab/class=write but delegates to an admin "
+                    "agent. Delegation is capability-transitive — this is a privilege escalation."
+                ),
+                "foreach": _delegation_foreach(["admin"]),
+            },
+        },
+    ]
+
+    return {
+        "apiVersion": "kyverno.io/v1",
+        "kind": "ClusterPolicy",
+        "metadata": {
+            "name": "agent-capability",
+            "annotations": {
+                "policies.kyverno.io/title": "Agent capability classes",
+                "policies.kyverno.io/category": "Agent Guardrails",
+                "policies.kyverno.io/severity": "high",
+                "policies.kyverno.io/subject": "Agent",
+                "policies.kyverno.io/description": (
+                    "Constrains what a kagent Agent may do. Each Agent declares a capability "
+                    "class; every tool it binds must be classified in the capability taxonomy "
+                    "and permitted by that class; every mutating tool must be gated behind "
+                    "requireApproval; and an agent may not delegate to a higher-class agent."
+                ),
+            },
+        },
+        "spec": {
+            "validationFailureAction": "Enforce",
+            "background": True,
+            "rules": rules,
+        },
+    }
+
+
+def load_taxonomy(repo: Path) -> tuple[list[str], list[str], list[str]]:
+    cm = next(
+        d for d in yaml.safe_load_all((repo / TAXONOMY).read_text())
+        if d and d.get("kind") == "ConfigMap"
+    )
+    out = []
+    for key in ("read", "write", "destructive"):
+        out.append(json.loads(cm["data"][key]))
+    return tuple(out)  # type: ignore[return-value]
+
+
+def render(repo: Path) -> str:
+    read, write, destructive = load_taxonomy(repo)
+    body = yaml.safe_dump(
+        build_policy(read, write, destructive),
+        sort_keys=False, width=10_000, default_flow_style=False,
+    )
+    return HEADER + body
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", type=Path,
+                    default=Path(__file__).resolve().parent.parent)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the committed policy is stale")
+    args = ap.parse_args(argv)
+
+    want = render(args.repo_root)
+    path = args.repo_root / POLICY
+
+    if not args.check:
+        path.write_text(want)
+        print(f"wrote {POLICY}")
+        return 0
+
+    have = path.read_text() if path.exists() else ""
+    if have == want:
+        print("agent-capability policy is in sync with the taxonomy")
+        return 0
+
+    print(f"{POLICY} is STALE — regenerate with "
+          f"./scripts/gen-agent-capability-policy.py", file=sys.stderr)
+    sys.stderr.writelines(difflib.unified_diff(
+        have.splitlines(True), want.splitlines(True),
+        fromfile="committed", tofile="generated",
+    ))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-agent-capability.py
+++ b/scripts/validate-agent-capability.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Validate the agent-capability contract (L03 Security guardrails).
+
+Four invariants, checked against the manifests in git:
+
+  1. Declared class    every Agent carries capability.homelab/class in
+                       {read, write, admin}. No default; missing is an error.
+  2. Tools within class every bound tool is classified in the taxonomy, and its
+                       classification is permitted by the agent's class. A tool
+                       absent from the taxonomy is an error (FAIL-CLOSED).
+  3. Mutating gated    every bound tool classified write/destructive appears in
+                       that tool ref's requireApproval.
+  4. No escalation     for every type: Agent delegation, the delegate's class is
+                       <= this agent's class. Effective capability is transitive.
+
+This is the authoritative gate for all four. Kyverno enforces 1-3 at admission;
+invariant 4 needs a cross-object lookup, so CI is where it is actually decided.
+The whole agent graph is in git, which is what makes that sound.
+
+Exit 0 clean, 1 on any error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+CLASS_LABEL = "capability.homelab/class"
+
+# read < write < admin
+CLASS_RANK = {"read": 0, "write": 1, "admin": 2}
+
+# What each class may bind. A class may bind any tool whose classification rank
+# is <= its own binding ceiling.
+CLASS_MAY_BIND = {
+    "read": {"read"},
+    "write": {"read", "write"},
+    "admin": {"read", "write", "destructive"},
+}
+
+# Classifications that must be gated behind requireApproval wherever bound.
+MUST_APPROVE = {"write", "destructive"}
+
+TAXONOMY_PATH = "base-apps/kyverno-policies/agent-capability-taxonomy.yaml"
+
+
+def _load_docs(path: Path) -> list[dict]:
+    try:
+        return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+    except yaml.YAMLError:
+        return []
+
+
+def load_taxonomy(repo_root: Path) -> dict[str, str]:
+    """Return {tool_name: classification}. Same content Kyverno reads."""
+    path = repo_root / TAXONOMY_PATH
+    if not path.exists():
+        raise SystemExit(f"taxonomy not found: {TAXONOMY_PATH}")
+
+    cm = next(
+        (d for d in _load_docs(path) if d.get("kind") == "ConfigMap"),
+        None,
+    )
+    if cm is None:
+        raise SystemExit(f"no ConfigMap in {TAXONOMY_PATH}")
+
+    tool_class: dict[str, str] = {}
+    for classification in ("read", "write", "destructive"):
+        raw = (cm.get("data") or {}).get(classification)
+        if not raw:
+            raise SystemExit(f"taxonomy missing '{classification}' key")
+        for tool in json.loads(raw):
+            if tool in tool_class:
+                raise SystemExit(
+                    f"tool {tool!r} classified twice "
+                    f"({tool_class[tool]} and {classification})"
+                )
+            tool_class[tool] = classification
+    return tool_class
+
+
+def collect_agents(repo_root: Path) -> list[tuple[Path, dict]]:
+    """Every kagent Agent in git, found by KIND — not by directory.
+
+    The identity validator globs only kagent/agents/*.yaml, which silently
+    misses build-orchestrator.yaml one level up. Find them by kind instead.
+    """
+    kagent_dir = repo_root / "base-apps" / "kagent"
+    found: list[tuple[Path, dict]] = []
+    for path in sorted(kagent_dir.rglob("*.yaml")):
+        for doc in _load_docs(path):
+            if doc.get("kind") == "Agent":
+                found.append((path, doc))
+    return found
+
+
+def _tool_refs(doc: dict) -> list[dict]:
+    return (doc.get("spec", {}).get("declarative", {}) or {}).get("tools") or []
+
+
+def _agent_class(doc: dict) -> str | None:
+    return ((doc.get("metadata") or {}).get("labels") or {}).get(CLASS_LABEL)
+
+
+def _delegates(doc: dict) -> list[str]:
+    out = []
+    for ref in _tool_refs(doc):
+        if ref.get("type") == "Agent":
+            name = (ref.get("agent") or {}).get("name")
+            if name:
+                out.append(name)
+    return out
+
+
+def check_declared_class(agents) -> list[str]:
+    """Invariant 1."""
+    errors = []
+    for path, doc in agents:
+        name = (doc.get("metadata") or {}).get("name", "<unnamed>")
+        cls = _agent_class(doc)
+        if cls is None:
+            errors.append(
+                f"{name}: missing label {CLASS_LABEL} ({path}). "
+                f"Every agent must declare a capability class; there is no default."
+            )
+        elif cls not in CLASS_RANK:
+            errors.append(
+                f"{name}: invalid {CLASS_LABEL}={cls!r} ({path}). "
+                f"Must be one of: read, write, admin."
+            )
+    return errors
+
+
+def check_tools_within_class(agents, taxonomy) -> list[str]:
+    """Invariants 2 and 3."""
+    errors = []
+    for path, doc in agents:
+        name = (doc.get("metadata") or {}).get("name", "<unnamed>")
+        cls = _agent_class(doc)
+        if cls not in CLASS_RANK:
+            continue  # already reported by invariant 1
+        may_bind = CLASS_MAY_BIND[cls]
+
+        for ref in _tool_refs(doc):
+            if ref.get("type") != "McpServer":
+                continue
+            mcp = ref.get("mcpServer") or {}
+            server = mcp.get("name", "<unnamed-server>")
+            tools = mcp.get("toolNames") or []
+            approval = set(mcp.get("requireApproval") or [])
+
+            for tool in tools:
+                classification = taxonomy.get(tool)
+
+                # Invariant 2a — fail closed on unknown tools.
+                if classification is None:
+                    errors.append(
+                        f"{name}: tool {tool!r} (server {server}) is not in the "
+                        f"capability taxonomy. Classify it in {TAXONOMY_PATH} "
+                        f"before binding it."
+                    )
+                    continue
+
+                # Invariant 2b — within class.
+                if classification not in may_bind:
+                    errors.append(
+                        f"{name}: class {cls!r} may not bind {classification!r} "
+                        f"tool {tool!r} (server {server}). "
+                        f"Permitted: {sorted(may_bind)}."
+                    )
+                    continue
+
+                # Invariant 3 — mutating tools must be gated.
+                if classification in MUST_APPROVE and tool not in approval:
+                    errors.append(
+                        f"{name}: {classification} tool {tool!r} (server {server}) "
+                        f"is bound but absent from requireApproval."
+                    )
+    return errors
+
+
+def check_no_escalation(agents) -> list[str]:
+    """Invariant 4 — delegation is capability-transitive.
+
+    An agent's effective class is the max of its declared class and the
+    effective class of everything it delegates to. Declaring below your
+    effective class is an escalation path and is rejected.
+    """
+    errors = []
+    by_name = {
+        (doc.get("metadata") or {}).get("name"): doc
+        for _, doc in agents
+        if (doc.get("metadata") or {}).get("name")
+    }
+
+    def effective(name: str, seen: tuple[str, ...]) -> int:
+        """Max class rank reachable from `name`, following delegations."""
+        if name in seen:
+            errors.append(
+                f"delegation cycle: {' -> '.join(seen + (name,))}"
+            )
+            return CLASS_RANK["read"]
+        doc = by_name.get(name)
+        if doc is None:
+            return CLASS_RANK["read"]  # dangling ref, reported separately
+        own = CLASS_RANK.get(_agent_class(doc) or "", CLASS_RANK["read"])
+        ranks = [own]
+        for d in _delegates(doc):
+            ranks.append(effective(d, seen + (name,)))
+        return max(ranks)
+
+    for _, doc in agents:
+        name = (doc.get("metadata") or {}).get("name")
+        cls = _agent_class(doc)
+        if not name or cls not in CLASS_RANK:
+            continue
+
+        for delegate in _delegates(doc):
+            if delegate not in by_name:
+                errors.append(
+                    f"{name}: delegates to {delegate!r}, which does not exist "
+                    f"in git. Dangling delegation."
+                )
+                continue
+            d_eff = effective(delegate, (name,))
+            if d_eff > CLASS_RANK[cls]:
+                d_cls = next(
+                    k for k, v in CLASS_RANK.items() if v == d_eff
+                )
+                errors.append(
+                    f"{name}: class {cls!r} delegates to {delegate!r} whose "
+                    f"effective class is {d_cls!r} — privilege escalation. "
+                    f"An agent cannot delegate above its own class."
+                )
+    return errors
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the agent-capability contract."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root
+
+    taxonomy = load_taxonomy(repo_root)
+    agents = collect_agents(repo_root)
+
+    if not agents:
+        print("no Agent manifests found — nothing to validate", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    errors += check_declared_class(agents)
+    errors += check_tools_within_class(agents, taxonomy)
+    errors += check_no_escalation(agents)
+
+    print(
+        f"agent-capability: {len(agents)} agents, "
+        f"{len(taxonomy)} classified tools"
+    )
+    for _, doc in sorted(agents, key=lambda a: (a[1].get("metadata") or {}).get("name", "")):
+        name = (doc.get("metadata") or {}).get("name")
+        cls = _agent_class(doc) or "UNDECLARED"
+        delegates = _delegates(doc)
+        suffix = f" -> {', '.join(delegates)}" if delegates else ""
+        print(f"  {cls:<11} {name}{suffix}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  ERROR {e}", file=sys.stderr)
+        return 1
+
+    print("\nagent-capability contract: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent-capability/kyverno/bad-agents.yaml
+++ b/tests/agent-capability/kyverno/bad-agents.yaml
@@ -1,0 +1,158 @@
+# Each Agent here violates exactly ONE rule of ClusterPolicy/agent-capability.
+# run.sh asserts every one of them is DENIED. If a fixture starts passing, the
+# policy has regressed — that is the point of the file.
+---
+# rule 1 — no capability class declared
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-no-class
+  namespace: kagent
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_get_resources]
+---
+# rule 1 — class is not one of read|write|admin
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-invalid-class
+  namespace: kagent
+  labels:
+    capability.homelab/class: superuser
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_get_resources]
+---
+# rule 2 — binds a tool that is not in the taxonomy (fail-closed; simulates a
+# chart bump introducing a new tool nobody has triaged)
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-unclassified-tool
+  namespace: kagent
+  labels:
+    capability.homelab/class: admin
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_get_resources, k8s_brand_new_tool_from_chart_bump]
+---
+# rule 3 — a read agent binding a destructive tool. This is the shape of the
+# homelab-knowledge hole, expressed directly rather than via delegation.
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-read-binds-destructive
+  namespace: kagent
+  labels:
+    capability.homelab/class: read
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_get_resources, k8s_delete_resource]
+          requireApproval: [k8s_delete_resource]
+---
+# rule 4 — a write agent binding a destructive tool
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-write-binds-destructive
+  namespace: kagent
+  labels:
+    capability.homelab/class: write
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_get_resources, k8s_execute_command]
+          requireApproval: [k8s_execute_command]
+---
+# rule 5 — mutating tool bound with NO requireApproval at all. This is exactly
+# what observability-agent looked like before it was adopted and gated.
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-ungated-mutating
+  namespace: kagent
+  labels:
+    capability.homelab/class: write
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-grafana-mcp
+          toolNames: [search_dashboards, update_dashboard]
+---
+# rule 5 — PARTIAL requireApproval: delete is gated, patch is not. This is the
+# real k8s-agent bug (four label/annotation mutators bound but ungated).
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-partially-gated
+  namespace: kagent
+  labels:
+    capability.homelab/class: admin
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: kagent-tool-server
+          toolNames: [k8s_delete_resource, k8s_label_resource]
+          requireApproval: [k8s_delete_resource]
+---
+# rule 6 — a read agent DELEGATING to an admin agent. This is the exact
+# homelab-knowledge -> k8s-agent hole, and it is the one admission previously let
+# through: the agent binds no mutating tool of its own, so rules 1-5 all pass.
+# Its effective capability is admin because it can simply ask k8s-agent.
+# run.sh mocks the delegate's class as `admin` via the values file.
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-read-delegates-to-admin
+  namespace: kagent
+  labels:
+    capability.homelab/class: read
+spec:
+  declarative:
+    tools:
+      - type: McpServer
+        mcpServer:
+          name: agent-docs
+          toolNames: [get_file_contents]
+      - type: Agent
+        agent:
+          name: k8s-agent
+---
+# rule 7 — a write agent delegating to an admin agent
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bad-write-delegates-to-admin
+  namespace: kagent
+  labels:
+    capability.homelab/class: write
+spec:
+  declarative:
+    tools:
+      - type: Agent
+        agent:
+          name: k8s-agent

--- a/tests/agent-capability/kyverno/run.sh
+++ b/tests/agent-capability/kyverno/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Verification of ClusterPolicy/agent-capability with the kyverno CLI.
+#
+#   ./tests/agent-capability/kyverno/run.sh
+#
+# This runs the SHIPPED policy file VERBATIM — no rewriting, no substitution.
+# The artifact under test is byte-for-byte the artifact Argo applies. That is why
+# the policy embeds its taxonomy inline instead of reading a ConfigMap at runtime:
+# a context.configMap lookup could not be resolved by the CLI, so the riskiest
+# path would have been the one path never tested. See
+# scripts/gen-agent-capability-policy.py for the full rationale.
+#
+# Asserts both directions:
+#   1. every real Agent in git PASSES     — no false positive. A policy that
+#      blocked a live agent would wedge the kagent app on next Argo sync.
+#   2. every fixture in bad-agents.yaml is DENIED — no false negative. One fixture
+#      per rule; if any starts passing, the policy has regressed.
+#
+# THE ONE THING MOCKED: rules 6-7 (delegation) make a Kyverno `apiCall` to read
+# the delegate Agent's class, and the CLI has no cluster to call. values.yaml
+# supplies `delegateClass` per resource — the deny logic is exercised for real,
+# only the lookup is stubbed. That call fires solely inside
+# `foreach tools[?type=='Agent']`, so an agent with no delegations never touches
+# it: the blast radius of an apiCall failure is the delegating agents alone.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HERE="$REPO_ROOT/tests/agent-capability/kyverno"
+POLICY="$REPO_ROOT/base-apps/kyverno-policies/agent-capability.yaml"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+command -v kyverno >/dev/null || { echo "kyverno CLI not found" >&2; exit 127; }
+
+fail=0
+
+# ---------------------------------------------------------------- 0. the policy
+# must be in sync with its source of truth, or we are testing a stale artifact.
+echo "── 0. policy is in sync with the taxonomy ──────────────────────────────"
+if python3 "$REPO_ROOT/scripts/gen-agent-capability-policy.py" --check --repo-root "$REPO_ROOT"; then
+  echo "   ✓ generated policy matches the committed one"
+else
+  echo "   ✗ policy is stale — regenerate it" >&2
+  fail=1
+fi
+
+# ------------------------------------------------------- collect the real agents
+python3 - "$REPO_ROOT" "$WORK" <<'PY'
+import sys, yaml, pathlib
+repo, work = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+docs = []
+for p in sorted((repo / "base-apps" / "kagent").rglob("*.yaml")):
+    for d in yaml.safe_load_all(p.read_text()):
+        if isinstance(d, dict) and d.get("kind") == "Agent":
+            docs.append(d)
+with open(work / "good.yaml", "w") as f:
+    yaml.safe_dump_all(docs, f, sort_keys=False, width=400)
+print(f"real agents under test: {len(docs)}")
+PY
+
+echo
+echo "── 1. real agents must all PASS ────────────────────────────────────────"
+# `|| true`: kyverno apply exits non-zero whenever a policy denies — the EXPECTED
+# outcome for the fixtures in step 2. Without this, set -e aborts on the first
+# correct denial.
+out="$(kyverno apply "$POLICY" --resource "$WORK/good.yaml" \
+        --values-file "$HERE/values.yaml" 2>&1 | tail -1 || true)"
+echo "   $out"
+if grep -qE 'fail: 0,.*error: 0' <<<"$out"; then
+  echo "   ✓ no false positives, no rule errors"
+else
+  echo "   ✗ a real agent is blocked, or a rule errored" >&2
+  fail=1
+fi
+
+echo
+echo "── 2. every violating fixture must be DENIED ───────────────────────────"
+# one resource at a time, so no fixture can mask another
+python3 - "$HERE/bad-agents.yaml" "$WORK" <<'PY'
+import sys, yaml, pathlib
+src, work = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+for d in yaml.safe_load_all(src.read_text()):
+    if isinstance(d, dict) and d.get("kind") == "Agent":
+        yaml.safe_dump(d, open(work / f"bad-{d['metadata']['name']}.yaml", "w"),
+                       sort_keys=False, width=400)
+PY
+
+for f in "$WORK"/bad-*.yaml; do
+  name="$(basename "$f" .yaml | sed 's/^bad-//')"
+  res="$(kyverno apply "$POLICY" --resource "$f" \
+          --values-file "$HERE/values.yaml" 2>&1 | tail -1 || true)"
+  if grep -qE 'fail: [1-9]' <<<"$res"; then
+    echo "   ✓ DENIED   $name"
+  else
+    echo "   ✗ ALLOWED  $name   <-- policy regression ($res)" >&2
+    fail=1
+  fi
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "agent-capability policy: OK"
+else
+  echo "agent-capability policy: FAILED" >&2
+fi
+exit "$fail"

--- a/tests/agent-capability/kyverno/values.yaml
+++ b/tests/agent-capability/kyverno/values.yaml
@@ -1,0 +1,35 @@
+---
+# Stubs the ONE thing the kyverno CLI cannot resolve offline: the `apiCall` in
+# rules 6-7, which reads the delegate Agent's capability class from the cluster.
+#
+# Everything else in the policy — including the whole taxonomy — is evaluated for
+# real against the shipped policy file. Only this lookup is supplied here, so the
+# delegation deny-logic is genuinely exercised.
+#
+# `delegateClass` is the class the policy would have READ from the delegate. Set
+# it to what the real delegate actually declares:
+#
+#   homelab-knowledge  -> k8s-reader   (read)   must PASS
+#   bad-read-delegates-to-admin  -> k8s-agent  (admin)  must be DENIED
+#   bad-write-delegates-to-admin -> k8s-agent  (admin)  must be DENIED
+#
+# Agents absent from this list have no `type: Agent` delegation, so the foreach
+# body never runs and no apiCall is made.
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Value
+metadata:
+  name: values
+policies:
+  - name: agent-capability
+    resources:
+      # real agents
+      - name: homelab-knowledge
+        values:
+          delegateClass: read
+      # fixtures
+      - name: bad-read-delegates-to-admin
+        values:
+          delegateClass: admin
+      - name: bad-write-delegates-to-admin
+        values:
+          delegateClass: admin

--- a/tests/agent-capability/test_validate_agent_capability.py
+++ b/tests/agent-capability/test_validate_agent_capability.py
@@ -1,0 +1,214 @@
+"""Tests for the agent-capability contract validator.
+
+Every invariant gets a negative test. A validator that only ever passes is
+indistinguishable from one that does nothing, so each test builds a synthetic
+repo that VIOLATES one invariant and asserts the violation is caught.
+"""
+from pathlib import Path
+import importlib.util
+import json
+import textwrap
+
+import pytest
+import yaml
+
+SPEC = importlib.util.spec_from_file_location(
+    "validate_agent_capability",
+    Path(__file__).resolve().parents[2] / "scripts" / "validate-agent-capability.py",
+)
+vac = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(vac)
+
+
+TAXONOMY = {
+    "read": ["k8s_get_resources", "get_file_contents"],
+    "write": ["k8s_patch_resource"],
+    "destructive": ["k8s_delete_resource", "k8s_execute_command"],
+}
+
+
+def make_repo(tmp_path: Path, agents: list[dict]) -> Path:
+    """Build a throwaway repo: the taxonomy ConfigMap + the given Agent docs."""
+    tax_dir = tmp_path / "base-apps" / "kyverno-policies"
+    tax_dir.mkdir(parents=True)
+    (tax_dir / "agent-capability-taxonomy.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": {"name": "agent-capability-taxonomy"},
+                "data": {k: json.dumps(v) for k, v in TAXONOMY.items()},
+            }
+        )
+    )
+    agent_dir = tmp_path / "base-apps" / "kagent" / "agents"
+    agent_dir.mkdir(parents=True)
+    for doc in agents:
+        name = doc["metadata"]["name"]
+        (agent_dir / f"{name}.yaml").write_text(yaml.safe_dump(doc))
+    return tmp_path
+
+
+def agent(name, cls, tools=None, approval=None, delegates=None):
+    """Build an Agent doc. cls=None omits the class label entirely."""
+    refs = []
+    if tools:
+        mcp = {"name": "kagent-tool-server", "toolNames": tools}
+        if approval:
+            mcp["requireApproval"] = approval
+        refs.append({"type": "McpServer", "mcpServer": mcp})
+    for d in delegates or []:
+        refs.append({"type": "Agent", "agent": {"name": d}})
+
+    meta = {"name": name, "namespace": "kagent"}
+    if cls is not None:
+        meta["labels"] = {vac.CLASS_LABEL: cls}
+    return {
+        "apiVersion": "kagent.dev/v1alpha2",
+        "kind": "Agent",
+        "metadata": meta,
+        "spec": {"declarative": {"tools": refs}},
+    }
+
+
+def run(tmp_path, agents) -> int:
+    return vac.main(["--repo-root", str(make_repo(tmp_path, agents))])
+
+
+# --------------------------------------------------------------- happy path
+
+def test_valid_repo_passes(tmp_path):
+    assert run(tmp_path, [
+        agent("reader", "read", tools=["k8s_get_resources"]),
+        agent("operator", "admin",
+              tools=["k8s_get_resources", "k8s_delete_resource"],
+              approval=["k8s_delete_resource"]),
+    ]) == 0
+
+
+# ------------------------------------------- invariant 1: declared class
+
+def test_missing_class_label_is_error(tmp_path):
+    assert run(tmp_path, [agent("nolabel", None, tools=["k8s_get_resources"])]) == 1
+
+
+def test_invalid_class_value_is_error(tmp_path):
+    assert run(tmp_path, [agent("bogus", "superuser", tools=["k8s_get_resources"])]) == 1
+
+
+# ------------------------------------- invariant 2: tools within class
+
+def test_read_agent_binding_destructive_tool_is_error(tmp_path):
+    """The core capability check: a read agent may not hold delete."""
+    assert run(tmp_path, [
+        agent("sneaky", "read",
+              tools=["k8s_get_resources", "k8s_delete_resource"],
+              approval=["k8s_delete_resource"]),
+    ]) == 1
+
+
+def test_write_agent_binding_destructive_tool_is_error(tmp_path):
+    assert run(tmp_path, [
+        agent("mid", "write",
+              tools=["k8s_execute_command"],
+              approval=["k8s_execute_command"]),
+    ]) == 1
+
+
+def test_unclassified_tool_is_error(tmp_path):
+    """FAIL-CLOSED: a tool absent from the taxonomy cannot be bound.
+
+    This is what protects against a chart upgrade silently widening capability.
+    """
+    assert run(tmp_path, [
+        agent("future", "admin", tools=["k8s_brand_new_tool_from_chart_bump"]),
+    ]) == 1
+
+
+# ------------------------------------ invariant 3: mutating tools gated
+
+def test_write_tool_without_approval_is_error(tmp_path):
+    assert run(tmp_path, [
+        agent("ungated", "write", tools=["k8s_patch_resource"], approval=[]),
+    ]) == 1
+
+
+def test_destructive_tool_without_approval_is_error(tmp_path):
+    """The exact regression that already happened once, silently, for days."""
+    assert run(tmp_path, [
+        agent("ungated", "admin", tools=["k8s_delete_resource"], approval=[]),
+    ]) == 1
+
+
+def test_partial_approval_is_error(tmp_path):
+    """Gating SOME mutating tools is not enough — this was k8s-agent's real bug."""
+    assert run(tmp_path, [
+        agent("partial", "admin",
+              tools=["k8s_delete_resource", "k8s_patch_resource"],
+              approval=["k8s_delete_resource"]),   # patch left ungated
+    ]) == 1
+
+
+# ------------------------------------- invariant 4: no escalation
+
+def test_read_agent_delegating_to_admin_is_error(tmp_path):
+    """The homelab-knowledge -> k8s-agent hole."""
+    assert run(tmp_path, [
+        agent("docs", "read", tools=["get_file_contents"], delegates=["operator"]),
+        agent("operator", "admin",
+              tools=["k8s_delete_resource"], approval=["k8s_delete_resource"]),
+    ]) == 1
+
+
+def test_read_agent_delegating_to_read_is_ok(tmp_path):
+    """The fix: delegate to a read-only agent instead."""
+    assert run(tmp_path, [
+        agent("docs", "read", tools=["get_file_contents"], delegates=["reader"]),
+        agent("reader", "read", tools=["k8s_get_resources"]),
+    ]) == 0
+
+
+def test_escalation_is_transitive(tmp_path):
+    """read -> read -> admin must still be caught. Capability is transitive.
+
+    A one-hop check would pass this: `docs` delegates to `middle`, which is
+    itself declared `read`. Only following the chain finds the admin at the end.
+    """
+    assert run(tmp_path, [
+        agent("docs", "read", delegates=["middle"]),
+        agent("middle", "read", delegates=["operator"]),
+        agent("operator", "admin",
+              tools=["k8s_delete_resource"], approval=["k8s_delete_resource"]),
+    ]) == 1
+
+
+def test_dangling_delegation_is_error(tmp_path):
+    """observability-agent -> promql-agent, which does not exist."""
+    assert run(tmp_path, [
+        agent("orphan", "read", delegates=["does-not-exist"]),
+    ]) == 1
+
+
+def test_delegation_cycle_is_caught(tmp_path):
+    """Must terminate, not recurse forever."""
+    assert run(tmp_path, [
+        agent("a", "read", delegates=["b"]),
+        agent("b", "read", delegates=["a"]),
+    ]) == 1
+
+
+# ------------------------------------------------- discovery regression
+
+def test_agents_found_by_kind_not_directory(tmp_path):
+    """build-orchestrator.yaml lives OUTSIDE agents/, and the identity validator
+    globs only agents/*.yaml — so it has never been checked. Find by kind."""
+    repo = make_repo(tmp_path, [agent("in-dir", "read", tools=["k8s_get_resources"])])
+    stray = repo / "base-apps" / "kagent" / "stray-orchestrator.yaml"
+    stray.write_text(yaml.safe_dump(
+        agent("stray", "read",
+              tools=["k8s_delete_resource"], approval=["k8s_delete_resource"])
+    ))
+    found = {(d.get("metadata") or {}).get("name") for _, d in vac.collect_agents(repo)}
+    assert found == {"in-dir", "stray"}
+    # and the stray's violation is actually caught
+    assert vac.main(["--repo-root", str(repo)]) == 1


### PR DESCRIPTION
Closes the first increment of the **L03 Security (agent guardrails)** pillar.

Identity answered *who* an agent is — its credentials are scoped to a dedicated Vault path. This answers **what an agent may do**.

## The contract

Every kagent `Agent` declares a **capability class** (`read` | `write` | `admin`), and four invariants are enforced:

| # | Invariant | |
|---|---|---|
| 1 | **Declared class** | no default — an unlabelled agent is denied |
| 2 | **Tools within class** | a tool absent from the taxonomy is **denied** (fail-closed) |
| 3 | **Mutating tools gated** | every `write`/`destructive` tool must appear in `requireApproval` |
| 4 | **No escalation** | an agent may not delegate above its own class |

Invariant 2 is fail-closed on purpose: a chart upgrade that introduces new tools cannot silently widen any agent's capability — the tools must be triaged into the taxonomy before they are bindable.

## Two live holes closed

**`homelab-knowledge` was transitively `admin`.** Its own three tools are read-only (backed by a `--read-only` MCP binary), but it delegated to `k8s-agent` — so it could reach `k8s_delete_resource`, `k8s_apply_manifest`, and `k8s_execute_command` just by asking. It now delegates to a new read-only **`k8s-reader`** agent: it keeps its live-cluster investigation ability, and its effective capability is genuinely `read`.

**`k8s-agent` bound four label/annotation mutators with no approval gate.** Not cosmetic — Argo CD sync behaviour and Kyverno matching are both label/annotation-driven, so an agent holding them can disable the controls that hold it in.

## Two things found along the way

**`observability-agent` was never read-only,** despite the repo comment saying so. It binds 34 `kagent-grafana-mcp` tools with **zero** `requireApproval`, three of them mutating (`update_dashboard`, `create_incident`, `add_activity_to_incident`), and carried a **dangling delegation to `promql-agent`** — an agent that doesn't exist and is disabled in the chart. Its `systemMessage` also enumerated tools that aren't bound (`delete`, `restore_version`, `get_permissions`, `calculate_diff`), so the LLM would try to call them and fail.

Adopted into Git as class `write`, mutating tools gated, dead delegation removed, prompt corrected to match what's actually bound. It escaped review because `kagent-grafana-mcp` is exempt by name from the identity contract's "MCP server must exist in Git" invariant — its 34 tools had never been looked at.

**Kyverno's background scanning has never worked for Agents.** `agent-identity` declares `background: true` and produces *zero* PolicyReports, because the reports controller has no RBAC to read `kagent.dev/Agent`. Admission was unaffected (the webhook is handed the object), but there's been no report and no visibility into existing agents. Granted — scoped to the **reports controller alone**: the admission controller doesn't need read access to validate, and the background controller only reconciles `generate`/`mutate` rules, of which these policies have none.

## Enforcement — two gates

**CI** (`scripts/validate-agent-capability.py`) is authoritative for all four invariants, and is the only place the **full transitive closure** over the agent graph is computed. It finds agents by `kind`, not by directory — `build-orchestrator.yaml` lives outside `agents/` and the identity validator has never checked it.

**Kyverno** (`ClusterPolicy/agent-capability`, `Enforce`) checks all four at admission. Rules 6–7 (delegation) matter because **the escalation is reachable by an agent, not just a careless PR**: `k8s-agent` holds `k8s_create_resource`, so it could be driven to create a `read`-class Agent that delegates straight back to itself — binding no mutating tool of its own, and passing every other rule. One hop is inductively sufficient at admission; CI covers the later-promotion case.

## Why the policy is generated

The policy **embeds the taxonomy inline** rather than reading a ConfigMap at admission time, compiled by `scripts/gen-agent-capability-policy.py` (CI fails on drift).

A `context.configMap` lookup sits at *rule* level — evaluated for **every** Agent — so one failure (RBAC, sync ordering, schema) errors every rule and `failurePolicy: Fail` then denies **all** Agent writes, wedging the kagent app. It's also unresolvable by the `kyverno` CLI, so that single riskiest path would have been the one path no test could cover: the policy we shipped wouldn't be the policy we tested. Inlining removes the lookup and closes both gaps.

## Verification

```
✓ policy in sync with taxonomy
pass: 22, fail: 0, error: 0     ← all 8 real agents, SHIPPED policy run verbatim
✓ DENIED  bad-no-class                ✓ DENIED  bad-read-binds-destructive
✓ DENIED  bad-invalid-class           ✓ DENIED  bad-write-binds-destructive
✓ DENIED  bad-unclassified-tool       ✓ DENIED  bad-ungated-mutating
✓ DENIED  bad-partially-gated
✓ DENIED  bad-read-delegates-to-admin     ← the escalation, blocked
✓ DENIED  bad-write-delegates-to-admin
```

- 25 unit tests (incl. the transitive `read → read → admin` case a one-hop check would miss)
- 9 Kyverno fixtures, one per rule, each run in isolation so none masks another
- `yamllint`, `kubeconform`, and **server-side dry-run against the live API** — all clean

## Deployment note

Watch the first Argo sync. The only runtime lookup left is the `apiCall` in rules 6–7, and it fires **only** inside `foreach tools[?type=='Agent']` — an agent with no delegations never triggers it, so the blast radius of a failure is the delegating agents alone, not every Agent in the cluster.

Spec: `docs/superpowers/specs/2026-07-13-agent-capability-classes-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf