### PR TITLE
fix(loki): lifecycle filter/expiration must be lists for provider-aws v2

### DIFF
--- a/base-apps/loki-aws-infrastructure/s3-lifecycle.yaml
+++ b/base-apps/loki-aws-infrastructure/s3-lifecycle.yaml
@@ -25,17 +25,21 @@ spec:
     rule:
       - id: cost-optimization
         status: Enabled
-        # filter is an Object with a prefix field
+        # filter and expiration are single-element lists, not objects. The
+        # provider-aws v2 (upbound) schema models these Terraform single-nested
+        # blocks as arrays; the older provider used objects. They were left as
+        # objects here after the provider upgrade, which broke Argo CD's
+        # structured-merge diff ("expected list, got map") even though the live
+        # resource reconciled fine. Matches the sibling agent-audit lifecycle.
         filter:
-          prefix: ""  # Apply to all objects in the bucket
+          - prefix: ""  # Apply to all objects in the bucket
         # transition is an array of objects
         transition:
           - days: 30
             storageClass: STANDARD_IA
           - days: 90
             storageClass: DEEP_ARCHIVE
-        # expiration is an Object with a days field
         expiration:
-          days: 365
+          - days: 365
   providerConfigRef:
     name: default


### PR DESCRIPTION
## What

Fixes the `ComparisonError` on the `loki-aws-infrastructure` Argo CD app (spotted in the UI — app shows Healthy but sync status **Unknown**, Argo can't diff it):

```
.spec.forProvider.rule[0].expiration: expected list, got &{map[days:365]}
.spec.forProvider.rule[0].filter: expected list, got &{map[prefix:]}
```

## Root cause

The Upbound provider-aws was upgraded to v2.5.3. Its v2 schema models the S3 lifecycle rule's `filter` and `expiration` single-nested blocks as **arrays** (`type: array`), but this manifest still wrote them as **objects** — the pre-upgrade shape. `transition` was already a list, which is why only those two fields errored.

The managed resource itself is fine (`SYNCED=True READY=True`; the live object stores both as single-element lists), so nothing was actually broken in AWS — but Argo CD builds a typed value from the *Git config* against the *current CRD schema*, and the list-vs-map mismatch made it unable to compute a diff.

## Verification done against the live cluster

- CRD `bucketlifecycleconfigurations.s3.aws.upbound.io` v1beta2: `filter`, `expiration`, `transition` are all `type: array`
- Live `loki-logs-lifecycle` object stores `filter: [{prefix: ""}]` and `expiration: [{days: 365}]`
- The sibling `agent-audit-aws-infrastructure/s3-lifecycle.yaml` (added last week, post-upgrade) already uses the list form

## Impact

**No-op to the cluster** — the manifest now matches the live object exactly; this only lets Argo compute the diff again. `yamllint` clean.

## Post-merge verification

```bash
kubectl -n argo-cd get application loki-aws-infrastructure \
  -o jsonpath='{.status.sync.status}{"\n"}'   # expect Synced (was Unknown)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ