### PR TITLE
feat(backstage): New Application scaffolder template + deploy v1.4.11

### DIFF
--- a/.github/workflows/okf-autosync.yaml
+++ b/.github/workflows/okf-autosync.yaml
@@ -5,6 +5,9 @@ on:
     paths: ['base-apps/**']
 permissions:
   contents: write
+concurrency:
+  group: okf-autosync-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
 jobs:
   autosync:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/okf-autosync.yaml
+++ b/.github/workflows/okf-autosync.yaml
@@ -1,0 +1,40 @@
+name: OKF Auto-Sync
+on:
+  pull_request:
+    branches: [main]
+    paths: ['base-apps/**']
+permissions:
+  contents: write
+jobs:
+  autosync:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml==6.0.2
+      - name: Regenerate base-apps/index.md + sync scope
+        run: |
+          python scripts/gen-okf.py --repo-root .
+          for d in base-apps/*/; do
+            app=$(basename "$d")
+            if [ -f "$d/docs.md" ] && [ -f "$d/runbook.md" ] && [ -f "$d/catalog-info.yaml" ]; then
+              grep -qxF "$app" scripts/agent-docs-scope.txt || echo "$app" >> scripts/agent-docs-scope.txt
+            fi
+          done
+      - name: Commit + push if changed
+        run: |
+          if [ -n "$(git status --porcelain base-apps/index.md scripts/agent-docs-scope.txt)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add base-apps/index.md scripts/agent-docs-scope.txt
+            git commit -m "chore(okf): auto-sync index + scope for base-apps change"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "nothing to sync"
+          fi

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -142,6 +142,23 @@ jobs:
       - name: Check TechDocs scaffolding is in sync with docs.md/runbook.md
         run: python scripts/gen-techdocs.py --repo-root . --check
 
+  new-app-template-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: |
+          pip install pyyaml==6.0.2 pytest==8.3.3 jinja2==3.1.4
+          curl -sL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
+          pip install yamllint==1.35.1
+      - name: Render the template and run the repo validators on the output
+        run: python -m pytest tests/new-app-template/ -q
+
   okf-validate:
     runs-on: ubuntu-latest
     steps:

--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.10
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.11
         imagePullPolicy: Always
         ports:
         - containerPort: 7007

--- a/docs/superpowers/plans/2026-07-20-backstage-new-app-template.md
+++ b/docs/superpowers/plans/2026-07-20-backstage-new-app-template.md
@@ -720,7 +720,54 @@ git commit -m "$(printf 'feat(new-app): conditional ingress/secrets/config skele
 
 ---
 
-## Task 4: CI job + backstage location + delivery
+## Task 4: OKF auto-sync workflow + CI job + backstage location + delivery
+
+- [ ] **Step 0: Add the OKF auto-sync workflow** — create `.github/workflows/okf-autosync.yaml`. On a PR touching `base-apps/**` (same-repo only), regenerate `base-apps/index.md` + sync `agent-docs-scope.txt`, and push back to the PR branch so scaffolded (and hand-added) apps reach green with no manual step:
+
+```yaml
+name: OKF Auto-Sync
+on:
+  pull_request:
+    branches: [main]
+    paths: ['base-apps/**']
+permissions:
+  contents: write
+jobs:
+  autosync:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml==6.0.2
+      - name: Regenerate base-apps/index.md + sync scope
+        run: |
+          python scripts/gen-okf.py --repo-root .
+          for d in base-apps/*/; do
+            app=$(basename "$d")
+            if [ -f "$d/docs.md" ] && [ -f "$d/runbook.md" ] && [ -f "$d/catalog-info.yaml" ]; then
+              grep -qxF "$app" scripts/agent-docs-scope.txt || echo "$app" >> scripts/agent-docs-scope.txt
+            fi
+          done
+      - name: Commit + push if changed
+        run: |
+          if [ -n "$(git status --porcelain base-apps/index.md scripts/agent-docs-scope.txt)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add base-apps/index.md scripts/agent-docs-scope.txt
+            git commit -m "chore(okf): auto-sync index + scope for base-apps change"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "nothing to sync"
+          fi
+```
+
+Idempotent (the follow-up `synchronize` event re-runs but changes nothing → no loop). Also convert `templates/new-app/template.yaml` to block-style YAML where it currently uses flow `{ }` (cosmetic; not CI-gated but matches repo convention).
 
 - [ ] **Step 1: Add the `new-app-template-validate` CI job** to `.github/workflows/validate.yaml` (after `techdocs-validate`):
 

--- a/docs/superpowers/plans/2026-07-20-backstage-new-app-template.md
+++ b/docs/superpowers/plans/2026-07-20-backstage-new-app-template.md
@@ -1,0 +1,783 @@
+# New Application Golden-Path Template — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Backstage scaffolder template (`templates/new-app/`) that renders a complete `base-apps/<app>/` GitOps app and opens a PR to `arigsela/kubernetes` — correct-by-construction against every CI gate.
+
+**Architecture:** `kind: Template` + Nunjucks `skeleton*/` dirs, delivered via `publish:github:pull-request`. A local **render-test harness** (Python + Jinja2 mimicking Backstage's `${{ }}` delimiters) renders the skeleton with sample inputs and runs the repo's own validators, proving the generated PR is green before any deploy. The template + skeleton live in the kubernetes repo (url `catalog.location`); a one-time backstage-image change registers the location.
+
+**Tech Stack:** Backstage scaffolder (Nunjucks), Python 3.12 + Jinja2 + pytest (render harness), the repo's existing validators, GitHub Actions.
+
+## Global Constraints
+
+- **Skeleton templating syntax** (Backstage Nunjucks): variables `${{ values.x }}`; control flow `{% if values.x %}…{% endif %}`, `{% for k, v in values.map %}`. Stay within this common subset (also valid in Jinja2) so the render harness is a faithful proxy. Templated **file/dir names** use `${{ values.name }}` literally in the path.
+- **The rendered output MUST pass every gate** in `.github/workflows/validate.yaml`: `yaml-lint` (block-style, 2-space indent), `kubernetes-validate` (kubeconform; `mkdocs.yml` skipped), `ingress-policy` (Ingress needs `nginx.ingress.kubernetes.io/whitelist-source-range`), `agent-docs-validate`, `techdocs-validate` (`gen-techdocs.py --check`), `catalog-refs-validate`.
+- **Base the skeleton on real manifests** (do not invent shapes): `base-apps/dex/{deployment,service,ingress,secret-store,external-secret,configmap}.yaml`, `base-apps/dex.yaml` (Argo App with `directory.exclude: '{catalog-info.yaml,mkdocs.yml}'`), `templates/agent-docs/{catalog-info.yaml,docs.md,runbook.md}` (frontmatter contract), and `scripts/gen-techdocs.py`'s `MKDOCS_TEMPLATE`.
+- **Publish syntax** (mirror the removed application template): `publish:github:pull-request`, `repoUrl: github.com?repo=kubernetes&owner=arigsela`, output `${{ steps.publish.output.remoteUrl }}`.
+- **`docs/index.md` == `docs.md` and `docs/runbook.md` == `runbook.md`** byte-for-byte (rendered from identical skeleton content) so `gen-techdocs.py --check` passes.
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b`.
+
+## File Structure
+
+**kubernetes repo** (branch `backstage-new-app-template`):
+- Create `templates/new-app/template.yaml` — the `kind: Template`.
+- Create `templates/new-app/skeleton/…` — core files (templated names):
+  `base-apps/${{ values.name }}.yaml`, and under `base-apps/${{ values.name }}/`:
+  `deployments.yaml`, `services.yaml`, `catalog-info.yaml`, `docs.md`, `runbook.md`,
+  `mkdocs.yml`, `docs/index.md`, `docs/runbook.md`.
+- Create `templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml`.
+- Create `templates/new-app/skeleton-secrets/base-apps/${{ values.name }}/{secret-store.yaml,external-secret.yaml}`.
+- Create `templates/new-app/skeleton-config/base-apps/${{ values.name }}/configmap.yaml`.
+- Create `scripts/render-new-app.py` — render harness (Jinja2, `${{ }}` delimiters, templated paths, conditional skeleton dirs).
+- Create `tests/new-app-template/test_render_new_app.py` — pytest: render canonical samples → run validators → assert green.
+- Modify `.github/workflows/validate.yaml` — add a `new-app-template-validate` job.
+
+**backstage repo** (branch `new-app-template-location`, one-time):
+- Modify `app-config.yaml` + `app-config.production.yaml` — add the url `catalog.location` for the template.
+
+---
+
+## Task 1: Render-test harness
+
+The gate for everything else: render a skeleton dir (+ conditional dirs) with values, into an output tree, mirroring Backstage's `fetch:template` (templated paths + `${{ }}`/`{% if %}`).
+
+**Files:**
+- Create: `scripts/render-new-app.py`
+- Create: `tests/new-app-template/test_render_new_app.py`
+
+**Interfaces:**
+- Produces: `render(skeleton_dirs: list[Path], values: dict, out_dir: Path) -> list[Path]` — renders each skeleton dir into `out_dir`, templating file/dir names and contents; returns written paths. CLI: `python3 scripts/render-new-app.py --template templates/new-app --values <json> --out <dir> [--ingress] [--secrets] [--config]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/new-app-template/test_render_new_app.py`:
+
+```python
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "render-new-app.py"
+_spec = importlib.util.spec_from_file_location("render_new_app", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+REPO = Path(__file__).resolve().parents[2]
+SKEL = REPO / "templates" / "new-app"
+
+SAMPLE = {
+    "name": "sample-app",
+    "description": "A sample scaffolded app.",
+    "image": "nginx:1.27",
+    "containerPort": 8080,
+    "replicas": 1,
+    "namespace": "sample-app",
+    "system": "default/platform-tooling",
+    "owner": "group:default/platform",
+    "tags": ["nginx"],
+    "exposeIngress": True,
+    "host": "sample-app",
+    "needsConfig": True,
+    "configData": {"LOG_LEVEL": "info"},
+    "needsSecrets": True,
+    "cpuRequest": "100m", "cpuLimit": "500m",
+    "memRequest": "128Mi", "memLimit": "256Mi",
+}
+
+
+def _render(tmp: Path, values: dict, ingress: bool, secrets: bool, config: bool) -> Path:
+    dirs = [SKEL / "skeleton"]
+    if ingress:
+        dirs.append(SKEL / "skeleton-ingress")
+    if secrets:
+        dirs.append(SKEL / "skeleton-secrets")
+    if config:
+        dirs.append(SKEL / "skeleton-config")
+    mod.render(dirs, values, tmp)
+    return tmp
+
+
+def test_render_produces_expected_files(tmp_path):
+    _render(tmp_path, SAMPLE, True, True, True)
+    app = tmp_path / "base-apps" / "sample-app"
+    assert (tmp_path / "base-apps" / "sample-app.yaml").is_file()
+    for f in ["deployments.yaml", "services.yaml", "catalog-info.yaml", "docs.md",
+              "runbook.md", "mkdocs.yml", "docs/index.md", "docs/runbook.md",
+              "nginx-ingress.yaml", "secret-store.yaml", "external-secret.yaml",
+              "configmap.yaml"]:
+        assert (app / f).is_file(), f"missing {f}"
+    # techdocs copies must equal the canonical docs (gen-techdocs --check contract)
+    assert (app / "docs" / "index.md").read_text() == (app / "docs.md").read_text()
+    assert (app / "docs" / "runbook.md").read_text() == (app / "runbook.md").read_text()
+    # no un-rendered template markers remain
+    for p in app.rglob("*"):
+        if p.is_file():
+            assert "${{" not in p.read_text() and "{%" not in p.read_text(), f"unrendered: {p}"
+
+
+def test_rendered_output_passes_repo_validators(tmp_path):
+    # Render into a throwaway COPY of the repo so the real validators run against it.
+    import shutil
+    work = tmp_path / "repo"
+    shutil.copytree(REPO, work, ignore=shutil.ignore_patterns(
+        ".git", "node_modules", ".superpowers", "base-apps"), dirs_exist_ok=False)
+    # Bring base-apps but only the taxonomy + a couple deps the sample refs need.
+    (work / "base-apps").mkdir(exist_ok=True)
+    shutil.copytree(REPO / "catalog", work / "catalog", dirs_exist_ok=True)
+    for dep in ["vault"]:
+        shutil.copytree(REPO / "base-apps" / dep, work / "base-apps" / dep, dirs_exist_ok=True)
+    dirs = [SKEL / "skeleton", SKEL / "skeleton-ingress", SKEL / "skeleton-secrets", SKEL / "skeleton-config"]
+    mod.render(dirs, SAMPLE, work)
+    app = work / "base-apps" / "sample-app"
+
+    # yamllint (block style)
+    r = subprocess.run(["yamllint", "-c", str(REPO / ".yamllint.yaml")] +
+                       [str(p) for p in app.rglob("*.yaml")] + [str(work / "base-apps" / "sample-app.yaml")],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, f"yamllint:\n{r.stdout}\n{r.stderr}"
+    # gen-techdocs --check (docs/ copies in sync)
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "gen-techdocs.py"),
+                        "--repo-root", str(work), "--check"], capture_output=True, text=True)
+    assert r.returncode == 0, f"gen-techdocs:\n{r.stdout}"
+    # agent-docs contract
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "validate-agent-docs.py"),
+                        "--repo-root", str(work)], capture_output=True, text=True)
+    assert r.returncode == 0, f"agent-docs:\n{r.stdout}"
+    # ingress whitelist gate
+    ing = (app / "nginx-ingress.yaml").read_text()
+    assert "whitelist-source-range" in ing
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/arisela/git/kubernetes && python3 -m pytest tests/new-app-template/ -q`
+Expected: FAIL — `render-new-app.py` and the skeleton don't exist yet.
+
+- [ ] **Step 3: Write the render harness**
+
+Create `scripts/render-new-app.py`:
+
+```python
+#!/usr/bin/env python3
+"""Render the new-app scaffolder skeleton locally (proxy for Backstage's
+fetch:template) so the output can be run through the repo's CI validators.
+
+Backstage uses Nunjucks with variable delimiters `${{ }}`; Jinja2 configured the
+same way renders the common subset we use (variables, {% if %}, {% for %}) and
+templated file/dir NAMES. This is a faithful pre-deploy proxy; the authoritative
+check remains Backstage's template-editor dry-run.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from jinja2 import Environment, StrictUndefined
+
+_ENV = Environment(
+    variable_start_string="${{",
+    variable_end_string="}}",
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+
+
+def _render_str(text, values):
+    return _ENV.from_string(text).render(values=values)
+
+
+def render(skeleton_dirs, values, out_dir):
+    """Render each skeleton dir into out_dir. Templates both file/dir names and
+    file contents. Returns the list of written file paths."""
+    written = []
+    out_dir = Path(out_dir)
+    for skel in skeleton_dirs:
+        skel = Path(skel)
+        for src in sorted(skel.rglob("*")):
+            if src.is_dir():
+                continue
+            rel = src.relative_to(skel)
+            # template each path segment (handles ${{ values.name }} in names)
+            rel_rendered = Path(*[_render_str(part, values) for part in rel.parts])
+            dst = out_dir / rel_rendered
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(_render_str(src.read_text(), values))
+            written.append(dst)
+    return written
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--template", required=True, help="templates/new-app dir")
+    ap.add_argument("--values", required=True, help="JSON of parameter values")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--ingress", action="store_true")
+    ap.add_argument("--secrets", action="store_true")
+    ap.add_argument("--config", action="store_true")
+    args = ap.parse_args()
+    tmpl = Path(args.template)
+    dirs = [tmpl / "skeleton"]
+    if args.ingress:
+        dirs.append(tmpl / "skeleton-ingress")
+    if args.secrets:
+        dirs.append(tmpl / "skeleton-secrets")
+    if args.config:
+        dirs.append(tmpl / "skeleton-config")
+    n = render(dirs, json.loads(args.values), Path(args.out))
+    print(f"rendered {len(n)} files to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Create a minimal fixture skeleton to make Step-1's first test pass structurally**
+
+(Real skeleton comes in Tasks 2–3; but the harness must be provably correct now. Add a throwaway fixture and a focused harness unit test.)
+
+Create `tests/new-app-template/test_harness_unit.py`:
+
+```python
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "render-new-app.py"
+_spec = importlib.util.spec_from_file_location("render_new_app", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def test_templated_paths_and_content(tmp_path):
+    skel = tmp_path / "skel"
+    (skel / "base-apps" / "${{ values.name }}").mkdir(parents=True)
+    (skel / "base-apps" / "${{ values.name }}.yaml").write_text("name: ${{ values.name }}\n")
+    (skel / "base-apps" / "${{ values.name }}" / "f.yaml").write_text(
+        "{% if values.on %}on: true{% endif %}\n")
+    out = tmp_path / "out"
+    mod.render([skel], {"name": "foo", "on": True}, out)
+    assert (out / "base-apps" / "foo.yaml").read_text() == "name: foo\n"
+    assert (out / "base-apps" / "foo" / "f.yaml").read_text() == "on: true\n"
+```
+
+- [ ] **Step 5: Run the harness unit test to verify it passes**
+
+Run: `cd /Users/arisela/git/kubernetes && pip install jinja2 >/dev/null 2>&1; python3 -m pytest tests/new-app-template/test_harness_unit.py -q`
+Expected: PASS. (The full `test_render_new_app.py` still fails until Tasks 2–3 create the real skeleton — that's expected.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git add scripts/render-new-app.py tests/new-app-template/
+git commit -m "$(printf 'feat(new-app): render-test harness for the scaffolder skeleton\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+```
+
+---
+
+## Task 2: template.yaml + core skeleton
+
+**Files:** create `templates/new-app/template.yaml` + the 9 core `skeleton/` files.
+
+**Interfaces:** Consumes the render harness (Task 1) for testing. Produces the template + core skeleton that Task 3 extends and Task 4 registers.
+
+- [ ] **Step 1: Write `templates/new-app/template.yaml`**
+
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: new-application
+  title: New Application
+  description: Scaffold a complete base-apps GitOps app and open a PR.
+  tags: [recommended, gitops, base-apps]
+spec:
+  type: service
+  owner: group:default/platform
+  parameters:
+    - title: Identity
+      required: [name, description, system]
+      properties:
+        name:
+          title: Name
+          type: string
+          description: kebab-case app name (also the dir + namespace default)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+        description:
+          title: Description
+          type: string
+        system:
+          title: System
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind: System
+        owner:
+          title: Owner
+          type: string
+          default: group:default/platform
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind: [Group, User]
+        tags:
+          title: Tags
+          type: array
+          items: { type: string }
+    - title: Workload
+      required: [image, containerPort]
+      properties:
+        image: { title: Container image, type: string }
+        containerPort: { title: Container port, type: integer, default: 8080 }
+        replicas: { title: Replicas, type: integer, default: 1 }
+        namespace:
+          title: Namespace
+          type: string
+          description: defaults to the app name
+    - title: Networking & Config
+      properties:
+        exposeIngress: { title: Expose via nginx Ingress, type: boolean, default: false }
+        host:
+          title: Ingress host label (<host>.arigsela.com)
+          type: string
+        needsConfig: { title: Add a ConfigMap (envFrom), type: boolean, default: false }
+        needsSecrets: { title: Add Vault SecretStore + ExternalSecret, type: boolean, default: false }
+    - title: Resources
+      properties:
+        cpuRequest: { title: CPU request, type: string, default: 100m }
+        cpuLimit: { title: CPU limit, type: string, default: 500m }
+        memRequest: { title: Memory request, type: string, default: 128Mi }
+        memLimit: { title: Memory limit, type: string, default: 256Mi }
+  steps:
+    - id: fetch-core
+      name: Render core
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values: &vals
+          name: ${{ parameters.name }}
+          description: ${{ parameters.description }}
+          image: ${{ parameters.image }}
+          containerPort: ${{ parameters.containerPort }}
+          replicas: ${{ parameters.replicas }}
+          namespace: ${{ parameters.namespace if parameters.namespace else parameters.name }}
+          system: ${{ parameters.system }}
+          owner: ${{ parameters.owner }}
+          tags: ${{ parameters.tags }}
+          exposeIngress: ${{ parameters.exposeIngress }}
+          host: ${{ parameters.host }}
+          needsConfig: ${{ parameters.needsConfig }}
+          needsSecrets: ${{ parameters.needsSecrets }}
+          configData: ${{ parameters.configData if parameters.configData else {} }}
+          cpuRequest: ${{ parameters.cpuRequest }}
+          cpuLimit: ${{ parameters.cpuLimit }}
+          memRequest: ${{ parameters.memRequest }}
+          memLimit: ${{ parameters.memLimit }}
+    - id: fetch-ingress
+      name: Render ingress
+      if: ${{ parameters.exposeIngress }}
+      action: fetch:template
+      input: { url: ./skeleton-ingress, values: *vals }
+    - id: fetch-secrets
+      name: Render secrets
+      if: ${{ parameters.needsSecrets }}
+      action: fetch:template
+      input: { url: ./skeleton-secrets, values: *vals }
+    - id: fetch-config
+      name: Render config
+      if: ${{ parameters.needsConfig }}
+      action: fetch:template
+      input: { url: ./skeleton-config, values: *vals }
+    - id: publish
+      name: Open PR
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=kubernetes&owner=arigsela
+        branchName: new-app/${{ parameters.name }}
+        title: "feat(${{ parameters.name }}): onboard new application"
+        description: |
+          Scaffolded via the New Application template.
+          System: ${{ parameters.system }} · Owner: ${{ parameters.owner }}
+  output:
+    links:
+      - title: Pull request
+        url: ${{ steps.publish.output.remoteUrl }}
+```
+
+> Note: `configData` isn't a top-level parameter above (a key/value map field needs a custom field or a JSON textarea). For v1, add a `configData` object property under "Networking & Config" as `type: object` with `additionalProperties: {type: string}`; the render harness already accepts it. Keep the `values` mapping as written.
+
+- [ ] **Step 2: Write the 9 core skeleton files**
+
+Create each under `templates/new-app/skeleton/`, templatizing the real manifests (Global Constraints list the sources). Key ones:
+
+`base-apps/${{ values.name }}.yaml` (from `base-apps/dex.yaml`):
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: ${{ values.name }}
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/${{ values.name }}
+    directory:
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{ values.namespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+`base-apps/${{ values.name }}/deployments.yaml` (generic; `envFrom` only if `needsConfig`; tcpSocket probes to avoid assuming a health path):
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  labels:
+    app: ${{ values.name }}
+spec:
+  replicas: ${{ values.replicas }}
+  selector:
+    matchLabels:
+      app: ${{ values.name }}
+  template:
+    metadata:
+      labels:
+        app: ${{ values.name }}
+    spec:
+      containers:
+        - name: ${{ values.name }}
+          image: ${{ values.image }}
+          ports:
+            - name: http
+              containerPort: ${{ values.containerPort }}
+{% if values.needsConfig %}          envFrom:
+            - configMapRef:
+                name: ${{ values.name }}-config
+{% endif %}          resources:
+            requests:
+              cpu: ${{ values.cpuRequest }}
+              memory: ${{ values.memRequest }}
+            limits:
+              cpu: ${{ values.cpuLimit }}
+              memory: ${{ values.memLimit }}
+          readinessProbe:
+            tcpSocket:
+              port: ${{ values.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+```
+
+`base-apps/${{ values.name }}/services.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  labels:
+    app: ${{ values.name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: ${{ values.name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: ${{ values.containerPort }}
+```
+
+`base-apps/${{ values.name }}/catalog-info.yaml` (from `templates/agent-docs/catalog-info.yaml`; `dependsOn` vault only if `needsSecrets`):
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=${{ values.name }}'
+    backstage.io/kubernetes-namespace: ${{ values.namespace }}
+  tags: ${{ values.tags }}
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner }}
+  system: ${{ values.system }}
+{% if values.needsSecrets %}  dependsOn:
+    - resource:vault/vault
+{% endif %}
+```
+
+`base-apps/${{ values.name }}/docs.md` and `docs/index.md` (identical; from `templates/agent-docs/docs.md`):
+
+```markdown
+---
+type: "Kubernetes App Guide"
+title: "${{ values.name }}"
+description: "${{ values.description }}"
+app: ${{ values.name }}
+catalog_entity: ${{ values.name }}
+kind: docs
+namespace: ${{ values.namespace }}
+last_reviewed: 2026-07-20
+status: current
+tags: ${{ values.tags }}
+sources:
+  - base-apps/${{ values.name }}/deployments.yaml
+---
+
+# ${{ values.name }}
+
+## What it is
+${{ values.description }}
+
+## Architecture & data flow
+_Fill in: how requests flow, dependencies, config sources._
+
+## Where config lives
+- Manifests: `base-apps/${{ values.name }}/`
+```
+
+`base-apps/${{ values.name }}/runbook.md` and `docs/runbook.md` (identical; from `templates/agent-docs/runbook.md`): same frontmatter with `type: "Kubernetes App Runbook"`, `title: "${{ values.name }} — Runbook"`, `kind: runbook`, then starter `## Failure modes` / `## Checks` / `## Fixes` sections.
+
+`base-apps/${{ values.name }}/mkdocs.yml` (exactly `gen-techdocs.py`'s `MKDOCS_TEMPLATE` with `site_name: ${{ values.name }}`):
+
+```yaml
+site_name: ${{ values.name }}
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core
+```
+
+- [ ] **Step 3: Render + validate against sample values**
+
+Run:
+```bash
+cd /Users/arisela/git/kubernetes
+pip install jinja2 >/dev/null 2>&1
+python3 -m pytest tests/new-app-template/ -q
+```
+Expected: PASS — including `test_rendered_output_passes_repo_validators` (yamllint, gen-techdocs --check, agent-docs, ingress whitelist all green on the rendered sample). Fix skeleton whitespace/indent until green (block-style YAML; watch the `{% if %}` indentation so the rendered YAML stays 2-space correct).
+
+- [ ] **Step 4: Confirm no un-rendered markers + catalog refs resolve**
+
+Run:
+```bash
+cd /Users/arisela/git/kubernetes
+python3 scripts/render-new-app.py --template templates/new-app --values '{"name":"sample-app","description":"x","image":"nginx","containerPort":8080,"replicas":1,"namespace":"sample-app","system":"default/platform-tooling","owner":"group:default/platform","tags":["nginx"],"needsConfig":false,"needsSecrets":true,"cpuRequest":"100m","cpuLimit":"500m","memRequest":"128Mi","memLimit":"256Mi"}' --out /tmp/na --secrets
+grep -RnE '\$\{\{|\{%' /tmp/na && echo "UNRENDERED!" || echo "clean"
+```
+Expected: `clean`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git add templates/new-app/template.yaml templates/new-app/skeleton/
+git commit -m "$(printf 'feat(new-app): template.yaml + core skeleton\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+```
+
+---
+
+## Task 3: Conditional skeletons (ingress / secrets / config)
+
+**Files:** `templates/new-app/skeleton-ingress/…`, `skeleton-secrets/…`, `skeleton-config/…`.
+
+- [ ] **Step 1: `skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml`** (from `base-apps/dex/ingress.yaml`; MUST keep `whitelist-source-range`):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ${{ values.host }}.arigsela.com
+      secretName: ${{ values.name }}-tls
+  rules:
+    - host: ${{ values.host }}.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ${{ values.name }}
+                port:
+                  number: 80
+```
+
+> The default `whitelist-source-range` is `10.0.0.0/8` (internal). Note in the PR body that the author should widen it to their home IPs if the app must be reachable externally (see `base-apps/dex/ingress.yaml` for the standard allowlist).
+
+- [ ] **Step 2: `skeleton-secrets/base-apps/${{ values.name }}/secret-store.yaml`** (from dex; role = namespace):
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: ${{ values.namespace }}
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "${{ values.namespace }}"
+          serviceAccountRef:
+            name: "default"
+```
+
+- [ ] **Step 3: `skeleton-secrets/base-apps/${{ values.name }}/external-secret.yaml`** (generic; `dataFrom` extract pulls all properties under the Vault key `<name>`):
+
+```yaml
+# Seed the Vault key k8s-secrets/${{ values.name }} with your app's secrets;
+# every property under it is synced into the ${{ values.name }}-secrets Secret.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ${{ values.name }}-secrets
+  namespace: ${{ values.namespace }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: ${{ values.name }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ${{ values.name }}
+```
+
+- [ ] **Step 4: `skeleton-config/base-apps/${{ values.name }}/configmap.yaml`** (from `configData` map):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ values.name }}-config
+  namespace: ${{ values.namespace }}
+data:
+{% for k, v in values.configData.items() %}  ${{ k }}: "${{ v }}"
+{% endfor %}
+```
+
+- [ ] **Step 5: Full render + validate (all toggles on)**
+
+Run: `cd /Users/arisela/git/kubernetes && python3 -m pytest tests/new-app-template/ -q`
+Expected: PASS — `test_render_produces_expected_files` (all 12 files) and `test_rendered_output_passes_repo_validators` green with ingress+secrets+config. Also run kubeconform on the rendered manifests:
+```bash
+python3 scripts/render-new-app.py --template templates/new-app --values '{"name":"sample-app","description":"x","image":"nginx:1.27","containerPort":8080,"replicas":1,"namespace":"sample-app","system":"default/platform-tooling","owner":"group:default/platform","tags":["nginx"],"needsConfig":true,"configData":{"LOG_LEVEL":"info"},"needsSecrets":true,"exposeIngress":true,"host":"sample-app","cpuRequest":"100m","cpuLimit":"500m","memRequest":"128Mi","memLimit":"256Mi"}' --out /tmp/na2 --ingress --secrets --config
+find /tmp/na2/base-apps -name '*.yaml' ! -name 'mkdocs.yml' ! -name 'catalog-info.yaml' | xargs kubeconform -strict -ignore-missing-schemas -summary
+```
+Expected: kubeconform reports the Deployment/Service/Ingress/ConfigMap/SecretStore/ExternalSecret Valid or Skipped, 0 Errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git add templates/new-app/skeleton-ingress templates/new-app/skeleton-secrets templates/new-app/skeleton-config
+git commit -m "$(printf 'feat(new-app): conditional ingress/secrets/config skeletons\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+```
+
+---
+
+## Task 4: CI job + backstage location + delivery
+
+- [ ] **Step 1: Add the `new-app-template-validate` CI job** to `.github/workflows/validate.yaml` (after `techdocs-validate`):
+
+```yaml
+  new-app-template-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: |
+          pip install pyyaml==6.0.2 pytest==8.3.3 jinja2==3.1.4
+          curl -sL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
+          pip install yamllint==1.35.1
+      - name: Render the template and run the repo validators on the output
+        run: python -m pytest tests/new-app-template/ -q
+```
+
+- [ ] **Step 2: Commit (kubernetes) + run the full validator sweep**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git add .github/workflows/validate.yaml
+git commit -m "$(printf 'ci(new-app): render + validate the scaffolder skeleton\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+python3 -m pytest tests/new-app-template/ tests/techdocs/ tests/catalog-refs/ -q
+```
+
+- [ ] **Step 3: Register the location in backstage config** (branch `new-app-template-location` in `/Users/arisela/git/backstage`, from `homepage` — the deployed source of truth; verify with `git log`):
+
+In `app-config.yaml` (after the api-entities url location) and `app-config.production.yaml` (matching spot), add:
+
+```yaml
+    # New Application golden-path scaffolder template (arigsela/kubernetes).
+    - type: url
+      target: https://github.com/arigsela/kubernetes/blob/main/templates/new-app/template.yaml
+      rules:
+        - allow: [Template]
+```
+
+Validate: `yarn backstage-cli config:check --lax` → no errors. Commit.
+
+**Delivery (controller):** build **v1.4.11** from the backstage branch (`yarn build:all` → `docker buildx build --platform linux/amd64 --push --provenance=false` → confirm `linux/amd64`); open the backstage PR; open a kubernetes PR bumping `deployments.yaml` to v1.4.11.
+
+---
+
+## Task 5: Post-deploy verification (manual)
+
+- [ ] **Step 1:** After deploy, open Backstage **Create** → "New Application" → fill the form → **Dry Run** (template editor) with all toggles on. Confirm the rendered files match the local harness output (no errors).
+- [ ] **Step 2:** Do a real run → it opens a PR on `arigsela/kubernetes`. Confirm that PR's CI (all gates) is **green with no manual fixes**.
+- [ ] **Step 3:** Merge the test PR → Argo creates the app; Backstage ingests the Component (catalog-info + Docs tab). Then clean up the test app if desired.
+
+## Self-Review
+
+- **Spec coverage:** form/steps → Task 2 template.yaml; core files → Task 2; conditionals → Task 3; correct-by-construction proof → Task 1 harness + Task 4 CI job; location + delivery → Task 4; dry-run/PR/merge verification → Task 5. All spec sections covered.
+- **Placeholder scan:** complete code for the harness, template.yaml, and every skeleton file; `configData` field caveat called out explicitly (not a TODO).
+- **Consistency:** `render(skeleton_dirs, values, out_dir)` signature used identically in harness + both tests; `docs/index.md`==`docs.md` and `docs/runbook.md`==`runbook.md` enforced by the test; `${{ }}`/`{% %}` subset used throughout; `repoUrl`/`remoteUrl` mirror the real application template.

--- a/docs/superpowers/specs/2026-07-20-backstage-new-app-template-design.md
+++ b/docs/superpowers/specs/2026-07-20-backstage-new-app-template-design.md
@@ -1,0 +1,145 @@
+# Design: Backstage "New Application" golden-path template
+
+**Date:** 2026-07-20
+**Status:** design — pending user review
+**Topic:** A Backstage scaffolder template that generates a complete `base-apps/<app>/`
+GitOps application (matching every repo convention) and opens a PR to
+`arigsela/kubernetes`.
+
+## Goal
+
+Turn "create a new base-apps service" from a manual, convention-remembering chore
+into a form → PR. The generated PR is **correct-by-construction**: it passes every
+CI gate in the kubernetes repo (agent-docs, techdocs, catalog-refs, ingress-policy,
+yamllint, kubeconform) and follows the base-apps + agent-docs + TechDocs + secret
+conventions without the author re-deriving them.
+
+## Decisions (settled during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Mechanism | `kind: Template` + `skeleton/`, `publish:github:pull-request` to `arigsela/kubernetes` |
+| Template location | **kubernetes repo** `templates/new-app/`, registered via a url `catalog.location` (future edits are GitOps, no image) |
+| Workload | **Stateless HTTP service** (Deployment + Service) |
+| Optional pieces (form toggles) | **Ingress, Vault secrets, Config (ConfigMap+envFrom), Resource requests/limits** |
+| Publish | PR only (Backstage's built-in editor dry-run covers testing) |
+| No cluster mutation | The template only opens a PR; Argo deploys after merge |
+
+## Grounding (verified)
+
+- Scaffolder actions available: `fetch:template`, `publish:github:pull-request`
+  (`@backstage/plugin-scaffolder-backend-module-github`), GitHub integration token
+  with repo scope. `EntityPicker` field is available (used in the prior kagent template).
+- Existing skeletons to mirror: `templates/agent-docs/{catalog-info.yaml,docs.md,runbook.md}`
+  (the agent-docs contract, `REPLACE_ME` style) and `templates/agent-identity/`.
+- The CI gates the output must pass (`.github/workflows/validate.yaml`):
+  `yaml-lint`, `kubernetes-validate` (kubeconform, skips `mkdocs.yml`), `ingress-policy`
+  (whitelist-source-range required on Ingress), `agent-docs-validate`,
+  `techdocs-validate` (`gen-techdocs.py --check`), `catalog-refs-validate`.
+- Base-apps convention (from real apps like `dex`, `whoami-test`): each app is
+  `base-apps/<app>.yaml` (Argo `Application`, namespace `argo-cd`, source path
+  `base-apps/<app>`, `syncPolicy.automated` prune+selfHeal, `CreateNamespace=true`,
+  and `directory.exclude` when it has catalog-info/mkdocs) + `base-apps/<app>/` manifests.
+
+## Form (parameters)
+
+Multi-step, mirroring the kagent template's style.
+
+- **Identity:** `name` (string, `pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`),
+  `description` (string, one line), `system` (`ui:field: EntityPicker`,
+  `catalogFilter.kind: System`), `owner` (`EntityPicker`, kind `[Group, User]`,
+  default `group:default/platform`), `tags` (array of strings).
+- **Workload:** `image` (string), `containerPort` (integer, default 8080),
+  `replicas` (integer, default 1), `namespace` (string, default `${{ parameters.name }}`).
+- **Networking & Config:**
+  - `exposeIngress` (boolean) → `host` (string, ingress at `<host>.arigsela.com`).
+  - `needsConfig` (boolean) → `configData` (map of string→string).
+  - `needsSecrets` (boolean).
+- **Resources:** `cpuRequest` / `cpuLimit` / `memRequest` / `memLimit` (strings,
+  prefilled defaults e.g. `100m`/`500m`/`128Mi`/`256Mi`).
+
+## Steps
+
+1. `fetch:template` — render the **core** `skeleton/` into the workspace with all
+   parameter values. Templated file/dir names produce `base-apps/${{ name }}.yaml`
+   and `base-apps/${{ name }}/...`.
+2. `fetch:template` (`if: ${{ parameters.exposeIngress }}`) — render `skeleton-ingress/`
+   (`nginx-ingress.yaml` with the whitelist annotation).
+3. `fetch:template` (`if: ${{ parameters.needsSecrets }}`) — render `skeleton-secrets/`
+   (`secret-store.yaml` + `external-secret.yaml`).
+4. `fetch:template` (`if: ${{ parameters.needsConfig }}`) — render `skeleton-config/`
+   (`configmap.yaml`; the Deployment already wires `envFrom` guarded by `needsConfig`).
+5. `publish:github:pull-request` — open a PR against `arigsela/kubernetes`
+   (`repoUrl: github.com?owner=arigsela&repo=kubernetes`), `branchName: new-app/${{ name }}`,
+   title `feat(<name>): onboard new application`, body summarizing inputs.
+
+Output: link to the PR. (No `catalog:register` — the discovery provider ingests the
+entity after the PR merges; registering from an unmerged branch is undesirable.)
+
+## Generated files
+
+**Core (always):**
+
+- `base-apps/<name>.yaml` — Argo `Application` (namespace `argo-cd`, source path
+  `base-apps/<name>`, destination namespace `<namespace>`, `syncPolicy.automated`
+  prune+selfHeal + `CreateNamespace=true`, `directory.exclude: '{catalog-info.yaml,mkdocs.yml}'`).
+- `base-apps/<name>/deployments.yaml` — Deployment (`app=<name>` labels, `image`,
+  `containerPort`, `replicas`, resource requests/limits, `envFrom` configmap only if `needsConfig`).
+- `base-apps/<name>/services.yaml` — Service (`port: 80` → `targetPort: containerPort`, ClusterIP).
+- `base-apps/<name>/catalog-info.yaml` — `Component` (annotations `agent-docs/path: docs.md`,
+  `backstage.io/techdocs-ref: dir:.`, `kubernetes-label-selector: app=<name>`,
+  `kubernetes-namespace: <namespace>`; spec `type: service`, `lifecycle: experimental`,
+  `owner`, `system`, `tags`, `dependsOn` incl. `resource:vault/vault` if `needsSecrets`).
+- `base-apps/<name>/docs.md` + `runbook.md` — agent-docs frontmatter contract
+  (type/title/description/app/catalog_entity/kind/namespace/last_reviewed/status/tags/sources)
+  + starter body sections.
+- `base-apps/<name>/mkdocs.yml` — TechDocs (`docs_dir: docs`, nav Overview/Runbook, `techdocs-core`).
+- `base-apps/<name>/docs/index.md` + `docs/runbook.md` — copies rendered **identical**
+  to `docs.md`/`runbook.md` (so `gen-techdocs.py --check` passes immediately).
+
+**Conditional:**
+
+- `nginx-ingress.yaml` — Ingress at `<host>.arigsela.com`, **with** `nginx.ingress.kubernetes.io/whitelist-source-range` (ingress-policy gate).
+- `secret-store.yaml` + `external-secret.yaml` — per-namespace `SecretStore` (Vault
+  `k8s-secrets` KV, role `<namespace>`) + `ExternalSecret`.
+- `configmap.yaml` — ConfigMap from `configData`.
+
+## Correct-by-construction (gate → how satisfied)
+
+| CI gate | How the skeleton satisfies it |
+|---|---|
+| `agent-docs-validate` | docs.md/runbook.md carry the full frontmatter; catalog-info kind ∈ {Component}; `agent-docs/path: docs.md` present; names consistent |
+| `techdocs-validate` (`gen-techdocs.py --check`) | mkdocs.yml + `docs/index.md` (=docs.md) + `docs/runbook.md` (=runbook.md) generated in-sync |
+| `catalog-refs-validate` | `owner`/`system` from EntityPickers resolve; `dependsOn` uses existing refs (vault) |
+| `ingress-policy` | Ingress includes `whitelist-source-range` |
+| `yaml-lint` | block-style YAML, 2-space indent |
+| `kubernetes-validate` | valid k8s manifests; `mkdocs.yml` skipped by the job's filter |
+| Argo sync | `directory.exclude: '{catalog-info.yaml,mkdocs.yml}'` so Argo never applies them |
+
+## Delivery
+
+1. **kubernetes repo:** add `templates/new-app/` (`template.yaml` + `skeleton*/` dirs).
+2. **backstage repo (one-time):** add a url `catalog.location` for
+   `https://github.com/arigsela/kubernetes/blob/main/templates/new-app/template.yaml`
+   with `rules: [allow: [Template]]` to `app-config.yaml` + `app-config.production.yaml`.
+   → build **v1.4.11** (linux/amd64) + a kubernetes deploy bump.
+3. After deploy, the template appears in Create. Future template/skeleton edits are
+   pure GitOps (catalog refresh on the 30-min discovery / location refresh).
+
+## Verification
+
+- Backstage template editor **dry-run** renders the skeleton for each toggle combination
+  without errors.
+- A real run opens a PR; that PR's CI (all gates above) goes green without manual fixes.
+- Merging the PR → Argo creates the app; Backstage ingests the Component (catalog-info +
+  Docs tab).
+
+## Risks / out of scope
+
+- Only stateless HTTP `Deployment`; StatefulSet/CronJob/Job deferred.
+- `system` must be an existing System (EntityPicker); onboarding a brand-new system is
+  a separate `platform-entities.yaml` edit.
+- No database provisioning (candidate B) or secret seeding (`vault:setup`) in this
+  template; `needsSecrets` only scaffolds the SecretStore/ExternalSecret wiring.
+- The skeleton's starter docs are stubs the author fills in; the frontmatter/structure
+  is correct, the prose is a starting point.

--- a/docs/superpowers/specs/2026-07-20-backstage-new-app-template-design.md
+++ b/docs/superpowers/specs/2026-07-20-backstage-new-app-template-design.md
@@ -116,6 +116,20 @@ entity after the PR merges; registering from an unmerged branch is undesirable.)
 | `kubernetes-validate` | valid k8s manifests; `mkdocs.yml` skipped by the job's filter |
 | Argo sync | `directory.exclude: '{catalog-info.yaml,mkdocs.yml}'` so Argo never applies them |
 
+## OKF index auto-sync (added after Task-2 review)
+
+A scaffolded PR adds a `base-apps/<app>/` dir, which trips two aggregate gates the
+template cannot satisfy from its workspace: `okf-validate` (`gen-okf.py --check` —
+`base-apps/index.md` needs a new row) and agent-docs index-coverage. Resolution: a
+new **`.github/workflows/okf-autosync.yaml`** runs on `pull_request` touching
+`base-apps/**` (same-repo PRs only), regenerates `base-apps/index.md` via
+`gen-okf.py`, appends contract-complete apps to `scripts/agent-docs-scope.txt`, and
+commits+pushes back to the PR branch (idempotent — no loop). This keeps the
+scaffolded PR "green with no manual fixes" and benefits hand-added apps too.
+
+Known v1 limitation: `last_reviewed` in the generated docs is a baked date (the
+scaffolder cannot compute "today"); the PR body reminds the author to update it.
+
 ## Delivery
 
 1. **kubernetes repo:** add `templates/new-app/` (`template.yaml` + `skeleton*/` dirs).

--- a/scripts/render-new-app.py
+++ b/scripts/render-new-app.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Render the new-app scaffolder skeleton locally (proxy for Backstage's
+fetch:template) so the output can be run through the repo's CI validators.
+
+Backstage uses Nunjucks with variable delimiters `${{ }}`; Jinja2 configured the
+same way renders the common subset we use (variables, {% if %}, {% for %}) and
+templated file/dir NAMES. This is a faithful pre-deploy proxy; the authoritative
+check remains Backstage's template-editor dry-run.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from jinja2 import Environment, StrictUndefined
+
+_ENV = Environment(
+    variable_start_string="${{",
+    variable_end_string="}}",
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+
+
+def _render_str(text, values):
+    return _ENV.from_string(text).render(values=values)
+
+
+def render(skeleton_dirs, values, out_dir):
+    """Render each skeleton dir into out_dir. Templates both file/dir names and
+    file contents. Returns the list of written file paths."""
+    written = []
+    out_dir = Path(out_dir)
+    for skel in skeleton_dirs:
+        skel = Path(skel)
+        for src in sorted(skel.rglob("*")):
+            if src.is_dir():
+                continue
+            rel = src.relative_to(skel)
+            # template each path segment (handles ${{ values.name }} in names)
+            rel_rendered = Path(*[_render_str(part, values) for part in rel.parts])
+            dst = out_dir / rel_rendered
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(_render_str(src.read_text(), values))
+            written.append(dst)
+    return written
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--template", required=True, help="templates/new-app dir")
+    ap.add_argument("--values", required=True, help="JSON of parameter values")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--ingress", action="store_true")
+    ap.add_argument("--secrets", action="store_true")
+    ap.add_argument("--config", action="store_true")
+    args = ap.parse_args()
+    tmpl = Path(args.template)
+    dirs = [tmpl / "skeleton"]
+    if args.ingress:
+        dirs.append(tmpl / "skeleton-ingress")
+    if args.secrets:
+        dirs.append(tmpl / "skeleton-secrets")
+    if args.config:
+        dirs.append(tmpl / "skeleton-config")
+    n = render(dirs, json.loads(args.values), Path(args.out))
+    print(f"rendered {len(n)} files to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/new-app/skeleton-config/base-apps/${{ values.name }}/configmap.yaml
+++ b/templates/new-app/skeleton-config/base-apps/${{ values.name }}/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ values.name }}-config
+  namespace: ${{ values.namespace }}
+data:
+{% for k, v in values.configData.items() %}  ${{ k }}: "${{ v }}"
+{% endfor %}

--- a/templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml
+++ b/templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ${{ values.host }}.arigsela.com
+      secretName: ${{ values.name }}-tls
+  rules:
+    - host: ${{ values.host }}.arigsela.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ${{ values.name }}
+                port:
+                  number: 80

--- a/templates/new-app/skeleton-secrets/base-apps/${{ values.name }}/external-secret.yaml
+++ b/templates/new-app/skeleton-secrets/base-apps/${{ values.name }}/external-secret.yaml
@@ -1,0 +1,18 @@
+# Seed the Vault key k8s-secrets/${{ values.name }} with your app's secrets;
+# every property under it is synced into the ${{ values.name }}-secrets Secret.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ${{ values.name }}-secrets
+  namespace: ${{ values.namespace }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: ${{ values.name }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ${{ values.name }}

--- a/templates/new-app/skeleton-secrets/base-apps/${{ values.name }}/secret-store.yaml
+++ b/templates/new-app/skeleton-secrets/base-apps/${{ values.name }}/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: ${{ values.namespace }}
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "${{ values.namespace }}"
+          serviceAccountRef:
+            name: "default"

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: ${{ values.name }}
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/${{ values.name }}
+    directory:
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{ values.namespace }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=${{ values.name }}'
+    backstage.io/kubernetes-namespace: ${{ values.namespace }}
+  tags: ${{ values.tags }}
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner }}
+  system: ${{ values.system }}
+{% if values.needsSecrets %}  dependsOn:
+    - resource:vault/vault
+{% endif %}

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/deployments.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/deployments.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  labels:
+    app: ${{ values.name }}
+spec:
+  replicas: ${{ values.replicas }}
+  selector:
+    matchLabels:
+      app: ${{ values.name }}
+  template:
+    metadata:
+      labels:
+        app: ${{ values.name }}
+    spec:
+      containers:
+        - name: ${{ values.name }}
+          image: ${{ values.image }}
+          ports:
+            - name: http
+              containerPort: ${{ values.containerPort }}
+{% if values.needsConfig %}          envFrom:
+            - configMapRef:
+                name: ${{ values.name }}-config
+{% endif %}          resources:
+            requests:
+              cpu: ${{ values.cpuRequest }}
+              memory: ${{ values.memRequest }}
+            limits:
+              cpu: ${{ values.cpuLimit }}
+              memory: ${{ values.memLimit }}
+          readinessProbe:
+            tcpSocket:
+              port: ${{ values.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
@@ -1,0 +1,25 @@
+---
+type: "Kubernetes App Guide"
+title: "${{ values.name }}"
+description: "${{ values.description }}"
+app: ${{ values.name }}
+catalog_entity: ${{ values.name }}
+kind: docs
+namespace: ${{ values.namespace }}
+last_reviewed: 2026-07-20
+status: current
+tags: ${{ values.tags }}
+sources:
+  - base-apps/${{ values.name }}/deployments.yaml
+---
+
+# ${{ values.name }}
+
+## What it is
+${{ values.description }}
+
+## Architecture & data flow
+_Fill in: how requests flow, dependencies, config sources._
+
+## Where config lives
+- Manifests: `base-apps/${{ values.name }}/`

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
@@ -1,0 +1,25 @@
+---
+type: "Kubernetes App Guide"
+title: "${{ values.name }}"
+description: "${{ values.description }}"
+app: ${{ values.name }}
+catalog_entity: ${{ values.name }}
+kind: docs
+namespace: ${{ values.namespace }}
+last_reviewed: 2026-07-20
+status: current
+tags: ${{ values.tags }}
+sources:
+  - base-apps/${{ values.name }}/deployments.yaml
+---
+
+# ${{ values.name }}
+
+## What it is
+${{ values.description }}
+
+## Architecture & data flow
+_Fill in: how requests flow, dependencies, config sources._
+
+## Where config lives
+- Manifests: `base-apps/${{ values.name }}/`

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
@@ -1,0 +1,26 @@
+---
+type: "Kubernetes App Runbook"
+title: "${{ values.name }} — Runbook"
+description: "Operational runbook for ${{ values.name }}: failure modes, checks, and fixes."
+app: ${{ values.name }}
+catalog_entity: ${{ values.name }}
+kind: runbook
+namespace: ${{ values.namespace }}
+last_reviewed: 2026-07-20
+status: current
+tags: ${{ values.tags }}
+sources:
+  - base-apps/${{ values.name }}/deployments.yaml
+---
+
+# ${{ values.name }} — Runbook
+
+## Failure modes
+_Fill in: known ways this app breaks and their observable symptoms._
+
+## Checks
+- Manifests: `base-apps/${{ values.name }}/`
+- Pods: `kubectl -n ${{ values.namespace }} get pods -l app=${{ values.name }}`
+
+## Fixes
+_Fill in: remediation steps once a failure mode above is confirmed._

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/mkdocs.yml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: ${{ values.name }}
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
@@ -1,0 +1,26 @@
+---
+type: "Kubernetes App Runbook"
+title: "${{ values.name }} — Runbook"
+description: "Operational runbook for ${{ values.name }}: failure modes, checks, and fixes."
+app: ${{ values.name }}
+catalog_entity: ${{ values.name }}
+kind: runbook
+namespace: ${{ values.namespace }}
+last_reviewed: 2026-07-20
+status: current
+tags: ${{ values.tags }}
+sources:
+  - base-apps/${{ values.name }}/deployments.yaml
+---
+
+# ${{ values.name }} — Runbook
+
+## Failure modes
+_Fill in: known ways this app breaks and their observable symptoms._
+
+## Checks
+- Manifests: `base-apps/${{ values.name }}/`
+- Pods: `kubectl -n ${{ values.namespace }} get pods -l app=${{ values.name }}`
+
+## Fixes
+_Fill in: remediation steps once a failure mode above is confirmed._

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/services.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/services.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ values.name }}
+  namespace: ${{ values.namespace }}
+  labels:
+    app: ${{ values.name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: ${{ values.name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: ${{ values.containerPort }}

--- a/templates/new-app/template.yaml
+++ b/templates/new-app/template.yaml
@@ -38,35 +38,66 @@ spec:
         tags:
           title: Tags
           type: array
-          items: { type: string }
+          items:
+            type: string
     - title: Workload
       required: [image, containerPort]
       properties:
-        image: { title: Container image, type: string }
-        containerPort: { title: Container port, type: integer, default: 8080 }
-        replicas: { title: Replicas, type: integer, default: 1 }
+        image:
+          title: Container image
+          type: string
+        containerPort:
+          title: Container port
+          type: integer
+          default: 8080
+        replicas:
+          title: Replicas
+          type: integer
+          default: 1
         namespace:
           title: Namespace
           type: string
           description: defaults to the app name
     - title: Networking & Config
       properties:
-        exposeIngress: { title: Expose via nginx Ingress, type: boolean, default: false }
+        exposeIngress:
+          title: Expose via nginx Ingress
+          type: boolean
+          default: false
         host:
           title: Ingress host label (<host>.arigsela.com)
           type: string
-        needsConfig: { title: Add a ConfigMap (envFrom), type: boolean, default: false }
-        needsSecrets: { title: Add Vault SecretStore + ExternalSecret, type: boolean, default: false }
+        needsConfig:
+          title: Add a ConfigMap (envFrom)
+          type: boolean
+          default: false
+        needsSecrets:
+          title: Add Vault SecretStore + ExternalSecret
+          type: boolean
+          default: false
         configData:
           title: ConfigMap data
           type: object
-          additionalProperties: { type: string }
+          additionalProperties:
+            type: string
     - title: Resources
       properties:
-        cpuRequest: { title: CPU request, type: string, default: 100m }
-        cpuLimit: { title: CPU limit, type: string, default: 500m }
-        memRequest: { title: Memory request, type: string, default: 128Mi }
-        memLimit: { title: Memory limit, type: string, default: 256Mi }
+        cpuRequest:
+          title: CPU request
+          type: string
+          default: 100m
+        cpuLimit:
+          title: CPU limit
+          type: string
+          default: 500m
+        memRequest:
+          title: Memory request
+          type: string
+          default: 128Mi
+        memLimit:
+          title: Memory limit
+          type: string
+          default: 256Mi
   steps:
     - id: fetch-core
       name: Render core
@@ -96,17 +127,23 @@ spec:
       name: Render ingress
       if: ${{ parameters.exposeIngress }}
       action: fetch:template
-      input: { url: ./skeleton-ingress, values: *vals }
+      input:
+        url: ./skeleton-ingress
+        values: *vals
     - id: fetch-secrets
       name: Render secrets
       if: ${{ parameters.needsSecrets }}
       action: fetch:template
-      input: { url: ./skeleton-secrets, values: *vals }
+      input:
+        url: ./skeleton-secrets
+        values: *vals
     - id: fetch-config
       name: Render config
       if: ${{ parameters.needsConfig }}
       action: fetch:template
-      input: { url: ./skeleton-config, values: *vals }
+      input:
+        url: ./skeleton-config
+        values: *vals
     - id: publish
       name: Open PR
       action: publish:github:pull-request

--- a/templates/new-app/template.yaml
+++ b/templates/new-app/template.yaml
@@ -117,6 +117,10 @@ spec:
         description: |
           Scaffolded via the New Application template.
           System: ${{ parameters.system }} · Owner: ${{ parameters.owner }}
+
+          Before merging: review `docs.md` / `runbook.md` and bump `last_reviewed`
+          to today's date — the scaffolder bakes in its render date, which is
+          almost certainly not your merge date.
   output:
     links:
       - title: Pull request

--- a/templates/new-app/template.yaml
+++ b/templates/new-app/template.yaml
@@ -1,0 +1,123 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: new-application
+  title: New Application
+  description: Scaffold a complete base-apps GitOps app and open a PR.
+  tags: [recommended, gitops, base-apps]
+spec:
+  type: service
+  owner: group:default/platform
+  parameters:
+    - title: Identity
+      required: [name, description, system]
+      properties:
+        name:
+          title: Name
+          type: string
+          description: kebab-case app name (also the dir + namespace default)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+        description:
+          title: Description
+          type: string
+        system:
+          title: System
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind: System
+        owner:
+          title: Owner
+          type: string
+          default: group:default/platform
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind: [Group, User]
+        tags:
+          title: Tags
+          type: array
+          items: { type: string }
+    - title: Workload
+      required: [image, containerPort]
+      properties:
+        image: { title: Container image, type: string }
+        containerPort: { title: Container port, type: integer, default: 8080 }
+        replicas: { title: Replicas, type: integer, default: 1 }
+        namespace:
+          title: Namespace
+          type: string
+          description: defaults to the app name
+    - title: Networking & Config
+      properties:
+        exposeIngress: { title: Expose via nginx Ingress, type: boolean, default: false }
+        host:
+          title: Ingress host label (<host>.arigsela.com)
+          type: string
+        needsConfig: { title: Add a ConfigMap (envFrom), type: boolean, default: false }
+        needsSecrets: { title: Add Vault SecretStore + ExternalSecret, type: boolean, default: false }
+        configData:
+          title: ConfigMap data
+          type: object
+          additionalProperties: { type: string }
+    - title: Resources
+      properties:
+        cpuRequest: { title: CPU request, type: string, default: 100m }
+        cpuLimit: { title: CPU limit, type: string, default: 500m }
+        memRequest: { title: Memory request, type: string, default: 128Mi }
+        memLimit: { title: Memory limit, type: string, default: 256Mi }
+  steps:
+    - id: fetch-core
+      name: Render core
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values: &vals
+          name: ${{ parameters.name }}
+          description: ${{ parameters.description }}
+          image: ${{ parameters.image }}
+          containerPort: ${{ parameters.containerPort }}
+          replicas: ${{ parameters.replicas }}
+          namespace: ${{ parameters.namespace if parameters.namespace else parameters.name }}
+          system: ${{ parameters.system }}
+          owner: ${{ parameters.owner }}
+          tags: ${{ parameters.tags }}
+          exposeIngress: ${{ parameters.exposeIngress }}
+          host: ${{ parameters.host }}
+          needsConfig: ${{ parameters.needsConfig }}
+          needsSecrets: ${{ parameters.needsSecrets }}
+          configData: ${{ parameters.configData if parameters.configData else {} }}
+          cpuRequest: ${{ parameters.cpuRequest }}
+          cpuLimit: ${{ parameters.cpuLimit }}
+          memRequest: ${{ parameters.memRequest }}
+          memLimit: ${{ parameters.memLimit }}
+    - id: fetch-ingress
+      name: Render ingress
+      if: ${{ parameters.exposeIngress }}
+      action: fetch:template
+      input: { url: ./skeleton-ingress, values: *vals }
+    - id: fetch-secrets
+      name: Render secrets
+      if: ${{ parameters.needsSecrets }}
+      action: fetch:template
+      input: { url: ./skeleton-secrets, values: *vals }
+    - id: fetch-config
+      name: Render config
+      if: ${{ parameters.needsConfig }}
+      action: fetch:template
+      input: { url: ./skeleton-config, values: *vals }
+    - id: publish
+      name: Open PR
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=kubernetes&owner=arigsela
+        branchName: new-app/${{ parameters.name }}
+        title: "feat(${{ parameters.name }}): onboard new application"
+        description: |
+          Scaffolded via the New Application template.
+          System: ${{ parameters.system }} · Owner: ${{ parameters.owner }}
+  output:
+    links:
+      - title: Pull request
+        url: ${{ steps.publish.output.remoteUrl }}

--- a/tests/new-app-template/test_harness_unit.py
+++ b/tests/new-app-template/test_harness_unit.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "render-new-app.py"
+_spec = importlib.util.spec_from_file_location("render_new_app", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def test_templated_paths_and_content(tmp_path):
+    skel = tmp_path / "skel"
+    (skel / "base-apps" / "${{ values.name }}").mkdir(parents=True)
+    (skel / "base-apps" / "${{ values.name }}.yaml").write_text("name: ${{ values.name }}\n")
+    (skel / "base-apps" / "${{ values.name }}" / "f.yaml").write_text(
+        "{% if values.on %}on: true{% endif %}\n")
+    out = tmp_path / "out"
+    mod.render([skel], {"name": "foo", "on": True}, out)
+    assert (out / "base-apps" / "foo.yaml").read_text() == "name: foo\n"
+    assert (out / "base-apps" / "foo" / "f.yaml").read_text() == "on: true\n"

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "render-new-app.py"
+_spec = importlib.util.spec_from_file_location("render_new_app", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+REPO = Path(__file__).resolve().parents[2]
+SKEL = REPO / "templates" / "new-app"
+
+SAMPLE = {
+    "name": "sample-app",
+    "description": "A sample scaffolded app.",
+    "image": "nginx:1.27",
+    "containerPort": 8080,
+    "replicas": 1,
+    "namespace": "sample-app",
+    "system": "default/platform-tooling",
+    "owner": "group:default/platform",
+    "tags": ["nginx"],
+    "exposeIngress": True,
+    "host": "sample-app",
+    "needsConfig": True,
+    "configData": {"LOG_LEVEL": "info"},
+    "needsSecrets": True,
+    "cpuRequest": "100m", "cpuLimit": "500m",
+    "memRequest": "128Mi", "memLimit": "256Mi",
+}
+
+
+def _render(tmp: Path, values: dict, ingress: bool, secrets: bool, config: bool) -> Path:
+    dirs = [SKEL / "skeleton"]
+    if ingress:
+        dirs.append(SKEL / "skeleton-ingress")
+    if secrets:
+        dirs.append(SKEL / "skeleton-secrets")
+    if config:
+        dirs.append(SKEL / "skeleton-config")
+    mod.render(dirs, values, tmp)
+    return tmp
+
+
+def test_render_produces_expected_files(tmp_path):
+    _render(tmp_path, SAMPLE, True, True, True)
+    app = tmp_path / "base-apps" / "sample-app"
+    assert (tmp_path / "base-apps" / "sample-app.yaml").is_file()
+    for f in ["deployments.yaml", "services.yaml", "catalog-info.yaml", "docs.md",
+              "runbook.md", "mkdocs.yml", "docs/index.md", "docs/runbook.md",
+              "nginx-ingress.yaml", "secret-store.yaml", "external-secret.yaml",
+              "configmap.yaml"]:
+        assert (app / f).is_file(), f"missing {f}"
+    # techdocs copies must equal the canonical docs (gen-techdocs --check contract)
+    assert (app / "docs" / "index.md").read_text() == (app / "docs.md").read_text()
+    assert (app / "docs" / "runbook.md").read_text() == (app / "runbook.md").read_text()
+    # no un-rendered template markers remain
+    for p in app.rglob("*"):
+        if p.is_file():
+            assert "${{" not in p.read_text() and "{%" not in p.read_text(), f"unrendered: {p}"
+
+
+def test_rendered_output_passes_repo_validators(tmp_path):
+    # Render into a throwaway COPY of the repo so the real validators run against it.
+    import shutil
+    work = tmp_path / "repo"
+    shutil.copytree(REPO, work, ignore=shutil.ignore_patterns(
+        ".git", "node_modules", ".superpowers", "base-apps"), dirs_exist_ok=False)
+    # Bring base-apps but only the taxonomy + a couple deps the sample refs need.
+    (work / "base-apps").mkdir(exist_ok=True)
+    shutil.copytree(REPO / "catalog", work / "catalog", dirs_exist_ok=True)
+    for dep in ["vault"]:
+        shutil.copytree(REPO / "base-apps" / dep, work / "base-apps" / dep, dirs_exist_ok=True)
+    dirs = [SKEL / "skeleton", SKEL / "skeleton-ingress", SKEL / "skeleton-secrets", SKEL / "skeleton-config"]
+    mod.render(dirs, SAMPLE, work)
+    app = work / "base-apps" / "sample-app"
+
+    # yamllint (block style)
+    r = subprocess.run(["yamllint", "-c", str(REPO / ".yamllint.yaml")] +
+                       [str(p) for p in app.rglob("*.yaml")] + [str(work / "base-apps" / "sample-app.yaml")],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, f"yamllint:\n{r.stdout}\n{r.stderr}"
+    # gen-techdocs --check (docs/ copies in sync)
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "gen-techdocs.py"),
+                        "--repo-root", str(work), "--check"], capture_output=True, text=True)
+    assert r.returncode == 0, f"gen-techdocs:\n{r.stdout}"
+    # agent-docs contract
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "validate-agent-docs.py"),
+                        "--repo-root", str(work)], capture_output=True, text=True)
+    assert r.returncode == 0, f"agent-docs:\n{r.stdout}"
+    # ingress whitelist gate
+    ing = (app / "nginx-ingress.yaml").read_text()
+    assert "whitelist-source-range" in ing

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "render-new-app.py"
 _spec = importlib.util.spec_from_file_location("render_new_app", _SCRIPT)
 mod = importlib.util.module_from_spec(_spec)
@@ -100,7 +102,7 @@ def test_rendered_output_passes_repo_validators(tmp_path):
     _copy_tracked_repo(work)
 
     dirs = [SKEL / "skeleton", SKEL / "skeleton-ingress", SKEL / "skeleton-secrets", SKEL / "skeleton-config"]
-    mod.render(dirs, SAMPLE, work)
+    written = mod.render(dirs, SAMPLE, work)
     app = work / "base-apps" / "sample-app"
 
     # Regenerate base-apps/index.md for the newly-scaffolded app (mirrors the
@@ -132,3 +134,28 @@ def test_rendered_output_passes_repo_validators(tmp_path):
     # ingress whitelist gate
     ing = (app / "nginx-ingress.yaml").read_text()
     assert "whitelist-source-range" in ing
+
+    # kubeconform (CI's kubernetes-validate job, .github/workflows/validate.yaml).
+    # mkdocs.yml has no 'kind' (Backstage TechDocs config, not a k8s manifest)
+    # and catalog-info.yaml is a Backstage entity, not a k8s manifest -- CI
+    # drops/skips both, so exclude them here too. `written` already includes
+    # base-apps/sample-app.yaml (the Argo CD Application manifest, rendered
+    # from the skeleton's top-level file), so no need to add it separately.
+    if shutil.which("kubeconform") is None:
+        pytest.skip("kubeconform not installed")
+    kc_files = [str(p) for p in written
+                if p.suffix in (".yaml", ".yml")
+                and p.name not in ("mkdocs.yml", "catalog-info.yaml")]
+    assert str(work / "base-apps" / "sample-app.yaml") in kc_files
+    r = subprocess.run(
+        ["kubeconform",
+         "-strict",
+         "-ignore-missing-schemas",
+         "-schema-location", "default",
+         "-schema-location",
+         "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/"
+         "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+         "-kubernetes-version", "1.33.0"] + kc_files,
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, f"kubeconform:\n{r.stdout}\n{r.stderr}"

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -30,6 +31,33 @@ SAMPLE = {
     "cpuRequest": "100m", "cpuLimit": "500m",
     "memRequest": "128Mi", "memLimit": "256Mi",
 }
+
+
+def _copy_tracked_repo(dest: Path) -> Path:
+    """Copy every git-tracked file in REPO into dest, preserving relative
+    paths, so the real repo validators can run against a disposable copy.
+
+    Deliberately NOT a shutil.copytree over the live working tree: this repo
+    carries large local-only artifacts that are never committed --
+    terraform/roots/*/.terraform (a gitignored provider cache, ~1.7GB on a
+    machine that has run `terraform init`) and docs/reference/claude-agents
+    (a gitignored ~60MB reference clone) chief among them. `git ls-files`
+    gives exactly what CI's checkout would see (~5MB, 600ish files): .git,
+    node_modules, and .superpowers are excluded for free because none of
+    them are tracked.
+    """
+    files = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    for rel in files:
+        src = REPO / rel
+        if not src.is_file():
+            continue
+        dst = dest / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+    return dest
 
 
 def _render(tmp: Path, values: dict, ingress: bool, secrets: bool, config: bool) -> Path:
@@ -63,33 +91,44 @@ def test_render_produces_expected_files(tmp_path):
 
 
 def test_rendered_output_passes_repo_validators(tmp_path):
-    # Render into a throwaway COPY of the repo so the real validators run against it.
-    import shutil
+    # Render into a throwaway COPY of the FULL repo (every existing base-apps/
+    # app included) so the real validators see exactly what they'd see in CI:
+    # validate-agent-docs.py's index-coverage check requires a row for every
+    # base-apps/<app> dir, not just a stub subset.
     work = tmp_path / "repo"
-    shutil.copytree(REPO, work, ignore=shutil.ignore_patterns(
-        ".git", "node_modules", ".superpowers", "base-apps"), dirs_exist_ok=False)
-    # Bring base-apps but only the taxonomy + a couple deps the sample refs need.
-    (work / "base-apps").mkdir(exist_ok=True)
-    shutil.copytree(REPO / "catalog", work / "catalog", dirs_exist_ok=True)
-    for dep in ["vault"]:
-        shutil.copytree(REPO / "base-apps" / dep, work / "base-apps" / dep, dirs_exist_ok=True)
+    work.mkdir()
+    _copy_tracked_repo(work)
+
     dirs = [SKEL / "skeleton", SKEL / "skeleton-ingress", SKEL / "skeleton-secrets", SKEL / "skeleton-config"]
     mod.render(dirs, SAMPLE, work)
     app = work / "base-apps" / "sample-app"
+
+    # Regenerate base-apps/index.md for the newly-scaffolded app (mirrors the
+    # CI auto-sync workflow added in Task 4) and put sample-app in scope so
+    # the contract validators actually check its generated docs.
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "gen-okf.py"),
+                        "--repo-root", str(work)], capture_output=True, text=True)
+    assert r.returncode == 0, f"gen-okf (write):\n{r.stdout}\n{r.stderr}"
+    scope = work / "scripts" / "agent-docs-scope.txt"
+    scope.write_text(scope.read_text().rstrip("\n") + "\nsample-app\n")
 
     # yamllint (block style)
     r = subprocess.run(["yamllint", "-c", str(REPO / ".yamllint.yaml")] +
                        [str(p) for p in app.rglob("*.yaml")] + [str(work / "base-apps" / "sample-app.yaml")],
                        capture_output=True, text=True)
     assert r.returncode == 0, f"yamllint:\n{r.stdout}\n{r.stderr}"
-    # gen-techdocs --check (docs/ copies in sync)
-    r = subprocess.run([sys.executable, str(REPO / "scripts" / "gen-techdocs.py"),
+    # OKF bundle in sync (base-apps/index.md matches every app's doc frontmatter)
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "gen-okf.py"),
                         "--repo-root", str(work), "--check"], capture_output=True, text=True)
-    assert r.returncode == 0, f"gen-techdocs:\n{r.stdout}"
-    # agent-docs contract
+    assert r.returncode == 0, f"gen-okf --check:\n{r.stdout}\n{r.stderr}"
+    # agent-docs contract (contract files, frontmatter, catalog_entity match, sources resolve)
     r = subprocess.run([sys.executable, str(REPO / "scripts" / "validate-agent-docs.py"),
                         "--repo-root", str(work)], capture_output=True, text=True)
-    assert r.returncode == 0, f"agent-docs:\n{r.stdout}"
+    assert r.returncode == 0, f"agent-docs:\n{r.stdout}\n{r.stderr}"
+    # catalog entity references resolve (system/owner/dependsOn:vault)
+    r = subprocess.run([sys.executable, str(REPO / "scripts" / "validate-catalog-refs.py"),
+                        "--repo-root", str(work)], capture_output=True, text=True)
+    assert r.returncode == 0, f"catalog-refs:\n{r.stdout}\n{r.stderr}"
     # ingress whitelist gate
     ing = (app / "nginx-ingress.yaml").read_text()
     assert "whitelist-source-range" in ing


### PR DESCRIPTION
## What

The **New Application** golden-path scaffolder template + its supporting harness/CI, and the v1.4.11 deploy that registers it.

- **`templates/new-app/`** — a `kind: Template` + `skeleton*/` that renders a complete `base-apps/<app>/` (Deployment/Service + optional Ingress/secrets/config, catalog-info, agent-docs, techdocs, Argo App) and opens a PR to this repo. **Correct-by-construction**: the rendered output passes every CI gate.
- **`scripts/render-new-app.py` + `tests/new-app-template/`** — a render harness (Jinja2 mimics Backstage Nunjucks) that renders the skeleton and runs the repo's own validators (yamllint, kubeconform, gen-okf --check, agent-docs, catalog-refs) on the output — the proof of correctness, wired into a `new-app-template-validate` CI job.
- **`.github/workflows/okf-autosync.yaml`** — on PRs touching `base-apps/**`, regenerates `base-apps/index.md` + syncs `agent-docs-scope.txt` and pushes back to the PR branch, so a scaffolded (or hand-added) app reaches green with **zero manual steps**.
- **Deploy:** bumps the portal image to **v1.4.11** (registers the template location).

## Pairs with

`arigsela/backstage` PR #39 (adds the catalog location; cumulative branch also carries the home page + template cleanup). Image v1.4.11 built from it (linux/amd64, in ECR).

## Verification

- `pytest tests/new-app-template/` → renders the template and runs all repo validators (incl. **kubeconform**) on the output; green.
- 4 per-task reviews (harness, template+core, conditionals, workflow+CI+location) — all approved, fault-injection-verified.

Spec: `docs/superpowers/specs/2026-07-20-backstage-new-app-template-design.md` · Plan: `docs/superpowers/plans/2026-07-20-backstage-new-app-template.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b
