### PR TITLE
chore(kagent): remove the dead agents.platform.ai annotation contract (P1)

### DIFF
--- a/base-apps/kagent/agents/dungeon-crawler-carl-agent.yaml
+++ b/base-apps/kagent/agents/dungeon-crawler-carl-agent.yaml
@@ -17,22 +17,6 @@ metadata:
     terasky.backstage.io/links: '[{"url":"https://kagent.arigsela.com/agents/kagent/dungeon-crawler-carl-agent/chat","title":"Chat with this agent","icon":"chat"}]'
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/dungeon-crawler-carl-agent.yaml
     backstage.io/owner: group:default/platform-engineering
-    # === agents.platform.ai/* v1 contract ===
-    # Structured metadata mirrored to the Backstage catalog by the TeraSky
-    # kubernetes-ingestor. Consumed by future MCP-backed assistants to
-    # enumerate and call this agent. Contract spec:
-    # docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
-    agents.platform.ai/version: "v1"
-    agents.platform.ai/runtime: kagent
-    agents.platform.ai/description: |-
-      expert in the book dungeon crawler carl
-    # Port 8080 is the kagent default A2A service port.
-    agents.platform.ai/a2a-endpoint: http://dungeon-crawler-carl-agent.kagent.svc.cluster.local:8080
-    agents.platform.ai/skills: |-
-      [{"id":"dungeon-crawler-carl-lore","name":"Dungeon Crawler Carl Lore Expert","description":"Provides in-depth knowledge about characters, plot points, and world-building from the Dungeon Crawler Carl series."},{"id":"carl-character-analysis","name":"Carl Character Analysis","description":"Analyzes character development, motivations, and relationships within the Dungeon Crawler Carl narrative."},{"id":"dungeon-crawler-mechanics-guide","name":"Dungeon Crawler Mechanics Guide","description":"Explains the game mechanics, progression systems, and dungeon exploration elements featured in Dungeon Crawler Carl."}]
-    agents.platform.ai/delegates: |-
-      []
-    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
 spec:
   description: |-
     expert in the book dungeon crawler carl

--- a/base-apps/kagent/agents/k8s-reader.yaml
+++ b/base-apps/kagent/agents/k8s-reader.yaml
@@ -34,16 +34,6 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/k8s-reader.yaml
     backstage.io/owner: group:default/platform-engineering
-    agents.platform.ai/version: "v1"
-    agents.platform.ai/runtime: kagent
-    agents.platform.ai/description: |-
-      Read-only Kubernetes cluster investigator. Observes state; cannot change it.
-    agents.platform.ai/a2a-endpoint: http://k8s-reader.kagent.svc.cluster.local:8080
-    agents.platform.ai/skills: |-
-      [{"id":"cluster-inspection","name":"Cluster Inspection","description":"Reads Kubernetes resource state, events, logs and cluster configuration to answer questions and diagnose problems."}]
-    agents.platform.ai/delegates: |-
-      []
-    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
 spec:
   type: Declarative
   description: A read-only Kubernetes investigator. Inspects cluster state, events and

--- a/base-apps/kagent/agents/skill-suggester.yaml
+++ b/base-apps/kagent/agents/skill-suggester.yaml
@@ -16,22 +16,6 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/skill-suggester.yaml
     backstage.io/owner: group:default/platform-engineering
-    # === agents.platform.ai/* v1 contract ===
-    # Structured metadata mirrored to the Backstage catalog by the TeraSky
-    # kubernetes-ingestor. Consumed by future MCP-backed assistants to
-    # enumerate and call this agent. Contract spec:
-    # docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
-    agents.platform.ai/version: "v1"
-    agents.platform.ai/runtime: kagent
-    agents.platform.ai/description: |-
-      Suggests A2A skills for new kagent agents based on a one-line description
-    # Port 8080 is the kagent default A2A service port.
-    agents.platform.ai/a2a-endpoint: http://skill-suggester.kagent.svc.cluster.local:8080
-    agents.platform.ai/skills: |-
-      []
-    agents.platform.ai/delegates: |-
-      []
-    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
 spec:
   description: |-
     Suggests A2A skills for new kagent agents based on a one-line description

--- a/base-apps/kagent/docs.md
+++ b/base-apps/kagent/docs.md
@@ -66,6 +66,17 @@ The broad `vault-backend` `SecretStore` is **gone**. It authenticated as the nam
 kagent uses the **shared PostgreSQL** instance (`base-apps/postgresql/`) rather than the chart's bundled DB (`database.postgres.bundled.enabled: false` in `kagent.yaml`): `external-secrets.yaml` here syncs `kagent-db-credentials` (`db-url`, `db-user`, `db-password`, `db-name`) from Vault key `kagent-db`, matching the `kagent` role/database that `postgresql`'s `init-kagent-db` Job provisions with the `vector` extension enabled (see `base-apps/postgresql/docs.md`). The controller mounts that Secret's `db-url` at `/etc/kagent/secrets/db-url` (`kagent.yaml`'s `controller.volumes`/`volumeMounts`).
 
 ## Exposure
-The UI is at `kagent.arigsela.com` (`nginx-ingress.yaml`, IP-whitelisted). Agents are also invocable over **A2A**: each agent's Backstage annotations (e.g. `agents.platform.ai/a2a-endpoint` in `agents/dungeon-crawler-carl-agent.yaml`) point at `http://<agent>.kagent.svc.cluster.local:8080`. External MCP clients (e.g. Claude Code CLI) reach the controller's `/mcp` endpoint (`invoke_agent`/`list_agents`) at **`kagent-mcp.arigsela.com/mcp`** (`mcp-ingress.yaml`, fronting `kagent-controller:8083`), gated by the same IP whitelist plus HTTP basic auth (`kagent-mcp-basic-auth`, since `/mcp` has no auth of its own).
+The UI is at `kagent.arigsela.com` (`nginx-ingress.yaml`, IP-whitelisted). Agents are also invocable over **A2A** at `http://<agent>.kagent.svc.cluster.local:8080` (the kagent default A2A service port). External MCP clients (e.g. Claude Code CLI) reach the controller's `/mcp` endpoint (`invoke_agent`/`list_agents`) at **`kagent-mcp.arigsela.com/mcp`** (`mcp-ingress.yaml`, fronting `kagent-controller:8083`), gated by the same IP whitelist plus HTTP basic auth (`kagent-mcp-basic-auth`, since `/mcp` has no auth of its own).
+
+> The `agents.platform.ai/*` annotation contract was **removed** (2026-07-14). It
+> duplicated data already in the `Agent` spec — `skills` mirrored
+> `a2aConfig.skills`, `delegates` mirrored `tools[type: Agent]`, `a2a-endpoint` was
+> derivable from the name — and it was carried by only 3 of 8 agents, consumed by
+> nothing, enforced by nothing, with a spec doc that never existed. Its `delegates`
+> field never once held a non-empty value, while the two agents that actually
+> delegate did not carry the contract at all. If agent-to-agent discovery is wanted,
+> derive it from the `Agent` CR (which Backstage already ingests) rather than
+> hand-maintaining a parallel copy that drifts. See
+> `docs/superpowers/specs/2026-07-14-adp-remaining-pillars-roadmap.md` (P1).
 
 The MCP endpoint deliberately lives on its **own host**, not on `kagent.arigsela.com`. It used to be served at `kagent.arigsela.com/mcp`, where it shadowed the kagent UI's own "MCP & tools" page (also `/mcp`): the ingress won the path match, so clicking that menu item returned a basic-auth prompt instead of the page, and — because the match was `pathType: Prefix` — every `/mcp/*` UI route was unreachable too. Keep new UI-facing paths on `kagent.arigsela.com` and API/endpoint paths on `kagent-mcp.arigsela.com`. Note DNS for this cluster is created by hand in Route 53 (no external-dns, no wildcard), so a new host needs its A record added before cert-manager can complete the HTTP-01 challenge.


### PR DESCRIPTION
Roadmap **P1**. A contract nobody reads is worse than none — it looks like coverage.

## The evidence

Seven `agents.platform.ai/*` annotations on **3 of 8 agents**. Nothing consumes them, nothing enforces them, and the spec they cite (`2026-05-19-aicontext-catalog-kind-design.md`) **does not exist**. Their own comment says *"consumed by **future** MCP-backed assistants."*

**Every field duplicates the `Agent` spec:**

| annotation | duplicates |
|---|---|
| `skills` | `spec.declarative.a2aConfig.skills` |
| `delegates` | `spec.declarative.tools[type: Agent]` |
| `description` | `spec.description` |
| `a2a-endpoint` | derivable from the agent name |

That's exactly what the Identity design **explicitly rejected**: *"Rejected: a per-agent `agent-principal.yaml` source-of-truth — it duplicates `Agent.tools`/`ModelConfig` and drifts."* Same mistake, made in annotations instead of a file.

## It's vacuous where it exists and absent where it matters

| agent | `delegates` (annotation) | `delegates` (**actual spec**) |
|---|---|---|
| `dungeon-crawler-carl` | `[]` | `[]` |
| `k8s-reader` | `[]` | `[]` |
| `skill-suggester` | `[]` | `[]` |
| **`homelab-knowledge`** | **(none)** | **`k8s-reader`** |
| **`build-orchestrator`** | **(none)** | **`k8s-agent`, `istio-agent`** |

The `delegates` field has **never once held a non-empty value.** It hadn't drifted only because it never carried real data.

## What's removed, what's kept

Removed: the `agents.platform.ai/*` block from the three agents.

**Kept:** `terasky.backstage.io/*` and `backstage.io/*` — the TeraSky kubernetes-ingestor genuinely consumes those to mirror agents into the Backstage catalog. Capability class labels untouched.

If agent-to-agent discovery is wanted later, **derive it from the `Agent` CR** — which Backstage already ingests — rather than hand-maintaining a parallel copy that drifts.

## Verification

- identity + capability contracts **OK**
- **47 tests pass**
- `yamllint` / `kubeconform` clean
- all three agents still **accepted at admission** by both Kyverno policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf