### PR TITLE
fix(kagent): placeholder api_key for qwen-local so inference works

### DIFF
--- a/base-apps/kagent/model-configs/qwen-local.yaml
+++ b/base-apps/kagent/model-configs/qwen-local.yaml
@@ -11,8 +11,11 @@ spec:
   # Cosmetic: llama.cpp ignores the requested model name and serves whatever GGUF
   # is loaded. The server lives in base-apps/qwen (Qwen3.5-0.8B, CPU, llama.cpp).
   model: Qwen3.5-0.8B
+  # Placeholder key (see qwen-local-secret.yaml). qwen/llama.cpp needs no auth,
+  # but kagent's OpenAI client refuses to start without a non-empty api_key
+  # ("Missing credentials ... set OPENAI_API_KEY"). The value is not a secret.
+  apiKeySecret: qwen-local
+  apiKeySecretKey: OPENAI_API_KEY
   openAI:
-    # Points at the in-cluster qwen service (OpenAI-compatible /v1). No apiKey:
-    # llama.cpp is a no-auth local endpoint and the CRD only requires `model`
-    # (the Ollama embedding-model-config is keyless for the same reason).
+    # Points at the in-cluster qwen service (OpenAI-compatible /v1).
     baseUrl: http://qwen.qwen.svc.cluster.local:8080/v1

--- a/base-apps/kagent/qwen-local-secret.yaml
+++ b/base-apps/kagent/qwen-local-secret.yaml
@@ -1,0 +1,20 @@
+# NOT a credential. The qwen service (base-apps/qwen, llama.cpp) is a no-auth
+# local endpoint and ignores this value entirely. It exists only because
+# kagent's OpenAI client refuses to start without a non-empty api_key
+# ("Missing credentials ... set OPENAI_API_KEY environment variable"). Committed
+# in plaintext on purpose — there is no secret to protect.
+#
+# This is a core v1 Secret, NOT an ExternalSecret, so the agent-identity Kyverno
+# policy (which only gates ExternalSecrets through Vault) does not apply. If qwen
+# ever gains real auth, replace this with the per-consumer ESO/Vault trio.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: qwen-local
+  namespace: kagent
+  labels:
+    app.kubernetes.io/part-of: kagent
+    app.kubernetes.io/name: qwen-local
+type: Opaque
+stringData:
+  OPENAI_API_KEY: not-a-real-key-llama-cpp-ignores-this


### PR DESCRIPTION
## What

Follow-up to #411. The keyless `qwen-local` ModelConfig deployed cleanly and passed admission, but at **inference** kagent's OpenAI client rejects it:

```
Missing credentials. Please pass an `api_key` ... or set the OPENAI_API_KEY environment variable.
```

So kagent requires a non-empty key even for a no-auth local endpoint. This adds the placeholder we planned for.

## Files
- `base-apps/kagent/qwen-local-secret.yaml` — a **core `v1` Secret** with a fake `OPENAI_API_KEY`. **Not a credential** (llama.cpp ignores it); committed in plaintext on purpose. Being a core Secret (not an `ExternalSecret`), it is *not* gated by the `agent-identity` policy.
- `base-apps/kagent/model-configs/qwen-local.yaml` — now references it via `apiKeySecret: qwen-local` / `apiKeySecretKey: OPENAI_API_KEY`.

## Validation
- Reproduced the failure live: `invoke kagent/qwen-test` → "Missing credentials".
- Fix: `yamllint` clean, `kubectl --dry-run=server` accepts both.

## Test (post-merge)
```bash
kubectl -n kagent rollout status deploy/qwen-test   # picks up the new key
# then invoke kagent/qwen-test again — should get a real (if small/slow) reply
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
