### PR TITLE
chore(backstage): deploy portal image v1.4.6 (catalog enrichment P0+P1)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.5
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.6
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
## What

Bumps the Backstage portal image **v1.4.5 → v1.4.6** in `base-apps/backstage/deployments.yaml`, deploying the catalog-enrichment P0+P1 config merged in #389 (and the paired `arigsela/backstage` PR):

- Platform taxonomy (Group / Systems / Domains / User) now loads in **production** and the location rule admits `Domain`/`User`.
- API entities (`catalog/api-entities.yaml`) get ingested via the new url location; the `$text` spec hosts are allow-listed via `backend.reading.allow`.

## Image

`852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.6`
digest `sha256:cfc7501c46f7d756f5ee3470ec4376e18dc3876e82f2ac1d265c5637b8a7c6d3` — pushed 2026-07-17, built from `arigsela/backstage` main (host `yarn build:backend` + `packages/backend/Dockerfile`).

## Effect

Merging this syncs `deployments.yaml` via Argo CD (`imagePullPolicy: Always`) and rolls the backstage pod to v1.4.6.

## Post-rollout verification (plan Task 5)

- `ask hk`: the `platform` Group, Systems, Domains, and `arigsela` User resolve; no placeholder taxonomy entities.
- `/api-docs`: `chores-tracker-backend-api`, `weather-kitchen-backend-api`, `dex-oidc-api` appear; opening one renders the `$text`-fetched spec (confirms `reading.allow` + in-cluster fetch work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b
