### PR TITLE
fix(observability): S3 bucket InvalidTag — drop parens/comma from the Name tag

### DIFF
--- a/base-apps/agent-audit-aws-infrastructure/s3-bucket.yaml
+++ b/base-apps/agent-audit-aws-infrastructure/s3-bucket.yaml
@@ -21,7 +21,10 @@ spec:
   forProvider:
     region: us-east-1
     tags:
-      Name: "Agent Action Record (durable, redacted)"
+      # S3 tag VALUES allow only letters, digits, spaces and + - = . _ : / @ —
+      # NOT parentheses or commas. "Agent Action Record (durable, redacted)" was
+      # rejected by AWS with `InvalidTag`, leaving the bucket stuck Ready=False.
+      Name: "Agent Action Record durable redacted"
       Environment: "homelab"
       ManagedBy: "Crossplane"
       Purpose: "L03 Observability audit trail"


### PR DESCRIPTION
The agent-audit S3 bucket (O4, #361) was stuck `Ready=False` after merge:

```
Synced=False: ReconcileError | create failed ... api error InvalidTag:
The TagValue you have provided is invalid
```

**S3 tag values allow only letters, digits, spaces and `+ - = . _ : / @`** — not parentheses or commas. My `Name` tag was `"Agent Action Record (durable, redacted)"`; the `()` and `,` are rejected by AWS.

The sibling Loki bucket never hit this because its tags are plain words (`"Asela Chores Loki Logs Storage"`).

The IAM user, policy, and access key all reconciled fine — the connection secret `agent-audit-s3-creds` is written. **Only the bucket tag was invalid.** Fixed to `"Agent Action Record durable redacted"`, and I scanned every tag value across all six O4 infra manifests for illegal characters — this was the only one.

Verified against the live reconcile after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZL8aeGcrVQWxwRTVMWPkf