### PR TITLE
fix(n8n): drop rate limit on admin ingress — it 503s the SPA cold load

### DIFF
--- a/base-apps/n8n/nginx-ingress-admin.yaml
+++ b/base-apps/n8n/nginx-ingress-admin.yaml
@@ -12,10 +12,18 @@ metadata:
     # Backend Protocol
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
 
-    # Rate Limiting (prevent brute force attacks on admin UI)
-    # Increased from 10 to 100 to allow n8n's many JS assets to load on initial page load
-    nginx.ingress.kubernetes.io/limit-rps: "100"
-    nginx.ingress.kubernetes.io/limit-connections: "50"
+    # No per-request/connection rate limit on the admin UI.
+    #
+    # This ingress is already restricted to a handful of operator IPs by the
+    # whitelist-source-range below — that is the real access control, and n8n
+    # has its own login throttling on top. An nginx rate limit here only throttles
+    # already-trusted traffic, and it repeatedly broke the SPA: n8n's cold page
+    # load fires hundreds of parallel JS-chunk + /rest/* requests, which trip
+    # limit-rps/limit-connections and return 503. /rest/settings getting 503'd
+    # blanks the whole UI. The limit was already raised 10 -> 100 once for this
+    # reason; the n8n v2.30.5 upgrade (more, finer-grained chunks) blew past 100.
+    # Removing it ends the whack-a-mole. The public webhook ingress keeps its
+    # rate limits, since that one is not IP-restricted.
 
     # 🔒 IP WHITELIST - Admin UI Only
     # Only these IPs can access the n8n admin interface


### PR DESCRIPTION
## Symptom

n8n admin UI renders blank; console shows:
```
GET https://n8n.arigsela.com/rest/settings 503 (Service Unavailable)
Failed to initialize settings store (AxiosError 503)
TypeError: Cannot read properties of undefined (reading 'managedByEnv')
```

## Root cause — the nginx rate limit, not n8n

Verified against the live cluster:
- `/rest/settings` returns **200 direct to the pod** and on sequential curls through the ingress
- A burst of **120 parallel** requests through the ingress returns **51× 503 / 69× 200**

n8n's cold page load fires hundreds of parallel requests (lazy-loaded JS chunks + several `/rest/*` calls). That burst trips the `n8n-admin` ingress's `limit-rps: 100` / `limit-connections: 50`, and nginx returns 503 for the overflow. When `/rest/settings` is one of the 503'd requests, the settings store never initializes and the whole SPA renders blank.

This was latent: the limit was **already bumped 10 → 100 once** for the same reason (see the old comment). The `n8nio/n8n:latest` tag rolling the pod to **v2.30.5** (more, finer-grained chunks) pushed the cold-load burst past 100. Clearing browser cache makes it reproduce every time, since it forces a full cold fetch.

## Fix

Remove `limit-rps`/`limit-connections` from the **admin** ingress. It's already restricted to a few operator IPs via `whitelist-source-range` (the real access control), and n8n has its own login throttling — so the rate limit only throttled trusted traffic while repeatedly breaking the UI. The **public webhook ingress keeps its limits** (unchanged).

## Post-merge verification

```bash
# burst should now be all 200
for i in $(seq 1 120); do curl -s -o /dev/null -w '%{http_code}\n' https://n8n.arigsela.com/rest/settings & done | sort | uniq -c
# then hard-reload the UI — sign-in page should render
```

## Follow-up (separate)

The underlying trigger is the `n8nio/n8n:latest` tag (audit finding #9) — the restart during the alerting work silently upgraded n8n. Still recommend pinning to `n8nio/n8n:2.30.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ