### PR TITLE
feat(identity): Dex OIDC provider fronting GitHub (Vault human login) [Phase 2]

### DIFF
--- a/base-apps/_INDEX.md
+++ b/base-apps/_INDEX.md
@@ -19,6 +19,7 @@ Pilot apps carry the full agent-docs contract; others are stubs pending backfill
 | backstage | Internal developer portal / software catalog (Backstage, shared PostgreSQL, Vault, kubernetes-ingestor) | backstage | docs.md | runbook.md | catalog-info.yaml |
 | chores-tracker-frontend | HTMX/nginx web frontend for Chores Tracker | chores-tracker-frontend | docs.md | runbook.md | catalog-info.yaml |
 | coroot | eBPF-based observability/APM (Coroot operator + instance, node/cluster agents, ClickHouse) | coroot | docs.md | runbook.md | catalog-info.yaml |
+| dex | OIDC provider fronting GitHub — issuer for Vault OIDC (human `vault` login via GitHub SSO) | dex | | | |
 | crossplane-aws-provider | | | | | |
 | crossplane-compositions | | | | | |
 | crossplane-functions | | | | | |

--- a/base-apps/dex.yaml
+++ b/base-apps/dex.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dex
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/dex
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dex
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/dex/configmap.yaml
+++ b/base-apps/dex/configmap.yaml
@@ -1,0 +1,55 @@
+# Dex OIDC provider config. Dex fronts GitHub (which is not OIDC-native) and
+# exposes a real OIDC issuer that Vault trusts.
+#
+# issuer MUST be the exact URL both the browser (GitHub redirect) and Vault
+# (OIDC discovery) use — see the deployment/runbook for the in-cluster
+# reachability of dex.arigsela.com from the Vault pod.
+#
+# Secrets ($GITHUB_CLIENT_ID/$GITHUB_CLIENT_SECRET/$VAULT_CLIENT_SECRET) are
+# substituted from the dex-secrets Secret at startup (Dex expands $ENV refs when
+# the file is loaded via `dex serve`).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex-config
+  namespace: dex
+data:
+  config.yaml: |
+    issuer: https://dex.arigsela.com
+
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+
+    web:
+      http: 0.0.0.0:5556
+
+    # Vault is an OIDC client of Dex. The secret matches Vault's oidc auth
+    # config (oidc_client_secret). redirectURIs cover the Vault CLI helper
+    # (localhost:8250) and the Vault UI OIDC callback.
+    staticClients:
+      - id: vault
+        name: Vault
+        secretEnv: VAULT_CLIENT_SECRET
+        redirectURIs:
+          - http://localhost:8250/oidc/callback
+          - https://vault.local/ui/vault/auth/oidc/oidc/callback
+          - https://vault.10.0.1.110/ui/vault/auth/oidc/oidc/callback
+
+    connectors:
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: $GITHUB_CLIENT_ID
+          clientSecret: $GITHUB_CLIENT_SECRET
+          redirectURI: https://dex.arigsela.com/callback
+          # No `orgs:` restriction here — that only works for GitHub *orgs*, and
+          # this is a personal account. Access is locked down one layer up:
+          # Vault's oidc role binds to the specific GitHub login (bound_claims),
+          # and the Dex ingress is IP-allowlisted. If you later move to a GitHub
+          # org, add an `orgs:` filter here too.
+
+    oauth2:
+      skipApprovalScreen: true

--- a/base-apps/dex/deployment.yaml
+++ b/base-apps/dex/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    app: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+      annotations:
+        # Roll when the config changes so Dex reloads it.
+        checksum/config: "c8490e95d6e05a03"
+    spec:
+      serviceAccountName: dex
+      nodeSelector:
+        node.kubernetes.io/workload: infrastructure
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.41.1
+          command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
+          ports:
+            - name: http
+              containerPort: 5556
+          # GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET / VAULT_CLIENT_SECRET —
+          # Dex expands these $ENV refs in config.yaml at load time.
+          envFrom:
+            - secretRef:
+                name: dex-secrets
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5556
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5556
+            initialDelaySeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: dex-config

--- a/base-apps/dex/external-secret.yaml
+++ b/base-apps/dex/external-secret.yaml
@@ -1,0 +1,34 @@
+# Dex's secrets, from Vault key k8s-secrets/dex:
+#   github-client-id / github-client-secret — the GitHub OAuth App you register
+#     (github.com -> Settings -> Developer settings -> OAuth Apps), callback
+#     https://dex.arigsela.com/callback
+#   vault-client-secret — the shared secret between Dex's `vault` staticClient
+#     and Vault's oidc auth config (generated during setup).
+# Consumed by the Dex Deployment via envFrom; the config.yaml references them
+# as $GITHUB_CLIENT_ID / $GITHUB_CLIENT_SECRET / $VAULT_CLIENT_SECRET.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-secrets
+  namespace: dex
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: dex-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_CLIENT_ID
+      remoteRef:
+        key: dex
+        property: github-client-id
+    - secretKey: GITHUB_CLIENT_SECRET
+      remoteRef:
+        key: dex
+        property: github-client-secret
+    - secretKey: VAULT_CLIENT_SECRET
+      remoteRef:
+        key: dex
+        property: vault-client-secret

--- a/base-apps/dex/ingress.yaml
+++ b/base-apps/dex/ingress.yaml
@@ -1,0 +1,36 @@
+# Dex is reached by the browser during the GitHub SSO redirect, and by Vault
+# for OIDC discovery. TLS via letsencrypt-prod; IP-allowlisted like the other
+# admin surfaces (Dex only ever serves your own login).
+#
+# NOTE: Vault (in-cluster) must be able to reach https://dex.arigsela.com for
+# OIDC discovery. If the Vault pod can't resolve/route to the public hostname,
+# add a CoreDNS rewrite so dex.arigsela.com resolves to the ingress in-cluster.
+# See base-apps/dex — verified during rollout.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dex
+  namespace: dex
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - dex.arigsela.com
+      secretName: dex-tls
+  rules:
+    - host: dex.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dex
+                port:
+                  number: 5556

--- a/base-apps/dex/rbac.yaml
+++ b/base-apps/dex/rbac.yaml
@@ -1,0 +1,34 @@
+# Dex with kubernetes storage stores its state (auth requests/codes, refresh
+# tokens, signing keys, the oauth2 clients, etc.) as custom resources in the
+# dex.coreos.com API group. It needs RBAC to create those CRDs on first run and
+# to manage the resources thereafter.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+  - apiGroups: ["dex.coreos.com"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+  - kind: ServiceAccount
+    name: dex
+    namespace: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex
+  namespace: dex

--- a/base-apps/dex/secret-store.yaml
+++ b/base-apps/dex/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: dex
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "dex"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/dex/service.yaml
+++ b/base-apps/dex/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    app: dex
+spec:
+  type: ClusterIP
+  selector:
+    app: dex
+  ports:
+    - name: http
+      port: 5556
+      targetPort: 5556


### PR DESCRIPTION
**Phase 2** of moving Vault auth off the root token. Phase 1 (MCP on a scoped AppRole) is already done. This adds **Dex** so your *human* `vault login` uses GitHub SSO → an identity-tied, expiring, admin-scoped token, with root sealed away as break-glass.

## ⚠️ Draft — do not merge yet

Dex won't start until Vault key `k8s-secrets/dex` is seeded, which needs **your GitHub OAuth App**. Sequence:
1. You register the GitHub OAuth App (details below) → send me client id + secret
2. I seed `k8s-secrets/dex` (+ the generated vault-client-secret)
3. Merge → Dex deploys
4. I configure Vault `oidc` auth against Dex + the `admin` role, and we test `vault login -method=oidc`

## What's in the app
- Dex Deployment (`ghcr.io/dexidp/dex:v2.41.1`), kubernetes CRD storage, config via ConfigMap (checksum-annotated)
- GitHub connector + a `vault` staticClient; secrets via ExternalSecret from `k8s-secrets/dex`
- Service + IP-allowlisted TLS ingress `dex.arigsela.com`
- RBAC for Dex's kubernetes storage

## Already done out-of-band (Vault)
- `dex` policy + k8s-auth role (so the ExternalSecret can read its key)
- `admin` policy (broad management, identity-tied) that the human OIDC login maps to
- Generated the Vault↔Dex `vault-client-secret` (held; seeded with your GitHub creds)

## GitHub OAuth App to register
github.com → Settings → Developer settings → **OAuth Apps** → New:
- **Application name:** Homelab Dex (or anything)
- **Homepage URL:** `https://dex.arigsela.com`
- **Authorization callback URL:** `https://dex.arigsela.com/callback`

Then send me the **Client ID** and a generated **Client secret**.

## Known follow-up (handled at rollout)
Vault (in-cluster) must reach `https://dex.arigsela.com` for OIDC discovery. If the Vault pod can't route to the public host, I'll add a CoreDNS rewrite so it resolves to the ingress internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ