### PR TITLE
feat(observability): GitOps-managed n8n workflow for Grafana alert delivery

### DIFF
--- a/base-apps/logging/grafana-alerting.yaml
+++ b/base-apps/logging/grafana-alerting.yaml
@@ -18,14 +18,14 @@
 # DELIVERY
 #
 # Grafana POSTs to an n8n webhook, and n8n fans out to wherever you want — Slack,
-# email, phone push — changeable later without touching the cluster. There was no
-# Slack credential anywhere in Vault, and n8n is already running with a webhook
-# ingress, so this needs no new secret and no new component either.
+# email, phone push — changeable later without touching the cluster.
 #
-#   ⚠ YOU MUST CREATE THE n8n WORKFLOW. Add a Webhook node listening on the path
-#     `grafana-alerts` (POST). Until it exists, Grafana's notifications will 404 —
-#     the alert rules still evaluate and are visible in Grafana's UI, but nothing
-#     will reach you.
+#   The receiving workflow is GitOps-managed since 2026-07-15:
+#   base-apps/n8n/workflows-configmap.yaml defines it (Webhook node on path
+#   `grafana-alerts` → Slack #oncall-alerts) and base-apps/n8n/import-workflows-job.yaml
+#   imports and activates it on every n8n app sync. If the workflow is ever
+#   missing or inactive, Grafana's notifications 404 — the alert rules still
+#   evaluate and are visible in Grafana's UI, but nothing will reach you.
 #
 # WHAT IS DELIBERATELY NOT SENT
 #

--- a/base-apps/n8n/deployments.yaml
+++ b/base-apps/n8n/deployments.yaml
@@ -59,6 +59,15 @@ spec:
               name: n8n-secrets
               key: encryption-key
 
+        # Slack bot token for GitOps-managed workflows (workflows-configmap.yaml).
+        # Read inside workflow expressions as {{ $env.SLACK_BOT_TOKEN }} so no
+        # n8n credential object (encrypted, DB-resident, un-importable) is needed.
+        - name: SLACK_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: slack-bot-token
+
         # UPDATED: Webhook URL (changed to HTTPS)
         - name: WEBHOOK_URL
           value: "https://n8n.arigsela.com/"

--- a/base-apps/n8n/docs.md
+++ b/base-apps/n8n/docs.md
@@ -3,9 +3,9 @@ app: n8n
 catalog_entity: n8n
 kind: docs
 namespace: n8n
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-15
 status: current
-tags: [automation, postgresql, webhooks]
+tags: [automation, postgresql, webhooks, alerting]
 sources:
   - base-apps/n8n/deployments.yaml
   - base-apps/n8n/external-secrets.yaml
@@ -14,12 +14,17 @@ sources:
   - base-apps/n8n/services.yaml
   - base-apps/n8n/nginx-ingress-admin.yaml
   - base-apps/n8n/nginx-ingress-webhook.yaml
+  - base-apps/n8n/workflows-configmap.yaml
+  - base-apps/n8n/import-workflows-job.yaml
 ---
 
 # n8n
 
 ## What it is
 n8n (`n8nio/n8n:latest`) is a workflow-automation platform, deployed as a single-replica `Deployment` (`deployments.yaml`) in the `n8n` namespace, listening on container port `5678`.
+
+## GitOps-managed workflows
+Most workflows are authored in the UI and live only in n8n's database, but workflows that other cluster components depend on are declared in Git: `workflows-configmap.yaml` holds the workflow JSON and `import-workflows-job.yaml` (an Argo CD PreSync hook Job) imports and activates it with the n8n CLI on every sync (idempotent upsert by fixed workflow id). Currently one workflow is managed this way: **Grafana Alerts to Slack** — the `POST /webhook/grafana-alerts` endpoint that `base-apps/logging/grafana-alerting.yaml` delivers all Grafana alert notifications to; it formats the unified-alerting payload and posts to Slack `#oncall-alerts` using the `SLACK_BOT_TOKEN` env var (Vault key `n8n`, property `slack-bot-token` — deliberately an env var, not an n8n credential object, because credential objects are encrypted at rest and cannot be imported declaratively). Caveat: n8n registers webhook routes at pod startup, so a change to the workflow JSON alone re-imports the DB row but needs a pod restart to take effect.
 
 ## Architecture & data flow
 The `Deployment` runs one pod on nodes labeled `node.kubernetes.io/workload: application`, with `fsGroup`/`runAsUser`/`runAsGroup` all set to `1000` so it can write to its mounted volume. A `n8n-pvc` `PersistentVolumeClaim` (`pvc.yaml`, `5Gi`, `storageClassName: local-path`) is mounted at `/home/node/.n8n` — this holds n8n's local state directory (settings file, etc.), **not** workflow/execution data: `DB_TYPE` is set to `postgresdb` (`deployments.yaml`), so n8n persists workflows, credentials, and execution history in the shared PostgreSQL instance (`base-apps/postgresql`) via `DB_POSTGRESDB_HOST/PORT/DATABASE/USER/PASSWORD` env vars sourced from the `n8n-secrets` Secret. The `n8n` `Service` (`services.yaml`, ClusterIP, port `5678`) fronts the pod for both ingresses below.

--- a/base-apps/n8n/external-secrets.yaml
+++ b/base-apps/n8n/external-secrets.yaml
@@ -49,3 +49,8 @@ spec:
       remoteRef:
         key: n8n
         property: basic-auth-password
+    # Slack bot token for GitOps-managed workflows (workflows-configmap.yaml)
+    - secretKey: slack-bot-token
+      remoteRef:
+        key: n8n
+        property: slack-bot-token

--- a/base-apps/n8n/import-workflows-job.yaml
+++ b/base-apps/n8n/import-workflows-job.yaml
@@ -1,0 +1,100 @@
+# Imports the GitOps-managed workflows (workflows-configmap.yaml) into n8n's
+# database and activates them, using the n8n CLI against the same Postgres the
+# Deployment uses.
+#
+# PreSync, not PostSync: n8n only registers webhook routes for active workflows
+# at pod startup. Running the import BEFORE the main sync means that when a
+# Deployment change in the same sync rolls the pod, the new pod starts with the
+# workflow already in the database and registers its webhook immediately —
+# no ordering race. On syncs that don't roll the pod, the import is still a
+# safe upsert (fixed workflow id); see the ConfigMap header for the restart
+# caveat on workflow-only changes.
+#
+# BeforeHookCreation delete policy keeps the last run's logs around for
+# debugging until the next sync recreates the Job.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: n8n-import-workflows
+  namespace: n8n
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app: n8n-import-workflows
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: import
+        image: n8nio/n8n:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -e
+          n8n import:workflow --input=/workflows/grafana-alerts.json
+          n8n update:workflow --id=grafana-alerts-slack --active=true
+        env:
+        # Same database wiring as the n8n Deployment — the CLI talks straight
+        # to the DB, no running n8n server involved.
+        - name: DB_TYPE
+          value: "postgresdb"
+        - name: DB_POSTGRESDB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: db-host
+        - name: DB_POSTGRESDB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: db-port
+        - name: DB_POSTGRESDB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: db-name
+        - name: DB_POSTGRESDB_USER
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: db-user
+        - name: DB_POSTGRESDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: db-password
+        - name: N8N_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: n8n-secrets
+              key: encryption-key
+        # The CLI wants a writable settings dir; keep it off the Deployment's
+        # PVC so the Job never contends with the running pod.
+        - name: N8N_USER_FOLDER
+          value: /tmp/n8n
+        volumeMounts:
+        - name: workflows
+          mountPath: /workflows
+          readOnly: true
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: workflows
+        configMap:
+          name: n8n-workflows

--- a/base-apps/n8n/workflows-configmap.yaml
+++ b/base-apps/n8n/workflows-configmap.yaml
@@ -1,0 +1,98 @@
+# GitOps-managed n8n workflows.
+#
+# n8n stores workflows in its Postgres database, not on disk, so they can't be
+# applied as Kubernetes resources directly. Instead this ConfigMap holds the
+# workflow JSON and import-workflows-job.yaml (an Argo CD PreSync hook) imports
+# it into the database with the n8n CLI on every sync. The import upserts by the
+# workflow's fixed "id", so re-running is a no-op when nothing changed.
+#
+# grafana-alerts.json — the alert-delivery endpoint Grafana depends on
+# (base-apps/logging/grafana-alerting.yaml posts to
+# http://n8n.n8n.svc.cluster.local:5678/webhook/grafana-alerts). Three nodes:
+#   Webhook (POST /webhook/grafana-alerts)
+#     → Code (format Grafana's unified-alerting payload into a Slack message)
+#     → HTTP Request (Slack chat.postMessage to #oncall-alerts).
+# Slack auth deliberately avoids n8n's encrypted credential store (credential
+# objects can't be imported declaratively without sharing the encryption key
+# material in Git): the HTTP node reads {{ $env.SLACK_BOT_TOKEN }}, injected
+# into the n8n Deployment from the n8n-secrets Secret (Vault key n8n,
+# property slack-bot-token).
+#
+# NOTE: n8n registers webhook routes for active workflows at STARTUP. Changing
+# only this ConfigMap re-imports the workflow into the DB but the running pod
+# keeps serving the old version until it restarts — bump the deployment (or
+# delete the pod) after workflow-only changes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: n8n-workflows
+  namespace: n8n
+data:
+  grafana-alerts.json: |
+    {
+      "id": "grafana-alerts-slack",
+      "name": "Grafana Alerts to Slack",
+      "active": true,
+      "nodes": [
+        {
+          "parameters": {
+            "httpMethod": "POST",
+            "path": "grafana-alerts",
+            "options": {}
+          },
+          "id": "b1f6c1e0-4a6e-4a01-8000-000000000001",
+          "name": "Grafana Webhook",
+          "type": "n8n-nodes-base.webhook",
+          "typeVersion": 2,
+          "position": [0, 0],
+          "webhookId": "b1f6c1e0-4a6e-4a01-8000-00000000000a"
+        },
+        {
+          "parameters": {
+            "jsCode": "const p = $json.body ?? $json;\nconst status = (p.status || 'unknown').toUpperCase();\nconst emoji = p.status === 'resolved' ? ':white_check_mark:' : ':rotating_light:';\nconst lines = (p.alerts || []).map((a) => {\n  const name = (a.labels && a.labels.alertname) || 'unknown-alert';\n  const sev = a.labels && a.labels.severity ? ' [' + a.labels.severity + ']' : '';\n  const summary = (a.annotations && (a.annotations.summary || a.annotations.description)) || '';\n  return emoji + ' *' + name + '*' + sev + ' (' + a.status + ') ' + summary;\n});\nconst text = ['*Grafana: ' + (p.title || status) + '*', ...lines].join('\\n');\nreturn [{ json: { slack: { channel: '#oncall-alerts', text: text, unfurl_links: false } } }];"
+          },
+          "id": "b1f6c1e0-4a6e-4a01-8000-000000000002",
+          "name": "Format Alert",
+          "type": "n8n-nodes-base.code",
+          "typeVersion": 2,
+          "position": [220, 0]
+        },
+        {
+          "parameters": {
+            "method": "POST",
+            "url": "https://slack.com/api/chat.postMessage",
+            "sendHeaders": true,
+            "headerParameters": {
+              "parameters": [
+                {
+                  "name": "Authorization",
+                  "value": "=Bearer {{ $env.SLACK_BOT_TOKEN }}"
+                },
+                {
+                  "name": "Content-Type",
+                  "value": "application/json"
+                }
+              ]
+            },
+            "sendBody": true,
+            "specifyBody": "json",
+            "jsonBody": "={{ JSON.stringify($json.slack) }}",
+            "options": {}
+          },
+          "id": "b1f6c1e0-4a6e-4a01-8000-000000000003",
+          "name": "Post to Slack",
+          "type": "n8n-nodes-base.httpRequest",
+          "typeVersion": 4.2,
+          "position": [440, 0]
+        }
+      ],
+      "connections": {
+        "Grafana Webhook": {
+          "main": [[{ "node": "Format Alert", "type": "main", "index": 0 }]]
+        },
+        "Format Alert": {
+          "main": [[{ "node": "Post to Slack", "type": "main", "index": 0 }]]
+        }
+      },
+      "settings": { "executionOrder": "v1" }
+    }


### PR DESCRIPTION
## What

Addresses audit finding **#3**: the Grafana → n8n alert pipeline's last hop didn't exist. Verified live before this PR:

```
POST https://n8n.arigsela.com/webhook/grafana-alerts → 404
{"message": "The requested webhook \"POST grafana-alerts\" is not registered."}
```

Both alert rules (`agent-ungated-tool` critical, `falco-sensitive-detection` warning) evaluated but delivered nowhere.

## How

n8n stores workflows in Postgres, not on disk — so the workflow is declared as JSON in a ConfigMap and imported by an Argo CD **PreSync hook Job** running the n8n CLI against the same database (idempotent upsert by fixed workflow id, then activate). This mirrors the repo's existing init-Job pattern (`postgresql/init-kagent-db.yaml`).

**Workflow**: `Webhook (POST /webhook/grafana-alerts)` → `Code` (format Grafana unified-alerting payload) → `HTTP Request` (Slack `chat.postMessage` to **#oncall-alerts**).

**Slack auth**: via `SLACK_BOT_TOKEN` env var read by workflow expressions (`{{ $env.SLACK_BOT_TOKEN }}`) — deliberately **not** an n8n credential object, since those are encrypted at rest and can't be imported declaratively without putting key material in Git.

**Why PreSync**: n8n registers webhook routes for active workflows at pod **startup**. PreSync puts the DB row in place first; the `SLACK_BOT_TOKEN` deployment change in this same PR then rolls the pod, which registers the route. No ordering race.

## Files

- `base-apps/n8n/workflows-configmap.yaml` — workflow JSON (new)
- `base-apps/n8n/import-workflows-job.yaml` — PreSync import Job (new)
- `base-apps/n8n/deployments.yaml` — add `SLACK_BOT_TOKEN` env
- `base-apps/n8n/external-secrets.yaml` — map `slack-bot-token` from Vault key `n8n`
- `base-apps/logging/grafana-alerting.yaml` — replace stale "YOU MUST CREATE THE n8n WORKFLOW" warning with pointer to the managed workflow
- `base-apps/n8n/docs.md` — document the pattern + restart caveat

## Secret-management impact

Vault key `k8s-secrets/n8n` gained property `slack-bot-token` (**already seeded** — same bot token cluster-scanner uses for #oncall-alerts; verified merge-write preserved the 9 existing properties). No other secret changes. The ExternalSecret refreshes hourly; the new key will be present in `n8n-secrets` before this merges.

## Validation

- `yamllint` clean (one unavoidable long-line **warning** for the single-line JSON string)
- `kubeconform -strict` valid
- Workflow JSON parse-verified (id `grafana-alerts-slack`, active, 3 nodes, path `grafana-alerts`)

## Post-merge verification

```bash
kubectl -n n8n logs job/n8n-import-workflows        # import + activate succeeded
curl -s -X POST https://n8n.arigsela.com/webhook/grafana-alerts \
  -H 'Content-Type: application/json' \
  -d '{"status":"firing","title":"test","alerts":[{"status":"firing","labels":{"alertname":"manual-test","severity":"info"},"annotations":{"summary":"pipeline smoke test"}}]}'
# expect 200 and a message in #oncall-alerts
```

**Caveat (documented in-file)**: future changes to the workflow JSON alone re-import the DB row but need a pod restart to take effect — n8n only registers webhook routes at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ