### PR TITLE
feat(vault): HTTPS ingress for the Vault UI at vault.arigsela.com

### DIFF
--- a/base-apps/dex/configmap.yaml
+++ b/base-apps/dex/configmap.yaml
@@ -36,6 +36,7 @@ data:
           - http://localhost:8250/oidc/callback
           - https://vault.local/ui/vault/auth/oidc/oidc/callback
           - https://vault.10.0.1.110/ui/vault/auth/oidc/oidc/callback
+          - https://vault.arigsela.com/ui/vault/auth/oidc/oidc/callback
 
     connectors:
       - type: github

--- a/base-apps/dex/deployment.yaml
+++ b/base-apps/dex/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: dex
       annotations:
         # Roll when the config changes so Dex reloads it.
-        checksum/config: "c8490e95d6e05a03"
+        checksum/config: "5326419fe0a7dc38"
     spec:
       serviceAccountName: dex
       nodeSelector:

--- a/base-apps/vault/ingress-public.yaml
+++ b/base-apps/vault/ingress-public.yaml
@@ -1,0 +1,40 @@
+# HTTPS ingress for the Vault UI at vault.arigsela.com.
+#
+# nginx terminates TLS (letsencrypt-prod) and proxies to Vault's HTTP listener
+# on :8200 (the listener itself is still tls_disable — that's a separate change,
+# audit finding #2). So browser->nginx is encrypted; the nginx->Vault hop stays
+# in-cluster plaintext. IP-allowlisted like the other admin surfaces.
+#
+# This is a SEPARATE ingress from `vault-internal` (the .local hosts), and
+# deliberately does NOT set rewrite-target: the Vault UI/API needs its real
+# paths (/ui, /v1, /ui/vault/auth/oidc/oidc/callback) intact.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-ui
+  namespace: vault
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - vault.arigsela.com
+      secretName: vault-arigsela-tls
+  rules:
+    - host: vault.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault
+                port:
+                  number: 8200


### PR DESCRIPTION
Adds a TLS-terminating ingress so you can reach the Vault UI over **HTTPS** at `vault.arigsela.com` with a real Let's Encrypt cert, instead of the current plaintext `vault.local`/`vault.10.0.1.110` hosts.

## Changes
- **`base-apps/vault/ingress-public.yaml`** — new `vault-ui` Ingress: letsencrypt-prod TLS, IP-allowlisted, `backend-protocol: HTTP` to the vault service :8200, **no** `rewrite-target` (the UI/API need their real `/ui`, `/v1` paths). Separate from the existing `vault-internal` ingress, which is untouched.
- **`base-apps/dex`** — add `https://vault.arigsela.com/ui/vault/auth/oidc/oidc/callback` to the Vault OIDC client's redirect URIs so **GitHub OIDC login works from the UI** (config checksum bumped so Dex rolls and reloads).

## Out-of-band (already done)
- Route53 `A vault.arigsela.com -> 73.7.190.154` (INSYNC)
- Same redirect URI added to the live Vault `oidc` `admin` role

## Scope / what this is NOT
This encrypts **browser → nginx** only. Vault's own listener is still `tls_disable: 1`, so nginx→Vault and in-cluster traffic stay plaintext — that's **audit finding #2**, a separate/bigger change touching every SecretStore. This PR is purely the UI-access improvement.

## Post-merge verification (I'll run)
```bash
kubectl -n vault get ingress vault-ui
kubectl -n vault get certificate vault-arigsela-tls   # Ready=True after LE challenge
# then browse https://vault.arigsela.com -> OIDC login via GitHub
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ