### PR TITLE
fix(homelab-agent): drop a2aConfig + ports from BYO CR (kagent 0.9.11 schema)

### DIFF
--- a/base-apps/kagent/agents/homelab-agent.yaml
+++ b/base-apps/kagent/agents/homelab-agent.yaml
@@ -20,12 +20,16 @@ metadata:
 spec:
   description: LangGraph BYO agent — answers homelab GitOps/architecture and live-cluster questions (parity with homelab-knowledge), with conversation memory.
   type: BYO
+  # No a2aConfig: it is Declarative-only in the kagent 0.9.11 CRD. This BYO
+  # agent advertises its skills (repo-knowledge, cluster-troubleshooting,
+  # deployment-guidance) via the A2A agent card the container serves at
+  # /.well-known/agent.json; kagent introspects that card.
   byo:
     deployment:
       image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/homelab-agent:v0.2.0
       serviceAccountName: homelab-agent
-      ports:
-        - containerPort: 8080
+      # No `ports` field — the kagent 0.9.11 BYO contract assumes the container
+      # serves A2A on :8080 (kagent wires the Service itself).
       resources:
         requests:
           cpu: 100m
@@ -69,28 +73,3 @@ spec:
           value: http://homelab-agent.kagent.svc.cluster.local:8080
         - name: LOG_LEVEL
           value: INFO
-  a2aConfig:
-    skills:
-      - id: repo-knowledge
-        name: Repo & Architecture Knowledge
-        description: Explain what's deployed, where it lives in the GitOps repo, and how components are wired together.
-        examples:
-          - What is cert-manager and how does it issue certs here?
-          - Who owns chores-tracker-backend and what does it depend on?
-          - Where does vault store its config and how is it unsealed?
-        tags: [gitops, documentation, architecture]
-      - id: cluster-troubleshooting
-        name: Cluster State Troubleshooting
-        description: Diagnose issues by checking live pod/deployment/event state and correlating with the GitOps manifests.
-        examples:
-          - cert-manager Certificates are stuck pending — walk me through the runbook.
-          - chores-tracker-backend is CrashLooping — what does its runbook say to check?
-          - Is the argo-cd control plane healthy?
-        tags: [troubleshooting, kubernetes, argocd]
-      - id: deployment-guidance
-        name: Deployment & Onboarding Guidance
-        description: Recommend how to onboard a new app following the established base-apps patterns (Crossplane composition, SecretStore, ingress, ECR auth).
-        examples:
-          - I want to deploy a new service called billing-api. What's the right pattern?
-          - How do I add Vault secrets for a new namespace?
-        tags: [onboarding, crossplane, idp]


### PR DESCRIPTION
## Problem

PR #384's `homelab-agent` Agent CR failed Argo sync:

```
failed to create typed patch object (kagent/homelab-agent): .spec.a2aConfig: field not declared in schema
```

The kagent **0.9.11** Agent CRD does not have `spec.a2aConfig` (it's **Declarative-only**, under `spec.declarative.a2aConfig`), and `spec.byo.deployment` has **no `ports`** field either. The `2026-07-16` example this was modeled on was inaccurate about the BYO schema.

## Fix

Remove both fields from the BYO CR:
- **`a2aConfig`** — a BYO agent advertises its skills (`repo-knowledge`, `cluster-troubleshooting`, `deployment-guidance`) via the A2A agent card the **container itself serves** at `/.well-known/agent.json` (built in `server.py`); kagent introspects that card. Skills need not (and can't) be re-declared in the CR.
- **`ports`** — the kagent BYO contract assumes the container serves A2A on `:8080`; kagent wires the Service itself.

## Validation

Verified against the **live cluster CRD**, not guesswork:

```
$ kubectl apply --dry-run=server -f base-apps/kagent/agents/homelab-agent.yaml
agent.kagent.dev/homelab-agent created (server dry run)
```

`yamllint -c .yamllint.yaml` clean. All other manifests (ESO, init-Job, SA) are unchanged and already valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAjPtHX3iurStfUiZ9PwbB