### PR TITLE
fix(new-app): tags render yamllint-clean (spaced flow list)

### DIFF
--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
     backstage.io/kubernetes-label-selector: 'app=${{ values.name }}'
     backstage.io/kubernetes-namespace: ${{ values.namespace }}
-  tags: ${{ values.tags | dump }}
+  tags: [{% for t in values.tags %}"${{ t }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 spec:
   type: service
   lifecycle: experimental

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs.md
@@ -8,7 +8,7 @@ kind: docs
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags | dump }}
+tags: [{% for t in values.tags %}"${{ t }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/index.md
@@ -8,7 +8,7 @@ kind: docs
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags | dump }}
+tags: [{% for t in values.tags %}"${{ t }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/docs/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags | dump }}
+tags: [{% for t in values.tags %}"${{ t }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
+++ b/templates/new-app/skeleton/base-apps/${{ values.name }}/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ${{ values.namespace }}
 last_reviewed: 2026-07-20
 status: current
-tags: ${{ values.tags | dump }}
+tags: [{% for t in values.tags %}"${{ t }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 sources:
   - base-apps/${{ values.name }}/deployments.yaml
 ---

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -24,7 +24,7 @@ SAMPLE = {
     "namespace": "sample-app",
     "system": "default/platform-tooling",
     "owner": "group:default/platform",
-    "tags": ["nginx"],
+    "tags": ["nginx", "web"],
     "exposeIngress": True,
     "host": "sample-app",
     "needsConfig": True,


### PR DESCRIPTION
The scaffolded PR failed yaml-lint: \`catalog-info.yaml 11 [commas] too few spaces after comma\`.

**Cause:** \`${{ values.tags | dump }}\` renders \`[\"test\",\"whoami\"]\` (no space after comma) in Backstage Nunjucks — the repo yamllint \`commas\` rule requires a space. My render-test used a single-tag sample, so it never produced a comma.

**Fix:** render tags via an inline loop -> \`[\"test\", \"whoami\"]\` (matches the dex convention, yamllint-clean, handles empty -> \`[]\`). Verified identical in the harness AND real Nunjucks. The render-test sample now uses 2 tags and lints catalog-info.yaml so this cant regress.

Pure skeleton change (GitOps-fetched) — no image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b