### PR TITLE
fix(n8n): make the workflows ConfigMap a PreSync hook so the import Job can mount it

### DIFF
--- a/base-apps/n8n/import-workflows-job.yaml
+++ b/base-apps/n8n/import-workflows-job.yaml
@@ -20,9 +20,13 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    # After the ConfigMap hook (wave -1) so the volume mount resolves.
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   backoffLimit: 2
-  activeDeadlineSeconds: 300
+  # Generous: the first run on a cold node pulls the full n8nio/n8n image
+  # before the CLI can start.
+  activeDeadlineSeconds: 600
   template:
     metadata:
       labels:

--- a/base-apps/n8n/workflows-configmap.yaml
+++ b/base-apps/n8n/workflows-configmap.yaml
@@ -22,11 +22,21 @@
 # only this ConfigMap re-imports the workflow into the DB but the running pod
 # keeps serving the old version until it restarts — bump the deployment (or
 # delete the pod) after workflow-only changes.
+#
+# This ConfigMap is itself a PreSync hook (wave -1, before the import Job at
+# wave 0) because the Job mounts it: as a plain resource it would only be
+# applied in the MAIN sync phase, which never runs until PreSync completes —
+# on a fresh sync the Job's pod would hang forever on
+# 'configmap "n8n-workflows" not found' (observed live on first rollout).
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: n8n-workflows
   namespace: n8n
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   grafana-alerts.json: |
     {


### PR DESCRIPTION
## What

Fixes the n8n sync loop introduced by PR #363. The PreSync import Job mounts the `n8n-workflows` ConfigMap, but that ConfigMap was a plain resource — applied in the **main** sync phase, which never runs until PreSync completes. Chicken-and-egg: on first rollout the hook pod hung on `configmap "n8n-workflows" not found`, hit the Job's 300s deadline, and Argo retried the same dead end (observed live: 3 consecutive `DeadlineExceeded` events).

## Fix

- ConfigMap becomes a PreSync hook at **wave -1** (before the Job at wave 0), so it exists before the pod schedules
- Job `activeDeadlineSeconds` 300 → **600**: the first successful run still has to pull the full `n8nio/n8n` image cold before the CLI can start

## Post-merge verification

```bash
kubectl -n n8n get job n8n-import-workflows            # expect Complete
kubectl -n n8n logs job/n8n-import-workflows           # import + activate output
kubectl -n argo-cd get application n8n                 # expect Synced/Healthy
curl -s -X POST https://n8n.arigsela.com/webhook/grafana-alerts \
  -H 'Content-Type: application/json' \
  -d '{"status":"firing","title":"test","alerts":[{"status":"firing","labels":{"alertname":"manual-test","severity":"info"},"annotations":{"summary":"pipeline smoke test"}}]}'
# expect 200 + a message in #oncall-alerts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ