### PR TITLE
chore(qwen): pin llama.cpp image to digest + default thinking off

### DIFF
--- a/base-apps/qwen/deployments.yaml
+++ b/base-apps/qwen/deployments.yaml
@@ -60,8 +60,10 @@ spec:
         - name: llama-server
           # CPU-only llama.cpp OpenAI-compatible server (the :server tag is the CPU
           # build; :server-cuda is the GPU one). This cluster has no GPU.
-          # TODO: pin to an immutable build digest for reproducible GitOps.
-          image: ghcr.io/ggml-org/llama.cpp:server
+          # Pinned by digest for reproducible GitOps — this is the exact build
+          # verified to load the Qwen3.5 architecture (was :server). To upgrade:
+          # pull the tag, confirm it still loads the model + mmproj, then re-pin.
+          image: ghcr.io/ggml-org/llama.cpp@sha256:e10504c7f5c5bacece7e7e5957760eee53868642d853fe5ecfe8611065929a24
           args:
             - --model
             - /models/Qwen3.5-0.8B-UD-Q4_K_XL.gguf
@@ -79,6 +81,14 @@ spec:
             - "8192"
             - --threads
             - "6"
+            # Default thinking OFF: this GGUF's chat template defaults to reasoning,
+            # which on a 0.8B burns the token budget (and can loop) before answering.
+            # Applies the request-level kwarg we verified, as a server-wide default;
+            # callers can still re-enable per request by sending
+            # chat_template_kwargs {"enable_thinking": true}. (--jinja is on by
+            # default, which this flag requires.)
+            - --chat-template-kwargs
+            - '{"enable_thinking":false}'
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## What
Two small hardening changes to `base-apps/qwen/deployments.yaml`, both verified against the running pod.

## Changes
1. **Pin the image by digest** — `ghcr.io/ggml-org/llama.cpp@sha256:e10504c7…`, the exact build currently running and confirmed to load the Qwen3.5 architecture. Replaces the mutable `:server` tag (also clears the `disallow-latest-tag` audit policy). To upgrade: pull the tag, confirm it still loads model + mmproj, then re-pin.
2. **Thinking off by default** — `--chat-template-kwargs '{"enable_thinking":false}'`. This GGUF's chat template defaults to reasoning; on a 0.8B that burns the token budget (and can loop) before answering. Makes the clean behavior the default; callers can opt back in per request with `chat_template_kwargs {"enable_thinking": true}`.

## Why it's safe
- The flag is confirmed present in the running build (`llama-server --help`), and `--jinja` (its prerequisite) is on by default.
- The digest is exactly what the live pod reports (`imageID`).

## Validation
`yamllint` · `kubeconform` · `kubectl --dry-run=client` — all pass.

## Rollout note
`strategy: Recreate` → brief outage as the pod restarts. It re-reads the same PVC-cached model, so **no re-download**. After sync:
```bash
kubectl -n qwen rollout status deploy/qwen
# a plain chat call should now return content without passing enable_thinking:false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
