### PR TITLE
fix(observability): Grafana alert queries never matched — parse JSON, don't substring it

### DIFF
--- a/base-apps/logging/grafana-alerting.yaml
+++ b/base-apps/logging/grafana-alerting.yaml
@@ -115,9 +115,16 @@ data:
                     type: loki
                     uid: loki
                   queryType: instant
+                  # Parse the JSON, do not substring-match it. The summary is
+                  # emitted by json.dumps, which writes `"severity": "warning"` WITH
+                  # a space after the colon — a `|= "\"severity\":\"warning\""`
+                  # line filter (no space) never matches, so the first version of
+                  # this rule could not fire. Verified against live Loki: the line
+                  # filter returns 0, `| json | severity="warning"` returns 1.
                   expr: >-
                     sum(count_over_time({namespace="postgresql", app="agent-audit"}
-                    |= "agent-audit-ungated" |= "\"severity\":\"warning\"" [24h]))
+                    |= "agent-audit-ungated" | json
+                    | check="agent-audit-ungated" | severity="warning" [24h]))
               - refId: threshold
                 relativeTimeRange:
                   from: 86400
@@ -167,9 +174,13 @@ data:
                     type: loki
                     uid: loki
                   queryType: instant
+                  # Same fix: parse the JSON and match the `rule` field, rather
+                  # than substring-matching the rendered line. `|= "priority"` is
+                  # kept only as a cheap pre-filter to skip Falco's non-JSON startup
+                  # noise before `| json`. Verified against live Loki: returns 236.
                   expr: >-
-                    sum(count_over_time({namespace="falco"} |= "\"priority\""
-                    |~ "Read sensitive file untrusted|Contact K8S API Server From Container"
+                    sum(count_over_time({namespace="falco"} |= "priority" | json
+                    | rule=~"Read sensitive file untrusted|Contact K8S API Server From Container"
                     [1h]))
               - refId: threshold
                 relativeTimeRange:


### PR DESCRIPTION
**Verification against the live cluster caught this**, after #358/#359 merged. Both O3 alert rules were written with LogQL **line filters** that substring-match the rendered log line — and the byte layout doesn't match what the emitters actually write. **Neither alert could fire.**

## The bug

**agent-audit:** the summary is emitted by Python's `json.dumps`, which writes
```
"severity": "warning"     ← space after the colon
```
but the rule filtered for
```
|= "\"severity\":\"warning\""     ← no space
```
Confirmed in Loki: the line filter returns **0** for a finding that is demonstrably present (`o2-verify` job's log line is right there under `app=agent-audit`). `| json | severity="warning"` returns **1**.

**falco:** same class of fragility — substring-matching a rendered field instead of parsing it.

## The fix

Both rules now use `| json` and match **fields** (`check`, `severity`, `rule`) rather than raw bytes — spacing- and key-order-independent. A cheap `|= "..."` line filter stays in front of `| json` only to skip non-JSON lines (Falco's startup noise) before parsing.

## Verified end to end against live Loki

| query | before | after |
|---|---|---|
| `agent-audit … \| json \| severity="warning"` | **0** | **1** |
| `falco … \| json \| rule=~"…"` | **0** | **236** |

And re-provisioned into `grafana/grafana:11.3.1` — both rules load with the corrected expressions.

## Why it matters

This is **exactly the failure mode this whole pillar is about** — a control that looks configured but does nothing. It's the fourth instance in this arc, and the only reason it surfaced is that O2 shipped, its CronJob ran **in-cluster**, and I tested the alert query against the **real line it produces** rather than against an assumption of the format.

The lesson I'd underline: verifying "Grafana provisioned 2 rules" was necessary but **not sufficient** — a provisioned rule with a query that matches nothing is the same silent no-op as an unprovisioned one. You have to run the query against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf