### PR TITLE
feat(backstage): complete catalog taxonomy (Domains, User, all Systems)

### DIFF
--- a/catalog/platform-entities.yaml
+++ b/catalog/platform-entities.yaml
@@ -1,9 +1,27 @@
-# Backstage-only catalog entities (Group + Systems) for the platform taxonomy.
+# Backstage-only catalog entities (Domains + Group + User + Systems) for the
+# platform taxonomy.
 # NOT a Kubernetes manifest and NOT under base-apps/, so Argo CD never syncs it.
 # Ingested by Backstage via a url catalog Location (arigsela/backstage app-config).
 # These give the base-apps/* Resources/Components resolvable owner (Group) and
-# system (System) relations. All in the default namespace so the pilots'
+# system (System) relations, group Systems into Domains, and give the platform
+# Group a real member (User). All in the default namespace so the pilots'
 # fully-qualified refs (group:default/platform, default/platform-*) resolve.
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: platform
+  description: Shared platform capabilities — infrastructure the products build on.
+spec:
+  owner: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: products
+  description: End-user application products running on the platform.
+spec:
+  owner: platform
+---
 apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
@@ -14,28 +32,85 @@ spec:
   children: []
 ---
 apiVersion: backstage.io/v1alpha1
+kind: User
+metadata:
+  name: arigsela
+  description: Platform engineer.
+spec:
+  memberOf:
+    - platform
+---
+apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: platform-networking
-  description: Networking and certificate capabilities.
+  description: Networking and certificate capabilities (cert-manager, nginx-ingress).
 spec:
   owner: platform
+  domain: platform
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: platform-secrets
-  description: Secret management capabilities.
+  description: Secret management capabilities (Vault).
 spec:
   owner: platform
+  domain: platform
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: platform-gitops
-  description: GitOps and continuous delivery capabilities.
+  description: GitOps and continuous delivery capabilities (Argo CD, Atlantis).
 spec:
   owner: platform
+  domain: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: platform-ai
+  description: AI and agent capabilities (kagent, ollama).
+spec:
+  owner: platform
+  domain: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: platform-automation
+  description: Authentication and workflow automation (dex, n8n).
+spec:
+  owner: platform
+  domain: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: platform-data
+  description: Stateful data services (PostgreSQL).
+spec:
+  owner: platform
+  domain: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: platform-observability
+  description: Observability and incident response (coroot, logging, oncall-agent).
+spec:
+  owner: platform
+  domain: platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: platform-tooling
+  description: Developer tooling and internal portal (Backstage).
+spec:
+  owner: platform
+  domain: platform
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System
@@ -44,3 +119,13 @@ metadata:
   description: Chores Tracker application system.
 spec:
   owner: platform
+  domain: products
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: weather-kitchen
+  description: Weather Kitchen application system.
+spec:
+  owner: platform
+  domain: products


### PR DESCRIPTION
## What

Extends `catalog/platform-entities.yaml` (the Backstage-only taxonomy ingested via URL Location) so it matches what the `base-apps/*/catalog-info.yaml` pilots actually reference.

### Problem
The 18 pilots referenced **10 Systems** and `group:default/platform`, but the taxonomy file only defined **4 Systems** and a member-less Group. Result:
- 6 Systems (`platform-ai`, `platform-automation`, `platform-data`, `platform-observability`, `platform-tooling`, `weather-kitchen`) rendered as auto-generated placeholder entities — no description, no owner.
- The `platform` Group had zero members (no `User` existed), so "owned by me" / org-graph views were empty.
- No `Domain` grouping the Systems.

### Change
- **+6 System entities** — every referenced System now resolves.
- **+2 Domains** (`platform`, `products`); every System assigned a `domain`.
- **+1 User** (`arigsela`, `memberOf: [platform]`) so ownership resolves to a human.

### Verification
- `yamllint catalog/platform-entities.yaml` → clean
- 14 documents parse (2 Domains, 1 Group, 1 User, 10 Systems)
- `comm` diff of referenced vs defined Systems → **no dangling references remain**

This is a Backstage-only catalog file (not under `base-apps/`), so Argo CD does not sync it — Backstage picks it up on its next catalog refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)