### PR TITLE
fix(observability): stop the Falco alert firing on legit controller API traffic

### DIFF
--- a/base-apps/logging/grafana-alerting.yaml
+++ b/base-apps/logging/grafana-alerting.yaml
@@ -177,10 +177,27 @@ data:
                   # Same fix: parse the JSON and match the `rule` field, rather
                   # than substring-matching the rendered line. `|= "priority"` is
                   # kept only as a cheap pre-filter to skip Falco's non-JSON startup
-                  # noise before `| json`. Verified against live Loki: returns 236.
+                  # noise before `| json`.
+                  #
+                  # "Contact K8S API Server From Container" is excluded for the
+                  # controllers that talk to the API *by design* — argo-cd (GitOps
+                  # reconcile), backstage (catalog ingestor), openshell (sandbox
+                  # manager), kagent (its k8s agents). They emit thousands of these
+                  # events/hour and kept this alert permanently firing on benign
+                  # control-plane traffic, which is just alert fatigue. The exclusion
+                  # binds ONLY to that rule: LogQL groups `and` tighter than `or`, so
+                  # this reads `Read-sensitive-file  OR  (Contact-API AND ns-not-a-
+                  # controller)`. So a sensitive-file read STILL alerts from any
+                  # namespace (incl. these four, where it matters most), and an
+                  # *unexpected* container contacting the API STILL alerts — only the
+                  # known controllers are silenced. Verified against live Loki: the
+                  # 2658-events/h baseline drops to 0, and the sensitive-file clause
+                  # is provably unaffected by the namespace filter.
                   expr: >-
                     sum(count_over_time({namespace="falco"} |= "priority" | json
-                    | rule=~"Read sensitive file untrusted|Contact K8S API Server From Container"
+                    | (rule="Read sensitive file untrusted"
+                    or rule="Contact K8S API Server From Container"
+                    and output_fields_k8s_ns_name!~"argo-cd|backstage|openshell|kagent")
                     [1h]))
               - refId: threshold
                 relativeTimeRange:


### PR DESCRIPTION
## What

The **"Falco detected a sensitive-file read or unexpected API access"** alert has been firing continuously (3h+). Investigated the actual detections behind it — all benign.

## Root cause

Every recent event is the `Contact K8S API Server From Container` rule, from controllers that contact the K8S API **by design**:

| Namespace | events/hour | why it hits the API |
|---|---|---|
| backstage | 2456 | kubernetes-ingestor / Kubernetes plugin polling the catalog |
| argo-cd | 141 | GitOps controller reconciling every app |
| openshell | 61 | sandbox pod provisioning/management |

Zero `Read sensitive file untrusted` events. So the alert was pure **alert fatigue** — and now that the n8n → Slack path works, it would also nag `#oncall-alerts`.

## Fix

Exclude the known API-contacting controllers (`argo-cd`, `backstage`, `openshell`, `kagent`) from the **Contact-API rule only**, using LogQL precedence (`and` binds tighter than `or`):

```
Read-sensitive-file  OR  (Contact-API  AND  ns not a known controller)
```

This preserves the detection's intent:
- a **sensitive-file read still alerts from ANY namespace** — including these four, where it matters most (argo-cd holds cluster creds, backstage aggregates secrets)
- an **unexpected container contacting the API still alerts** — only the known controllers are silenced

## Verified against live Loki before committing

- Confirmed the flattened label is `output_fields_k8s_ns_name`
- Baseline **2658 events/h → 0** with the exclusion (alert will resolve to Normal)
- Proved (T2 in testing) the namespace filter binds **only** to the Contact-API clause, leaving the sensitive-file clause matching all namespaces
- `yamllint` clean, `kubeconform` valid

## Post-merge

The alert should flip from Firing → Normal within an evaluation cycle (5m). If it ever fires again, it's now a *real* signal — an unexpected container hitting the API, or any sensitive-file read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ