### PR TITLE
feat(kagent): wire local Qwen3.5-0.8B as a ModelConfig + test agent

### DIFF
--- a/base-apps/kagent/agents/qwen-test.yaml
+++ b/base-apps/kagent/agents/qwen-test.yaml
@@ -1,0 +1,45 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: qwen-test
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: qwen-test
+    app: kagent
+    arigsela.com/idp-managed: "true"
+    # Pure LLM, tools: []. Nothing to gate. (agent-capability policy: read class.)
+    capability.homelab/class: read
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/qwen-test.yaml
+    backstage.io/owner: group:default/platform-engineering
+spec:
+  description: |-
+    Throwaway wiring test for the local Qwen3.5-0.8B model (base-apps/qwen,
+    llama.cpp, CPU). No tools — validates only that kagent can reach the local
+    OpenAI-compatible endpoint. Not for real work: a 0.8B is unreliable at
+    tool-calling and delegation, so keep real agents on the Anthropic model.
+  type: Declarative
+  declarative:
+    modelConfig: qwen-local
+    runtime: python
+    stream: true
+    systemMessage: |
+      You are a small local test model (Qwen3.5-0.8B) served in-cluster via
+      llama.cpp. You exist only to confirm that kagent can reach the local model.
+      Answer briefly and directly. You have no tools and no cluster access. If
+      asked to do anything requiring tools, live cluster state, or multi-step
+      reasoning, say plainly that you are only a wiring test for the local model
+      and cannot do that.
+    tools: []
+    deployment:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi

--- a/base-apps/kagent/model-configs/qwen-local.yaml
+++ b/base-apps/kagent/model-configs/qwen-local.yaml
@@ -1,0 +1,18 @@
+apiVersion: kagent.dev/v1alpha2
+kind: ModelConfig
+metadata:
+  name: qwen-local
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: qwen-local
+spec:
+  provider: OpenAI
+  # Cosmetic: llama.cpp ignores the requested model name and serves whatever GGUF
+  # is loaded. The server lives in base-apps/qwen (Qwen3.5-0.8B, CPU, llama.cpp).
+  model: Qwen3.5-0.8B
+  openAI:
+    # Points at the in-cluster qwen service (OpenAI-compatible /v1). No apiKey:
+    # llama.cpp is a no-auth local endpoint and the CRD only requires `model`
+    # (the Ollama embedding-model-config is keyless for the same reason).
+    baseUrl: http://qwen.qwen.svc.cluster.local:8080/v1


### PR DESCRIPTION
## What

Wires the local **Qwen3.5-0.8B** server (`base-apps/qwen`, llama.cpp, CPU — from #410) into **kagent** as an OpenAI-compatible model, plus a throwaway no-tool agent to exercise it from the kagent UI.

## Files
- `base-apps/kagent/model-configs/qwen-local.yaml` — `ModelConfig`, provider `OpenAI`, `openAI.baseUrl` → the in-cluster `qwen` service. **Keyless** (llama.cpp needs no auth; the CRD only requires `model`, like the Ollama embedding config).
- `base-apps/kagent/agents/qwen-test.yaml` — minimal `Agent`, `tools: []`, `capability.homelab/class: read`.

## Why a throwaway test agent (not a real one)
A 0.8B model is unreliable at the structured tool-calling and delegation kagent agents depend on — `homelab-knowledge` runs on Sonnet *specifically* for that. So `qwen-test` has no tools; it just proves the kagent → qwen path works. **Real agents are untouched** and stay on `anthropic-claude-sonnet-4-6`.

## Deploy
Recurse-synced by the existing `kagent-secrets` Application. No new Application, no secret, no Vault plumbing.

## Validation
- `yamllint` clean
- `kubectl --dry-run=server` → both resources accepted, passing CRD schema **and** the `agent-capability` / `agent-identity` **Enforce** Kyverno policies.

## One runtime unknown
Admission accepts the keyless ModelConfig, but whether kagent 0.9.11's OpenAI client connects with no API key is only exercised at inference. If it insists on a non-empty key, the fix is a one-line follow-up (add a placeholder plain Secret — not an ExternalSecret, so not gated by `agent-identity`).

## Test (post-merge)
```bash
kubectl -n kagent get agent qwen-test
kubectl -n kagent get modelconfig qwen-local
# then in the kagent UI, chat with `qwen-test`: "Say hi in one word."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
