### PR TITLE
fix(gitops): clear residual sync noise from the adoption + alert-delivery rollout

### DIFF
--- a/base-apps/n8n/deployments.yaml
+++ b/base-apps/n8n/deployments.yaml
@@ -68,6 +68,15 @@ spec:
               name: n8n-secrets
               key: slack-bot-token
 
+        # n8n blocks $env access in expressions by default; without this the
+        # grafana-alerts workflow dies with "ExpressionError: access to env
+        # vars denied" (observed on first live execution). Trade-off: any
+        # workflow author can read this pod's env (DB creds, encryption key) —
+        # acceptable here because the editor UI is IP-allowlisted + basic-auth
+        # and this is a single-operator instance.
+        - name: N8N_BLOCK_ENV_ACCESS_IN_NODE
+          value: "false"
+
         # UPDATED: Webhook URL (changed to HTTPS)
         - name: WEBHOOK_URL
           value: "https://n8n.arigsela.com/"

--- a/base-apps/postgresql/cnpg-cluster.yaml
+++ b/base-apps/postgresql/cnpg-cluster.yaml
@@ -59,12 +59,12 @@ spec:
         name: postgresql-credentials
   managed:
     roles:
+      # superuser/createdb/createrole are omitted, not set to false: the CNPG
+      # webhook strips explicit-false defaults, so declaring them makes Argo
+      # see a permanent live-vs-Git diff (observed after adoption).
       - name: n8n
         ensure: present
         login: true
-        superuser: false
-        createdb: false
-        createrole: false
         passwordSecret:
           name: postgresql-credentials
   monitoring:

--- a/base-apps/postgresql/init-kagent-audit-role.yaml
+++ b/base-apps/postgresql/init-kagent-audit-role.yaml
@@ -10,7 +10,7 @@
 # ServiceAccount, SecretStore, Vault role and per-consumer key — the agent-identity
 # contract). It is never in git.
 #
-# Idempotent: safe to re-run. Argo recreates this Job after its TTL expires.
+# Idempotent: safe to re-run. Runs as a Sync hook on every sync (see below).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,6 +19,11 @@ metadata:
   annotations:
     # After init-kagent-db (which creates the kagent database this role reads).
     argocd.argoproj.io/sync-wave: "1"
+    # Sync hook, not a desired-state resource — same rationale as
+    # init-kagent-db: a self-deleting Job in desired state leaves the app
+    # permanently OutOfSync/Missing between syncs.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 5

--- a/base-apps/postgresql/init-kagent-db.yaml
+++ b/base-apps/postgresql/init-kagent-db.yaml
@@ -3,6 +3,14 @@ kind: Job
 metadata:
   name: init-kagent-db
   namespace: postgresql
+  annotations:
+    # Sync hook, not a desired-state resource: with ttlSecondsAfterFinished the
+    # completed Job deletes itself, which left the app permanently
+    # OutOfSync/Missing between syncs. As a hook it re-runs on every sync
+    # (idempotent by design) and is cleaned up on success without registering
+    # as drift.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 5


### PR DESCRIPTION
## What

Three small fixes for issues observed live after merging #362/#363/#365/#366. After this, both `postgresql` and `n8n` should settle at **Synced/Healthy**, and the alert pipeline delivers end-to-end.

### 1. n8n: unblock `$env` in workflow expressions

The webhook now returns 200 and starts the workflow — but executions **744/745 errored** with `ExpressionError: access to env vars denied`: n8n blocks `$env` access in expressions by default (`N8N_BLOCK_ENV_ACCESS_IN_NODE` defaults to `true`), which the Slack node needs for its token. Sets it to `false`.

**Security trade-off (documented in-file):** workflow authors can read the pod's env (DB creds, encryption key). Acceptable here: the editor UI is IP-allowlisted + basic-auth, single-operator instance. The rollout also restarts the pod, which is harmless (workflow unchanged in DB).

### 2. postgresql: CNPG Cluster perpetual OutOfSync

The adopted manifest declared `superuser/createdb/createrole: false` on the managed `n8n` role; the CNPG webhook strips explicit-false defaults, so live never matches Git. Dropped the three fields (they are the defaults).

### 3. postgresql: self-deleting init Jobs registered as missing

`init-kagent-db` and `init-kagent-audit-role` set `ttlSecondsAfterFinished: 300` — as desired-state resources they delete themselves 5 minutes after success, leaving the app **permanently OutOfSync/Missing** between syncs (this predates the audit; the adoption sync made it visible). Converted both to **Sync hooks** with `hook-delete-policy: HookSucceeded`: same idempotent re-run-every-sync behavior (which their own comments describe as intended), no more phantom drift. Wave order preserved (`init-kagent-audit-role` stays at wave 1).

## Post-merge verification

```bash
kubectl -n argo-cd get application postgresql n8n    # both Synced/Healthy
curl -s -X POST https://n8n.arigsela.com/webhook/grafana-alerts \
  -H 'Content-Type: application/json' \
  -d '{"status":"firing","title":"test","alerts":[{"status":"firing","labels":{"alertname":"manual-test","severity":"info"},"annotations":{"summary":"smoke test"}}]}'
# then check #oncall-alerts for the message
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ