### PR TITLE
docs(okf): scope the conformance claim to the knowledge documents

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,9 @@ tags: [platform, gitops, kubernetes, okf]
 
 > **For agents:** Start here. Traverse: this bundle root → a directory `index.md` → an app's `docs.md`/`runbook.md` → the `sources:` files listed in that doc. This root is a **navigation/summary layer**; the `sources:` files are authoritative. If a summary here looks wrong, go read the source.
 
-This repository is an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (OKF) bundle: knowledge lives as markdown with YAML frontmatter beside the manifests it describes. Every `docs.md`/`runbook.md` is an OKF concept document (`type`, `title`, `description` plus this repo's own contract fields); every directory `index.md` is the OKF reserved directory listing. See `templates/agent-docs/README.md` for the contract, and `scripts/gen-okf.py --export` to emit a standalone, portable bundle for an agent that should not get the whole infrastructure repo.
+This repository's **knowledge documents** are [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (OKF v0.1) documents: markdown with YAML frontmatter, living beside the manifests they describe. Every `docs.md`/`runbook.md` is an OKF concept document (`type`, `title`, `description` plus this repo's own contract fields), and this file plus each directory `index.md` is OKF's reserved directory listing.
+
+The repository as a whole is **not** a strictly conformant OKF bundle, and does not try to be: `README.md`, `CLAUDE.md`, and the specs and plans under `docs/` carry no frontmatter, which OKF §9 would require of every non-reserved `.md`. For a strictly conformant, portable bundle — navigation and concept documents only, with `timestamp` derived from git — run `scripts/gen-okf.py --export <dir>`. That is what to hand an agent that should not get the whole infrastructure repo. See `templates/agent-docs/README.md` for the authoring contract.
 
 ## 1. System context
 - Kubernetes API: `https://192.168.0.100:6443`

--- a/scripts/gen-techdocs.py
+++ b/scripts/gen-techdocs.py
@@ -22,6 +22,16 @@ WHY COPIES (not docs_dir: '.' or symlinks):
   So docs.md/runbook.md stay canonical at the app root and are copied into docs/.
   This script keeps the copies in sync; the CI --check gate fails on drift.
 
+NOTE ON THE OKF RESERVED FILENAME:
+  docs/index.md is a *concept document* (a copy of docs.md) sitting on index.md,
+  which the Open Knowledge Format reserves for directory listings. MkDocs needs
+  that name for the nav root, so the collision stays. It is contained: these
+  copies are TechDocs build input only, and scripts/gen-okf.py --export walks
+  base-apps/<app>/docs.md|runbook.md directly and never descends into docs/, so
+  no copy reaches an OKF bundle. A strict OKF consumer crawling the repo in
+  place (rather than consuming an export) would misread these 18 files as
+  directory listings.
+
 Usage:
   python3 scripts/gen-techdocs.py --repo-root .            # write/update
   python3 scripts/gen-techdocs.py --repo-root . --check    # verify, exit 1 on drift

--- a/templates/agent-docs/README.md
+++ b/templates/agent-docs/README.md
@@ -12,6 +12,8 @@ Every in-scope `base-apps/<app>/` directory carries three files:
 
 These docs are [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (OKF v0.1) concept documents: markdown + YAML frontmatter, in git, beside the thing they describe. Conformance costs three fields (`type`, `title`, `description`) and buys interoperability — any OKF-speaking tool or agent can read this repo's knowledge without a bespoke parser. The repo root `index.md` is the bundle root (it carries `okf_version`), and each directory `index.md` is OKF's reserved directory listing.
 
+Scope note: it is the *knowledge documents* that are conformant, not the repository as a whole — `README.md`, `CLAUDE.md`, and the specs and plans under `docs/` have no frontmatter. `scripts/gen-okf.py --export` is what emits a strictly conformant bundle.
+
 OKF's `timestamp` (last meaningful change) is deliberately **not** stored in these files — it would go stale on every commit. `scripts/gen-okf.py --export` derives it from `git log` when emitting a standalone bundle. `last_reviewed` stays the separate, human attestation: *someone vouched for this*, not *this changed*.
 
 ## Frontmatter schema (docs.md / runbook.md)


### PR DESCRIPTION
Follow-up to #392. Docs and comments only — no behavior change.

A post-merge audit against the OKF v0.1 spec surfaced two accuracy problems. This fixes both.

## 1. The bundle root overstated its conformance claim

`index.md` said "This repository is an Open Knowledge Format bundle." Read against spec §9 — *every* non-reserved `.md` carries parseable frontmatter — that is false. 136 tracked markdown files have none: `README.md`, `CLAUDE.md`, and 61 files under `docs/superpowers/`.

The claim is now scoped to what is actually true and independently verified: the repo's **knowledge documents** are conformant, and `gen-okf.py --export` emits a strictly conformant bundle. The root now states plainly that the repository as a whole is not one, and does not try to be.

I introduced that line in #392, so this is my correction rather than a pre-existing issue.

## 2. TechDocs sits a concept document on an OKF reserved filename

Each `base-apps/<app>/docs/index.md` is a copy of `docs.md` — a concept document — but OKF reserves `index.md` for directory listings. That is 18 files.

MkDocs requires that name for the nav root, so the collision stays; this PR records it in `gen-techdocs.py` next to the existing rationale for why the files are copies. It is contained, and I verified that: `gen-okf.py --export` reads `base-apps/<app>/docs.md|runbook.md` directly and never descends into `docs/`, so no copy reaches a bundle. The exported bundle contains exactly 4 `index.md` files, all genuine directory listings. A strict OKF consumer crawling the repo *in place* rather than consuming an export would misread those 18 files.

## Verification

The conformance audit was written separately from `validate-agent-docs.py` and checks the spec's §9 rules directly, so it tests the claim rather than restating our own validator's opinion.

- [x] Exported bundle: **conformant** — 36 concept documents each with non-empty `type`, 4 directory listings, `okf_version: 0.1` declared
- [x] In-place knowledge documents: **conformant**
- [x] `validate-agent-docs.py`, `validate-catalog-refs.py`, `gen-techdocs.py --check`, `gen-okf.py --check` — all pass
- [x] `pytest tests/` — 146 passed

## Still unverified

No cluster access from my environment, so I could not confirm Argo CD has synced #392's correction to the `homelab-knowledge` agent's system message, nor that Backstage TechDocs still renders after the frontmatter change. Both should follow from the merge, but worth a glance at the Argo UI and one app's Docs tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNo1Yp3YCPcB2S18XXALwV
