### PR TITLE
feat(new-app): collision guard + Vault provisioning + ingress whitelist — MERGE AFTER v1.4.12

### DIFF
--- a/docs/superpowers/plans/2026-07-21-new-app-template-enhancements.md
+++ b/docs/superpowers/plans/2026-07-21-new-app-template-enhancements.md
@@ -1,0 +1,347 @@
+# New Application Template Enhancements — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a name-collision guard, Vault secret provisioning, and an ingress IP-whitelist form field to the New Application scaffolder template.
+
+**Architecture:** One backstage backend action (`newapp:validate-name`, mirroring `kagent:agent:validate-name`) → needs a new image. Two GitOps-only changes in the kubernetes repo (a `vault:setup` step + a `whitelist` param, both using things already in the deployed image). Land together — the validate-name step errors until the action is deployed.
+
+**Tech Stack:** Backstage scaffolder (Nunjucks + custom actions, TypeScript + jest), the existing `vault:setup` action, the render-test harness.
+
+## Global Constraints
+
+- **Mirror `packages/backend/src/modules/scaffolder/kagentValidateNameAction.ts`** exactly for the new action (Octokit `repos.getContent`, `fileExists`, `throw` on collision, reads `GITHUB_TOKEN`). OWNER=`arigsela`, REPO=`kubernetes`.
+- Collision check: `base-apps/<name>` (directory — `getContent` returns 200 if it exists) **OR** `base-apps/<name>.yaml` (Argo app). Throw if either exists.
+- **`vault:setup` inputs** (verified in `vaultSetupAction.ts`): `vaultRole`, `namespace`, `enableAuth`, `enableKnowledge`, `serviceAccountNames`. Always pass `enableAuth: true` (seeds a `jwt-secret` placeholder → ExternalSecret green); `enableKnowledge: ${{ parameters.seedOpenaiKey }}`.
+- **Whitelist default** (dex admin allowlist, verbatim): `73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8`.
+- Skeleton templating: Backstage Nunjucks (`${{ }}` vars). The render-test harness (Jinja2 + faithful filters) must stay green; add `whitelist` to its sample.
+- **Deploy ordering:** v1.4.12 (with the action) must deploy BEFORE the kubernetes template.yaml validate-name step reaches `main` (the live template is fetched from `main`; an unknown action id fails scaffolding).
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b`.
+
+## File Structure
+
+**backstage** (branch `new-app-validate-name`, from `homepage` — the deployed source of truth):
+- Create `packages/backend/src/modules/scaffolder/newAppValidateNameAction.ts`.
+- Create `packages/backend/src/modules/scaffolder/newAppValidateNameAction.test.ts`.
+- Modify `packages/backend/src/modules/scaffolder/index.ts` (import + register).
+
+**kubernetes** (branch `new-app-template-enhancements`, already has the spec):
+- Modify `templates/new-app/template.yaml` (2 params, validate-name step, vault-setup step, `&vals` additions).
+- Modify `templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml` (whitelist).
+- Modify `tests/new-app-template/test_render_new_app.py` (sample gains `whitelist`).
+
+---
+
+## Task 1: Collision-guard action (backstage)
+
+**Files:** create the action + test; modify `index.ts`.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /Users/arisela/git/backstage
+git checkout homepage && git pull --ff-only
+git checkout -b new-app-validate-name
+```
+
+- [ ] **Step 2: Create `packages/backend/src/modules/scaffolder/newAppValidateNameAction.ts`**
+
+```ts
+/**
+ * Custom Scaffolder Action: newapp:validate-name
+ * ===============================================
+ * Fails the New Application wizard if base-apps/<name> already exists (as a
+ * directory OR an Argo Application file base-apps/<name>.yaml), before
+ * publish:github:pull-request would merge into / overwrite an existing app.
+ * Reads process.env.GITHUB_TOKEN (same token as the other Octokit actions).
+ */
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import { Octokit } from '@octokit/rest';
+
+const OWNER = 'arigsela';
+const REPO = 'kubernetes';
+
+function isHttpError(err: unknown): err is { status: number; message?: string } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'status' in err &&
+    typeof (err as any).status === 'number'
+  );
+}
+
+async function pathExists(octokit: Octokit, path: string): Promise<boolean> {
+  try {
+    await octokit.repos.getContent({ owner: OWNER, repo: REPO, path });
+    return true;
+  } catch (err) {
+    if (isHttpError(err) && err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export function createNewAppValidateNameAction() {
+  return createTemplateAction({
+    id: 'newapp:validate-name',
+    description:
+      'Fails if base-apps/<name> already exists (directory or base-apps/<name>.yaml Argo app).',
+    schema: {
+      input: {
+        name: z =>
+          z
+            .string()
+            .regex(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/)
+            .describe('Proposed application name (kebab-case).'),
+      },
+    },
+    async handler(ctx) {
+      const { name } = ctx.input as { name: string };
+
+      const token = process.env.GITHUB_TOKEN;
+      if (!token) {
+        throw new Error(
+          'GITHUB_TOKEN env var is not set. Required for newapp:validate-name.',
+        );
+      }
+
+      const octokit = new Octokit({ auth: token });
+      const dirPath = `base-apps/${name}`;
+      const appPath = `base-apps/${name}.yaml`;
+
+      ctx.logger.info(`newapp:validate-name — checking for collisions on '${name}'`);
+
+      if (await pathExists(octokit, dirPath)) {
+        throw new Error(
+          `Application '${name}' already exists at ${dirPath}. Choose a different name.`,
+        );
+      }
+      if (await pathExists(octokit, appPath)) {
+        throw new Error(
+          `Application '${name}' already exists at ${appPath}. Choose a different name.`,
+        );
+      }
+
+      ctx.logger.info(`newapp:validate-name — name '${name}' is available.`);
+    },
+  });
+}
+```
+
+- [ ] **Step 3: Register in `packages/backend/src/modules/scaffolder/index.ts`**
+
+Add the import next to the other action imports:
+```ts
+import { createNewAppValidateNameAction } from './newAppValidateNameAction';
+```
+Add it to the `scaffolderActions.addActions( ... )` list (e.g. after `createKagentValidateNameAction(),`):
+```ts
+          createNewAppValidateNameAction(),
+```
+
+- [ ] **Step 4: Create `packages/backend/src/modules/scaffolder/newAppValidateNameAction.test.ts`**
+
+Mirror `kagentValidateNameAction.test.ts` (jest, `jest.mock('@octokit/rest')`, manual `createMockActionContext`). Cases:
+
+```ts
+import { createNewAppValidateNameAction } from './newAppValidateNameAction';
+
+jest.mock('@octokit/rest');
+import { Octokit } from '@octokit/rest';
+
+const MockedOctokit = Octokit as jest.MockedClass<typeof Octokit>;
+
+function buildMockOctokit() {
+  return { repos: { getContent: jest.fn() } } as any;
+}
+function createMockActionContext(opts: { input: Record<string, unknown> }) {
+  return {
+    input: opts.input,
+    output: jest.fn(),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), child: jest.fn().mockReturnThis() },
+    workspacePath: '/tmp/t', checkpoint: jest.fn(),
+    createTemporaryDirectory: jest.fn().mockResolvedValue('/tmp/t2'),
+    getInitiatorCredentials: jest.fn(), task: { id: 't' },
+  } as any;
+}
+function http(status: number) { const e: any = new Error(`HTTP ${status}`); e.status = status; return e; }
+
+describe('newapp:validate-name', () => {
+  let orig: string | undefined;
+  beforeEach(() => { orig = process.env.GITHUB_TOKEN; process.env.GITHUB_TOKEN = 'x'; MockedOctokit.mockClear(); });
+  afterEach(() => { if (orig === undefined) delete process.env.GITHUB_TOKEN; else process.env.GITHUB_TOKEN = orig; });
+
+  it('passes when neither path exists', async () => {
+    const oc = buildMockOctokit();
+    oc.repos.getContent.mockRejectedValue(http(404));
+    MockedOctokit.mockImplementation(() => oc);
+    await expect(
+      createNewAppValidateNameAction().handler(createMockActionContext({ input: { name: 'brand-new' } })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when the app directory exists', async () => {
+    const oc = buildMockOctokit();
+    oc.repos.getContent.mockImplementation(async ({ path }: any) =>
+      path === 'base-apps/whoami-test' ? { data: [] } : Promise.reject(http(404)),
+    );
+    MockedOctokit.mockImplementation(() => oc);
+    await expect(
+      createNewAppValidateNameAction().handler(createMockActionContext({ input: { name: 'whoami-test' } })),
+    ).rejects.toThrow(/already exists at base-apps\/whoami-test/);
+  });
+
+  it('throws when only the Argo app file exists', async () => {
+    const oc = buildMockOctokit();
+    oc.repos.getContent.mockImplementation(async ({ path }: any) =>
+      path === 'base-apps/foo.yaml' ? { data: {} } : Promise.reject(http(404)),
+    );
+    MockedOctokit.mockImplementation(() => oc);
+    await expect(
+      createNewAppValidateNameAction().handler(createMockActionContext({ input: { name: 'foo' } })),
+    ).rejects.toThrow(/already exists at base-apps\/foo\.yaml/);
+  });
+
+  it('throws when GITHUB_TOKEN is missing', async () => {
+    delete process.env.GITHUB_TOKEN;
+    await expect(
+      createNewAppValidateNameAction().handler(createMockActionContext({ input: { name: 'x' } })),
+    ).rejects.toThrow(/GITHUB_TOKEN/);
+  });
+});
+```
+
+- [ ] **Step 5: Type-check + test**
+
+Run:
+```bash
+cd /Users/arisela/git/backstage
+corepack prepare yarn@4.4.1 --activate >/dev/null 2>&1 || true
+yarn tsc
+yarn workspace backend test newAppValidateNameAction
+```
+Expected: tsc clean; the 4 tests pass. If `yarn workspace backend test <name>` filter differs, use `yarn workspace backend backstage-cli package test --watch=false newAppValidateNameAction`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/arisela/git/backstage
+git add packages/backend/src/modules/scaffolder/newAppValidateNameAction.ts packages/backend/src/modules/scaffolder/newAppValidateNameAction.test.ts packages/backend/src/modules/scaffolder/index.ts
+git commit -m "$(printf 'feat(scaffolder): newapp:validate-name collision guard\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+```
+
+---
+
+## Task 2: template.yaml steps/params + skeleton + render test (kubernetes)
+
+**Files:** `templates/new-app/template.yaml`, `templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml`, `tests/new-app-template/test_render_new_app.py`.
+
+Work from `/Users/arisela/git/kubernetes` on branch `new-app-template-enhancements` (already checked out).
+
+- [ ] **Step 1: Add two params to `template.yaml`** — under the "Networking & Config" `properties:`, add:
+
+```yaml
+        seedOpenaiKey:
+          title: Also seed an openai-api-key placeholder in Vault
+          type: boolean
+          default: false
+        whitelist:
+          title: Ingress source-IP allowlist (comma-separated CIDRs)
+          type: string
+          default: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8"
+```
+
+- [ ] **Step 2: Add `whitelist` to the `&vals` block** (so the ingress skeleton can use it), right after the `host:` line:
+
+```yaml
+          whitelist: ${{ parameters.whitelist }}
+```
+(`seedOpenaiKey` is NOT added to `&vals` — it's consumed directly by the vault-setup step below.)
+
+- [ ] **Step 3: Add the `validate-name` step as the FIRST step** (before `fetch-core`):
+
+```yaml
+    - id: validate-name
+      name: Check the name is available
+      action: newapp:validate-name
+      input:
+        name: ${{ parameters.name }}
+```
+
+- [ ] **Step 4: Add the `vault-setup` step** (after `fetch-config`, before `publish`):
+
+```yaml
+    - id: vault-setup
+      name: Provision Vault role + secrets
+      if: ${{ parameters.needsSecrets }}
+      action: vault:setup
+      input:
+        vaultRole: ${{ parameters.name }}
+        namespace: ${{ parameters.namespace if parameters.namespace else parameters.name }}
+        enableAuth: true
+        enableKnowledge: ${{ parameters.seedOpenaiKey }}
+        serviceAccountNames: default
+```
+
+- [ ] **Step 5: Use the whitelist in the ingress skeleton** — in `templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml`, change:
+
+```yaml
+    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+```
+to:
+```yaml
+    nginx.ingress.kubernetes.io/whitelist-source-range: "${{ values.whitelist }}"
+```
+
+- [ ] **Step 6: Add `whitelist` to the render-test SAMPLE** — in `tests/new-app-template/test_render_new_app.py`, add to the `SAMPLE` dict:
+
+```python
+    "whitelist": "10.0.0.0/8",
+```
+
+- [ ] **Step 7: Verify — render + yamllint + full suite**
+
+Run:
+```bash
+cd /Users/arisela/git/kubernetes
+python3 -m pytest tests/new-app-template/ -q
+python3 scripts/render-new-app.py --template templates/new-app --values '{"name":"wtest","description":"x","image":"traefik/whoami","containerPort":80,"replicas":1,"namespace":"wtest","system":"default/platform-tooling","owner":"group:default/platform","tags":["a","b"],"exposeIngress":true,"host":"wtest","needsConfig":false,"needsSecrets":false,"whitelist":"1.2.3.4/32,10.0.0.0/8","cpuRequest":"100m","cpuLimit":"500m","memRequest":"128Mi","memLimit":"256Mi"}' --out /tmp/wtest --ingress
+grep whitelist-source-range /tmp/wtest/base-apps/wtest/nginx-ingress.yaml
+yamllint -c .yamllint.yaml /tmp/wtest/base-apps/wtest/nginx-ingress.yaml && echo "ingress yamllint clean"
+python3 -c "import yaml; yaml.safe_load(open('templates/new-app/template.yaml')); print('template.yaml parses')"
+yamllint -c .yamllint.yaml templates/new-app/template.yaml && echo "template.yaml yamllint clean"
+```
+Expected: pytest passes; the rendered ingress shows `whitelist-source-range: "1.2.3.4/32,10.0.0.0/8"`, yamllint clean; template.yaml parses + yamllint clean (block style).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/arisela/git/kubernetes
+git add templates/new-app/template.yaml templates/new-app/skeleton-ingress tests/new-app-template/test_render_new_app.py
+git commit -m "$(printf 'feat(new-app): validate-name + vault:setup steps, ingress whitelist field\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b')"
+```
+
+---
+
+## Delivery (controller, after Tasks 1–2 pass review)
+
+1. **Build v1.4.12** from `/Users/arisela/git/backstage` branch `new-app-validate-name`:
+   `yarn tsc && yarn build:all` → `docker buildx build --platform linux/amd64 -t …/backstage-portal:v1.4.12 --push --provenance=false .` → confirm `linux/amd64`.
+2. **backstage PR** (`new-app-validate-name` → main).
+3. **kubernetes deploy PR**: bump `deployments.yaml` to v1.4.12.
+4. **Order matters:** merge + deploy v1.4.12 (the action exists) **before** merging the kubernetes template PR (whose validate-name step references it). If they merge out of order, the live template's validate-name step 400s until the image is up.
+
+## Verification (post-deploy)
+
+- Scaffold with an existing name (`whoami-test`) → wizard **fails** at "Check the name is available" with a clear message.
+- Scaffold a new app with **Secrets on** → after merge/deploy the `ExternalSecret` is **Ready** (the `jwt-secret` placeholder synced; Vault role/policy created by `vault:setup`).
+- Scaffold with **Ingress on** → the generated `nginx-ingress.yaml` carries the admin allowlist (or your edited value).
+
+## Self-Review
+
+- **Spec coverage:** collision guard → Task 1 action + Task 2 step; Vault provisioning → Task 2 vault-setup step (always `enableAuth: true`, optional `seedOpenaiKey`); whitelist → Task 2 param + skeleton. Delivery + ordering covered.
+- **Placeholders:** complete action/test code, exact template.yaml/skeleton edits, exact verify commands.
+- **Consistency:** `newapp:validate-name` id matches between the action, its registration, and the template step; `whitelist` flows param → `&vals` → skeleton → render-test sample; `vault:setup` inputs match `vaultSetupAction.ts`.

--- a/docs/superpowers/specs/2026-07-21-new-app-template-enhancements-design.md
+++ b/docs/superpowers/specs/2026-07-21-new-app-template-enhancements-design.md
@@ -1,0 +1,119 @@
+# Design: New Application template — 3 enhancements
+
+**Date:** 2026-07-21
+**Status:** design — pending user review
+**Topic:** Add a name-collision guard, Vault secret provisioning, and an ingress
+IP-whitelist form field to the New Application scaffolder template.
+
+## Goal
+
+Close three gaps found while validating the template against `whoami-test`:
+1. Scaffolding a name that already exists in `base-apps/` silently merges into the
+   old dir (orphaned resources, missing whitelist). → **collision guard**.
+2. The scaffolded `ExternalSecret` is `SecretSyncedError` because nothing provisions
+   the Vault role/policy/KV for the app. → **Vault secret provisioning**.
+3. The template's ingress hard-codes a minimal `whitelist-source-range: 10.0.0.0/8`,
+   so it doesn't carry the admin allowlist. → **whitelist form field**.
+
+## Decisions (settled during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Collision check | Fail if **`base-apps/<name>/` OR `base-apps/<name>.yaml`** exists |
+| Collision mechanism | New backend action `newapp:validate-name` (mirrors `kagent:agent:validate-name`), first scaffolder step |
+| Vault provisioning | `vault:setup` step (if Secrets on); **always seed a jwt-secret placeholder** so the ExternalSecret is green by default; optional openai-api-key toggle |
+| Whitelist | Form field `whitelist`, defaulting to the dex admin allowlist, rendered into the ingress |
+| Delivery | backstage image (the new action) → v1.4.12 + deploy; kubernetes GitOps (template.yaml + skeleton) — land together |
+
+## Grounding (verified)
+
+- `packages/backend/src/modules/scaffolder/kagentValidateNameAction.ts`
+  (`kagent:agent:validate-name`) uses Octokit `repos.getContent` to test path
+  existence and `throw`s a clear error, failing the wizard before publish. The new
+  action mirrors it for `base-apps/<name>`.
+- `vaultSetupAction.ts` (`vault:setup`): creates a Vault policy (`<role>-read`), a
+  Kubernetes auth role bound to the namespace's `default` SA, and seeds placeholder
+  KV at `k8s-secrets/data/<role>` — `openai-api-key` when `enableKnowledge`,
+  `jwt-secret` when `enableAuth` (create-if-not-exists). Reads `VAULT_ADDR` +
+  `VAULT_TOKEN` (already in the deployment; the removed application template used it).
+- The scaffolded `ExternalSecret` uses `dataFrom: extract` on `k8s-secrets/<name>`,
+  so any seeded placeholder syncs.
+- dex admin allowlist: `73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8`.
+- The template + skeleton are fetched from `main` at scaffold time (GitOps); only the
+  new action needs an image.
+
+## Design
+
+### 1. Collision guard (backstage image + template step)
+
+New action `newapp:validate-name` in `packages/backend/src/modules/scaffolder/newAppValidateNameAction.ts`
+(register in `index.ts`). Input `name`. Uses Octokit (GITHUB_TOKEN) to check
+`arigsela/kubernetes` for `base-apps/<name>/catalog-info.yaml` (dir marker) and
+`base-apps/<name>.yaml` (Argo app); throws
+`"Application '<name>' already exists (base-apps/<name>). Choose a different name."`
+if either exists. Added as the **first** step in `template.yaml`
+(`id: validate-name`, no `if:` guard — always runs).
+
+### 2. Vault secret provisioning (template step, GitOps)
+
+New form fields under "Networking & Config" (or a "Secrets" step):
+- `needsSecrets` (existing).
+- `seedOpenaiKey` (boolean, default false) → maps to `vault:setup` `enableKnowledge`.
+
+Add a step after the conditional fetches:
+```yaml
+- id: vault-setup
+  name: Provision Vault role + secrets
+  if: ${{ parameters.needsSecrets }}
+  action: vault:setup
+  input:
+    vaultRole: ${{ parameters.name }}
+    namespace: ${{ parameters.namespace if parameters.namespace else parameters.name }}
+    enableAuth: true            # always seed a jwt-secret placeholder -> ExternalSecret green
+    enableKnowledge: ${{ parameters.seedOpenaiKey }}
+    serviceAccountNames: default
+```
+Runs at scaffold time → the Vault role/policy/KV exist before the PR merges, so the
+deployed `ExternalSecret` authenticates and syncs (placeholder values the author
+replaces in Vault). Never puts real secrets through the form.
+
+### 3. Ingress whitelist field (template param + skeleton, GitOps)
+
+Add a form field:
+```yaml
+whitelist:
+  title: Ingress source-IP allowlist (comma-separated CIDRs)
+  type: string
+  default: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8"
+```
+Pass through `values` (`whitelist: ${{ parameters.whitelist }}`) and render in
+`skeleton-ingress/.../nginx-ingress.yaml`:
+```yaml
+    nginx.ingress.kubernetes.io/whitelist-source-range: "${{ values.whitelist }}"
+```
+
+## Delivery
+
+1. **backstage** (branch off `homepage`): add `newAppValidateNameAction.ts` + register
+   in `index.ts`; unit test mirroring `kagentValidateNameAction.test.ts`. Build
+   **v1.4.12** (linux/amd64), backstage PR, kubernetes deploy bump.
+2. **kubernetes** (this branch): `template.yaml` (validate-name step, vault-setup step,
+   `seedOpenaiKey` + `whitelist` params + the `values` mappings) + `skeleton-ingress`
+   whitelist. The render-test harness sample gains `whitelist` so rendering stays green.
+3. Land together — the `validate-name` step errors until the action is deployed.
+
+## Verification
+
+- Render harness: `whitelist` renders into the ingress; full suite green.
+- Backstage action unit test: throws when a `base-apps/<name>` path exists, passes otherwise.
+- Post-deploy: scaffolding an existing name (e.g. `whoami-test`) fails in the wizard;
+  a new app with Secrets on → the ExternalSecret syncs green; the ingress carries the
+  admin allowlist.
+
+## Risks / out of scope
+
+- `vault:setup` seeds only jwt/openai placeholders; apps needing other keys add them
+  in Vault post-scaffold (the `dataFrom: extract` ExternalSecret picks them up).
+- Collision guard checks `arigsela/kubernetes` `main` via the GitHub API at scaffold
+  time (a just-merged app appears immediately; an open unmerged PR's dir does not).
+- No change to the `configData`/tags handling (already fixed).

--- a/templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml
+++ b/templates/new-app/skeleton-ingress/base-apps/${{ values.name }}/nginx-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "${{ values.whitelist }}"
 spec:
   ingressClassName: nginx
   tls:

--- a/templates/new-app/template.yaml
+++ b/templates/new-app/template.yaml
@@ -75,6 +75,14 @@ spec:
           title: Add Vault SecretStore + ExternalSecret
           type: boolean
           default: false
+        seedOpenaiKey:
+          title: Also seed an openai-api-key placeholder in Vault
+          type: boolean
+          default: false
+        whitelist:
+          title: Ingress source-IP allowlist (comma-separated CIDRs)
+          type: string
+          default: "73.7.190.154/32,170.85.56.189/32,170.85.130.202/32,104.28.177.82/32,10.0.0.0/8"
         configData:
           title: Config entries (key/value)
           type: array
@@ -104,6 +112,11 @@ spec:
           type: string
           default: 256Mi
   steps:
+    - id: validate-name
+      name: Check the name is available
+      action: newapp:validate-name
+      input:
+        name: ${{ parameters.name }}
     - id: fetch-core
       name: Render core
       action: fetch:template
@@ -121,6 +134,7 @@ spec:
           tags: ${{ parameters.tags }}
           exposeIngress: ${{ parameters.exposeIngress }}
           host: ${{ parameters.host }}
+          whitelist: ${{ parameters.whitelist }}
           needsConfig: ${{ parameters.needsConfig }}
           needsSecrets: ${{ parameters.needsSecrets }}
           configData: ${{ parameters.configData if parameters.configData else [] }}
@@ -149,6 +163,16 @@ spec:
       input:
         url: ./skeleton-config
         values: *vals
+    - id: vault-setup
+      name: Provision Vault role + secrets
+      if: ${{ parameters.needsSecrets }}
+      action: vault:setup
+      input:
+        vaultRole: ${{ parameters.name }}
+        namespace: ${{ parameters.namespace if parameters.namespace else parameters.name }}
+        enableAuth: true
+        enableKnowledge: ${{ parameters.seedOpenaiKey }}
+        serviceAccountNames: default
     - id: publish
       name: Open PR
       action: publish:github:pull-request

--- a/tests/new-app-template/test_render_new_app.py
+++ b/tests/new-app-template/test_render_new_app.py
@@ -27,6 +27,7 @@ SAMPLE = {
     "tags": ["nginx", "web"],
     "exposeIngress": True,
     "host": "sample-app",
+    "whitelist": "10.0.0.0/8",
     "needsConfig": True,
     "configData": [{"key": "LOG_LEVEL", "value": "info"}],
     "needsSecrets": True,


### PR DESCRIPTION
Three enhancements to the New Application template:
1. **Collision guard** — a validate-name step (newapp:validate-name action) fails the wizard if base-apps/<name> already exists.
2. **Vault provisioning** — a vault:setup step (when Secrets on) creates the Vault role/policy + seeds a jwt-secret placeholder so the ExternalSecret goes green (optional openai-api-key toggle).
3. **Ingress whitelist field** — a whitelist form param defaulting to the dex admin allowlist, rendered into the ingress.

**MERGE ORDER:** merge https://github.com/arigsela/kubernetes/pull/405 (v1.4.12) and let it deploy FIRST — the live template is fetched from main, so the validate-name step 400s until the action is deployed. Then merge this.

Verified: render harness + yamllint + kubeconform green; backstage action has 4 passing unit tests; both tasks reviewed clean.

Spec: docs/superpowers/specs/2026-07-21-new-app-template-enhancements-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b