### PR TITLE
feat(identity): close the contract — retire the pilot staging

### DIFF
--- a/scripts/agent-identity-scope.txt
+++ b/scripts/agent-identity-scope.txt
@@ -1,6 +1,0 @@
-# agent-identity validator scope. Lines are "key: value"; # and blanks ignored.
-# pilot-credential: an ExternalSecret name that MUST be scoped (hard fail).
-# pilot-agent: an Agent name held to the model + capability invariants (hard fail).
-# Everything else is warn-only (visible backlog) this increment.
-pilot-credential: agent-docs-github-mcp-token
-pilot-agent: homelab-knowledge

--- a/scripts/validate-agent-identity.py
+++ b/scripts/validate-agent-identity.py
@@ -2,17 +2,28 @@
 """Validate the agent-identity ("agent principal") contract for kagent agents.
 
 An agent-principal = (credentials it can obtain) + (its model) + (its capability
-surface). Three invariants (see templates/agent-identity/README.md):
-  1. Scoped credentials: pilot credential ExternalSecrets resolve through a
-     dedicated scoped SecretStore + per-consumer Vault key (not 'vault-backend'
-     / the monolithic 'kagent' key). Non-pilot unscoped credentials warn.
-  2. In-git model identity: modelConfig/memory.modelConfig referenced by
-     in-scope agents resolve to a ModelConfig manifest in git (chart-generated
-     configs exempt). Pilot agent = hard fail; others warn.
-  3. Capability surface: each Agent McpServer tool ref resolves to an in-git MCP
-     server and lists non-empty toolNames. Pilot agent = hard fail; others warn.
+surface). Three invariants (see templates/agent-identity/README.md), and EVERY
+agent and credential is held to all three:
 
-Exit 1 on any hard error; warnings print but do not fail.
+  1. Scoped credentials: every ExternalSecret resolves through a dedicated scoped
+     SecretStore + per-consumer Vault key — never the broad 'vault-backend' store,
+     never the monolithic 'kagent' key.
+  2. In-git model identity: every modelConfig / memory.modelConfig resolves to a
+     ModelConfig manifest in git (chart-rendered configs exempt — see below).
+  3. Capability surface: every Agent McpServer tool ref resolves to an in-git MCP
+     server and lists explicit toolNames (no implicit bind-all).
+
+NO PILOT STAGING. This validator used to hold only a pilot agent + pilot
+credential to a hard failure and downgrade everything else to a warning, so that
+the gate could go green while the backlog stayed visible (design doc §44). That
+backlog is now empty: every credential is scoped and the broad store is retired.
+
+Keeping the staging after that point was actively harmful — it was a loaded gun.
+Stripping every toolName from k8s-agent (an implicit bind-all on the agent holding
+k8s_delete_resource and k8s_execute_command) produced a WARNING and exit 0. CI
+stayed green on a real capability regression. Everything is a hard error now.
+
+Exit 1 on any error.
 """
 from __future__ import annotations
 
@@ -23,6 +34,16 @@ import yaml
 
 BROAD_SECRETSTORE = "vault-backend"
 MONOLITHIC_VAULT_KEY = "kagent"
+
+# ModelConfigs rendered by the kagent Helm chart rather than declared as their own
+# manifest. Exempt, and legitimately so: the invariant exists to catch identity
+# that is INVISIBLE TO REVIEW — the design doc's complaint (§13) was a ModelConfig
+# "applied by hand, so it is invisible to GitOps and to review". default-model-config
+# is the opposite of that. Its definition lives in git at base-apps/kagent.yaml
+# (the `providers:` block: provider, model, apiKeySecretRef), is version-controlled,
+# and every change to it goes through review. Adopting it as a standalone manifest
+# would put the chart and Argo in a tug-of-war over the same object — the failure
+# mode that silently stripped the agents' HITL requireApproval gates on every sync.
 CHART_GENERATED_MODELCONFIGS = {"default-model-config"}
 # MCP servers rendered by the kagent Helm chart rather than declared in git.
 # Exempt for the same reason as CHART_GENERATED_MODELCONFIGS: they ARE
@@ -56,39 +77,26 @@ def collect_by_kind(repo_root: Path) -> dict[str, list[tuple[Path, dict]]]:
 
 
 def collect_agents(repo_root: Path) -> list[tuple[Path, dict]]:
+    """Every kagent Agent in git, found by KIND — not by directory.
+
+    This used to glob agents/*.yaml and then hardcode build-orchestrator.yaml,
+    which lives one level up. That worked only because someone remembered to add
+    the special case; the next agent placed outside agents/ would have been
+    silently unvalidated. Find them by what they ARE.
+    """
     kagent_dir = repo_root / "base-apps" / "kagent"
-    paths = sorted((kagent_dir / "agents").glob("*.yaml"))
-    extra = kagent_dir / "build-orchestrator.yaml"
-    if extra.is_file():
-        paths.append(extra)
     agents: list[tuple[Path, dict]] = []
-    for path in paths:
+    if not kagent_dir.is_dir():
+        return agents
+    for path in sorted(kagent_dir.rglob("*.yaml")):
         for doc in _load_docs(path):
             if doc.get("kind") == "Agent":
                 agents.append((path, doc))
     return agents
 
 
-def load_scope(repo_root: Path) -> tuple[set[str], set[str]]:
-    path = repo_root / "scripts" / "agent-identity-scope.txt"
-    pilot_secrets: set[str] = set()
-    pilot_agents: set[str] = set()
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or ":" not in line:
-            continue
-        key, val = line.split(":", 1)
-        key, val = key.strip(), val.strip()
-        if key == "pilot-credential":
-            pilot_secrets.add(val)
-        elif key == "pilot-agent":
-            pilot_agents.add(val)
-    return pilot_secrets, pilot_agents
-
-
-def check_credential_scoping(repo_root: Path, pilot_secrets: set[str]) -> tuple[list[str], list[str]]:
+def check_credential_scoping(repo_root: Path) -> list[str]:
     errors: list[str] = []
-    warnings: list[str] = []
     for _path, doc in collect_by_kind(repo_root).get("ExternalSecret", []):
         name = (doc.get("metadata") or {}).get("name")
         spec = doc.get("spec") or {}
@@ -97,17 +105,16 @@ def check_credential_scoping(repo_root: Path, pilot_secrets: set[str]) -> tuple[
             (ref.get("remoteRef") or {}).get("key")
             for ref in (spec.get("data") or [])
         }
-        scoped = store != BROAD_SECRETSTORE and MONOLITHIC_VAULT_KEY not in keys
-        if scoped:
+        if store != BROAD_SECRETSTORE and MONOLITHIC_VAULT_KEY not in keys:
             continue
-        detail = (f"{name}: credential is not scoped (store={store!r}, "
-                  f"keys={sorted(k for k in keys if k)})")
-        if name in pilot_secrets:
-            errors.append(detail + " — pilot credential must use a dedicated "
-                          "SecretStore and a per-consumer Vault key")
-        else:
-            warnings.append(detail + " — backlog for a later identity increment")
-    return errors, warnings
+        errors.append(
+            f"{name}: credential is not scoped (store={store!r}, "
+            f"keys={sorted(k for k in keys if k)}) — every credential must use a "
+            f"dedicated SecretStore and a per-consumer Vault key. The broad "
+            f"{BROAD_SECRETSTORE!r} store and the monolithic {MONOLITHIC_VAULT_KEY!r} "
+            f"key are retired."
+        )
+    return errors
 
 
 def _agent_model_refs(doc: dict) -> list[str]:
@@ -121,9 +128,8 @@ def _agent_model_refs(doc: dict) -> list[str]:
     return refs
 
 
-def check_model_config_in_git(repo_root: Path, pilot_agents: set[str]) -> tuple[list[str], list[str]]:
+def check_model_config_in_git(repo_root: Path) -> list[str]:
     errors: list[str] = []
-    warnings: list[str] = []
     in_git = {
         (doc.get("metadata") or {}).get("name")
         for _path, doc in collect_by_kind(repo_root).get("ModelConfig", [])
@@ -133,44 +139,56 @@ def check_model_config_in_git(repo_root: Path, pilot_agents: set[str]) -> tuple[
         for ref in _agent_model_refs(doc):
             if ref in in_git or ref in CHART_GENERATED_MODELCONFIGS:
                 continue
-            detail = f"{name}: modelConfig {ref!r} is not a ModelConfig manifest in git"
-            if name in pilot_agents:
-                errors.append(detail)
-            else:
-                warnings.append(detail + " — backlog")
-    return errors, warnings
+            errors.append(
+                f"{name}: modelConfig {ref!r} is not a ModelConfig manifest in git. "
+                f"An agent's model is part of its identity; it may not be applied "
+                f"out-of-band where review cannot see it."
+            )
+    return errors
 
 
-def check_capability_surface(repo_root: Path, pilot_agents: set[str]) -> tuple[list[str], list[str]]:
+def check_capability_surface(repo_root: Path) -> list[str]:
     errors: list[str] = []
-    warnings: list[str] = []
     by_kind = collect_by_kind(repo_root)
     mcp_names = {
         (doc.get("metadata") or {}).get("name")
         for kind in ("RemoteMCPServer", "MCPServer")
         for _path, doc in by_kind.get(kind, [])
     }
+    agent_names = {
+        (doc.get("metadata") or {}).get("name")
+        for _path, doc in collect_agents(repo_root)
+    }
     for _path, doc in collect_agents(repo_root):
         name = (doc.get("metadata") or {}).get("name")
         decl = (doc.get("spec") or {}).get("declarative") or {}
         for tool in decl.get("tools") or []:
-            if tool.get("type") != "McpServer":
+            kind = tool.get("type")
+            if kind == "Agent":
+                # A delegation to an agent that does not exist in git is an
+                # undeclared capability surface just as much as an unknown MCP
+                # server is. observability-agent carried a dangling ref to
+                # promql-agent — an agent that does not exist and is disabled in
+                # the chart — and nothing caught it.
+                ref = (tool.get("agent") or {}).get("name")
+                if ref and ref not in agent_names:
+                    errors.append(
+                        f"{name}: delegates to Agent {ref!r}, which does not exist "
+                        f"in git — dangling delegation"
+                    )
+                continue
+            if kind != "McpServer":
                 continue
             mcp = tool.get("mcpServer") or {}
             ref = mcp.get("name")
-            tool_names = mcp.get("toolNames") or []
-            problems = []
             if ref not in mcp_names and ref not in CHART_PROVIDED_MCPSERVERS:
-                problems.append(f"references unknown MCP server {ref!r}")
-            if not tool_names:
-                problems.append(f"MCP ref {ref!r} lists no toolNames (binds nothing)")
-            for problem in problems:
-                detail = f"{name}: {problem}"
-                if name in pilot_agents:
-                    errors.append(detail)
-                else:
-                    warnings.append(detail + " — backlog")
-    return errors, warnings
+                errors.append(f"{name}: references unknown MCP server {ref!r}")
+            if not mcp.get("toolNames"):
+                errors.append(
+                    f"{name}: MCP ref {ref!r} lists no toolNames — an implicit "
+                    f"bind-all. Every tool an agent may call must be named."
+                )
+    return errors
 
 
 def main(argv=None) -> int:
@@ -179,26 +197,23 @@ def main(argv=None) -> int:
     args = parser.parse_args(argv)
     repo_root = args.repo_root.resolve()
 
-    pilot_secrets, pilot_agents = load_scope(repo_root)
     errors: list[str] = []
-    warnings: list[str] = []
-    for check, arg in (
-        (check_credential_scoping, pilot_secrets),
-        (check_model_config_in_git, pilot_agents),
-        (check_capability_surface, pilot_agents),
+    for check in (
+        check_credential_scoping,
+        check_model_config_in_git,
+        check_capability_surface,
     ):
-        e, w = check(repo_root, arg)
-        errors.extend(e)
-        warnings.extend(w)
+        errors.extend(check(repo_root))
 
-    for w in warnings:
-        print(f"WARN: {w}")
-    for e in errors:
-        print(f"ERROR: {e}")
+    agents = collect_agents(repo_root)
+    print(f"agent-identity: {len(agents)} agents held to all three invariants")
+
     if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
         print(f"\nagent-identity validation FAILED with {len(errors)} error(s).")
         return 1
-    print(f"\nagent-identity validation passed ({len(warnings)} warning(s)).")
+    print("\nagent-identity contract: OK")
     return 0
 
 

--- a/templates/agent-identity/README.md
+++ b/templates/agent-identity/README.md
@@ -31,10 +31,18 @@ boundary (ModelConfig), and the capability boundary (`Agent.spec.declarative.too
    failure mode that silently stripped the agents' HITL `requireApproval` gates
    on every sync. The `toolNames` half still applies to them.
 
-The validator (`scripts/validate-agent-identity.py`) enforces these. Enforcement
-is staged: the pilot credential and pilot agent named in
-`scripts/agent-identity-scope.txt` are hard failures; every other unscoped
-consumer or unresolved reference is a warning (visible backlog).
+The validator (`scripts/validate-agent-identity.py`) enforces these. **Every agent
+and every credential is held to all three. There is no staging and no warn tier —
+a violation is a hard failure, whichever agent it is on.**
+
+It was staged once, for a good reason: increment 1 held only a pilot credential
+and pilot agent to the bar and downgraded the rest to warnings, so the gate could
+be green while the backlog stayed visible. That backlog is now empty — every
+credential is scoped and the broad store is retired — and keeping the staging past
+that point made it a loaded gun. Stripping *every* `toolName` from `k8s-agent` (an
+implicit bind-all on the agent holding `k8s_delete_resource` and
+`k8s_execute_command`) produced a **warning and exit 0**. CI stayed green on a real
+capability regression. `scripts/agent-identity-scope.txt` is deleted.
 
 ## Onboard a new agent identity-correctly
 
@@ -66,26 +74,44 @@ cluster is actually asked to run.
 The Kyverno policy denies: an `ExternalSecret` in `kagent` using the broad
 `vault-backend` store, one reading the monolithic `kagent` Vault key, and an
 `Agent` whose `McpServer` tool ref lists no `toolNames` (implicit bind-all).
-It carries one documented exclusion: `kagent-anthropic-secrets`, owned by the
-`kagent-config` Argo app outside this repo, which still reads the broad store.
-Remove that exclusion once that app is brought in and scoped.
+**It carries no exclusions.**
+
+## What this contract does NOT cover
+
+Identity says *who an agent is*. It says nothing about what an agent may **do** —
+that is the capability contract
+(`base-apps/kyverno-policies/agent-capability.yaml`,
+`scripts/validate-agent-capability.py`), which classifies every tool and forbids
+an agent from binding above its class or delegating above it. The two are
+complements; read both before onboarding an agent.
 
 ## Follow-ons (not yet enforced)
 
-- Onboarding the remaining declarative agents.
-- Dedicated per-agent Anthropic keys / budget caps; egress control.
+- **Dedicated per-agent Anthropic keys / budget caps.** Every agent shares the one
+  `kagent-anthropic` key today: no cost attribution, no spend cap, no way to tell
+  which agent is burning tokens.
+- **Egress control.** No `NetworkPolicy` or Istio `AuthorizationPolicy` anywhere
+  in `base-apps/kagent/`; agent pods have unrestricted egress.
 - Invariant 2 has no admission-time equivalent (Kyverno cannot read git). A
   cluster-existence check on the referenced `ModelConfig` would be the closest
   analogue if it proves worth the moving parts.
 
 ## Done
 
-- **Increment 1** — contract, validator, CI gate; pilot credential
-  (`agent-docs-github-mcp-token`) and pilot agent (`homelab-knowledge`).
-- **Increment 2** — every real credential in the `kagent` namespace is now
+- **Increment 1** — contract, validator, CI gate; proven end-to-end on a pilot
+  slice (`agent-docs-github-mcp-token` / `homelab-knowledge`).
+- **Increment 2** — every real credential in the `kagent` namespace is
   credential-scoped: `backstage-mcp-token`, `kagent-db-credentials` and
   `kagent-mcp-basic-auth` each resolve through their own ESO ServiceAccount,
-  `SecretStore`, Vault kubernetes-auth role and per-consumer Vault key. Nothing
-  in this namespace reads the monolithic `kagent` key any more. (The Plex/qBit
-  credential named in the original backlog is gone — that integration was
+  `SecretStore`, Vault kubernetes-auth role and per-consumer Vault key. (The
+  Plex/qBit credential in the original backlog is gone — that integration was
   removed, having never worked.)
+- **Increment 3** — the broad `vault-backend` store, the `kagent` Vault role and
+  policy, and the monolithic `k8s-secrets/kagent` key are all destroyed. Kyverno
+  enforces the contract at admission with no exclusions.
+- **Increment 4 (this one)** — the contract is closed. No pilot staging: every
+  agent and credential is held to all three invariants as a hard failure. Agents
+  are discovered by `kind` rather than by directory, so one placed outside
+  `agents/` can no longer slip through unvalidated. A dangling `type: Agent`
+  delegation is now an error too — `observability-agent` carried one to
+  `promql-agent`, an agent that does not exist, and nothing caught it.

--- a/tests/agent-identity/test_validate_agent_identity.py
+++ b/tests/agent-identity/test_validate_agent_identity.py
@@ -1,3 +1,9 @@
+"""Tests for the agent-identity contract validator.
+
+Every agent and every credential is held to all three invariants — there is no
+pilot staging any more, so there is no "warning" tier to test. A violation is an
+error, whichever agent it is on.
+"""
 from pathlib import Path
 import importlib.util
 
@@ -14,12 +20,6 @@ def _write(p: Path, text: str):
     p.write_text(text)
 
 
-def _scope(root: Path):
-    _write(root / "scripts" / "agent-identity-scope.txt",
-           "pilot-credential: agent-docs-github-mcp-token\n"
-           "pilot-agent: homelab-knowledge\n")
-
-
 def _external_secret(name: str, store: str, key: str) -> str:
     return (
         "apiVersion: external-secrets.io/v1beta1\n"
@@ -33,7 +33,8 @@ def _external_secret(name: str, store: str, key: str) -> str:
     )
 
 
-def _agent(name: str, model: str, mcp_ref: str, tool_names: list[str]) -> str:
+def _agent(name: str, model: str, mcp_ref: str, tool_names: list[str],
+           delegates: str | None = None) -> str:
     tn = "".join(f"        - {t}\n" for t in tool_names)
     tools = (
         "    tools:\n"
@@ -44,6 +45,8 @@ def _agent(name: str, model: str, mcp_ref: str, tool_names: list[str]) -> str:
         f"        name: {mcp_ref}\n"
         + ("        toolNames:\n" + tn if tool_names else "")
     )
+    if delegates:
+        tools += f"    - type: Agent\n      agent:\n        name: {delegates}\n"
     return (
         "apiVersion: kagent.dev/v1alpha2\n"
         "kind: Agent\n"
@@ -76,7 +79,6 @@ def _model_config(name: str) -> str:
 def _good_repo(tmp_path: Path) -> Path:
     root = tmp_path
     kd = root / "base-apps" / "kagent"
-    _scope(root)
     _write(kd / "agent-docs-mcp-external-secret.yaml",
            _external_secret("agent-docs-github-mcp-token", "vault-agent-docs-mcp",
                             "kagent-agent-docs-mcp"))
@@ -90,105 +92,119 @@ def _good_repo(tmp_path: Path) -> Path:
     return root
 
 
-def test_load_scope(tmp_path):
-    _scope(tmp_path)
-    secrets, agents = vai.load_scope(tmp_path)
-    assert secrets == {"agent-docs-github-mcp-token"}
-    assert agents == {"homelab-knowledge"}
+def test_good_repo_passes(tmp_path):
+    assert vai.main(["--repo-root", str(_good_repo(tmp_path))]) == 0
 
 
-def test_good_repo_passes_all(tmp_path):
+# ------------------------------------------- invariant 1: scoped credentials
+
+def test_broad_secretstore_is_error(tmp_path):
     root = _good_repo(tmp_path)
-    secrets, agents = vai.load_scope(root)
-    assert vai.check_credential_scoping(root, secrets) == ([], [])
-    assert vai.check_model_config_in_git(root, agents) == ([], [])
-    assert vai.check_capability_surface(root, agents) == ([], [])
-    assert vai.main(["--repo-root", str(root)]) == 0
-
-
-def test_pilot_unscoped_credential_is_error(tmp_path):
-    root = _good_repo(tmp_path)
-    # Regress the pilot ExternalSecret back to the broad store + monolithic key.
-    _write(root / "base-apps" / "kagent" / "agent-docs-mcp-external-secret.yaml",
-           _external_secret("agent-docs-github-mcp-token", "vault-backend", "kagent"))
-    secrets, _ = vai.load_scope(root)
-    errors, warnings = vai.check_credential_scoping(root, secrets)
-    assert any("agent-docs-github-mcp-token" in e for e in errors)
+    _write(root / "base-apps" / "kagent" / "bad.yaml",
+           _external_secret("some-cred", "vault-backend", "kagent-some-cred"))
     assert vai.main(["--repo-root", str(root)]) == 1
 
 
-def test_nonpilot_unscoped_credential_is_warning(tmp_path):
+def test_monolithic_vault_key_is_error(tmp_path):
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "db-external-secret.yaml",
-           _external_secret("kagent-db-credentials", "vault-backend", "kagent"))
-    secrets, _ = vai.load_scope(root)
-    errors, warnings = vai.check_credential_scoping(root, secrets)
-    assert errors == []
-    assert any("kagent-db-credentials" in w for w in warnings)
+    _write(root / "base-apps" / "kagent" / "bad.yaml",
+           _external_secret("some-cred", "vault-some-cred", "kagent"))
+    assert vai.main(["--repo-root", str(root)]) == 1
 
 
-def test_pilot_missing_modelconfig_is_error(tmp_path):
+def test_any_credential_is_held_to_the_bar_not_just_a_pilot(tmp_path):
+    """The staging is gone. An unscoped credential is an ERROR whatever its name.
+
+    This used to be a WARNING for everything except the one pilot credential, so
+    CI stayed green on a real regression.
+    """
     root = _good_repo(tmp_path)
-    (root / "base-apps" / "kagent" / "model-configs"
-     / "anthropic-claude-sonnet-4-6.yaml").unlink()
-    _, agents = vai.load_scope(root)
-    errors, _ = vai.check_model_config_in_git(root, agents)
-    assert any("anthropic-claude-sonnet-4-6" in e for e in errors)
+    _write(root / "base-apps" / "kagent" / "bad.yaml",
+           _external_secret("not-the-pilot", "vault-backend", "kagent"))
+    assert vai.main(["--repo-root", str(root)]) == 1
+
+
+# ---------------------------------------- invariant 2: in-git model identity
+
+def test_out_of_band_modelconfig_is_error(tmp_path):
+    root = _good_repo(tmp_path)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "applied-by-hand", "agent-docs", ["get_file_contents"]))
+    assert vai.main(["--repo-root", str(root)]) == 1
 
 
 def test_chart_generated_modelconfig_is_exempt(tmp_path):
+    """default-model-config is rendered by the chart from git-tracked Helm values
+    (base-apps/kagent.yaml `providers:`), so it IS visible to review. The invariant
+    exists to catch identity applied by hand, which this is not."""
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "agents" / "skill-suggester.yaml",
-           _agent("skill-suggester", "default-model-config", "agent-docs",
-                  ["get_file_contents"]))
-    _, agents = vai.load_scope(root)
-    errors, warnings = vai.check_model_config_in_git(root, agents)
-    # skill-suggester is not a pilot agent and default-model-config is exempt:
-    assert errors == []
-    assert not any("default-model-config" in w for w in warnings)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "default-model-config", "agent-docs", ["get_file_contents"]))
+    assert vai.main(["--repo-root", str(root)]) == 0
 
 
-def test_pilot_empty_toolnames_is_error(tmp_path):
+# ------------------------------------------ invariant 3: capability surface
+
+def test_empty_toolnames_is_error(tmp_path):
+    """An implicit bind-all. This is the exact regression the old pilot staging
+    let through as a warning on k8s-agent — the agent holding k8s_delete_resource."""
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "agents" / "homelab-knowledge.yaml",
-           _agent("homelab-knowledge", "anthropic-claude-sonnet-4-6", "agent-docs", []))
-    _, agents = vai.load_scope(root)
-    errors, _ = vai.check_capability_surface(root, agents)
-    assert any("toolNames" in e for e in errors)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6", "agent-docs", []))
+    assert vai.main(["--repo-root", str(root)]) == 1
 
 
-def test_pilot_unknown_mcp_ref_is_error(tmp_path):
+def test_unknown_mcp_ref_is_error(tmp_path):
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "agents" / "homelab-knowledge.yaml",
-           _agent("homelab-knowledge", "anthropic-claude-sonnet-4-6",
-                  "does-not-exist", ["t"]))
-    _, agents = vai.load_scope(root)
-    errors, _ = vai.check_capability_surface(root, agents)
-    assert any("does-not-exist" in e for e in errors)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6", "nope", ["x"]))
+    assert vai.main(["--repo-root", str(root)]) == 1
 
 
 def test_chart_provided_mcp_server_ref_is_exempt(tmp_path):
-    """kagent-tool-server is rendered by the kagent Helm chart, not declared in
-    git. Requiring it as a manifest would mean two Argo apps owning one object —
-    the tug-of-war that silently stripped the agents' HITL gates. Exempt, exactly
-    as default-model-config is for the model invariant."""
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "agents" / "k8s-agent.yaml",
-           _agent("k8s-agent", "default-model-config", "kagent-tool-server",
-                  ["k8s_get_resources"]))
-    _, agents = vai.load_scope(root)
-    errors, warnings = vai.check_capability_surface(root, agents)
-    assert errors == []
-    assert not any("kagent-tool-server" in w for w in warnings)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6",
+                  "kagent-tool-server", ["k8s_get_resources"]))
+    assert vai.main(["--repo-root", str(root)]) == 0
 
 
 def test_chart_provided_mcp_server_still_needs_toolnames(tmp_path):
-    """The exemption covers only 'does this ref resolve'. Invariant 3's real
-    teeth — no implicit bind-all — still apply to chart-provided servers."""
+    """Exempt from 'must exist in git', NOT from 'must name its tools'."""
     root = _good_repo(tmp_path)
-    _write(root / "base-apps" / "kagent" / "agents" / "homelab-knowledge.yaml",
-           _agent("homelab-knowledge", "anthropic-claude-sonnet-4-6",
-                  "kagent-tool-server", []))
-    _, agents = vai.load_scope(root)
-    errors, _ = vai.check_capability_surface(root, agents)
-    assert any("toolNames" in e for e in errors)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6", "kagent-tool-server", []))
+    assert vai.main(["--repo-root", str(root)]) == 1
+
+
+def test_dangling_delegation_is_error(tmp_path):
+    """observability-agent delegated to promql-agent, which does not exist and is
+    disabled in the chart. Nothing caught it. Now something does."""
+    root = _good_repo(tmp_path)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6", "agent-docs",
+                  ["get_file_contents"], delegates="does-not-exist"))
+    assert vai.main(["--repo-root", str(root)]) == 1
+
+
+def test_valid_delegation_passes(tmp_path):
+    root = _good_repo(tmp_path)
+    _write(root / "base-apps" / "kagent" / "agents" / "other.yaml",
+           _agent("other", "anthropic-claude-sonnet-4-6", "agent-docs",
+                  ["get_file_contents"], delegates="homelab-knowledge"))
+    assert vai.main(["--repo-root", str(root)]) == 0
+
+
+# ----------------------------------------------------- agent discovery
+
+def test_agents_found_by_kind_not_by_directory(tmp_path):
+    """collect_agents used to glob agents/*.yaml and then HARDCODE
+    build-orchestrator.yaml, which lives one level up. The next agent placed
+    outside agents/ would have been silently unvalidated. Find them by kind."""
+    root = _good_repo(tmp_path)
+    stray = root / "base-apps" / "kagent" / "stray-orchestrator.yaml"
+    _write(stray, _agent("stray", "anthropic-claude-sonnet-4-6", "agent-docs", []))
+    found = {(d.get("metadata") or {}).get("name") for _, d in vai.collect_agents(root)}
+    assert found == {"homelab-knowledge", "stray"}
+    # ...and the stray's bind-all is actually caught
+    assert vai.main(["--repo-root", str(root)]) == 1


### PR DESCRIPTION
Completes the Identity pillar against `docs/superpowers/specs/2026-07-11-agent-identity-principal-design.md`.

## The staging had become a loaded gun

The validator held only a **pilot agent** (`homelab-knowledge`) and a **pilot credential** (`agent-docs-github-mcp-token`) to a hard failure. Everything else was downgraded to a warning. That was correct for increment 1 — the design doc (§44) staged it deliberately so the gate could go green while the backlog stayed visible.

**That backlog is now empty.** Every credential is scoped, the broad `vault-backend` store and monolithic `kagent` key are destroyed, and the validator reports **zero warnings**. Past that point the staging protected nothing — it just meant a real regression would land as a warning.

Demonstrated by stripping *every* `toolName` from `k8s-agent` — an implicit bind-all on the agent holding `k8s_delete_resource` and `k8s_execute_command`:

```
WARN: k8s-agent: MCP ref 'kagent-tool-server' lists no toolNames — backlog
agent-identity validation passed (1 warning(s)).
exit 0                                    ← CI green on a capability regression
```

Now:
```
ERROR: k8s-agent: MCP ref 'kagent-tool-server' lists no toolNames — an implicit bind-all.
exit 1                                    ← hard failure
```

## Changes

**No staging.** Every agent and credential is held to all three invariants. `scripts/agent-identity-scope.txt` deleted.

**Agents discovered by `kind`, not directory.** `collect_agents()` globbed `agents/*.yaml` then *hardcoded* `build-orchestrator.yaml`, which lives one level up. It worked only because someone remembered the special case — the next agent placed outside `agents/` would have been silently unvalidated.

**Dangling delegations are errors.** `observability-agent` carried a `type: Agent` ref to `promql-agent` — an agent that doesn't exist and is disabled in the chart. Invariant 3 never looked at delegation refs at all.

## Two exemptions kept — and now justified in writing rather than silent

I went in intending to remove the `default-model-config` exemption and **backed out after reading the code.** It's legitimate: invariant 2 exists to catch identity that is *invisible to review* — the design doc's §13 complaint was a ModelConfig **"applied by hand"**. `default-model-config` is the opposite: its definition lives in Git at `base-apps/kagent.yaml`'s `providers:` block and Helm renders it. Adopting it as a standalone manifest would put the chart and Argo in a tug-of-war over one object — **the exact failure mode that silently stripped the agents' `requireApproval` gates on every sync.**

Same reasoning already covers `kagent-tool-server` / `kagent-grafana-mcp`. Both exemptions now carry their rationale in the code.

**README fix:** drops the stale claim that the Kyverno policy *"carries one documented exclusion: `kagent-anthropic-secrets`"*. It has carried none since that credential was scoped.

## Verification

- `agent-identity: 8 agents held to all three invariants` → **contract OK**
- **28 tests pass** (13 identity, rewritten for universal hard-fail; 15 capability)
- capability contract does not regress

## Note

This does **not** depend on #352, but **#352 is still open and the delegation escalation is live in the cluster** — a `read` agent delegating to `k8s-agent` (admin) is currently ALLOWED at admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf