### PR TITLE
harden(observability+n8n): Grafana creds from Vault; pin n8n image

### DIFF
--- a/base-apps/logging/grafana-admin-external-secret.yaml
+++ b/base-apps/logging/grafana-admin-external-secret.yaml
@@ -1,0 +1,32 @@
+# Grafana admin credentials, sourced from Vault instead of hardcoded in the
+# Deployment. Closes the audit's #1 finding: GF_SECURITY_ADMIN_USER/PASSWORD were
+# plaintext "admin"/"admin" in grafana-deployment.yaml, on an internet-reachable
+# ingress. The real password was already rotated and stored in Vault at
+# k8s-secrets/grafana (admin-user, admin-password); this syncs it into a Secret
+# the Deployment consumes.
+#
+# GF_SECURITY_ADMIN_PASSWORD only seeds the password on first boot (Grafana then
+# owns it in grafana.db), but sourcing it from Vault means a fresh boot / PVC
+# wipe uses the strong password rather than resetting to "admin".
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin
+  namespace: logging
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: grafana-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-user
+      remoteRef:
+        key: grafana
+        property: admin-user
+    - secretKey: admin-password
+      remoteRef:
+        key: grafana
+        property: admin-password

--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -81,10 +81,18 @@ spec:
           name: http
           protocol: TCP
         env:
+        # Sourced from Vault (k8s-secrets/grafana) via the grafana-admin
+        # ExternalSecret — no longer hardcoded. See grafana-admin-external-secret.yaml.
         - name: GF_SECURITY_ADMIN_USER
-          value: admin
+          valueFrom:
+            secretKeyRef:
+              name: grafana-admin
+              key: admin-user
         - name: GF_SECURITY_ADMIN_PASSWORD
-          value: admin
+          valueFrom:
+            secretKeyRef:
+              name: grafana-admin
+              key: admin-password
         - name: GF_USERS_ALLOW_SIGN_UP
           value: "false"
         - name: GF_SERVER_ROOT_URL

--- a/base-apps/n8n/deployments.yaml
+++ b/base-apps/n8n/deployments.yaml
@@ -37,7 +37,7 @@ spec:
       # unrelated app syncs and left the webhook active-in-DB but unregistered
       # whenever the pod didn't happen to restart — a real 404 we hit in prod.)
       - name: import-workflows
-        image: n8nio/n8n:latest
+        image: n8nio/n8n:2.30.5
         command: ["/bin/sh", "-c"]
         args:
         - |
@@ -93,7 +93,7 @@ spec:
             cpu: "500m"
       containers:
       - name: n8n
-        image: n8nio/n8n:latest
+        image: n8nio/n8n:2.30.5
         env:
         # Database Configuration
         - name: DB_TYPE


### PR DESCRIPTION
Two low-risk hardening changes, batched per request. (The two bigger items — Vault TLS and PVC backups — are deliberately **not** here; see below.)

## 1. Grafana admin creds out of plaintext (audit finding #1)

`grafana-deployment.yaml` hardcoded `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD = admin/admin` on an internet-reachable ingress. The real password was already rotated and stored in Vault (`k8s-secrets/grafana`); this adds a `grafana-admin` ExternalSecret and sources both env vars from it via `secretKeyRef`.

- Removes the plaintext password from Git.
- A fresh boot / PVC wipe now seeds the **strong** password instead of resetting to `admin`.
- **Out-of-band (done):** extended the `logging` Vault policy to read the `grafana` key, so the ExternalSecret can sync. (Vault policies aren't Terraform-managed — no IaC drift.)

## 2. Pin n8n to `2.30.5`

Both the main container and the import initContainer moved off `:latest`. The `:latest` tag silently upgraded n8n from a 94-day-old version to 2.30.5 on a routine restart earlier this week, which caused the stale-cache blank-UI incident. Pinning stops uncontrolled version jumps.

## Not included (by design)

- **Remove unused `db-password` from the `n8n` Vault key** — done as a live Vault op (it's data, not a manifest; can't be in a PR).
- **Vault TLS (audit #2)** — a cluster-wide migration (every SecretStore points at `http://vault…`; switching to HTTPS risks breaking all secret syncs). Needs its own staged PR.
- **PVC backups (audit #8)** — its own mini-project (bucket/IAM/CronJob + testing). The CNPG cluster already has S3 backups; the gap is the plain-Postgres/Vault/observability PVCs.

## Post-merge verification
```bash
kubectl -n logging get externalsecret grafana-admin          # SecretSynced
kubectl -n logging get secret grafana-admin -o jsonpath='{.data.admin-password}' | base64 -d | head -c 4  # matches Vault
# grafana rolls; log in with the Vault-stored password (unchanged value)
kubectl -n n8n get deploy n8n -o jsonpath='{..image}'         # both n8nio/n8n:2.30.5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ