### PR TITLE
chore(argocd): upgrade to chart 10.1.4, run 3.5.0-rc2 image

### DIFF
--- a/terraform/modules/argocd/variables.tf
+++ b/terraform/modules/argocd/variables.tf
@@ -8,9 +8,13 @@ variable "enabled" {
 variable "helm_services" {
   default = [
     {
-      name          = "argo-cd"
-      release_name  = "argo-cd"
-      chart_version = "9.0.5"
+      name         = "argo-cd"
+      release_name = "argo-cd"
+      # Latest GA argo-helm chart (appVersion v3.4.5). No chart packages Argo CD
+      # 3.5 yet; the 3.5.0-rc2 binaries are pinned via global.image.tag in the
+      # root module (terraform/roots/asela-cluster/argocd.tf). Bump this to the
+      # real 3.5 chart once argo-helm publishes it after 3.5 GA (~2026-08-04).
+      chart_version = "10.1.4"
       settings      = {}
     }
   ]

--- a/terraform/roots/asela-cluster/argocd.tf
+++ b/terraform/roots/asela-cluster/argocd.tf
@@ -7,6 +7,24 @@ module "argocd" {
   settings = {
     # Global node placement - applies to all ArgoCD components
     global = {
+      # Run the Argo CD 3.5.0-rc2 release candidate. No argo-helm chart packages
+      # 3.5 yet (chart 10.1.4 ships appVersion v3.4.5), so we override the image
+      # tag on the latest GA chart. global.image.tag applies to the core Argo CD
+      # components (server, repo-server, application-controller,
+      # applicationset-controller); dex and redis keep their chart-default images.
+      # 3.4->3.5 adds no new CRDs and mTLS is opt-in/off by default, so the 3.4.x
+      # chart manifests are compatible with the 3.5-rc2 binaries.
+      # Remove this override once chart_version points at a real 3.5 chart.
+      image = {
+        tag = "v3.5.0-rc2"
+      }
+      # Chart 10.0.0 flipped global.networkPolicy.create false->true. Pin it back
+      # to false to keep this upgrade behavior-preserving (no new NetworkPolicies
+      # introduced alongside the RC binary swap). Enabling netpols should be a
+      # separate, deliberate change once 3.5-rc is confirmed healthy.
+      networkPolicy = {
+        create = false
+      }
       nodeSelector = {
         "node.kubernetes.io/workload" = "infrastructure"
       }


### PR DESCRIPTION
## What

Upgrade the Argo CD control plane and run the **3.5.0-rc2** release candidate.

| File | Change |
|---|---|
| `terraform/modules/argocd/variables.tf` | chart `9.0.5` → **`10.1.4`** (latest GA chart, appVersion `v3.4.5`) |
| `terraform/roots/asela-cluster/argocd.tf` | `global.image.tag = v3.5.0-rc2`; `global.networkPolicy.create = false` |

Net effect: core components (server, repo-server, application-controller, applicationset-controller) run `quay.io/argoproj/argocd:v3.5.0-rc2` on the 3.4.x chart manifests. Dex/redis keep their chart-default images.

## Why an image override (not a chart bump to 3.5)

There is **no argo-helm chart for Argo CD 3.5 yet** — the latest chart `10.1.4` still ships appVersion `v3.4.5`. Argo CD 3.5 is currently **release-candidate only** (GA targets ~2026-08-04). So the RC runs as a `global.image.tag` override on the latest GA chart.

## Why it's safe enough

- **3.4→3.5 adds no new/changed CRDs** → the 3.4.x chart's bundled CRDs match the RC binaries.
- **3.5 internal mTLS is opt-in / off by default** → components don't fail without it.
- The only **chart 10.0.0** breaking change is `global.networkPolicy.create` flipping `false→true`; pinned back to `false` here to keep this a behavior-preserving version bump (enabling netpols should be a separate, deliberate change).

## Risk / rollback

- This is a **release candidate on the GitOps control plane** (binaries jump 3.1.9 → 3.5.0-rc2 in one hop). Review the Atlantis plan carefully before applying.
- **Rollback:** revert this PR (chart `9.0.5`, drop the `image`/`networkPolicy` overrides) and re-apply.
- Once 3.5 GA + a real chart land (~2026-08-04), drop the image override and bump `chart_version` to the 3.5 chart.

## Apply

Per `providers.tf`: run the gated **Terraform Apply** action (or `atlantis apply -p asela-cluster`) while this PR is **open**, then merge. Merged-but-unapplied = drift.

## Validation

`tofu fmt` clean; `tofu validate` → `Success! The configuration is valid.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGHyCrMqAYyVaZ5uJsoQz7
