### PR TITLE
feat(kagent): add qwen-openclaw harness (local qwen, no Slack)

### DIFF
--- a/base-apps/kagent/harnesses/qwen-openclaw.yaml
+++ b/base-apps/kagent/harnesses/qwen-openclaw.yaml
@@ -1,0 +1,14 @@
+apiVersion: kagent.dev/v1alpha2
+kind: AgentHarness
+metadata:
+  name: qwen-openclaw
+  namespace: kagent
+spec:
+  # openclaw is the backend proven to work on this cluster (see homelab-harness).
+  # The hermes/nemoclaw backends need the api_server control channel on
+  # 127.0.0.1:18642, which Hermes v0.18.0 refuses to start without API_SERVER_KEY
+  # — a key kagent 0.9.11 does not set and does not propagate via spec.env. So
+  # this uses openclaw with no messaging channels.
+  backend: openclaw
+  description: "Sandboxed openclaw agent driven by the local Qwen3.5-0.8B model (base-apps/qwen, llama.cpp, CPU). No messaging channels. Experimental — a 0.8B is weak at tool-calling."
+  modelConfigRef: qwen-local


### PR DESCRIPTION
## What
Adds `AgentHarness/qwen-openclaw` — a sandboxed agent driven by the local **Qwen3.5-0.8B** model, using the **openclaw** backend and **no Slack/messaging**.

## Why openclaw (not hermes/nemoclaw)
We root-caused the `qwen-hermes` failure: the `hermes` backend needs the api_server control channel on `127.0.0.1:18642`, which Hermes **v0.18.0** (from `hermes-sandbox-base:latest`) refuses to start without `API_SERVER_KEY` — a key **kagent 0.9.11 doesn't set and doesn't propagate via `spec.env`** (verified live, including a full sandbox recreate). This is independent of Slack. `openclaw` has no such requirement — your `homelab-harness` runs this exact shape and is Ready.

## Shape
Mirrors `base-apps/kagent/harnesses/homelab-harness.yaml`, swapping the model to `qwen-local`.

## Caveat
Still a 0.8B — it'll reach Ready and wire correctly, but sandbox/tool-calling performance will be weak. Experiment, not production.

## Validation
`yamllint` clean · `kubectl --dry-run=server` accepted.

## Deploy / verify (post-merge)
Recurse-synced by the `kagent-secrets` app.
```bash
kubectl -n kagent get agentharness qwen-openclaw
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
