### PR TITLE
feat(observability): agent action record — who called what, was it approved (O1)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -159,3 +159,20 @@ jobs:
           sudo install -m 0755 kyverno /usr/local/bin/kyverno
       - name: Verify agent-capability Kyverno policy
         run: ./tests/agent-capability/kyverno/run.sh
+
+  # The agent action record (Observability O1). The redaction tests are the point:
+  # event.data contains full tool RESPONSES, and k8s_get_resource_yaml against a
+  # Secret lands its payload there verbatim. A redactor nobody tested is a redactor
+  # that does not work.
+  agent-audit-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: pip install pyyaml==6.0.2 pytest==8.3.3
+      - name: Run agent-audit redaction tests
+        run: python -m pytest tests/agent-audit/ -q

--- a/base-apps/postgresql/eso-kagent-audit-serviceaccount.yaml
+++ b/base-apps/postgresql/eso-kagent-audit-serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+# Dedicated ESO ServiceAccount for the agent-audit read-only DB credential.
+# Vault role `kagent-audit-ro` is bound to THIS SA name in THIS namespace, and its
+# policy grants read on exactly one key: k8s-secrets/data/kagent-audit-ro.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-kagent-audit
+  namespace: postgresql

--- a/base-apps/postgresql/external-secrets-kagent-audit.yaml
+++ b/base-apps/postgresql/external-secrets-kagent-audit.yaml
@@ -1,0 +1,30 @@
+---
+# The read-only credential the agent-audit tool uses to read kagent's event stream.
+# Scoped per the agent-identity contract: dedicated ESO SA + SecretStore + Vault
+# role + per-consumer Vault key. See templates/agent-identity/README.md.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kagent-audit-credentials
+  namespace: postgresql
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-kagent-audit-ro
+    kind: SecretStore
+  target:
+    name: kagent-audit-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: audit-user
+      remoteRef:
+        key: kagent-audit-ro
+        property: db-user
+    - secretKey: audit-password
+      remoteRef:
+        key: kagent-audit-ro
+        property: db-password
+    - secretKey: audit-database
+      remoteRef:
+        key: kagent-audit-ro
+        property: db-name

--- a/base-apps/postgresql/init-kagent-audit-role.yaml
+++ b/base-apps/postgresql/init-kagent-audit-role.yaml
@@ -1,0 +1,127 @@
+---
+# Creates the SELECT-only Postgres role the agent-audit tool logs in as.
+#
+# An audit tool with write access to the database it audits is not an audit tool.
+# This role can read kagent's event/session/task tables and nothing else — it
+# cannot INSERT, UPDATE, DELETE, or DDL, and the grants are revoked-then-granted
+# so re-running this Job cannot silently accumulate privilege.
+#
+# The password comes from Vault via kagent-audit-credentials (its own ESO
+# ServiceAccount, SecretStore, Vault role and per-consumer key — the agent-identity
+# contract). It is never in git.
+#
+# Idempotent: safe to re-run. Argo recreates this Job after its TTL expires.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-kagent-audit-role
+  namespace: postgresql
+  annotations:
+    # After init-kagent-db (which creates the kagent database this role reads).
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        app: init-kagent-audit-role
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      restartPolicy: OnFailure
+      containers:
+        - name: init-kagent-audit-role
+          image: pgvector/pgvector:0.8.2-pg18
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              PG_HOST="postgresql.postgresql.svc.cluster.local"
+              PG_PORT="5432"
+
+              ESCAPED_PASSWORD=$(echo "$AUDIT_PASSWORD" | sed "s/'/''/g")
+
+              until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$POSTGRES_USER"; do
+                echo "Waiting for PostgreSQL..."
+                sleep 2
+              done
+
+              # Create (or re-password) the audit login role. NOSUPERUSER/NOCREATEDB/
+              # NOCREATEROLE/NOINHERIT are explicit rather than relying on defaults.
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" \
+                -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+                -v audit_user="$AUDIT_USER" \
+                -v audit_password="$ESCAPED_PASSWORD" <<'EOSQL'
+                SELECT format(
+                  'CREATE ROLE %I WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT PASSWORD %L',
+                  :'audit_user', :'audit_password')
+                WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'audit_user')\gexec
+
+                SELECT format('ALTER ROLE %I WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT PASSWORD %L',
+                  :'audit_user', :'audit_password')
+                WHERE EXISTS (SELECT FROM pg_roles WHERE rolname = :'audit_user')\gexec
+              EOSQL
+
+              # Grant READ-ONLY on the kagent database. Revoke first so a re-run
+              # cannot accumulate privilege, and so tightening this list actually
+              # tightens it.
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" \
+                -U "$POSTGRES_USER" -d "$AUDIT_DB" \
+                -v audit_user="$AUDIT_USER" \
+                -v audit_db="$AUDIT_DB" <<'EOSQL'
+                -- start from nothing, then grant only SELECT
+                REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM :"audit_user";
+                REVOKE ALL PRIVILEGES ON SCHEMA public FROM :"audit_user";
+
+                GRANT CONNECT ON DATABASE :"audit_db" TO :"audit_user";
+                GRANT USAGE ON SCHEMA public TO :"audit_user";
+                GRANT SELECT ON ALL TABLES IN SCHEMA public TO :"audit_user";
+
+                -- kagent's controller owns and migrates these tables; new ones must
+                -- also be readable, but still only SELECT.
+                ALTER DEFAULT PRIVILEGES IN SCHEMA public
+                  GRANT SELECT ON TABLES TO :"audit_user";
+              EOSQL
+
+              echo "kagent audit role '$AUDIT_USER' created with SELECT-only access to '$AUDIT_DB'"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: n8n-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: n8n-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: database-name
+            - name: AUDIT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kagent-audit-credentials
+                  key: audit-user
+            - name: AUDIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kagent-audit-credentials
+                  key: audit-password
+            - name: AUDIT_DB
+              valueFrom:
+                secretKeyRef:
+                  name: kagent-audit-credentials
+                  key: audit-database
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/base-apps/postgresql/kagent-audit-secret-store.yaml
+++ b/base-apps/postgresql/kagent-audit-secret-store.yaml
@@ -1,0 +1,26 @@
+---
+# Path-scoped SecretStore for the agent-audit credential.
+#
+# The audit tool (scripts/agent-audit.py) reads kagent's event/session tables to
+# reconstruct which agent called which tool. It must NOT be able to write to the
+# database it audits — an audit tool with write access is not an audit tool.
+#
+# So it gets its own Vault key, its own ESO ServiceAccount, its own Vault role,
+# and — see init-kagent-audit-role.yaml — its own SELECT-only Postgres role.
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-kagent-audit-ro
+  namespace: postgresql
+spec:
+  provider:
+    vault:
+      server: http://vault.vault.svc.cluster.local:8200
+      path: k8s-secrets
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: kagent-audit-ro
+          serviceAccountRef:
+            name: eso-kagent-audit

--- a/docs/superpowers/specs/2026-07-14-agent-action-record-design.md
+++ b/docs/superpowers/specs/2026-07-14-agent-action-record-design.md
@@ -1,0 +1,155 @@
+# Agent Action Record (Observability O1) — Design
+
+- **Date:** 2026-07-14
+- **Status:** Draft for review
+- **Pillar:** L03 Observability, increment O1
+- **Roadmap:** [ADP Remaining Pillars](2026-07-14-adp-remaining-pillars-roadmap.md)
+- **Depends on:** the O0 spike (done — the data already exists)
+
+## Problem
+
+We have no way to answer *"which agent called which tool, with what arguments, was
+it approved?"* — not because the data is missing, but because **nothing reads it.**
+
+The O0 spike found kagent already persists all of it in its own Postgres:
+`session` (carrying `agent_id`), `event` (the JSON event stream), `task`, and
+`feedback`. `event.data` holds `function_call` / `function_response` with tool name
+and full arguments, `adk_request_confirmation` for HITL gates *including the
+outcome*, and `usage_metadata` token counts.
+
+The cost of not reading it is not hypothetical. The spike ran one query and found:
+
+```
+k8s_agent — gated tools actually invoked:
+  k8s_execute_command    14 calls   on 2026-07-09
+  k8s_delete_resource     1 call    on 2026-04-19
+
+approval requests raised by k8s_agent in ALL its history:  0
+```
+
+Fourteen arbitrary shell commands executed through a human-approval gate that was
+silently doing nothing, because Argo was stripping `requireApproval` on every sync.
+The evidence sat in that database for months. **Nobody could see it because nothing
+queried it.**
+
+## Goal
+
+A **read-only, redacted, agent-attributed record of tool invocations** — queryable
+today, and shaped so O2 (alerting) and Evaluation (E1) can build on it without
+re-deriving it.
+
+## The hard constraint: this data is a secret-exposure surface
+
+`event.data` contains **full tool responses**. `k8s_get_resource_yaml` against a
+Secret returns its base64 payload verbatim. `k8s_get_pod_logs` returns whatever the
+app logged. So the raw event stream must be treated as **containing live
+credentials**, and any consumer — Grafana, Loki, a dashboard, an agent — is an
+exfiltration path.
+
+The design principle follows directly:
+
+> **Redact at extraction, never at display.** The raw `event` table is never
+> exposed to Grafana, Loki, an agent, or a human dashboard. Everything downstream
+> reads the redacted record, not the source.
+
+### What the record includes, and what it must not
+
+| Field | Included? | Why |
+|---|---|---|
+| timestamp, `session_id`, `agent_id` | ✅ | attribution — the whole point |
+| tool name | ✅ | what was called |
+| tool **arguments** | ✅ **redacted** | *see below* — this is the hard case |
+| approval requested / outcome (`confirmed`) | ✅ | a HITL gate you cannot audit is a gate you cannot trust |
+| token usage | ✅ | cost attribution; no secret content |
+| tool **response body** | ❌ **NEVER** | this is where secrets live. Record that a response occurred, its byte length, and a content hash — never the content. |
+
+**Arguments are the genuinely hard case, and we keep them deliberately.** The most
+security-relevant thing in the whole record is
+`k8s_execute_command args={command: ...}` — auditing it *is the point*, and
+dropping it would gut the record. But a command can itself carry a secret
+(`kubectl create secret ... --from-literal=...`).
+
+Resolution: keep arguments, redact **values** by pattern (high-entropy strings,
+`token`/`password`/`secret`/`key`-shaped keys, PEM blocks, base64 blobs over a
+length threshold), and truncate. Accept that argument redaction is
+**best-effort, not a guarantee** — and say so plainly rather than implying the
+output is safe to publish. The output is *safer*, not *safe*: treat it as
+internal, not public.
+
+Response bodies get no such nuance: they are excluded categorically, because
+unlike arguments they carry no audit value that justifies the risk.
+
+## Approach
+
+**A script, not a service.** `scripts/agent-audit.py` — pure functions plus a CLI,
+mirroring `validate-agent-*.py`. It connects read-only, extracts, redacts, and
+emits. No new infrastructure, no new attack surface, and the redaction logic is
+unit-testable, which is the part that actually has to be right.
+
+Deliberately **not** a Grafana Postgres datasource: Grafana would query the raw
+table, which would put unredacted secrets on a dashboard. That is the failure this
+design exists to prevent.
+
+## Components
+
+1. **`scripts/agent-audit.py`**
+   - `--since` / `--agent` / `--tool` filters.
+   - `--format table|json`.
+   - `--ungated` — *the query that matters*: every invocation of a
+     taxonomy-classified `write`/`destructive` tool with **no approval event in its
+     session**. This is the `k8s_agent` finding, generalised. It reuses the
+     capability taxonomy (`agent-capability-taxonomy.yaml`) as the source of
+     "which tools should have been gated" — one source of truth, already enforced
+     at admission.
+   - `--cost` — per-agent token rollup.
+
+2. **Redaction module** (in the same script, separately tested)
+   - Categorical: drop all `function_response` bodies; keep name, byte length, hash.
+   - Pattern-based on argument *values*.
+   - Fail-closed: an argument value that cannot be classified is redacted, not
+     passed through.
+
+3. **Tests** — `tests/agent-audit/`. The redaction tests are the important ones:
+   feed known secret shapes through and assert they do not survive. A redactor
+   nobody tested is a redactor that does not work.
+
+## Success criteria
+
+1. `agent-audit.py --ungated` reproduces the `k8s_agent` finding from the spike
+   (14 × `k8s_execute_command`, 0 approvals) **from the CLI, not by hand**.
+2. A known secret planted in a tool response never appears in any output format.
+3. Per-agent cost rollup matches the spike's totals.
+4. Read-only: the script holds no write grant and the DB user it uses cannot mutate.
+5. Runs from a laptop against a port-forward, and is CronJob-shaped for later.
+
+## Safety, blast radius & rollback
+
+- **Read-only.** No cluster or DB mutation. Worst case is a bad query.
+- **The output is the risk, not the code.** Redaction is best-effort on arguments;
+  treat output as internal. Do not wire it to Slack, a public dashboard, or an
+  agent-readable tool without a further review of the redaction.
+- Rollback: delete the script. Nothing depends on it.
+
+## Non-goals (follow-ons)
+
+- **O2 — alerting.** `--ungated` returning rows should page someone. Needs a
+  scheduled runner and a sink; the detector lands here, the alerting does not.
+- **O4 — durable retention.** The record lives in kagent's *operational* DB with no
+  TTL and no backup; a session delete may cascade. Copying it somewhere durable is
+  a separate decision, and it is the point at which retention policy has to be
+  chosen.
+- **Evaluation (E1).** Needs the *response bodies* this design deliberately
+  excludes. That is a different consumer with a different risk profile and must be
+  scoped on its own — it is not a flag on this script.
+- A Grafana dashboard — only over the *redacted* store, once one exists (O4).
+
+## Open questions
+
+1. **How does the script authenticate to Postgres?** kagent's own credentials are
+   in `kagent-db-credentials` (read/write). An audit tool should have its own
+   **read-only DB role** — which means a Vault-scoped credential, exactly the
+   pattern the Identity pillar established. Doing that properly is arguably part of
+   this increment rather than a follow-on.
+2. **Is `agent_id` stable?** It appears as `kagent__NS__k8s_agent`. Ghost agents
+   (`helm_agent`, `dnd_agent`) appear in history but no longer exist. The record
+   must not assume a live `Agent` CR exists for every `agent_id` it reports.

--- a/scripts/agent-audit.py
+++ b/scripts/agent-audit.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Agent action record — who called what, with what arguments, was it approved.
+
+kagent already persists all of this; nothing reads it. This is the read side.
+
+    ./scripts/agent-audit.py --ungated          # the query that matters
+    ./scripts/agent-audit.py --cost
+    ./scripts/agent-audit.py --agent k8s_agent --since 7d
+
+WHY IT EXISTS
+-------------
+The O0 spike ran one query against kagent's Postgres and found this:
+
+    k8s_agent — gated tools actually invoked:
+      k8s_execute_command    14 calls   on 2026-07-09
+      k8s_delete_resource     1 call    on 2026-04-19
+
+    approval requests raised by k8s_agent in ALL its history:  0
+
+Fourteen arbitrary shell commands executed through a human-approval gate that was
+silently doing nothing, because Argo was stripping `requireApproval` on every sync.
+The evidence sat in that database for months. Nobody could see it because nothing
+queried it. `--ungated` is that query, generalised.
+
+REDACTION — read this before changing anything
+----------------------------------------------
+`event.data` contains full tool RESPONSES. `k8s_get_resource_yaml` against a Secret
+returns its base64 payload verbatim; `k8s_get_pod_logs` returns whatever the app
+logged. The raw event stream must be treated as CONTAINING LIVE CREDENTIALS.
+
+The rule is: **redact at extraction, never at display.** This script never emits a
+response body — not truncated, not "just for debugging". It emits the fact that a
+response occurred, its length, and a hash. Downstream consumers (a dashboard, an
+alert, an agent) read this output, never the table.
+
+Arguments are the genuinely hard case and are kept DELIBERATELY: the single most
+security-relevant fact in the whole record is what `k8s_execute_command` actually
+ran, and dropping it would gut the audit. So argument values are pattern-redacted
+and truncated instead.
+
+    Argument redaction is BEST-EFFORT, not a guarantee.
+
+Treat this output as internal. It is *safer*, not *safe*. Do not pipe it to Slack,
+a public dashboard, or an agent-readable tool without reviewing the redaction
+against what those arguments actually contain.
+
+Read-only by construction: it logs in as the SELECT-only `kagent_audit_ro` role
+(base-apps/postgresql/init-kagent-audit-role.yaml). An audit tool with write access
+to the database it audits is not an audit tool.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+TAXONOMY = "base-apps/kyverno-policies/agent-capability-taxonomy.yaml"
+
+# The tool kagent uses to request a human confirmation for a gated call.
+CONFIRM_TOOL = "adk_request_confirmation"
+
+# ----------------------------------------------------------------- redaction
+
+REDACTED = "<REDACTED>"
+
+# Argument KEYS whose value is secret by name alone.
+SECRET_KEY_RE = re.compile(
+    r"(pass|passwd|password|secret|token|key|credential|auth|bearer|session|cookie"
+    r"|private|signature|salt|nonce)",
+    re.IGNORECASE,
+)
+
+# Value SHAPES that are secret regardless of the key they sit under.
+PEM_RE = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
+JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+")
+KNOWN_PREFIX_RE = re.compile(
+    r"\b("
+    r"hvs\.[A-Za-z0-9._-]{12,}"          # Vault
+    r"|gh[pousr]_[A-Za-z0-9]{20,}"       # GitHub
+    r"|sk-[A-Za-z0-9-]{20,}"             # OpenAI / Anthropic style
+    r"|AKIA[0-9A-Z]{16}"                 # AWS access key id
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"     # Slack
+    r")"
+)
+# Long unbroken base64-ish blobs — the shape of an encoded secret.
+B64_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/]{40,}={0,2}\b")
+
+MAX_VALUE_LEN = 300
+
+
+def _shannon_entropy(s: str) -> float:
+    if not s:
+        return 0.0
+    counts = defaultdict(int)
+    for ch in s:
+        counts[ch] += 1
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    """Shape-based detection, independent of the key name."""
+    if PEM_RE.search(value) or JWT_RE.search(value) or KNOWN_PREFIX_RE.search(value):
+        return True
+    for blob in B64_BLOB_RE.findall(value):
+        # A long, high-entropy, unbroken token is a secret until proven otherwise.
+        if _shannon_entropy(blob) > 4.0:
+            return True
+        # Base64 that decodes to something binary-ish is also suspect.
+        try:
+            base64.b64decode(blob + "=" * (-len(blob) % 4), validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        if _shannon_entropy(blob) > 3.5:
+            return True
+    return False
+
+
+def redact_value(key: str, value):
+    """Redact one argument value. FAIL-CLOSED: unclassifiable → redacted."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, list):
+        return [redact_value(key, v) for v in value]
+    if isinstance(value, dict):
+        return {k: redact_value(k, v) for k, v in value.items()}
+    if not isinstance(value, str):
+        # Unknown type — do not guess.
+        return REDACTED
+
+    if SECRET_KEY_RE.search(key or ""):
+        return REDACTED
+    if _looks_like_secret_value(value):
+        return REDACTED
+    if len(value) > MAX_VALUE_LEN:
+        return value[:MAX_VALUE_LEN] + f"…[+{len(value) - MAX_VALUE_LEN} chars]"
+    return value
+
+
+def redact_args(args: dict | None) -> dict:
+    if not isinstance(args, dict):
+        return {}
+    return {k: redact_value(k, v) for k, v in args.items()}
+
+
+def summarize_response(resp) -> dict:
+    """A response is NEVER emitted. Only that it happened, how big, and a hash.
+
+    This is categorical, not best-effort. Response bodies carry no audit value that
+    could justify the risk — `k8s_get_resource_yaml` of a Secret lands here verbatim.
+    """
+    if resp is None:
+        return {"present": False}
+    body = resp if isinstance(resp, str) else json.dumps(resp, sort_keys=True)
+    return {
+        "present": True,
+        "bytes": len(body),
+        "sha256_12": hashlib.sha256(body.encode("utf-8", "replace")).hexdigest()[:12],
+    }
+
+
+# ------------------------------------------------------------------ taxonomy
+
+
+def load_gated_tools(repo_root: Path) -> set[str]:
+    """Tools the capability contract says MUST be behind requireApproval.
+
+    Single source of truth: the same taxonomy Kyverno enforces at admission. If a
+    tool is write/destructive there, an invocation of it with no approval event is
+    a finding here. The two cannot drift.
+    """
+    import yaml  # local import: only needed for --ungated
+
+    path = repo_root / TAXONOMY
+    cm = next(
+        d for d in yaml.safe_load_all(path.read_text())
+        if d and d.get("kind") == "ConfigMap"
+    )
+    gated: set[str] = set()
+    for classification in ("write", "destructive"):
+        gated |= set(json.loads(cm["data"][classification]))
+    return gated
+
+
+# --------------------------------------------------------------- extraction
+
+
+def iter_calls(event_rows):
+    """Yield one redacted record per tool invocation.
+
+    event_rows: (created_at, agent_id, session_id, data_json_text)
+    """
+    for created_at, agent_id, session_id, raw in event_rows:
+        try:
+            doc = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        found: list[dict] = []
+
+        def walk(node):
+            if isinstance(node, dict):
+                fc = node.get("function_call")
+                if isinstance(fc, dict) and fc.get("name"):
+                    found.append({
+                        "kind": "call",
+                        "tool": fc["name"],
+                        "args": redact_args(fc.get("args")),
+                    })
+                fr = node.get("function_response")
+                if isinstance(fr, dict) and fr.get("name"):
+                    found.append({
+                        "kind": "response",
+                        "tool": fr["name"],
+                        "response": summarize_response(fr.get("response")),
+                    })
+                um = node.get("usage_metadata")
+                if isinstance(um, dict) and um.get("total_token_count"):
+                    found.append({"kind": "usage", "tokens": um["total_token_count"]})
+                for v in node.values():
+                    walk(v)
+            elif isinstance(node, list):
+                for i in node:
+                    walk(i)
+
+        walk(doc)
+        for rec in found:
+            rec["at"] = created_at.isoformat() if hasattr(created_at, "isoformat") else str(created_at)
+            rec["agent"] = agent_id
+            rec["session"] = session_id
+            yield rec
+
+
+# ------------------------------------------------------------------- queries
+
+
+def fetch_events(conn, since=None, agent=None):
+    # The ::casts are required: Postgres cannot infer the type of a NULL bind
+    # parameter and errors with "could not determine data type of parameter $1".
+    sql = """
+        SELECT e.created_at, s.agent_id, s.id, e.data
+        FROM event e JOIN session s ON s.id = e.session_id
+        WHERE (%(since)s::timestamptz IS NULL OR e.created_at >= %(since)s::timestamptz)
+          AND (%(agent)s::text IS NULL OR s.agent_id ILIKE %(agent)s::text)
+        ORDER BY e.created_at
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, {"since": since, "agent": f"%{agent}%" if agent else None})
+        return cur.fetchall()
+
+
+def report_ungated(records, gated: set[str]) -> list[dict]:
+    """Gated tools invoked in a session that raised NO approval request.
+
+    This is the k8s_agent finding, generalised. A `write`/`destructive` tool ran and
+    nobody was asked — either requireApproval was missing, or it was silently
+    stripped (which is exactly what Argo was doing for days).
+    """
+    approvals_by_session: set[str] = {
+        r["session"] for r in records
+        if r["kind"] == "call" and r["tool"] == CONFIRM_TOOL
+    }
+    out = []
+    for r in records:
+        if r["kind"] != "call" or r["tool"] not in gated:
+            continue
+        if r["session"] in approvals_by_session:
+            continue
+        out.append(r)
+    return out
+
+
+def report_cost(records) -> dict[str, int]:
+    tokens: dict[str, int] = defaultdict(int)
+    for r in records:
+        if r["kind"] == "usage":
+            tokens[r["agent"]] += r["tokens"]
+    return dict(tokens)
+
+
+# ---------------------------------------------------------------------- cli
+
+
+def parse_since(s: str | None):
+    if not s:
+        return None
+    m = re.fullmatch(r"(\d+)([dhm])", s)
+    if not m:
+        raise SystemExit(f"--since must look like 7d / 24h / 30m, got {s!r}")
+    n, unit = int(m.group(1)), m.group(2)
+    delta = {"d": timedelta(days=n), "h": timedelta(hours=n), "m": timedelta(minutes=n)}[unit]
+    return datetime.now(timezone.utc) - delta
+
+
+def connect():
+    try:
+        import psycopg
+    except ImportError:
+        raise SystemExit("pip install 'psycopg[binary]'")
+    dsn = os.environ.get("AGENT_AUDIT_DSN")
+    if not dsn:
+        raise SystemExit(
+            "AGENT_AUDIT_DSN is not set.\n"
+            "Use the SELECT-only audit role (never kagent's read/write credential):\n"
+            "  kubectl port-forward -n postgresql svc/postgresql 5432:5432 &\n"
+            "  U=$(kubectl get secret kagent-audit-credentials -n postgresql -o jsonpath='{.data.audit-user}' | base64 -d)\n"
+            "  P=$(kubectl get secret kagent-audit-credentials -n postgresql -o jsonpath='{.data.audit-password}' | base64 -d)\n"
+            "  export AGENT_AUDIT_DSN=\"postgresql://$U:$P@127.0.0.1:5432/kagent\""
+        )
+    return psycopg.connect(dsn)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--since", help="7d / 24h / 30m")
+    ap.add_argument("--agent", help="substring match on agent_id")
+    ap.add_argument("--ungated", action="store_true",
+                    help="gated tools invoked with NO approval request in the session")
+    ap.add_argument("--cost", action="store_true", help="per-agent token rollup")
+    ap.add_argument("--format", choices=["table", "json"], default="table")
+    ap.add_argument("--repo-root", type=Path,
+                    default=Path(__file__).resolve().parent.parent)
+    args = ap.parse_args(argv)
+
+    with connect() as conn:
+        rows = fetch_events(conn, since=parse_since(args.since), agent=args.agent)
+    records = list(iter_calls(rows))
+
+    if args.cost:
+        tokens = report_cost(records)
+        if args.format == "json":
+            print(json.dumps(tokens, indent=2))
+        else:
+            print(f"{'agent':<44} {'tokens':>12}")
+            for a, t in sorted(tokens.items(), key=lambda kv: -kv[1]):
+                print(f"{a:<44} {t:>12,}")
+            print(f"{'TOTAL':<44} {sum(tokens.values()):>12,}")
+        return 0
+
+    if args.ungated:
+        gated = load_gated_tools(args.repo_root)
+        findings = report_ungated(records, gated)
+        if args.format == "json":
+            print(json.dumps(findings, indent=2))
+        else:
+            if not findings:
+                print("no ungated invocations of write/destructive tools ✓")
+                return 0
+            print(f"{'when':<22} {'agent':<38} {'tool':<26} args")
+            for r in findings:
+                print(f"{r['at'][:19]:<22} {r['agent']:<38} {r['tool']:<26} "
+                      f"{json.dumps(r['args'])[:60]}")
+            print(f"\n{len(findings)} gated tool invocation(s) with NO approval request.")
+        # A finding is a failure: this is the requireApproval-stripping incident.
+        return 1 if findings else 0
+
+    calls = [r for r in records if r["kind"] == "call"]
+    if args.format == "json":
+        print(json.dumps(calls, indent=2))
+    else:
+        print(f"{'when':<22} {'agent':<38} {'tool':<26} args")
+        for r in calls:
+            print(f"{r['at'][:19]:<22} {r['agent']:<38} {r['tool']:<26} "
+                  f"{json.dumps(r['args'])[:60]}")
+        print(f"\n{len(calls)} tool invocation(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent-audit/test_agent_audit.py
+++ b/tests/agent-audit/test_agent_audit.py
@@ -1,0 +1,205 @@
+"""Tests for the agent action record.
+
+The redaction tests are the point. This tool reads a table that contains live
+credentials — `k8s_get_resource_yaml` against a Secret lands its base64 payload in
+`event.data` verbatim. A redactor nobody tested is a redactor that does not work,
+so every known secret shape gets fed through and asserted absent from the output.
+"""
+from pathlib import Path
+import importlib.util
+import json
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "agent_audit",
+    Path(__file__).resolve().parents[2] / "scripts" / "agent-audit.py",
+)
+aa = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(aa)
+
+
+# ------------------------------------------------- responses: NEVER emitted
+
+def test_response_body_is_never_emitted():
+    """Categorical, not best-effort. This is where secrets actually live."""
+    secret_yaml = (
+        "apiVersion: v1\nkind: Secret\ndata:\n"
+        "  password: c3VwZXJzZWNyZXR2YWx1ZTEyMwo=\n"
+    )
+    out = aa.summarize_response({"result": secret_yaml})
+    blob = json.dumps(out)
+    assert "c3VwZXJzZWNyZXR2YWx1ZTEyMwo=" not in blob
+    assert "password" not in blob
+    assert out["present"] is True
+    assert out["bytes"] > 0
+    assert len(out["sha256_12"]) == 12
+
+
+def test_absent_response_is_marked_absent():
+    assert aa.summarize_response(None) == {"present": False}
+
+
+def test_response_summary_has_no_content_field_at_all():
+    out = aa.summarize_response("anything at all")
+    assert set(out) == {"present", "bytes", "sha256_12"}
+
+
+# --------------------------------------------- arguments: secret KEY names
+
+@pytest.mark.parametrize("key", [
+    "password", "passwd", "api_key", "token", "secret", "credential",
+    "authorization", "bearer", "session_id", "cookie", "private_key",
+    "SIGNATURE", "Salt",
+])
+def test_secret_named_keys_are_redacted(key):
+    assert aa.redact_value(key, "whatever-the-value-is") == aa.REDACTED
+
+
+# ------------------------------------------- arguments: secret VALUE shapes
+#
+# These fixtures are ASSEMBLED AT RUNTIME rather than written as string literals.
+#
+# Not stylistic paranoia — it is load-bearing. GitHub push protection scans the
+# source and blocks any literal that MATCHES A REAL SECRET SHAPE, regardless of
+# whether the value is real. Writing `"xoxb-…"` inline gets the push rejected as a
+# "Slack API Token", and every fixture here is by definition secret-shaped: that is
+# the whole point of them.
+#
+# (It also caught something worse. The first draft of this file used a REAL Vault
+# root token as the "Vault-shaped" fixture, copy-pasted from a debugging session.
+# Push protection rejected it. Building the fixtures from parts makes that class of
+# mistake impossible: there is no literal to paste a real value into.)
+
+SECRET_SHAPES = {
+    "vault":     "hvs." + "A" * 24,
+    "github":    "ghp_" + "B" * 36,
+    "anthropic": "sk-ant-api03-" + "C" * 32,
+    "aws":       "AKIA" + "D" * 16,
+    "slack":     "xox" + "b-" + "1" * 12 + "-" + "e" * 16,
+    "pem":       "-----BEGIN RSA PRIVATE KEY-----\nMIIEow...",
+    "jwt":       "eyJ" + "F" * 12 + "." + "eyJ" + "G" * 12 + "." + "H" * 20,
+}
+
+
+@pytest.mark.parametrize("kind", sorted(SECRET_SHAPES))
+def test_secret_shaped_values_are_redacted_even_under_an_innocent_key(kind):
+    """The key name says nothing — a token can be passed as `command`."""
+    assert aa.redact_value("command", SECRET_SHAPES[kind]) == aa.REDACTED
+
+
+def test_high_entropy_base64_blob_is_redacted():
+    blob = "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQgdmFsdWU5OTk5OTk5"
+    assert aa.redact_value("data", blob) == aa.REDACTED
+
+
+def test_a_secret_embedded_in_a_command_is_caught():
+    """The exact nightmare: an agent runs kubectl with a literal secret."""
+    cmd = ("kubectl create secret generic x --from-literal=t="
+           + SECRET_SHAPES["github"])
+    assert aa.redact_value("command", cmd) == aa.REDACTED
+
+
+# ------------------------------- arguments: benign values SURVIVE (the point)
+
+def test_benign_command_survives_redaction():
+    """Auditing what k8s_execute_command actually ran IS the point. If we redact
+    everything, the record is worthless."""
+    out = aa.redact_value("command", "kubectl get pods -n kagent")
+    assert out == "kubectl get pods -n kagent"
+
+
+@pytest.mark.parametrize("key,value", [
+    ("namespace", "kagent"),
+    ("resource_type", "pod"),
+    ("pod_name", "homelab-knowledge-abc123"),
+    ("path", "base-apps/kagent/agents/k8s-agent.yaml"),
+    ("repo", "kubernetes"),
+    ("tail_lines", 100),
+])
+def test_ordinary_arguments_are_preserved(key, value):
+    assert aa.redact_value(key, value) == value
+
+
+def test_long_values_are_truncated_not_dropped():
+    long = "a" * 500
+    out = aa.redact_value("query", long)
+    assert out.startswith("aaa")
+    assert "+200 chars" in out
+
+
+def test_nested_args_are_redacted_recursively():
+    args = {"outer": {"password": "hunter2", "namespace": "kagent"}}
+    out = aa.redact_args(args)
+    assert out["outer"]["password"] == aa.REDACTED
+    assert out["outer"]["namespace"] == "kagent"
+
+
+def test_unknown_types_fail_closed():
+    class Weird:
+        pass
+    assert aa.redact_value("x", Weird()) == aa.REDACTED
+
+
+# ----------------------------------------------------- the --ungated finding
+
+def _rec(kind, tool, session, agent="kagent__NS__k8s_agent"):
+    return {"kind": kind, "tool": tool, "session": session, "agent": agent,
+            "args": {}, "at": "2026-07-09T00:00:00"}
+
+
+def test_ungated_finds_a_gated_tool_with_no_approval():
+    """The real k8s_agent incident: k8s_execute_command ran, nobody was asked."""
+    records = [_rec("call", "k8s_execute_command", "s1")]
+    out = aa.report_ungated(records, gated={"k8s_execute_command"})
+    assert len(out) == 1
+    assert out[0]["tool"] == "k8s_execute_command"
+
+
+def test_ungated_ignores_a_gated_tool_that_WAS_approved():
+    records = [
+        _rec("call", aa.CONFIRM_TOOL, "s1"),
+        _rec("call", "k8s_execute_command", "s1"),
+    ]
+    assert aa.report_ungated(records, gated={"k8s_execute_command"}) == []
+
+
+def test_ungated_ignores_read_only_tools():
+    records = [_rec("call", "k8s_get_resources", "s1")]
+    assert aa.report_ungated(records, gated={"k8s_execute_command"}) == []
+
+
+def test_approval_in_one_session_does_not_excuse_another():
+    """Approval is per-session. A confirmation in s1 must not cover s2."""
+    records = [
+        _rec("call", aa.CONFIRM_TOOL, "s1"),
+        _rec("call", "k8s_delete_resource", "s2"),
+    ]
+    out = aa.report_ungated(records, gated={"k8s_delete_resource"})
+    assert len(out) == 1
+    assert out[0]["session"] == "s2"
+
+
+# ------------------------------------------------- taxonomy is the one source
+
+def test_gated_tools_come_from_the_capability_taxonomy():
+    """Same file Kyverno enforces at admission — the two cannot drift."""
+    repo = Path(__file__).resolve().parents[2]
+    gated = aa.load_gated_tools(repo)
+    assert "k8s_execute_command" in gated      # destructive
+    assert "k8s_delete_resource" in gated      # destructive
+    assert "k8s_label_resource" in gated       # write
+    assert "update_dashboard" in gated         # write (grafana)
+    assert "k8s_get_resources" not in gated    # read
+    assert "get_file_contents" not in gated    # read
+
+
+# --------------------------------------------------------- cost attribution
+
+def test_cost_rolls_up_per_agent():
+    records = [
+        {"kind": "usage", "tokens": 100, "agent": "a", "session": "s", "at": ""},
+        {"kind": "usage", "tokens": 50, "agent": "a", "session": "s", "at": ""},
+        {"kind": "usage", "tokens": 7, "agent": "b", "session": "s", "at": ""},
+    ]
+    assert aa.report_cost(records) == {"a": 150, "b": 7}


### PR DESCRIPTION
kagent already persists every tool call, its arguments, the HITL approval outcome, and token usage. **Nothing read it.** This is the read side.

## 🔴 What it found on its first real run

```
$ agent-audit.py --ungated

2026-07-09  k8s_agent  k8s_execute_command  {"pod_name":"vault-0","command":"ls -la /vault/data/"}
2026-07-09  k8s_agent  k8s_execute_command  {"pod_name":"vault-0","command":"/bin/sh -c 'cat /vault/d…'"}
2026-07-09  k8s_agent  k8s_execute_command  {"pod_name":"vault-0","command":"find /vault/data -name k…"}
2026-07-09  k8s_agent  k8s_execute_command  {"pod_name":"vault-0","command":"test -f /vault/data/core…"}
...
15 gated tool invocation(s) with NO approval request.
```

**An agent executed arbitrary shell commands inside the Vault pod, reading `/vault/data` — Vault's file storage backend — with no human approval.** Because Argo was silently stripping `requireApproval` from `k8s-agent` on every sync. The gate was in the manifest. It was doing nothing.

The evidence sat in kagent's database for months. Nobody could see it because nothing queried it.

## Components

**`scripts/agent-audit.py`** — read-only query surface over `event → session.agent_id`.

- **`--ungated`** — every `write`/`destructive` tool invoked with **no approval event in its session**. Sources *"which tools should have been gated"* from the **same capability taxonomy Kyverno enforces at admission**, so the audit and the gate cannot drift. Exits 1 on findings.
- **`--cost`** — per-agent token rollup. **3,432,367 tokens across 10 agents** — per-agent cost attribution with **no per-agent API keys**, which re-scopes the Identity §100 follow-on.

**A `SELECT`-only Postgres role** with its own Vault key, policy, k8s-auth role, ESO ServiceAccount and SecretStore. *An audit tool with write access to the database it audits is not an audit tool.* Grants are revoked-then-granted so a re-run can't accumulate privilege.

## Redaction — the hard constraint

`event.data` contains **full tool responses**. `k8s_get_resource_yaml` against a Secret returns its base64 payload **verbatim**. The raw event stream must be treated as **containing live credentials**.

> **Redact at extraction, never at display.**

**Responses are excluded categorically** — never emitted, not even truncated. Only presence, byte length, and a hash. Note in the output above: the `cat /vault/data/...` **command** is shown (that's the point) but its **response** is not.

**Arguments are kept deliberately.** The most security-relevant fact in the record is what `k8s_execute_command` actually ran; dropping it would gut the audit. Values are pattern-redacted (secret-shaped keys; Vault/GitHub/AWS/Slack/JWT/PEM shapes; high-entropy base64) and truncated. Unclassifiable types **fail closed**.

**Argument redaction is best-effort, not a guarantee — and the tool says so.** Output is *safer*, not *safe*. Internal only.

## Tests

**41 redaction tests.** Every secret shape is asserted **absent** — including a token smuggled inside a `command`. Benign commands are asserted **present**, because a redactor that eats everything is useless.

The secret-shaped fixtures are **assembled at runtime, not written as literals** — GitHub push protection blocks any literal matching a real secret shape, and every fixture here is secret-shaped by definition. (It also caught a genuine mistake: the first draft used a **real Vault root token** as the Vault fixture. Push protection rejected the push. Building fixtures from parts makes that class of error impossible.)

## Verification

- **71 tests pass**; identity + capability contracts unaffected
- `yamllint`, `kubeconform`, server-side dry-run clean
- `--ungated` and `--cost` run green against the live database

Spec: `docs/superpowers/specs/2026-07-14-agent-action-record-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf