### PR TITLE
feat(qwen): add Qwen3.5-0.8B multimodal server (llama.cpp, CPU-only)

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -46,6 +46,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | oncall-crewai |  |  |  |  |  |
 | openshell |  |  |  |  |  |
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) + CNPG cluster for chores-tracker (daily S3 backups) | postgresql | [docs.md](postgresql/docs.md) | [runbook.md](postgresql/runbook.md) | [catalog-info.yaml](postgresql/catalog-info.yaml) |
+| qwen | Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed | qwen | [docs.md](qwen/docs.md) | [runbook.md](qwen/runbook.md) | [catalog-info.yaml](qwen/catalog-info.yaml) |
 | vault | In-cluster secret backend (KV v2) | vault | [docs.md](vault/docs.md) | [runbook.md](vault/runbook.md) | [catalog-info.yaml](vault/catalog-info.yaml) |
 | vcluster-sandbox-1 |  |  |  |  |  |
 | weather-kitchen-backend | Backend API for Weather Kitchen (likely FastAPI, JWT, Vault-backed DB) | weather-kitchen | [docs.md](weather-kitchen-backend/docs.md) | [runbook.md](weather-kitchen-backend/runbook.md) | [catalog-info.yaml](weather-kitchen-backend/catalog-info.yaml) |

--- a/base-apps/qwen.yaml
+++ b/base-apps/qwen.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: qwen
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/qwen
+    directory:
+      # catalog-info.yaml is a Backstage entity and mkdocs.yml is TechDocs config;
+      # neither is a Kubernetes manifest. Exclude them so Argo CD does not try to
+      # apply them and fail sync. (docs.md/runbook.md/docs/ are .md and ignored.)
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: qwen
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/qwen/catalog-info.yaml
+++ b/base-apps/qwen/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: qwen
+  namespace: qwen
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=qwen'
+    backstage.io/kubernetes-namespace: qwen
+  tags: [llm, vision, multimodal, gpu-optional]
+spec:
+  type: service
+  lifecycle: experimental
+  owner: group:default/platform
+  system: default/platform-ai

--- a/base-apps/qwen/deployments.yaml
+++ b/base-apps/qwen/deployments.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen
+  namespace: qwen
+  labels:
+    app: qwen
+spec:
+  replicas: 1
+  # Single writer to a ReadWriteOnce PVC; Recreate avoids two pods contending for
+  # the model volume during a rollout (same pattern as the ollama app).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: qwen
+  template:
+    metadata:
+      labels:
+        app: qwen
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      initContainers:
+        # Pre-fetch the GGUF weights + vision projector (mmproj) onto the PVC so the
+        # server starts from local files. Idempotent: the PVC persists across pod
+        # restarts, so re-downloads only happen when a file is missing.
+        - name: download-model
+          image: curlimages/curl:8.11.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              BASE="https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main"
+              MODEL="Qwen3.5-0.8B-UD-Q4_K_XL.gguf"
+              MMPROJ="mmproj-F16.gguf"
+              cd /models
+              if [ ! -f "$MODEL" ]; then
+                echo "Downloading $MODEL ..."
+                curl -fSL -o "$MODEL.part" "$BASE/$MODEL" && mv "$MODEL.part" "$MODEL"
+              fi
+              if [ ! -f "$MMPROJ" ]; then
+                echo "Downloading $MMPROJ (vision projector) ..."
+                curl -fSL -o "$MMPROJ.part" "$BASE/$MMPROJ" && mv "$MMPROJ.part" "$MMPROJ"
+              fi
+              echo "Model assets ready:"
+              ls -lh /models
+          volumeMounts:
+            - name: models
+              mountPath: /models
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 512Mi
+      containers:
+        - name: llama-server
+          # CPU-only llama.cpp OpenAI-compatible server (the :server tag is the CPU
+          # build; :server-cuda is the GPU one). This cluster has no GPU.
+          # TODO: pin to an immutable build digest for reproducible GitOps.
+          image: ghcr.io/ggml-org/llama.cpp:server
+          args:
+            - --model
+            - /models/Qwen3.5-0.8B-UD-Q4_K_XL.gguf
+            - --mmproj
+            - /models/mmproj-F16.gguf
+            # No GPU: keep the vision projector on CPU instead of trying to offload it.
+            - --no-mmproj-offload
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
+            # Modest context: the model supports 262K, but a large KV cache is
+            # impractical on CPU. Raise if you need longer prompts.
+            - --ctx-size
+            - "8192"
+            - --threads
+            - "6"
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: models
+              mountPath: /models
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              # Generation and the CLIP/vision pass are CPU-bound; workers have
+              # ample idle cores. Memory headroom covers the F16 vision projector
+              # plus per-image tensors during multimodal requests.
+              cpu: "6"
+              memory: 8Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: qwen-models

--- a/base-apps/qwen/docs.md
+++ b/base-apps/qwen/docs.md
@@ -1,0 +1,61 @@
+---
+type: "Kubernetes App Guide"
+title: "Qwen3.5-0.8B"
+description: "Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed"
+app: qwen
+catalog_entity: qwen
+kind: docs
+namespace: qwen
+last_reviewed: 2026-07-21
+status: current
+tags: [llm, vision, multimodal, gpu-optional]
+sources:
+  - base-apps/qwen/deployments.yaml
+  - base-apps/qwen/pvc.yaml
+  - base-apps/qwen/services.yaml
+---
+
+# qwen
+
+## What it is
+Self-hosted [Qwen3.5-0.8B](https://huggingface.co/Qwen/Qwen3.5-0.8B) multimodal model (text + vision) served by [llama.cpp](https://github.com/ggml-org/llama.cpp)'s OpenAI-compatible `llama-server`. It is a base provider — other apps call it over HTTP; it does not depend on any other catalogued app. Runs independently of the `ollama` app so it never contends with the latency-critical embedding service used by kagent.
+
+## Why llama.cpp (not vLLM)
+This cluster has **no GPU**. vLLM's value is GPU paged-attention batching and its CPU backend does not (as of this writing) support the new Qwen3.5 architecture; llama.cpp is the engine Unsloth recommends for this model's vision, has first-class CPU support, and serves an OpenAI-compatible API. Vision works via a separate multimodal projector (`mmproj`) file.
+
+## Architecture & data flow
+Single-replica `Deployment` (`deployments.yaml`, `strategy: Recreate`) scheduled onto nodes labeled `node.kubernetes.io/workload: application` via `nodeSelector`. There is no GPU request anywhere in the spec, so this runs **CPU-only inference** — expect slower token throughput than a GPU-backed deployment, and noticeably slower first-token latency on image (vision) requests.
+
+An `initContainer` (`download-model`, `curlimages/curl`) fetches two files from the Unsloth GGUF repo onto the PVC before the server starts:
+
+- `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` — the ~0.6GB 4-bit quantized text weights.
+- `mmproj-F16.gguf` — the vision projector that turns image tokens into embeddings.
+
+The download is idempotent (skips files already present), so restarts do not re-download.
+
+The main container (`ghcr.io/ggml-org/llama.cpp:server`) runs `llama-server` with `--model` + `--mmproj --no-mmproj-offload` (CPU) and exposes port `8080` (`services.yaml`, Service `qwen`, `ClusterIP`) with HTTP `readinessProbe`/`livenessProbe` on `/health`. In-cluster consumers reach it at `http://qwen.qwen.svc.cluster.local:8080` — OpenAI-compatible at `/v1/chat/completions` (supply images as `image_url` content parts).
+
+## Where config lives
+- Workload, image, model/mmproj filenames, server flags, resource requests/limits: `deployments.yaml`.
+- Model storage: `pvc.yaml` — a 5Gi `ReadWriteOnce` PVC (`qwen-models`) mounted at `/models`. The only StorageClass (`local-path`) has `allowVolumeExpansion=false`, so the PVC cannot be grown in place — it must be recreated to resize.
+- Network exposure: `services.yaml` — ClusterIP Service `qwen` on port `8080`.
+
+## Resources
+Main container: requests `cpu: 1` / `memory: 2Gi`, limits `cpu: 6` / `memory: 8Gi`. Init container (download): requests `cpu: 200m` / `memory: 256Mi`, limits `cpu: 2` / `memory: 512Mi`. No GPU is requested.
+
+## Consuming the API
+```bash
+kubectl -n qwen port-forward svc/qwen 8080:8080
+# text
+curl localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
+  "messages":[{"role":"user","content":"Say hi in one word."}]}'
+# vision (image_url content part)
+curl localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
+  "messages":[{"role":"user","content":[
+    {"type":"text","text":"What is in this image?"},
+    {"type":"image_url","image_url":{"url":"https://example.com/pic.jpg"}}]}]}'
+```
+
+## Caveats
+- 0.8B is a small model — good for prototyping, classification, extraction, and vision experiments, **not** reliable multi-step reasoning or agentic tool-calling.
+- The container image tag (`:server`) and llama-server flag names are the most likely things to need a one-time adjustment after watching the first pod start; see the runbook.

--- a/base-apps/qwen/docs/index.md
+++ b/base-apps/qwen/docs/index.md
@@ -1,0 +1,61 @@
+---
+type: "Kubernetes App Guide"
+title: "Qwen3.5-0.8B"
+description: "Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed"
+app: qwen
+catalog_entity: qwen
+kind: docs
+namespace: qwen
+last_reviewed: 2026-07-21
+status: current
+tags: [llm, vision, multimodal, gpu-optional]
+sources:
+  - base-apps/qwen/deployments.yaml
+  - base-apps/qwen/pvc.yaml
+  - base-apps/qwen/services.yaml
+---
+
+# qwen
+
+## What it is
+Self-hosted [Qwen3.5-0.8B](https://huggingface.co/Qwen/Qwen3.5-0.8B) multimodal model (text + vision) served by [llama.cpp](https://github.com/ggml-org/llama.cpp)'s OpenAI-compatible `llama-server`. It is a base provider — other apps call it over HTTP; it does not depend on any other catalogued app. Runs independently of the `ollama` app so it never contends with the latency-critical embedding service used by kagent.
+
+## Why llama.cpp (not vLLM)
+This cluster has **no GPU**. vLLM's value is GPU paged-attention batching and its CPU backend does not (as of this writing) support the new Qwen3.5 architecture; llama.cpp is the engine Unsloth recommends for this model's vision, has first-class CPU support, and serves an OpenAI-compatible API. Vision works via a separate multimodal projector (`mmproj`) file.
+
+## Architecture & data flow
+Single-replica `Deployment` (`deployments.yaml`, `strategy: Recreate`) scheduled onto nodes labeled `node.kubernetes.io/workload: application` via `nodeSelector`. There is no GPU request anywhere in the spec, so this runs **CPU-only inference** — expect slower token throughput than a GPU-backed deployment, and noticeably slower first-token latency on image (vision) requests.
+
+An `initContainer` (`download-model`, `curlimages/curl`) fetches two files from the Unsloth GGUF repo onto the PVC before the server starts:
+
+- `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` — the ~0.6GB 4-bit quantized text weights.
+- `mmproj-F16.gguf` — the vision projector that turns image tokens into embeddings.
+
+The download is idempotent (skips files already present), so restarts do not re-download.
+
+The main container (`ghcr.io/ggml-org/llama.cpp:server`) runs `llama-server` with `--model` + `--mmproj --no-mmproj-offload` (CPU) and exposes port `8080` (`services.yaml`, Service `qwen`, `ClusterIP`) with HTTP `readinessProbe`/`livenessProbe` on `/health`. In-cluster consumers reach it at `http://qwen.qwen.svc.cluster.local:8080` — OpenAI-compatible at `/v1/chat/completions` (supply images as `image_url` content parts).
+
+## Where config lives
+- Workload, image, model/mmproj filenames, server flags, resource requests/limits: `deployments.yaml`.
+- Model storage: `pvc.yaml` — a 5Gi `ReadWriteOnce` PVC (`qwen-models`) mounted at `/models`. The only StorageClass (`local-path`) has `allowVolumeExpansion=false`, so the PVC cannot be grown in place — it must be recreated to resize.
+- Network exposure: `services.yaml` — ClusterIP Service `qwen` on port `8080`.
+
+## Resources
+Main container: requests `cpu: 1` / `memory: 2Gi`, limits `cpu: 6` / `memory: 8Gi`. Init container (download): requests `cpu: 200m` / `memory: 256Mi`, limits `cpu: 2` / `memory: 512Mi`. No GPU is requested.
+
+## Consuming the API
+```bash
+kubectl -n qwen port-forward svc/qwen 8080:8080
+# text
+curl localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
+  "messages":[{"role":"user","content":"Say hi in one word."}]}'
+# vision (image_url content part)
+curl localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
+  "messages":[{"role":"user","content":[
+    {"type":"text","text":"What is in this image?"},
+    {"type":"image_url","image_url":{"url":"https://example.com/pic.jpg"}}]}]}'
+```
+
+## Caveats
+- 0.8B is a small model — good for prototyping, classification, extraction, and vision experiments, **not** reliable multi-step reasoning or agentic tool-calling.
+- The container image tag (`:server`) and llama-server flag names are the most likely things to need a one-time adjustment after watching the first pod start; see the runbook.

--- a/base-apps/qwen/docs/runbook.md
+++ b/base-apps/qwen/docs/runbook.md
@@ -1,0 +1,52 @@
+---
+type: "Kubernetes App Runbook"
+title: "Qwen3.5 — Runbook"
+description: "Operational runbook for the qwen multimodal server: failure modes, checks, and fixes."
+app: qwen
+catalog_entity: qwen
+kind: runbook
+namespace: qwen
+last_reviewed: 2026-07-21
+status: current
+tags: [llm, vision, multimodal, gpu-optional]
+sources:
+  - base-apps/qwen/deployments.yaml
+  - base-apps/qwen/pvc.yaml
+  - base-apps/qwen/services.yaml
+---
+
+# qwen runbook
+
+## Failure modes
+
+### Symptom: pod stuck in `Init` / server never becomes ready
+- **Check:** `kubectl -n qwen logs deploy/qwen -c download-model` — the init container downloads the GGUF + mmproj from Hugging Face; a slow or failed download blocks the main container. Confirm files landed with `kubectl -n qwen exec deploy/qwen -c llama-server -- ls -lh /models`.
+- **Fix:** transient network/registry failures → `kubectl -n qwen delete pod -l app=qwen` to retry the init container. If Hugging Face URLs changed, PR the `BASE`/`MODEL`/`MMPROJ` values in `deployments.yaml`.
+
+### Symptom: `llama-server` CrashLoopBackOff immediately on start
+- **Likely cause:** image entrypoint or flag mismatch. The `ghcr.io/ggml-org/llama.cpp:server` entrypoint is `llama-server`; flag names (`--mmproj`, `--no-mmproj-offload`, `--ctx-size`) occasionally change between builds, and a brand-new model architecture may need a newer image than the one pulled.
+- **Check:** `kubectl -n qwen logs deploy/qwen -c llama-server` — look for "unknown argument", "unknown model architecture", or a failed `mmproj` load.
+- **Fix:** PR to pin a newer/known-good `image:` build digest in `deployments.yaml`, and/or adjust the flag names to match that build.
+
+### Symptom: OOMKilled on the `llama-server` container
+- **Check:** `kubectl -n qwen describe pod -l app=qwen` for `OOMKilled`; `kubectl -n qwen top pod -l app=qwen`. Vision requests load the F16 projector and per-image tensors, which spikes memory above the text-only baseline.
+- **Fix:** PR to raise `resources.limits.memory` in `deployments.yaml` (nodes have ample RAM headroom), or reduce `--ctx-size`.
+
+### Symptom: `PersistentVolumeClaim` full / download fails with no space left
+- **Check:** `kubectl -n qwen exec deploy/qwen -c llama-server -- df -h /models`; `kubectl -n qwen get pvc qwen-models`.
+- **Fix:** the PVC is 5Gi on `local-path`, which **cannot be expanded in place** (`allowVolumeExpansion=false`). To grow it: PR a larger `storage:` in `pvc.yaml`, then delete the PVC + pod so Argo CD recreates them (the model re-downloads on next start).
+
+### Symptom: vision requests fail but text works
+- **Check:** confirm the server was started with `--mmproj` and that `mmproj-F16.gguf` exists on the PVC. Some llama.cpp builds have had VLM/mmproj graph issues on certain architectures.
+- **Fix:** verify with a text-only call first (`/v1/chat/completions` with a string `content`); if only vision breaks, try a newer image build or the `mmproj-BF16.gguf` variant.
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge. `strategy: Recreate` means updates cause a brief full outage while the old pod terminates and the new one (including the `download-model` init container) starts.
+
+### Smoke test
+`kubectl -n qwen port-forward svc/qwen 8080:8080` then `curl localhost:8080/health` (expect `{"status":"ok"}`) and a `/v1/chat/completions` call.
+
+### Note on performance
+CPU-only inference — expect materially slower generation and image-processing latency than a GPU node pool. This is expected behavior, not a bug.

--- a/base-apps/qwen/mkdocs.yml
+++ b/base-apps/qwen/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: qwen
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/base-apps/qwen/pvc.yaml
+++ b/base-apps/qwen/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen-models
+  namespace: qwen
+  labels:
+    app: qwen
+spec:
+  accessModes:
+    - ReadWriteOnce
+  # NOTE: the only StorageClass (local-path) has allowVolumeExpansion=false, so
+  # this cannot be grown in place — size it up front. ~0.6GB weights + the F16
+  # vision projector + headroom fit comfortably in 5Gi.
+  resources:
+    requests:
+      storage: 5Gi

--- a/base-apps/qwen/runbook.md
+++ b/base-apps/qwen/runbook.md
@@ -1,0 +1,52 @@
+---
+type: "Kubernetes App Runbook"
+title: "Qwen3.5 — Runbook"
+description: "Operational runbook for the qwen multimodal server: failure modes, checks, and fixes."
+app: qwen
+catalog_entity: qwen
+kind: runbook
+namespace: qwen
+last_reviewed: 2026-07-21
+status: current
+tags: [llm, vision, multimodal, gpu-optional]
+sources:
+  - base-apps/qwen/deployments.yaml
+  - base-apps/qwen/pvc.yaml
+  - base-apps/qwen/services.yaml
+---
+
+# qwen runbook
+
+## Failure modes
+
+### Symptom: pod stuck in `Init` / server never becomes ready
+- **Check:** `kubectl -n qwen logs deploy/qwen -c download-model` — the init container downloads the GGUF + mmproj from Hugging Face; a slow or failed download blocks the main container. Confirm files landed with `kubectl -n qwen exec deploy/qwen -c llama-server -- ls -lh /models`.
+- **Fix:** transient network/registry failures → `kubectl -n qwen delete pod -l app=qwen` to retry the init container. If Hugging Face URLs changed, PR the `BASE`/`MODEL`/`MMPROJ` values in `deployments.yaml`.
+
+### Symptom: `llama-server` CrashLoopBackOff immediately on start
+- **Likely cause:** image entrypoint or flag mismatch. The `ghcr.io/ggml-org/llama.cpp:server` entrypoint is `llama-server`; flag names (`--mmproj`, `--no-mmproj-offload`, `--ctx-size`) occasionally change between builds, and a brand-new model architecture may need a newer image than the one pulled.
+- **Check:** `kubectl -n qwen logs deploy/qwen -c llama-server` — look for "unknown argument", "unknown model architecture", or a failed `mmproj` load.
+- **Fix:** PR to pin a newer/known-good `image:` build digest in `deployments.yaml`, and/or adjust the flag names to match that build.
+
+### Symptom: OOMKilled on the `llama-server` container
+- **Check:** `kubectl -n qwen describe pod -l app=qwen` for `OOMKilled`; `kubectl -n qwen top pod -l app=qwen`. Vision requests load the F16 projector and per-image tensors, which spikes memory above the text-only baseline.
+- **Fix:** PR to raise `resources.limits.memory` in `deployments.yaml` (nodes have ample RAM headroom), or reduce `--ctx-size`.
+
+### Symptom: `PersistentVolumeClaim` full / download fails with no space left
+- **Check:** `kubectl -n qwen exec deploy/qwen -c llama-server -- df -h /models`; `kubectl -n qwen get pvc qwen-models`.
+- **Fix:** the PVC is 5Gi on `local-path`, which **cannot be expanded in place** (`allowVolumeExpansion=false`). To grow it: PR a larger `storage:` in `pvc.yaml`, then delete the PVC + pod so Argo CD recreates them (the model re-downloads on next start).
+
+### Symptom: vision requests fail but text works
+- **Check:** confirm the server was started with `--mmproj` and that `mmproj-F16.gguf` exists on the PVC. Some llama.cpp builds have had VLM/mmproj graph issues on certain architectures.
+- **Fix:** verify with a text-only call first (`/v1/chat/completions` with a string `content`); if only vision breaks, try a newer image build or the `mmproj-BF16.gguf` variant.
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge. `strategy: Recreate` means updates cause a brief full outage while the old pod terminates and the new one (including the `download-model` init container) starts.
+
+### Smoke test
+`kubectl -n qwen port-forward svc/qwen 8080:8080` then `curl localhost:8080/health` (expect `{"status":"ok"}`) and a `/v1/chat/completions` call.
+
+### Note on performance
+CPU-only inference — expect materially slower generation and image-processing latency than a GPU node pool. This is expected behavior, not a bug.

--- a/base-apps/qwen/services.yaml
+++ b/base-apps/qwen/services.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen
+  namespace: qwen
+  labels:
+    app: qwen
+spec:
+  selector:
+    app: qwen
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  type: ClusterIP

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -17,3 +17,4 @@ coroot
 logging
 dex
 whoami-test
+qwen


### PR DESCRIPTION
## What

Adds a new GitOps base-app **`qwen`** that serves the multimodal (text + vision) **Qwen3.5-0.8B** model in-cluster via llama.cpp's OpenAI-compatible `llama-server`. Mirrors the existing `ollama` app structure.

## Files
- `base-apps/qwen.yaml` — Argo CD Application (master app-of-apps auto-creates it)
- `base-apps/qwen/{deployments,pvc,services}.yaml` — workload + 5Gi PVC + ClusterIP :8080
- `base-apps/qwen/{catalog-info.yaml,mkdocs.yml,docs.md,runbook.md,docs/}` — Backstage catalog + TechDocs

## Key decisions
- **llama.cpp, not vLLM.** Workers are Xeon E5-2670 (**AVX only — no AVX2/AVX-512**); vLLM's CPU backend needs AVX2 minimum, so it cannot run on this hardware. llama.cpp ships AVX/scalar builds. CPU-only (no GPU in cluster).
- **Model:** `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` (~0.6 GB) + `mmproj-F16.gguf` (vision projector), downloaded to the PVC by an idempotent init container.
- **Isolated namespace** so it never contends with the kagent-facing `ollama` embedding service.
- **PVC 5Gi, sized up front** — the only StorageClass (`local-path`) has `allowVolumeExpansion=false`.

## Deploy flow
Merge to `main` → Argo CD master app creates the `qwen` Application → auto-sync (prune + selfHeal). Blast radius is contained to the new `qwen` namespace.

## Validation
`yamllint` clean · `kubectl --dry-run=client` OK · `kubeconform` 3/3 valid (Application CRD skipped — no local schema).

## Known follow-ups (documented in `runbook.md`)
- Pin `ghcr.io/ggml-org/llama.cpp:server` to an immutable digest for reproducibility.
- Confirm `llama-server` flags/entrypoint on first boot — Qwen3.5 is a brand-new architecture, so the first `kubectl -n qwen logs` will tell us whether the pulled build needs a newer tag or a flag tweak.

## Test plan (post-merge)
```bash
kubectl -n qwen get pods -w
kubectl -n qwen logs deploy/qwen -c download-model   # model + mmproj download
kubectl -n qwen logs deploy/qwen -c llama-server     # server startup / arch load
kubectl -n qwen port-forward svc/qwen 8080:8080
curl localhost:8080/health                           # expect {"status":"ok"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
