### PR TITLE
fix(identity): scope the kagent DB credential in the postgresql namespace

### DIFF
--- a/base-apps/kyverno-policies/agent-identity.yaml
+++ b/base-apps/kyverno-policies/agent-identity.yaml
@@ -47,19 +47,35 @@ spec:
             secretStoreRef:
               name: "!vault-backend"
 
+    # CLUSTER-WIDE, deliberately — unlike the broad-store rule above, which stays
+    # scoped to `kagent` because `vault-backend` is a legitimate per-namespace
+    # SecretStore used by ~30 healthy ExternalSecrets across the cluster.
+    #
+    # This rule is different: the `k8s-secrets/kagent` key is DESTROYED. Nothing
+    # legitimate can read it, in any namespace, ever again. Scoping the check to
+    # the kagent namespace left a real hole — `postgresql/kagent-db-credentials` is
+    # a KAGENT credential that LIVES in the postgresql namespace, kept reading the
+    # monolithic key, broke silently when the key was destroyed (SecretSyncedError,
+    # "could not get secret data from provider"), and went unnoticed because its
+    # already-materialized Secret was left behind and kept working, stale.
+    #
+    # The contract was enforcing least privilege by LOCATION when it should enforce
+    # it by WHAT THE CREDENTIAL IS. A credential does not stop being kagent's
+    # because it is declared in another namespace.
     - name: credential-must-not-read-monolithic-vault-key
       match:
         any:
           - resources:
               kinds:
                 - external-secrets.io/v1beta1/ExternalSecret
-              namespaces:
-                - kagent
       validate:
         message: >-
           ExternalSecret '{{ request.object.metadata.name }}' must not read the monolithic
-          Vault key 'kagent' — that key holds every consumer's credential, so any token
-          able to read it can read them all. Use a per-consumer key (k8s-secrets/<consumer>).
+          Vault key 'kagent' — that key held every consumer's credential, so any token
+          able to read it could read them all. It has been DESTROYED; nothing can read it.
+          Use a per-consumer key (k8s-secrets/<consumer>) with its own ESO ServiceAccount,
+          SecretStore and Vault role. This rule is cluster-wide: a kagent credential does
+          not stop being kagent's because it is declared in another namespace.
           See templates/agent-identity/README.md (invariant 1).
         foreach:
           - list: "request.object.spec.data"

--- a/base-apps/postgresql/eso-kagent-db-serviceaccount.yaml
+++ b/base-apps/postgresql/eso-kagent-db-serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Dedicated ESO ServiceAccount for the kagent DB credential, in the postgresql
+# namespace. The Vault kubernetes-auth role `kagent-db` is bound to THIS SA name
+# in BOTH `kagent` and `postgresql`, so only its SecretStore can assume the role,
+# and the role reads exactly one Vault key.
+#
+# Why a copy lives here at all: the init-kagent-db Job runs in this namespace and
+# needs the kagent DB user/password to create the role and database. It is the same
+# credential kagent itself consumes, just needed from a second namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-kagent-db
+  namespace: postgresql

--- a/base-apps/postgresql/external-secrets-kagent.yaml
+++ b/base-apps/postgresql/external-secrets-kagent.yaml
@@ -1,3 +1,37 @@
+---
+# The kagent DB credential, as consumed by the init-kagent-db Job in THIS namespace.
+#
+# It previously read the monolithic `kagent` Vault key through the broad
+# `vault-backend` SecretStore. The agent-identity increment retired both — the
+# `kagent` Vault role, its policy, and the `k8s-secrets/kagent` key were destroyed —
+# which silently broke this ExternalSecret:
+#
+#   $ kubectl get externalsecret kagent-db-credentials -n postgresql
+#   kagent-db-credentials   1h   SecretSyncedError
+#   "could not get secret data from provider"
+#
+# Nothing noticed, for two reasons worth writing down:
+#
+#   1. The Secret it had already materialized was left behind. ESO could no longer
+#      REFRESH it, but the stale Secret persisted, so the init Job kept succeeding
+#      off data that can never be updated again. It worked by luck. A password
+#      rotation, or anyone deleting that Secret, would have broken the Job.
+#
+#   2. Both identity gates are scoped to the `kagent` NAMESPACE — the validator
+#      globs base-apps/kagent/, and the Kyverno rule matched namespaces: [kagent].
+#      This is a kagent credential that lives in `postgresql`, so it fell straight
+#      through. The contract enforced least privilege by LOCATION when it should
+#      enforce it by WHAT THE CREDENTIAL IS. Both gates are widened in this change.
+#
+# It now resolves through the same scoped path kagent itself uses: the dedicated
+# `eso-kagent-db` ServiceAccount → Vault role `kagent-db` → the per-consumer
+# `k8s-secrets/kagent-db` key. The Vault role is bound to that SA name in BOTH the
+# `kagent` and `postgresql` namespaces; the privilege is identical either way —
+# read exactly one Vault key.
+#
+# The secretKey names differ from the kagent-namespace copy because the init Job's
+# env vars expect kagent-user / kagent-password / kagent-database. Same Vault
+# properties underneath.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -6,7 +40,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-backend
+    name: vault-kagent-db
     kind: SecretStore
   target:
     name: kagent-db-credentials
@@ -14,13 +48,13 @@ spec:
   data:
     - secretKey: kagent-user
       remoteRef:
-        key: kagent
+        key: kagent-db
         property: db-user
     - secretKey: kagent-password
       remoteRef:
-        key: kagent
+        key: kagent-db
         property: db-password
     - secretKey: kagent-database
       remoteRef:
-        key: kagent
+        key: kagent-db
         property: db-name

--- a/base-apps/postgresql/kagent-db-secret-store.yaml
+++ b/base-apps/postgresql/kagent-db-secret-store.yaml
@@ -1,0 +1,27 @@
+---
+# Path-scoped SecretStore for the kagent DB credential, in the postgresql namespace.
+#
+# This replaces a reference to the broad `vault-backend` store + the monolithic
+# `kagent` Vault key, both of which were RETIRED by the agent-identity increment.
+# That retirement broke this ExternalSecret (SecretSyncedError, "could not get
+# secret data from provider") and nobody noticed, because both identity gates are
+# scoped to the `kagent` namespace: the validator globs base-apps/kagent/, and the
+# Kyverno rule matched namespaces: [kagent]. A kagent credential living in ANOTHER
+# namespace fell straight through. Both gates are widened in the same change.
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-kagent-db
+  namespace: postgresql
+spec:
+  provider:
+    vault:
+      server: http://vault.vault.svc.cluster.local:8200
+      path: k8s-secrets
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: kagent-db
+          serviceAccountRef:
+            name: eso-kagent-db

--- a/scripts/validate-agent-identity.py
+++ b/scripts/validate-agent-identity.py
@@ -95,9 +95,45 @@ def collect_agents(repo_root: Path) -> list[tuple[Path, dict]]:
     return agents
 
 
+def collect_external_secrets_repo_wide(repo_root: Path) -> list[tuple[Path, dict]]:
+    """Every ExternalSecret in base-apps/, NOT just base-apps/kagent/.
+
+    Why repo-wide: `postgresql/kagent-db-credentials` is a KAGENT credential that
+    LIVES in the postgresql namespace. It kept reading the monolithic `kagent` Vault
+    key, broke silently when that key was destroyed (SecretSyncedError), and was
+    invisible to this validator because it only ever globbed base-apps/kagent/.
+
+    The contract was enforcing least privilege by LOCATION when it should enforce it
+    by WHAT THE CREDENTIAL IS.
+    """
+    base = repo_root / "base-apps"
+    found: list[tuple[Path, dict]] = []
+    if not base.is_dir():
+        return found
+    for path in sorted(base.rglob("*.yaml")):
+        for doc in _load_docs(path):
+            if doc.get("kind") == "ExternalSecret":
+                found.append((path, doc))
+    return found
+
+
 def check_credential_scoping(repo_root: Path) -> list[str]:
+    """Invariant 1.
+
+    Two different scopes, deliberately:
+
+    * The monolithic `kagent` Vault key is checked REPO-WIDE. That key is destroyed;
+      nothing legitimate reads it from any namespace.
+    * The broad `vault-backend` SecretStore is only checked inside base-apps/kagent/.
+      `vault-backend` is a legitimate PER-NAMESPACE SecretStore name used by ~30
+      healthy ExternalSecrets across the cluster (atlantis, backstage, cert-manager,
+      mysql, n8n, ...). Only the one in the kagent namespace was retired. Flagging it
+      globally would be a false positive on most of the repo.
+    """
     errors: list[str] = []
-    for _path, doc in collect_by_kind(repo_root).get("ExternalSecret", []):
+    kagent_dir = repo_root / "base-apps" / "kagent"
+
+    for path, doc in collect_external_secrets_repo_wide(repo_root):
         name = (doc.get("metadata") or {}).get("name")
         spec = doc.get("spec") or {}
         store = (spec.get("secretStoreRef") or {}).get("name")
@@ -105,15 +141,26 @@ def check_credential_scoping(repo_root: Path) -> list[str]:
             (ref.get("remoteRef") or {}).get("key")
             for ref in (spec.get("data") or [])
         }
-        if store != BROAD_SECRETSTORE and MONOLITHIC_VAULT_KEY not in keys:
-            continue
-        errors.append(
-            f"{name}: credential is not scoped (store={store!r}, "
-            f"keys={sorted(k for k in keys if k)}) — every credential must use a "
-            f"dedicated SecretStore and a per-consumer Vault key. The broad "
-            f"{BROAD_SECRETSTORE!r} store and the monolithic {MONOLITHIC_VAULT_KEY!r} "
-            f"key are retired."
-        )
+
+        # repo-wide: the destroyed monolithic key
+        if MONOLITHIC_VAULT_KEY in keys:
+            errors.append(
+                f"{name} ({path}): reads the monolithic Vault key "
+                f"{MONOLITHIC_VAULT_KEY!r}, which is DESTROYED. It held every "
+                f"consumer's credential at once. Use a per-consumer key "
+                f"(k8s-secrets/<consumer>) with its own ESO ServiceAccount, "
+                f"SecretStore and Vault role. A kagent credential does not stop "
+                f"being kagent's because it is declared in another namespace."
+            )
+
+        # kagent namespace only: the retired broad store
+        in_kagent = kagent_dir in path.parents or path.parent == kagent_dir
+        if in_kagent and store == BROAD_SECRETSTORE:
+            errors.append(
+                f"{name} ({path}): uses the broad {BROAD_SECRETSTORE!r} SecretStore, "
+                f"which is retired in the kagent namespace. Every credential must "
+                f"resolve through a dedicated, path-scoped SecretStore."
+            )
     return errors
 
 

--- a/tests/agent-identity/test_validate_agent_identity.py
+++ b/tests/agent-identity/test_validate_agent_identity.py
@@ -124,6 +124,29 @@ def test_any_credential_is_held_to_the_bar_not_just_a_pilot(tmp_path):
     assert vai.main(["--repo-root", str(root)]) == 1
 
 
+def test_monolithic_key_is_caught_in_ANY_namespace(tmp_path):
+    """The regression that shipped: postgresql/kagent-db-credentials is a KAGENT
+    credential living in the postgresql namespace. It kept reading the monolithic
+    `kagent` key, broke silently when that key was destroyed, and was invisible
+    because the validator only globbed base-apps/kagent/."""
+    root = _good_repo(tmp_path)
+    _write(root / "base-apps" / "postgresql" / "external-secrets-kagent.yaml",
+           _external_secret("kagent-db-credentials", "vault-backend", "kagent"))
+    assert vai.main(["--repo-root", str(root)]) == 1
+
+
+def test_vault_backend_OUTSIDE_kagent_is_not_flagged(tmp_path):
+    """`vault-backend` is a legitimate PER-NAMESPACE SecretStore name used by ~30
+    healthy ExternalSecrets (atlantis, backstage, cert-manager, mysql, n8n, ...).
+    Only the kagent-namespace one was retired. Flagging it globally would be a
+    false positive across most of the repo — so the broad-store check stays scoped
+    while the monolithic-key check goes repo-wide."""
+    root = _good_repo(tmp_path)
+    _write(root / "base-apps" / "atlantis" / "external-secrets.yaml",
+           _external_secret("atlantis-env", "vault-backend", "atlantis/aws"))
+    assert vai.main(["--repo-root", str(root)]) == 0
+
+
 # ---------------------------------------- invariant 2: in-git model identity
 
 def test_out_of_band_modelconfig_is_error(tmp_path):


### PR DESCRIPTION
> ## ⚠️ Requires a Vault change BEFORE merge — see below

**This is a regression from the Identity increment, live since it shipped.** I caused it; I found it while starting O1.

## What broke

`postgresql/kagent-db-credentials` read the monolithic `kagent` Vault key through the broad `vault-backend` store. The Identity increment **destroyed both**. It has been failing ever since:

```
$ kubectl get externalsecret kagent-db-credentials -n postgresql
kagent-db-credentials   1h   SecretSyncedError
"could not get secret data from provider"
```

**kagent itself was never affected** — all five of its ExternalSecrets are `SecretSynced` on their scoped stores.

## Why nobody noticed — two failures, both fixed here

**1. It works by luck.** The Secret ESO had already materialized was left behind. ESO can no longer *refresh* it, but the stale Secret persists — so `init-kagent-db` keeps succeeding off data that can never be updated again. A password rotation, or anyone deleting that Secret, breaks it.

**2. Both gates are scoped to the `kagent` namespace.** The validator globbed `base-apps/kagent/`; the Kyverno rule matched `namespaces: ['kagent']`. This is a **kagent credential that lives in `postgresql`** — it fell straight through.

> The contract was enforcing least privilege **by location**, when it should enforce it **by what the credential is**. A credential doesn't stop being kagent's because it's declared in another namespace.

## The fix

- `postgresql` gets its own `eso-kagent-db` ServiceAccount + path-scoped `vault-kagent-db` SecretStore, resolving the same per-consumer `k8s-secrets/kagent-db` key kagent uses.
- Kyverno `credential-must-not-read-monolithic-vault-key` → **cluster-wide**. That key is destroyed; nothing legitimate reads it anywhere.
- The validator checks the monolithic key **repo-wide**.

## The widenings are deliberately asymmetric

`credential-must-not-use-broad-secretstore` **stays scoped to `kagent`**. `vault-backend` is a legitimate **per-namespace** SecretStore name used by **~30 healthy ExternalSecrets** (atlantis, backstage, cert-manager, mysql, n8n, …). Only the kagent one was retired — flagging it globally would false-positive across most of the repo.

This also corrects an overclaim in my earlier docs: *"the broad `vault-backend` store is gone"* was only ever true **of the kagent namespace**.

## 🔑 Vault change required (I have no token; you hold it)

The `kagent-db` role must accept the `eso-kagent-db` SA in **both** namespaces. Check the current values first, then preserve them:

```bash
export VAULT_ADDR=http://127.0.0.1:8200   # port-forward already running
vault read auth/kubernetes/role/kagent-db          # note policies + ttl

vault write auth/kubernetes/role/kagent-db \
  bound_service_account_names=eso-kagent-db \
  bound_service_account_namespaces=kagent,postgresql \
  policies=<as read above> \
  ttl=<as read above>
```

The privilege is unchanged either way — that role reads **exactly one** Vault key.

## Verification

- Validator **catches** the regression when reintroduced; **0 false positives** on the ~30 legit `vault-backend` users
- 15 identity tests + capability contract pass
- `yamllint`, `kubeconform`, server-side dry-run all clean

## Also found (pre-existing, NOT touched)

Three unrelated ExternalSecrets are already failing: `langflow-ide/langflow-api-secrets`, `oncall-crewai/knowledge-agent-secrets`, and `postgresql/postgresql-backup-credentials` (which reads a `mysql` key — looks misconfigured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf