### PR TITLE
feat(openclaw-qwen): standalone OpenClaw agent driven by local qwen

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -44,6 +44,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | ollama | Local LLM/embedding model server (Ollama, CPU-only, PVC-backed) | ollama | [docs.md](ollama/docs.md) | [runbook.md](ollama/runbook.md) | [catalog-info.yaml](ollama/catalog-info.yaml) |
 | oncall-agent | AI on-call/incident-response agent (Anthropic Claude, Slack, GitOps PRs) | oncall-agent | [docs.md](oncall-agent/docs.md) | [runbook.md](oncall-agent/runbook.md) | [catalog-info.yaml](oncall-agent/catalog-info.yaml) |
 | oncall-crewai |  |  |  |  |  |
+| openclaw-qwen | Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox | openclaw-qwen | [docs.md](openclaw-qwen/docs.md) | [runbook.md](openclaw-qwen/runbook.md) | [catalog-info.yaml](openclaw-qwen/catalog-info.yaml) |
 | openshell |  |  |  |  |  |
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) + CNPG cluster for chores-tracker (daily S3 backups) | postgresql | [docs.md](postgresql/docs.md) | [runbook.md](postgresql/runbook.md) | [catalog-info.yaml](postgresql/catalog-info.yaml) |
 | qwen | Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed | qwen | [docs.md](qwen/docs.md) | [runbook.md](qwen/runbook.md) | [catalog-info.yaml](qwen/catalog-info.yaml) |

--- a/base-apps/openclaw-qwen.yaml
+++ b/base-apps/openclaw-qwen.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: openclaw-qwen
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/openclaw-qwen
+    directory:
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    # Dedicated namespace — NOT the pre-existing (unrelated, orphaned) `openclaw`
+    # namespace that already owns svc/ingress openclaw.arigsela.com.
+    namespace: openclaw-qwen
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/openclaw-qwen/catalog-info.yaml
+++ b/base-apps/openclaw-qwen/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: openclaw-qwen
+  namespace: openclaw-qwen
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=openclaw-qwen'
+    backstage.io/kubernetes-namespace: openclaw-qwen
+  tags: [llm, agent, coding-agent, local, gpu-optional]
+spec:
+  type: service
+  lifecycle: experimental
+  owner: group:default/platform
+  system: default/platform-ai

--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-qwen-config
+  namespace: openclaw-qwen
+  labels:
+    app: openclaw-qwen
+    app.kubernetes.io/name: openclaw-qwen
+    app.kubernetes.io/part-of: platform-ai
+data:
+  # OpenClaw config, seeded into the pod's writable HOME by the init container.
+  # Points OpenClaw's "openai" provider straight at the in-cluster qwen service
+  # (base-apps/qwen). Because this runs as a plain Deployment (NOT an openshell
+  # sandbox), there is no egress proxy in the way — OpenClaw reaches qwen
+  # directly. apiKey is a placeholder; llama.cpp ignores it. Gateway binds
+  # loopback with no auth: it is only reachable from inside the pod (via
+  # `kubectl exec`), never on the cluster network.
+  openclaw.json: |
+    {
+      "gateway": { "mode": "local", "bind": "loopback", "auth": { "mode": "none" }, "port": 18800 },
+      "models": {
+        "mode": "merge",
+        "providers": {
+          "openai": {
+            "baseUrl": "http://qwen.qwen.svc.cluster.local:8080/v1",
+            "apiKey": "not-needed",
+            "auth": "api-key",
+            "api": "openai-completions",
+            "models": [ { "id": "Qwen3.5-0.8B", "name": "Qwen3.5-0.8B" } ]
+          }
+        }
+      },
+      "agents": { "defaults": { "model": { "primary": "openai/Qwen3.5-0.8B" } } }
+    }

--- a/base-apps/openclaw-qwen/deployment.yaml
+++ b/base-apps/openclaw-qwen/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-qwen
+  namespace: openclaw-qwen
+  labels:
+    app: openclaw-qwen
+    app.kubernetes.io/name: openclaw-qwen
+    app.kubernetes.io/part-of: platform-ai
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openclaw-qwen
+  template:
+    metadata:
+      labels:
+        app: openclaw-qwen
+        app.kubernetes.io/name: openclaw-qwen
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      initContainers:
+        # Seed the config from the ConfigMap into the pod's writable HOME.
+        # OpenClaw needs a writable ~/.openclaw (sessions, state), so the
+        # read-only ConfigMap can't be mounted there directly.
+        - name: seed-config
+          image: ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /state/.openclaw
+              cp /config/openclaw.json /state/.openclaw/openclaw.json
+              echo "seeded /state/.openclaw/openclaw.json"
+          volumeMounts:
+            - name: state
+              mountPath: /state
+            - name: config
+              mountPath: /config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      containers:
+        - name: openclaw
+          # Same image the kagent openclaw harness uses; run OpenClaw directly
+          # instead of the openshell sandbox supervisor. Inference happens in the
+          # qwen pod, so this container itself stays light (Node orchestration).
+          image: ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4
+          command:
+            - sh
+            - -c
+            - exec openclaw gateway run --auth none --bind loopback --port 18800
+          env:
+            - name: HOME
+              value: /state
+          volumeMounts:
+            - name: state
+              mountPath: /state
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          livenessProbe:
+            # Gateway binds loopback, so a normal tcpSocket probe (pod IP) can't
+            # reach it — check the listening socket in /proc instead.
+            # 18800 = 0x4970.
+            exec:
+              command:
+                - sh
+                - -c
+                - grep -qi ':4970 ' /proc/net/tcp
+            initialDelaySeconds: 40
+            periodSeconds: 30
+            failureThreshold: 4
+      volumes:
+        - name: state
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: openclaw-qwen-config

--- a/base-apps/openclaw-qwen/docs.md
+++ b/base-apps/openclaw-qwen/docs.md
@@ -1,0 +1,53 @@
+---
+type: "Kubernetes App Guide"
+title: "OpenClaw + qwen (standalone)"
+description: "Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox"
+app: openclaw-qwen
+catalog_entity: openclaw-qwen
+kind: docs
+namespace: openclaw-qwen
+last_reviewed: 2026-07-22
+status: current
+tags: [llm, agent, coding-agent, local, gpu-optional]
+sources:
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/deployment.yaml
+---
+
+# openclaw-qwen
+
+## What it is
+A **standalone** [OpenClaw](https://github.com/kagent-dev) coding/ops agent (a Claude-Code-style TUI agent) running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`, llama.cpp, CPU). Lives in its own `openclaw-qwen` namespace — deliberately NOT the pre-existing, unrelated `openclaw` namespace (which owns `svc/ingress openclaw.arigsela.com`).
+
+## Why standalone (not a kagent AgentHarness)
+kagent's `AgentHarness` runs OpenClaw inside an **openshell sandbox**, which forces outbound traffic through an egress proxy. That proxy drops OpenClaw's calls to the *internal* `qwen.qwen.svc.cluster.local` service, so every agent turn failed with `[assistant turn failed before producing content]` — the request never reached qwen. Running OpenClaw as a plain Deployment removes the proxy: OpenClaw talks straight to qwen. Verified: a one-shot turn returns a real answer and the request lands in qwen's logs.
+
+## Architecture & data flow
+Single-replica `Deployment` (`strategy: Recreate`) on nodes labeled `node.kubernetes.io/workload: application`. An `initContainer` copies `openclaw.json` from the ConfigMap into the pod's writable `HOME` (`/state/.openclaw/`, an `emptyDir`). The main container runs `openclaw gateway run --auth none --bind loopback --port 18800`.
+
+The config points OpenClaw's `openai` provider at `http://qwen.qwen.svc.cluster.local:8080/v1` (model `Qwen3.5-0.8B`, placeholder api key — llama.cpp ignores it) and sets it as the default agent model. Inference happens in the qwen pod, so this container stays light.
+
+## How to interact
+The gateway binds **loopback only** — it is not exposed on the cluster network (no Service). You reach it from inside the pod via `kubectl exec`:
+
+```bash
+# interactive agent TUI (connects to the loopback gateway)
+kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui
+
+# or the local-embedded chat TUI (no gateway needed)
+kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw chat
+
+# non-interactive one-shot (good for a smoke test)
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Say hi in one word" --local
+```
+Confirm you're on qwen: the TUI status bar should show `openai/Qwen3.5-0.8B` (not `gpt-5.5`).
+
+## Where config lives
+- Model provider, gateway mode, default model: `configmap.yaml` (`openclaw.json`).
+- Workload, image (pinned by digest), init seed, resources: `deployment.yaml`.
+- No Service by design (loopback-only). No secrets (qwen needs no auth).
+
+## Caveats
+- **0.8B on CPU**: agent turns are slow and the model is weak at multi-step tool-calling — expect sluggish, rough behavior. The *plumbing* is correct; the model is the limit. For real work, point the config at a bigger model (and ideally a GPU).
+- State (`/state`) is an `emptyDir` — sessions/workspace do not survive a pod restart. Add a PVC if you need persistence.

--- a/base-apps/openclaw-qwen/docs/index.md
+++ b/base-apps/openclaw-qwen/docs/index.md
@@ -1,0 +1,53 @@
+---
+type: "Kubernetes App Guide"
+title: "OpenClaw + qwen (standalone)"
+description: "Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox"
+app: openclaw-qwen
+catalog_entity: openclaw-qwen
+kind: docs
+namespace: openclaw-qwen
+last_reviewed: 2026-07-22
+status: current
+tags: [llm, agent, coding-agent, local, gpu-optional]
+sources:
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/deployment.yaml
+---
+
+# openclaw-qwen
+
+## What it is
+A **standalone** [OpenClaw](https://github.com/kagent-dev) coding/ops agent (a Claude-Code-style TUI agent) running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`, llama.cpp, CPU). Lives in its own `openclaw-qwen` namespace — deliberately NOT the pre-existing, unrelated `openclaw` namespace (which owns `svc/ingress openclaw.arigsela.com`).
+
+## Why standalone (not a kagent AgentHarness)
+kagent's `AgentHarness` runs OpenClaw inside an **openshell sandbox**, which forces outbound traffic through an egress proxy. That proxy drops OpenClaw's calls to the *internal* `qwen.qwen.svc.cluster.local` service, so every agent turn failed with `[assistant turn failed before producing content]` — the request never reached qwen. Running OpenClaw as a plain Deployment removes the proxy: OpenClaw talks straight to qwen. Verified: a one-shot turn returns a real answer and the request lands in qwen's logs.
+
+## Architecture & data flow
+Single-replica `Deployment` (`strategy: Recreate`) on nodes labeled `node.kubernetes.io/workload: application`. An `initContainer` copies `openclaw.json` from the ConfigMap into the pod's writable `HOME` (`/state/.openclaw/`, an `emptyDir`). The main container runs `openclaw gateway run --auth none --bind loopback --port 18800`.
+
+The config points OpenClaw's `openai` provider at `http://qwen.qwen.svc.cluster.local:8080/v1` (model `Qwen3.5-0.8B`, placeholder api key — llama.cpp ignores it) and sets it as the default agent model. Inference happens in the qwen pod, so this container stays light.
+
+## How to interact
+The gateway binds **loopback only** — it is not exposed on the cluster network (no Service). You reach it from inside the pod via `kubectl exec`:
+
+```bash
+# interactive agent TUI (connects to the loopback gateway)
+kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui
+
+# or the local-embedded chat TUI (no gateway needed)
+kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw chat
+
+# non-interactive one-shot (good for a smoke test)
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Say hi in one word" --local
+```
+Confirm you're on qwen: the TUI status bar should show `openai/Qwen3.5-0.8B` (not `gpt-5.5`).
+
+## Where config lives
+- Model provider, gateway mode, default model: `configmap.yaml` (`openclaw.json`).
+- Workload, image (pinned by digest), init seed, resources: `deployment.yaml`.
+- No Service by design (loopback-only). No secrets (qwen needs no auth).
+
+## Caveats
+- **0.8B on CPU**: agent turns are slow and the model is weak at multi-step tool-calling — expect sluggish, rough behavior. The *plumbing* is correct; the model is the limit. For real work, point the config at a bigger model (and ideally a GPU).
+- State (`/state`) is an `emptyDir` — sessions/workspace do not survive a pod restart. Add a PVC if you need persistence.

--- a/base-apps/openclaw-qwen/docs/runbook.md
+++ b/base-apps/openclaw-qwen/docs/runbook.md
@@ -1,0 +1,48 @@
+---
+type: "Kubernetes App Runbook"
+title: "OpenClaw + qwen — Runbook"
+description: "Operational runbook for the standalone OpenClaw agent: failure modes, checks, and fixes."
+app: openclaw-qwen
+catalog_entity: openclaw-qwen
+kind: runbook
+namespace: openclaw-qwen
+last_reviewed: 2026-07-22
+status: current
+tags: [llm, agent, coding-agent, local, gpu-optional]
+sources:
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/deployment.yaml
+---
+
+# openclaw-qwen runbook
+
+## Failure modes
+
+### Symptom: `[assistant turn failed before producing content]` / turns never reach qwen
+- **Check:** from inside the pod, `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- curl -sS -m10 http://qwen.qwen.svc.cluster.local:8080/health` (expect `{"status":"ok"}`), and `kubectl -n qwen logs deploy/qwen -c llama-server --since=2m | grep task` to see if requests land.
+- **Fix:** if the health check fails, qwen is down (see `base-apps/qwen`) or network policy is blocking. If health is OK but no requests land, confirm `HOME=/state` and that `/state/.openclaw/openclaw.json` exists and points at the qwen baseUrl (`exec ... -- cat /state/.openclaw/openclaw.json`). Unlike the openshell harness, this pod has no egress proxy, so proxy interception is not a factor here.
+
+### Symptom: TUI shows model `gpt-5.5` instead of `openai/Qwen3.5-0.8B`
+- **Check:** the config wasn't loaded — `exec ... -- sh -c 'HOME=/state openclaw config validate'` and inspect `/state/.openclaw/openclaw.json`.
+- **Fix:** ensure `HOME=/state` is set (env in `deployment.yaml`) and the init container seeded the config. Delete the pod to re-seed. `gpt-5.5` is OpenClaw's built-in fallback when it can't resolve the configured provider.
+
+### Symptom: pod CrashLoop / liveness failing
+- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen` and `kubectl -n openclaw-qwen describe pod -l app=openclaw-qwen`. The liveness probe greps `/proc/net/tcp` for the gateway port (18800 = `:4970`); if the gateway never binds, the probe fails.
+- **Fix:** check the gateway startup logs for config errors; verify the pinned image still ships `openclaw`. Raise `initialDelaySeconds` if the gateway is slow to bind on first start.
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`strategy: Recreate`) so the init container re-seeds `openclaw.json`.
+
+### Smoke test (does qwen answer?)
+```bash
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: what color is grass?" --local
+```
+
+### Point at a bigger / different model
+Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. (A larger model is the real fix for weak agent behavior.)
+
+### Note on performance
+Inference runs on the CPU-only qwen pod (Qwen3.5-0.8B). Agent turns are slow and the model is weak at tool-calling — expected, not a bug.

--- a/base-apps/openclaw-qwen/mkdocs.yml
+++ b/base-apps/openclaw-qwen/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: openclaw-qwen
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/base-apps/openclaw-qwen/runbook.md
+++ b/base-apps/openclaw-qwen/runbook.md
@@ -1,0 +1,48 @@
+---
+type: "Kubernetes App Runbook"
+title: "OpenClaw + qwen — Runbook"
+description: "Operational runbook for the standalone OpenClaw agent: failure modes, checks, and fixes."
+app: openclaw-qwen
+catalog_entity: openclaw-qwen
+kind: runbook
+namespace: openclaw-qwen
+last_reviewed: 2026-07-22
+status: current
+tags: [llm, agent, coding-agent, local, gpu-optional]
+sources:
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/deployment.yaml
+---
+
+# openclaw-qwen runbook
+
+## Failure modes
+
+### Symptom: `[assistant turn failed before producing content]` / turns never reach qwen
+- **Check:** from inside the pod, `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- curl -sS -m10 http://qwen.qwen.svc.cluster.local:8080/health` (expect `{"status":"ok"}`), and `kubectl -n qwen logs deploy/qwen -c llama-server --since=2m | grep task` to see if requests land.
+- **Fix:** if the health check fails, qwen is down (see `base-apps/qwen`) or network policy is blocking. If health is OK but no requests land, confirm `HOME=/state` and that `/state/.openclaw/openclaw.json` exists and points at the qwen baseUrl (`exec ... -- cat /state/.openclaw/openclaw.json`). Unlike the openshell harness, this pod has no egress proxy, so proxy interception is not a factor here.
+
+### Symptom: TUI shows model `gpt-5.5` instead of `openai/Qwen3.5-0.8B`
+- **Check:** the config wasn't loaded — `exec ... -- sh -c 'HOME=/state openclaw config validate'` and inspect `/state/.openclaw/openclaw.json`.
+- **Fix:** ensure `HOME=/state` is set (env in `deployment.yaml`) and the init container seeded the config. Delete the pod to re-seed. `gpt-5.5` is OpenClaw's built-in fallback when it can't resolve the configured provider.
+
+### Symptom: pod CrashLoop / liveness failing
+- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen` and `kubectl -n openclaw-qwen describe pod -l app=openclaw-qwen`. The liveness probe greps `/proc/net/tcp` for the gateway port (18800 = `:4970`); if the gateway never binds, the probe fails.
+- **Fix:** check the gateway startup logs for config errors; verify the pinned image still ships `openclaw`. Raise `initialDelaySeconds` if the gateway is slow to bind on first start.
+
+## How-to
+
+### Deploy / update
+Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`strategy: Recreate`) so the init container re-seeds `openclaw.json`.
+
+### Smoke test (does qwen answer?)
+```bash
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: what color is grass?" --local
+```
+
+### Point at a bigger / different model
+Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. (A larger model is the real fix for weak agent behavior.)
+
+### Note on performance
+Inference runs on the CPU-only qwen pod (Qwen3.5-0.8B). Agent turns are slow and the model is weak at tool-calling — expected, not a bug.

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -18,3 +18,4 @@ logging
 dex
 whoami-test
 qwen
+openclaw-qwen


### PR DESCRIPTION
## What
Adds **`base-apps/openclaw-qwen`** — a **standalone** OpenClaw coding agent running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model. This is the "Option 1" clean alternative to the kagent AgentHarness, which couldn't reach qwen.

## Why standalone (the AgentHarness dead-end)
kagent's `AgentHarness` runs OpenClaw inside an **openshell sandbox** whose **egress proxy drops OpenClaw's calls to the internal `qwen.qwen.svc` service** — every agent turn failed with `[assistant turn failed before producing content]`, and the request never reached qwen. A plain Deployment has no egress proxy, so OpenClaw talks straight to qwen.

**Verified end-to-end:** `openclaw infer model run … --local` returned real answers (`"Blue."`, `"Green"`, `"four"`) and the requests landed in qwen's `llama-server` logs — the exact traffic that never arrived inside the sandbox.

## Design
- `configmap.yaml` — seeds `openclaw.json` (OpenClaw `openai` provider → `http://qwen.qwen.svc.cluster.local:8080/v1`, `Qwen3.5-0.8B` as the default agent model; placeholder api key).
- `deployment.yaml` — runs `openclaw gateway run --auth none --bind loopback`, image pinned by digest, init container seeds config into a writable `HOME`.
- **No Service by design** — the gateway binds loopback only, so there is no unauthenticated code-exec endpoint on the cluster network. Reach it via `kubectl exec`.
- **Dedicated `openclaw-qwen` namespace** — deliberately avoids the pre-existing, unrelated `openclaw` namespace (see Heads up).

## How to use (post-merge)
```bash
kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui     # agent TUI
kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw chat    # local chat
# smoke test:
kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "hi" --local
```

## Validation
`yamllint` clean · `kubeconform` valid · live apply + smoke test (returned `"four"`) then torn down.

## Caveat
0.8B on CPU: slow and weak at tool-calling. Plumbing is correct; the model is the limit. Swap the config's model for a bigger one (ideally on a GPU) for real work.

## ⚠️ Heads up (unrelated to this PR)
There's a **pre-existing `openclaw` namespace** (~153 days old: `svc/openclaw` :18789 + `ingress openclaw.arigsela.com`, bjw-s app-template style, **no running pods**, **not in GitOps**). Looks orphaned. This PR does not touch it — worth deciding separately whether to revive or delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
