### PR TITLE
fix(new-app): Nunjucks-faithful rendering (tags | dump, configData list)

### DIFF
--- a/scripts/render-new-app.py
+++ b/scripts/render-new-app.py
@@ -20,6 +20,12 @@ _ENV = Environment(
     undefined=StrictUndefined,
     keep_trailing_newline=True,
 )
+# Nunjucks-faithful `dump` filter (== JSON.stringify, no spaces). Backstage
+# templates render via Nunjucks, not Jinja2; Jinja2's default str() of a list
+# (`['a', 'b']`) is not valid YAML, while Nunjucks' `dump` filter produces
+# `["a","b"]`, which is. Match that exactly so `${{ values.tags | dump }}`
+# renders identically in this harness and in real Backstage.
+_ENV.filters["dump"] = lambda x: json.dumps(x, separators=(",", ":"), ensure_ascii=False)
 
 
 def _render_str(text, values):

--- a/templates/new-app/skeleton-config/base-apps/${{ values.name }}/configmap.yaml
+++ b/templates/new-app/skeleton-config/base-apps/${{ values.name }}/configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ${{ values.name }}-config
   namespace: ${{ values.namespace }}
 data:
-{% for k, v in values.configData.items() %}  ${{ k }}: "${{ v }}"
+{% for item in values.configData %}  ${{ item.key }}: "${{ item.value }}"
 {% endfor %}

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
     backstage.io/kubernetes-label-selector: 'app=${{ values.name }}'
     backstage.io/kubernetes-namespace: ${{ values.namespace }}
-  tags: ${{ values.tags }}
+  tags: ${{ values.tags | dump }}
 spec:
   type: service
   lifecycle: experimental

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
@@ -8,7 +8,7 @@ kind: docs
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags }}
+tags: ${{ values.tags | dump }}
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
@@ -8,7 +8,7 @@ kind: docs
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags }}
+tags: ${{ values.tags | dump }}
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags }}
+tags: ${{ values.tags | dump }}
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags }}
+tags: ${{ values.tags | dump }}
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/template.yaml
+++ b/templates/new-app/template.yaml
@@ -76,10 +76,15 @@ spec:
           type: boolean
           default: false
         configData:
-          title: ConfigMap data
-          type: object
-          additionalProperties:
-            type: string
+          title: Config entries (key/value)
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
     - title: Resources
       properties:
         cpuRequest:
@@ -118,7 +123,7 @@ spec:
           host: ${{ parameters.host }}
           needsConfig: ${{ parameters.needsConfig }}
           needsSecrets: ${{ parameters.needsSecrets }}
-          configData: ${{ parameters.configData if parameters.configData else {} }}
+          configData: ${{ parameters.configData if parameters.configData else [] }}
           cpuRequest: ${{ parameters.cpuRequest }}
           cpuLimit: ${{ parameters.cpuLimit }}
           memRequest: ${{ parameters.memRequest }}

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -28,7 +28,7 @@ SAMPLE = {
     "exposeIngress": True,
     "host": "sample-app",
     "needsConfig": True,
-    "configData": {"LOG_LEVEL": "info"},
+    "configData": [{"key": "LOG_LEVEL", "value": "info"}],
     "needsSecrets": True,
     "cpuRequest": "100m", "cpuLimit": "500m",
     "memRequest": "128Mi", "memLimit": "256Mi",


### PR DESCRIPTION
The New Application template skeleton (merged in #398) used constructs that render differently in Backstage's real Nunjucks than in the Jinja2 render harness — a real bug the harness masked:

- \`tags: ${{ values.tags }}\` -> Nunjucks renders \`test,whoami\` (broken scalar), not a list. Fixed: \`tags: ${{ values.tags | dump }}\` (+ a Nunjucks-faithful \`dump\` filter in the harness).
- ConfigMap \`{% for k,v in configData.items() %}\` -> ERRORS in Nunjucks (no \`.items()\`). Fixed: \`configData\` is now a list of {key,value}, iterated with \`{% for item in ... %}\` (identical in both engines).

**Verified cross-engine:** the fixed harness and Backstage's real Nunjucks now produce IDENTICAL output for both cases. Pure skeleton/harness change (GitOps-fetched) — no image rebuild.

Merge this before using the template; #398 shipped the buggy skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b