### PR TITLE
fix(gitops): add resources-finalizer to all Argo CD Application manifests

### DIFF
--- a/base-apps/agent-audit-aws-infrastructure.yaml
+++ b/base-apps/agent-audit-aws-infrastructure.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: agent-audit-aws-infrastructure
   namespace: argo-cd
 spec:

--- a/base-apps/agent-sandbox-crds.yaml
+++ b/base-apps/agent-sandbox-crds.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: agent-sandbox-crds
   namespace: argo-cd
   annotations:

--- a/base-apps/argo-cd.yaml
+++ b/base-apps/argo-cd.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-cd-config
   namespace: argo-cd
 spec:

--- a/base-apps/argo-rollouts-config.yaml
+++ b/base-apps/argo-rollouts-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-rollouts-config
   namespace: argo-cd
 spec:

--- a/base-apps/argo-rollouts.yaml
+++ b/base-apps/argo-rollouts.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-rollouts
   namespace: argo-cd
 spec:

--- a/base-apps/argo-workflow-tasks.yaml
+++ b/base-apps/argo-workflow-tasks.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-workflow-tasks
   namespace: argo-cd
 spec:

--- a/base-apps/argo-workflows-aws-infrastructure.yaml
+++ b/base-apps/argo-workflows-aws-infrastructure.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-workflows-aws-infrastructure
   namespace: argo-cd
 spec:

--- a/base-apps/argo-workflows-config.yaml
+++ b/base-apps/argo-workflows-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-workflows-config
   namespace: argo-cd
 spec:

--- a/base-apps/argo-workflows.yaml
+++ b/base-apps/argo-workflows.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: argo-workflows
   namespace: argo-cd
 spec:

--- a/base-apps/atlantis-config.yaml
+++ b/base-apps/atlantis-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: atlantis-config
   namespace: argo-cd
 spec:

--- a/base-apps/atlantis.yaml
+++ b/base-apps/atlantis.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: atlantis
   namespace: argo-cd
 spec:

--- a/base-apps/backstage.yaml
+++ b/base-apps/backstage.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: backstage
   namespace: argo-cd
 spec:

--- a/base-apps/cert-manager-config.yaml
+++ b/base-apps/cert-manager-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: cert-manager-config
   namespace: argo-cd
 spec:

--- a/base-apps/cert-manager.yaml
+++ b/base-apps/cert-manager.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: cert-manager
   namespace: argo-cd
 spec:

--- a/base-apps/chores-tracker-backend.yaml
+++ b/base-apps/chores-tracker-backend.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: chores-tracker-backend
   namespace: argo-cd
 spec:

--- a/base-apps/chores-tracker-frontend.yaml
+++ b/base-apps/chores-tracker-frontend.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: chores-tracker-frontend
   namespace: argo-cd
 spec:

--- a/base-apps/cnpg-system.yaml
+++ b/base-apps/cnpg-system.yaml
@@ -12,6 +12,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: cnpg-system
   namespace: argo-cd
 spec:

--- a/base-apps/coroot.yaml
+++ b/base-apps/coroot.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: coroot
   namespace: argo-cd
 spec:

--- a/base-apps/crossplane-aws-provider.yaml
+++ b/base-apps/crossplane-aws-provider.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: crossplane-aws-provider
   namespace: argo-cd
 spec:

--- a/base-apps/crossplane-compositions.yaml
+++ b/base-apps/crossplane-compositions.yaml
@@ -3,6 +3,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: crossplane-compositions
   namespace: argo-cd
 spec:

--- a/base-apps/crossplane-functions.yaml
+++ b/base-apps/crossplane-functions.yaml
@@ -4,6 +4,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: crossplane-functions
   namespace: argo-cd
 spec:

--- a/base-apps/crossplane-system.yaml
+++ b/base-apps/crossplane-system.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: crossplane-system
   namespace: argo-cd
 spec:

--- a/base-apps/dex.yaml
+++ b/base-apps/dex.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: dex
   namespace: argo-cd
 spec:

--- a/base-apps/ecr-auth.yaml
+++ b/base-apps/ecr-auth.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: ecr-auth
   namespace: argo-cd
 spec:

--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: external-secrets
   namespace: argo-cd
 spec:

--- a/base-apps/falco.yaml
+++ b/base-apps/falco.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: falco
   namespace: argo-cd
 spec:

--- a/base-apps/istio-ambient-config.yaml
+++ b/base-apps/istio-ambient-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-ambient-config
   namespace: argo-cd
   annotations:

--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-base
   namespace: argo-cd
   annotations:

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-cni
   namespace: argo-cd
   annotations:

--- a/base-apps/istio-gateway-api.yaml
+++ b/base-apps/istio-gateway-api.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-gateway-api
   namespace: argo-cd
   annotations:

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-istiod
   namespace: argo-cd
   annotations:

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: istio-ztunnel
   namespace: argo-cd
   annotations:

--- a/base-apps/kagent-crds.yaml
+++ b/base-apps/kagent-crds.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: kagent-crds
   namespace: argo-cd
   annotations:

--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: kagent-secrets
   namespace: argo-cd
   annotations:

--- a/base-apps/kagent.yaml
+++ b/base-apps/kagent.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: kagent
   namespace: argo-cd
   annotations:

--- a/base-apps/kyverno-policies.yaml
+++ b/base-apps/kyverno-policies.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: kyverno-policies
   namespace: argo-cd
 spec:

--- a/base-apps/kyverno.yaml
+++ b/base-apps/kyverno.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: kyverno
   namespace: argo-cd
 spec:

--- a/base-apps/logging.yaml
+++ b/base-apps/logging.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: logging
   namespace: argo-cd
 spec:

--- a/base-apps/loki-aws-infrastructure.yaml
+++ b/base-apps/loki-aws-infrastructure.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: loki-aws-infrastructure
   namespace: argo-cd
 spec:

--- a/base-apps/n8n.yaml
+++ b/base-apps/n8n.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: n8n
   namespace: argo-cd
 spec:

--- a/base-apps/nginx-ingress.yaml
+++ b/base-apps/nginx-ingress.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: nginx-ingress
   namespace: argo-cd
 spec:

--- a/base-apps/ollama.yaml
+++ b/base-apps/ollama.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: ollama
   namespace: argo-cd
 spec:

--- a/base-apps/oncall-agent.yaml
+++ b/base-apps/oncall-agent.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: oncall-agent
   namespace: argo-cd
 spec:

--- a/base-apps/oncall-crewai.yaml
+++ b/base-apps/oncall-crewai.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: oncall-crewai
   namespace: argo-cd
 spec:

--- a/base-apps/openshell-secrets.yaml
+++ b/base-apps/openshell-secrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: openshell-secrets
   namespace: argo-cd
   annotations:

--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: openshell
   namespace: argo-cd
   annotations:

--- a/base-apps/postgresql.yaml
+++ b/base-apps/postgresql.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: postgresql
   namespace: argo-cd
 spec:

--- a/base-apps/vault.yaml
+++ b/base-apps/vault.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: vault
   namespace: argo-cd
 spec:

--- a/base-apps/vcluster-sandbox-1.yaml
+++ b/base-apps/vcluster-sandbox-1.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: vcluster-sandbox-1
   namespace: argo-cd
 spec:

--- a/base-apps/weather-kitchen-backend.yaml
+++ b/base-apps/weather-kitchen-backend.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: weather-kitchen-backend
   namespace: argo-cd
 spec:

--- a/base-apps/weather-kitchen-frontend.yaml
+++ b/base-apps/weather-kitchen-frontend.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: weather-kitchen-frontend
   namespace: argo-cd
 spec:

--- a/base-apps/whoami-test.yaml
+++ b/base-apps/whoami-test.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   name: whoami-test
   namespace: argo-cd
 spec:


### PR DESCRIPTION
## Why

When you remove an app by deleting its `base-apps/<app>.yaml`, the master-app (app-of-apps) prunes the Argo **Application object** — but does **not** cascade-delete the resources it managed, because the child Applications carried no `resources-finalizer`. The workloads get **orphaned and keep running**.

This bit us for real with **cluster-scanner**: PR #372 removed its Application, but the CronJob kept firing daily and **posting to Slack for days afterward**. I had to delete the namespace by hand to actually stop it.

## Fix

Add `resources-finalizer.argocd.argoproj.io` to `metadata.finalizers` on **all 52** Application manifests, so a future removal cascades to the app's own resources (namespace, workloads, secrets, PVCs).

- **Non-disruptive:** a finalizer only changes *deletion* behavior — it does nothing to running apps. master-app just adds the field on next sync.
- Text-inserted after `metadata:` — comments and formatting preserved (no YAML round-trip).

## Validation
- 52/52 files parse as valid YAML with exactly `[resources-finalizer.argocd.argoproj.io]`
- `kubeconform -strict`: 0 invalid
- `yamllint`: 0 errors

## Follow-ups (deliberately NOT in this PR)
- **New apps** must include the finalizer too. Worth documenting in `base-apps/README.md`, or —
- **Longer term:** convert the plain app-of-apps master-app into an **ApplicationSet** whose template stamps the finalizer automatically. That's the idiomatic single-point fix, but it's a bigger, riskier migration (changes how all 50+ apps are discovered/owned), so I deferred it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaeDGfDh1dgrtZ55YZ1nZ