### PR TITLE
chore(backstage): deploy v1.4.9 (catalog-graph tile fix)

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.8
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.9
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Bumps backstage-portal v1.4.8 -> v1.4.9. Fixes the home-page Catalog Graph tile: it now seeds the standalone graph with domain roots (rootEntityRefs[]=domain:default/platform&products) so it opens on a populated graph instead of an empty canvas.

Pairs with the tile change on arigsela/backstage#39 (branch homepage, commit a81e362). Image is linux/amd64, in ECR.

After merge: Argo rolls the pod to v1.4.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b