### PR TITLE
fix(homelab-agent): bump image to v0.3.0 (UI conversation history)

### DIFF
--- a/base-apps/kagent/agents/homelab-agent.yaml
+++ b/base-apps/kagent/agents/homelab-agent.yaml
@@ -26,7 +26,7 @@ spec:
   # /.well-known/agent.json; kagent introspects that card.
   byo:
     deployment:
-      image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/homelab-agent:v0.2.0
+      image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/homelab-agent:v0.3.0
       serviceAccountName: homelab-agent
       # No `ports` field — the kagent 0.9.11 BYO contract assumes the container
       # serves A2A on :8080 (kagent wires the Service itself).


### PR DESCRIPTION
Bumps the `homelab-agent` BYO image `v0.2.0 → v0.3.0`.

## Why
The deployed `v0.2.0` used the a2a-sdk `InMemoryTaskStore`, so BYO conversation tasks were never written to the kagent controller DB — the UI listed the session but replayed **no messages** (`list-tasks-db count:0`). Confirmed in the controller logs.

`v0.3.0` (claude-agents PR #66) backs the A2A `DefaultRequestHandler` with kagent's **`KAgentTaskStore` + `KAgentRequestContextBuilder`** when `KAGENT_URL` is present, so tasks persist and the UI replays history. It keeps the custom executor, so token streaming + progress + conversation memory are unchanged. Degrades to in-memory locally.

## Validation
`kubectl apply --dry-run=server` → `agent.kagent.dev/homelab-agent configured`; yamllint clean. One-line image change.

After merge, Argo rolls the deployment to v0.3.0; then a UI test (ask → navigate away → click the conversation → it should replay) confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAjPtHX3iurStfUiZ9PwbB