### PR TITLE
chore(backstage): deploy v1.4.12 (validate-name action) — MERGE FIRST

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.11
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.12
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Bumps backstage-portal v1.4.11 -> v1.4.12 (linux/amd64), which adds the newapp:validate-name collision-guard action. **Merge this FIRST** and let Argo roll to v1.4.12, THEN merge the template-enhancements PR (whose validate-name step calls this action). Paired backstage PR #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b