### PR TITLE
fix(security): grant Kyverno admission RBAC so delegation rules actually deny

### DIFF
--- a/base-apps/kyverno-policies/agent-capability.yaml
+++ b/base-apps/kyverno-policies/agent-capability.yaml
@@ -32,10 +32,22 @@
 # computes the full transitive closure over the graph in git, and background
 # PolicyReports re-scan existing agents.
 #
-# Rules 6-7 are the ONLY rules that make a runtime API call (to read the
-# delegate's class). That call is made inside `foreach tools[?type=='Agent']`, so
-# it never fires for an agent that has no delegations — the blast radius of an
-# apiCall failure is the delegating agents alone, not every Agent in the cluster.
+# Rules 6-7 are the ONLY rules that make a runtime API call (an `apiCall` reading
+# the delegate's class). It fires only inside `foreach tools[?type=='Agent']`, so
+# an agent with no delegations never triggers it.
+#
+# !!! That apiCall FAILS OPEN, and that is the sharp edge of this policy. !!!
+# When a Kyverno context entry cannot load, Kyverno SKIPS the rule — it does not
+# deny. So if the admission controller loses read access to kagent.dev/agents, the
+# delegation rules silently stop enforcing and an escalating Agent is ADMITTED.
+# Observed for real:
+#     ERR failed to load data  error="failed to fetch ..."
+#     TRC validation passed          <-- the escalation was allowed
+# The RBAC that keeps this working is base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
+# (aggregate-to-admission-controller). Do not remove that aggregation: rules 1-5
+# need no RBAC, but rules 6-7 do, and they degrade silently without it. CI cannot
+# catch that — it is a cluster-RBAC property, not a manifest property. The
+# admission probe in the runbook is what catches it.
 #
 # ---------------------------------------------------------------------------
 # KYVERNO NOTES — both cost real debugging time. Read before editing the generator.

--- a/base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
+++ b/base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
@@ -18,26 +18,46 @@
 #   Warning: system:serviceaccount:kyverno:kyverno-reports-controller requires
 #   permissions get,list,watch for resource kagent.dev/v1alpha2/Agent
 #
-# Why ONLY the reports controller
-# -------------------------------
-# Kyverno names exactly one service account in that warning, and the scope of this
-# ClusterRole is deliberately held to it. The other two controllers do not need it,
-# and granting them access would widen a security-critical component's permissions
-# beyond anything demonstrated:
+# Which controllers, and why — each one demonstrated, none granted on a hunch
+# --------------------------------------------------------------------------
 #
-#   admission controller  — does NOT need read access to validate. The API server
-#                           hands it the object in the AdmissionReview payload.
-#                           This is why agent-identity has been enforcing
-#                           correctly at admission all along with no RBAC at all.
+#   admission controller  — REQUIRED, and this was learned the hard way.
 #
-#   background controller — reconciles `generate` and `mutate-existing` rules.
-#                           Both agent policies are validate-only (zero generate
-#                           or mutate rules), so it has no work to do on Agents.
-#                           Add it here only if a generate/mutate rule is ever
-#                           introduced for this kind.
+#       Validating an object needs no RBAC: the API server hands the object to the
+#       webhook in the AdmissionReview payload. That is why agent-identity has
+#       enforced correctly at admission all along with no RBAC at all.
 #
-# Read-only verbs: Kyverno never needs to mutate an Agent. It validates them at
-# admission (no RBAC) and reports on them in the background (this grant).
+#       But agent-capability rules 6-7 (delegation) make a Kyverno `apiCall` to
+#       READ THE DELEGATE Agent's class. That is an outbound API request made BY
+#       THE ADMISSION CONTROLLER, and it needs RBAC. Without this grant:
+#
+#           kubectl logs -n kyverno deploy/kyverno-admission-controller
+#           ERR failed to load data  error="failed to fetch ..."
+#           TRC validation passed
+#
+#       Note the second line. When a context entry fails to load, Kyverno SKIPS
+#       the rule — it does NOT deny. The delegation rules therefore fail OPEN, and
+#       a read-class Agent delegating to an admin agent is ADMITTED. Verified: the
+#       escalation probe was allowed until this aggregation was added back.
+#
+#   reports controller    — REQUIRED. It LISTs and WATCHes to produce PolicyReports
+#       and re-scan existing objects, and it makes the same apiCall during
+#       background scans. Kyverno asks for it by name when either agent policy is
+#       applied:
+#
+#           Warning: system:serviceaccount:kyverno:kyverno-reports-controller
+#           requires permissions get,list,watch for resource kagent.dev/v1alpha2/Agent
+#
+#       Without it, `background: true` is silently a no-op for Agents — which is
+#       exactly what agent-identity has been doing since it shipped: enforcing at
+#       admission while producing ZERO PolicyReports.
+#
+#   background controller — NOT granted. It reconciles `generate` and
+#       `mutate-existing` rules; both agent policies are validate-only (zero
+#       generate or mutate rules), so it has no work to do on Agents. Add it here
+#       only if such a rule is ever introduced for this kind.
+#
+# Read-only verbs: Kyverno never needs to mutate an Agent.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -45,6 +65,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
   labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
     rbac.kyverno.io/aggregate-to-reports-controller: "true"
 rules:
   - apiGroups: ["kagent.dev"]

--- a/scripts/gen-agent-capability-policy.py
+++ b/scripts/gen-agent-capability-policy.py
@@ -69,10 +69,22 @@ HEADER = """\
 # computes the full transitive closure over the graph in git, and background
 # PolicyReports re-scan existing agents.
 #
-# Rules 6-7 are the ONLY rules that make a runtime API call (to read the
-# delegate's class). That call is made inside `foreach tools[?type=='Agent']`, so
-# it never fires for an agent that has no delegations — the blast radius of an
-# apiCall failure is the delegating agents alone, not every Agent in the cluster.
+# Rules 6-7 are the ONLY rules that make a runtime API call (an `apiCall` reading
+# the delegate's class). It fires only inside `foreach tools[?type=='Agent']`, so
+# an agent with no delegations never triggers it.
+#
+# !!! That apiCall FAILS OPEN, and that is the sharp edge of this policy. !!!
+# When a Kyverno context entry cannot load, Kyverno SKIPS the rule — it does not
+# deny. So if the admission controller loses read access to kagent.dev/agents, the
+# delegation rules silently stop enforcing and an escalating Agent is ADMITTED.
+# Observed for real:
+#     ERR failed to load data  error="failed to fetch ..."
+#     TRC validation passed          <-- the escalation was allowed
+# The RBAC that keeps this working is base-apps/kyverno-policies/kyverno-kagent-read-rbac.yaml
+# (aggregate-to-admission-controller). Do not remove that aggregation: rules 1-5
+# need no RBAC, but rules 6-7 do, and they degrade silently without it. CI cannot
+# catch that — it is a cluster-RBAC property, not a manifest property. The
+# admission probe in the runbook is what catches it.
 #
 # ---------------------------------------------------------------------------
 # KYVERNO NOTES — both cost real debugging time. Read before editing the generator.


### PR DESCRIPTION
## The delegation rules were failing open

Right after #351 went `Enforce`, I probed the live cluster. A `read`-class Agent delegating to `k8s-agent` (admin) — **the exact privilege escalation rules 6–7 exist to block** — was **ADMITTED**.

```
✗ ALLOWED (wanted DENIED)   read -> k8s-agent (admin) : the escalation
```

## Root cause

Rules 6–7 read the delegate's class with a Kyverno `apiCall`. That's an **outbound API request made by the admission controller**, so it needs RBAC.

`kyverno-kagent-read-rbac.yaml` aggregated only to the **reports** controller, on the reasoning that *"the admission controller doesn't need read access to validate — the API server hands it the object in the payload."*

That reasoning is correct for rules 1–5, and it's exactly why `agent-identity` has always enforced correctly with **zero** RBAC. It does **not** hold for a context lookup. The grant was narrowed in review *before* the `apiCall` rules existed, and was never re-checked against them.

## Why this is the dangerous kind of bug

It fails **open**, silently:

```
ERR failed to load data  error="failed to fetch ..."
TRC validation passed          <-- the escalation was allowed
```

When a context entry can't load, Kyverno **skips the rule** rather than denying. So losing this RBAC doesn't wedge the cluster — it quietly stops enforcing, while the policy still reports `Enforce`/`Ready`. The policy header claimed the *opposite* (that an apiCall failure would fail closed); that claim was wrong and is corrected here.

**CI cannot catch this.** It's a cluster-RBAC property, not a manifest property, and the offline Kyverno CLI stubs the `apiCall`. Only an admission probe against a live cluster finds it — which is why the probe is now written down.

## The fix

Adds `aggregate-to-admission-controller`. The **background** controller is still *not* granted — it only reconciles `generate`/`mutate` rules, and both agent policies are validate-only.

## Verification (live cluster)

| Probe | Before | After |
|---|---|---|
| `read` → `k8s-agent` (admin) | ❌ ALLOWED | ✅ **DENIED** |
| `read` → `k8s-reader` (read) | ALLOWED | ALLOWED |
| all 8 real agents apply | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf