### PR TITLE
fix(openclaw-qwen): official token-auth pattern so the TUI can send; qwen ctx 32K

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -44,7 +44,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | ollama | Local LLM/embedding model server (Ollama, CPU-only, PVC-backed) | ollama | [docs.md](ollama/docs.md) | [runbook.md](ollama/runbook.md) | [catalog-info.yaml](ollama/catalog-info.yaml) |
 | oncall-agent | AI on-call/incident-response agent (Anthropic Claude, Slack, GitOps PRs) | oncall-agent | [docs.md](oncall-agent/docs.md) | [runbook.md](oncall-agent/runbook.md) | [catalog-info.yaml](oncall-agent/catalog-info.yaml) |
 | oncall-crewai |  |  |  |  |  |
-| openclaw-qwen | Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox | openclaw-qwen | [docs.md](openclaw-qwen/docs.md) | [runbook.md](openclaw-qwen/runbook.md) | [catalog-info.yaml](openclaw-qwen/catalog-info.yaml) |
+| openclaw-qwen | Standalone OpenClaw agent (official image, token auth) driven by the local Qwen3.5-0.8B model | openclaw-qwen | [docs.md](openclaw-qwen/docs.md) | [runbook.md](openclaw-qwen/runbook.md) | [catalog-info.yaml](openclaw-qwen/catalog-info.yaml) |
 | openshell |  |  |  |  |  |
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) + CNPG cluster for chores-tracker (daily S3 backups) | postgresql | [docs.md](postgresql/docs.md) | [runbook.md](postgresql/runbook.md) | [catalog-info.yaml](postgresql/catalog-info.yaml) |
 | qwen | Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed | qwen | [docs.md](qwen/docs.md) | [runbook.md](qwen/runbook.md) | [catalog-info.yaml](qwen/catalog-info.yaml) |

--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -8,16 +8,21 @@ metadata:
     app.kubernetes.io/name: openclaw-qwen
     app.kubernetes.io/part-of: platform-ai
 data:
-  # OpenClaw config, seeded into the pod's writable HOME by the init container.
-  # Points OpenClaw's "openai" provider straight at the in-cluster qwen service
-  # (base-apps/qwen). Because this runs as a plain Deployment (NOT an openshell
-  # sandbox), there is no egress proxy in the way — OpenClaw reaches qwen
-  # directly. apiKey is a placeholder; llama.cpp ignores it. Gateway binds
-  # loopback with no auth: it is only reachable from inside the pod (via
-  # `kubectl exec`), never on the cluster network.
+  # Follows OpenClaw's official k8s config (docs.openclaw.ai/install/kubernetes):
+  # gateway.auth.mode "token" — shared-secret auth that grants the OPERATOR role,
+  # so the TUI can actually send (unlike "none", which is read-only). The token
+  # comes from the OPENCLAW_GATEWAY_TOKEN env (secret.yaml). The `openai` provider
+  # points at the in-cluster qwen model; a plain Deployment has no egress proxy,
+  # so it reaches qwen directly.
   openclaw.json: |
     {
-      "gateway": { "mode": "local", "bind": "loopback", "auth": { "mode": "none" }, "port": 18800 },
+      "gateway": {
+        "mode": "local",
+        "bind": "loopback",
+        "port": 18789,
+        "auth": { "mode": "token" },
+        "controlUi": { "enabled": true }
+      },
       "models": {
         "mode": "merge",
         "providers": {
@@ -26,9 +31,20 @@ data:
             "apiKey": "not-needed",
             "auth": "api-key",
             "api": "openai-completions",
+            "timeoutSeconds": 1200,
             "models": [ { "id": "Qwen3.5-0.8B", "name": "Qwen3.5-0.8B" } ]
           }
         }
       },
-      "agents": { "defaults": { "model": { "primary": "openai/Qwen3.5-0.8B" } } }
+      "agents": {
+        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/Qwen3.5-0.8B" }, "timeoutSeconds": 1200 },
+        "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "~/.openclaw/workspace" } ]
+      },
+      "cron": { "enabled": false }
     }
+  AGENTS.md: |
+    # OpenClaw Assistant
+
+    You are a helpful AI assistant running in Kubernetes, backed by a local
+    Qwen3.5-0.8B model. Keep answers short and direct — the model is small and
+    runs on CPU, so brevity matters.

--- a/base-apps/openclaw-qwen/deployment.yaml
+++ b/base-apps/openclaw-qwen/deployment.yaml
@@ -22,70 +22,109 @@ spec:
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
-        # Seed the config from the ConfigMap into the pod's writable HOME.
-        # OpenClaw needs a writable ~/.openclaw (sessions, state), so the
-        # read-only ConfigMap can't be mounted there directly.
-        - name: seed-config
-          image: ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4
+        # Seed the config + AGENTS.md into the writable HOME (the ConfigMap is
+        # read-only; OpenClaw needs a writable ~/.openclaw for sessions/state).
+        - name: init-config
+          image: busybox:1.37
           command:
             - sh
             - -c
             - |
-              set -eu
-              mkdir -p /state/.openclaw
-              cp /config/openclaw.json /state/.openclaw/openclaw.json
-              echo "seeded /state/.openclaw/openclaw.json"
+              cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+              mkdir -p /home/node/.openclaw/workspace
+              cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 50m
+            limits:
+              memory: 64Mi
+              cpu: 100m
           volumeMounts:
-            - name: state
-              mountPath: /state
+            - name: home
+              mountPath: /home/node/.openclaw
             - name: config
               mountPath: /config
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 256Mi
       containers:
-        - name: openclaw
-          # Same image the kagent openclaw harness uses; run OpenClaw directly
-          # instead of the openshell sandbox supervisor. Inference happens in the
-          # qwen pod, so this container itself stays light (Node orchestration).
-          image: ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4
+        - name: gateway
+          # Official OpenClaw image + command (docs.openclaw.ai/install/kubernetes).
+          image: ghcr.io/openclaw/openclaw:slim
           command:
-            - sh
-            - -c
-            - exec openclaw gateway run --auth none --bind loopback --port 18800
+            - node
+            - /app/dist/index.js
+            - gateway
+            - run
+          ports:
+            - name: gateway
+              containerPort: 18789
           env:
             - name: HOME
-              value: /state
-          volumeMounts:
-            - name: state
-              mountPath: /state
+              value: /home/node
+            - name: OPENCLAW_CONFIG_DIR
+              value: /home/node/.openclaw
+            - name: NODE_ENV
+              value: production
+            # Token auth -> operator role for connecting clients (the TUI via exec
+            # inherits this env and authenticates as operator, so it can send).
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-qwen-secrets
+                  key: OPENCLAW_GATEWAY_TOKEN
           resources:
             requests:
-              cpu: 250m
               memory: 512Mi
+              cpu: 250m
             limits:
-              cpu: "2"
               memory: 2Gi
+              cpu: "1"
           livenessProbe:
-            # Gateway binds loopback, so a normal tcpSocket probe (pod IP) can't
-            # reach it — check the listening socket in /proc instead.
-            # 18800 = 0x4970.
             exec:
               command:
-                - sh
-                - -c
-                - grep -qi ':4970 ' /proc/net/tcp
-            initialDelaySeconds: 40
+                - node
+                - -e
+                - "require('http').get('http://127.0.0.1:18789/healthz', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+            initialDelaySeconds: 60
             periodSeconds: 30
-            failureThreshold: 4
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - node
+                - -e
+                - "require('http').get('http://127.0.0.1:18789/readyz', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: home
+              mountPath: /home/node/.openclaw
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
       volumes:
-        - name: state
-          emptyDir: {}
+        - name: home
+          persistentVolumeClaim:
+            claimName: openclaw-qwen-home
         - name: config
           configMap:
             name: openclaw-qwen-config
+        - name: tmp
+          emptyDir: {}

--- a/base-apps/openclaw-qwen/docs.md
+++ b/base-apps/openclaw-qwen/docs.md
@@ -1,7 +1,7 @@
 ---
 type: "Kubernetes App Guide"
 title: "OpenClaw + qwen (standalone)"
-description: "Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox"
+description: "Standalone OpenClaw agent (official image, token auth) driven by the local Qwen3.5-0.8B model"
 app: openclaw-qwen
 catalog_entity: openclaw-qwen
 kind: docs
@@ -10,44 +10,42 @@ last_reviewed: 2026-07-22
 status: current
 tags: [llm, agent, coding-agent, local, gpu-optional]
 sources:
-  - base-apps/openclaw-qwen/configmap.yaml
   - base-apps/openclaw-qwen/deployment.yaml
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/secret.yaml
 ---
 
 # openclaw-qwen
 
 ## What it is
-A **standalone** [OpenClaw](https://github.com/kagent-dev) coding/ops agent (a Claude-Code-style TUI agent) running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`, llama.cpp, CPU). Lives in its own `openclaw-qwen` namespace — deliberately NOT the pre-existing, unrelated `openclaw` namespace (which owns `svc/ingress openclaw.arigsela.com`).
+A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
 
-## Why standalone (not a kagent AgentHarness)
-kagent's `AgentHarness` runs OpenClaw inside an **openshell sandbox**, which forces outbound traffic through an egress proxy. That proxy drops OpenClaw's calls to the *internal* `qwen.qwen.svc.cluster.local` service, so every agent turn failed with `[assistant turn failed before producing content]` — the request never reached qwen. Running OpenClaw as a plain Deployment removes the proxy: OpenClaw talks straight to qwen. Verified: a one-shot turn returns a real answer and the request lands in qwen's logs.
+## Why this shape (two things that matter)
+1. **Token auth, not `--auth none`.** OpenClaw gates `operator.write` (the ability to *send*) behind an operator identity. Shared-secret **token** auth auto-approves the connecting client as **operator**; `none` leaves it read-only. The gateway reads `OPENCLAW_GATEWAY_TOKEN` (from `secret.yaml`); a client that inherits that env authenticates as operator.
+2. **Standalone, not a kagent AgentHarness.** A plain Deployment has no openshell egress proxy, so OpenClaw reaches `qwen.qwen.svc.cluster.local:8080` directly (the harness proxy silently dropped those calls).
 
-## Architecture & data flow
-Single-replica `Deployment` (`strategy: Recreate`) on nodes labeled `node.kubernetes.io/workload: application`. An `initContainer` copies `openclaw.json` from the ConfigMap into the pod's writable `HOME` (`/state/.openclaw/`, an `emptyDir`). The main container runs `openclaw gateway run --auth none --bind loopback --port 18800`.
-
-The config points OpenClaw's `openai` provider at `http://qwen.qwen.svc.cluster.local:8080/v1` (model `Qwen3.5-0.8B`, placeholder api key — llama.cpp ignores it) and sets it as the default agent model. Inference happens in the qwen pod, so this container stays light.
-
-## How to interact
-The gateway binds **loopback only** — it is not exposed on the cluster network (no Service). You reach it from inside the pod via `kubectl exec`:
+## How to use it
+The gateway binds **loopback** inside the pod; reach it via `kubectl exec` (the `OPENCLAW_GATEWAY_TOKEN` env in the pod authenticates you as operator automatically):
 
 ```bash
-# interactive agent TUI (connects to the loopback gateway)
+# interactive agent TUI
 kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui
 
-# or the local-embedded chat TUI (no gateway needed)
-kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw chat
+# one-shot agent turn (non-interactive)
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- openclaw agent -m "your prompt" --agent default
 
-# non-interactive one-shot (good for a smoke test)
+# direct one-shot inference (fastest; skips the agent tool-prompt)
 kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
-  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Say hi in one word" --local
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "hi" --local
 ```
-Confirm you're on qwen: the TUI status bar should show `openai/Qwen3.5-0.8B` (not `gpt-5.5`).
 
-## Where config lives
-- Model provider, gateway mode, default model: `configmap.yaml` (`openclaw.json`).
-- Workload, image (pinned by digest), init seed, resources: `deployment.yaml`.
-- No Service by design (loopback-only). No secrets (qwen needs no auth).
+## Architecture & config
+- `deployment.yaml` — official image + `gateway run`, init container seeds config into the writable PVC home, hardened securityContext (non-root, read-only rootfs, dropped caps).
+- `configmap.yaml` — `openclaw.json` (`gateway.auth.mode: token`, `openai` provider → qwen, default model `openai/Qwen3.5-0.8B`) + `AGENTS.md`.
+- `secret.yaml` — `OPENCLAW_GATEWAY_TOKEN` (operator token).
+- `pvc.yaml` — 5Gi writable home (sessions/workspace). `service.yaml` — ClusterIP 18789 (for port-forward).
 
-## Caveats
-- **0.8B on CPU**: agent turns are slow and the model is weak at multi-step tool-calling — expect sluggish, rough behavior. The *plumbing* is correct; the model is the limit. For real work, point the config at a bigger model (and ideally a GPU).
-- State (`/state`) is an `emptyDir` — sessions/workspace do not survive a pod restart. Add a PVC if you need persistence.
+## Caveats (the honest part)
+- **It is slow.** OpenClaw's agent system prompt is ~20K tokens; qwen runs it on **CPU** at ~50 tok/s prompt-eval, so the *first* turn takes minutes. This is the 0.8B/CPU reality, not a bug.
+- Requires **qwen `--ctx-size` ≥ ~24K** (bumped to 32768) so the agent prompt fits — an 8K window overflows.
+- A 0.8B is weak at multi-step tool-calling. Great for learning OpenClaw's mechanics; for real agent work, point the config at a bigger model (ideally on a GPU).

--- a/base-apps/openclaw-qwen/docs/index.md
+++ b/base-apps/openclaw-qwen/docs/index.md
@@ -1,7 +1,7 @@
 ---
 type: "Kubernetes App Guide"
 title: "OpenClaw + qwen (standalone)"
-description: "Standalone OpenClaw coding agent driven by the local Qwen3.5-0.8B model, no openshell sandbox"
+description: "Standalone OpenClaw agent (official image, token auth) driven by the local Qwen3.5-0.8B model"
 app: openclaw-qwen
 catalog_entity: openclaw-qwen
 kind: docs
@@ -10,44 +10,43 @@ last_reviewed: 2026-07-22
 status: current
 tags: [llm, agent, coding-agent, local, gpu-optional]
 sources:
-  - base-apps/openclaw-qwen/configmap.yaml
   - base-apps/openclaw-qwen/deployment.yaml
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/secret.yaml
 ---
 
 # openclaw-qwen
 
 ## What it is
-A **standalone** [OpenClaw](https://github.com/kagent-dev) coding/ops agent (a Claude-Code-style TUI agent) running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`, llama.cpp, CPU). Lives in its own `openclaw-qwen` namespace — deliberately NOT the pre-existing, unrelated `openclaw` namespace (which owns `svc/ingress openclaw.arigsela.com`).
+A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
 
-## Why standalone (not a kagent AgentHarness)
-kagent's `AgentHarness` runs OpenClaw inside an **openshell sandbox**, which forces outbound traffic through an egress proxy. That proxy drops OpenClaw's calls to the *internal* `qwen.qwen.svc.cluster.local` service, so every agent turn failed with `[assistant turn failed before producing content]` — the request never reached qwen. Running OpenClaw as a plain Deployment removes the proxy: OpenClaw talks straight to qwen. Verified: a one-shot turn returns a real answer and the request lands in qwen's logs.
+## Why this shape (two things that matter)
+1. **Token auth, not `--auth none`.** OpenClaw gates `operator.write` (the ability to *send*) behind an operator identity. Shared-secret **token** auth auto-approves the connecting client as **operator**; `none` leaves it read-only. The gateway reads `OPENCLAW_GATEWAY_TOKEN` (from `secret.yaml`); a client that inherits that env authenticates as operator.
+2. **Standalone, not a kagent AgentHarness.** A plain Deployment has no openshell egress proxy, so OpenClaw reaches `qwen.qwen.svc.cluster.local:8080` directly (the harness proxy silently dropped those calls).
 
-## Architecture & data flow
-Single-replica `Deployment` (`strategy: Recreate`) on nodes labeled `node.kubernetes.io/workload: application`. An `initContainer` copies `openclaw.json` from the ConfigMap into the pod's writable `HOME` (`/state/.openclaw/`, an `emptyDir`). The main container runs `openclaw gateway run --auth none --bind loopback --port 18800`.
-
-The config points OpenClaw's `openai` provider at `http://qwen.qwen.svc.cluster.local:8080/v1` (model `Qwen3.5-0.8B`, placeholder api key — llama.cpp ignores it) and sets it as the default agent model. Inference happens in the qwen pod, so this container stays light.
-
-## How to interact
-The gateway binds **loopback only** — it is not exposed on the cluster network (no Service). You reach it from inside the pod via `kubectl exec`:
+## How to use it
+The gateway binds **loopback** inside the pod; reach it via `kubectl exec` (the `OPENCLAW_GATEWAY_TOKEN` env in the pod authenticates you as operator automatically):
 
 ```bash
-# interactive agent TUI (connects to the loopback gateway)
+# interactive agent TUI
 kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui
 
-# or the local-embedded chat TUI (no gateway needed)
-kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw chat
+# one-shot agent turn (non-interactive)
+kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- openclaw agent -m "your prompt" --agent default
 
-# non-interactive one-shot (good for a smoke test)
+# direct one-shot inference (fastest; skips the agent tool-prompt)
 kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
-  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Say hi in one word" --local
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "hi" --local
 ```
-Confirm you're on qwen: the TUI status bar should show `openai/Qwen3.5-0.8B` (not `gpt-5.5`).
 
-## Where config lives
-- Model provider, gateway mode, default model: `configmap.yaml` (`openclaw.json`).
-- Workload, image (pinned by digest), init seed, resources: `deployment.yaml`.
-- No Service by design (loopback-only). No secrets (qwen needs no auth).
+## Architecture & config
+- `deployment.yaml` — official image + `gateway run`, init container seeds config into the writable PVC home, hardened securityContext (non-root, read-only rootfs, dropped caps).
+- `configmap.yaml` — `openclaw.json` (`gateway.auth.mode: token`, `openai` provider → qwen, default model `openai/Qwen3.5-0.8B`) + `AGENTS.md`.
+- `secret.yaml` — `OPENCLAW_GATEWAY_TOKEN` (operator token).
+- `pvc.yaml` — 5Gi writable home (sessions/workspace). `service.yaml` — ClusterIP 18789 (for port-forward).
 
-## Caveats
-- **0.8B on CPU**: agent turns are slow and the model is weak at multi-step tool-calling — expect sluggish, rough behavior. The *plumbing* is correct; the model is the limit. For real work, point the config at a bigger model (and ideally a GPU).
-- State (`/state`) is an `emptyDir` — sessions/workspace do not survive a pod restart. Add a PVC if you need persistence.
+## Caveats (the honest part)
+- **It is slow.** OpenClaw's agent system prompt is ~20K tokens; qwen runs it on **CPU** at ~50 tok/s prompt-eval, so the *first* turn takes minutes. This is the 0.8B/CPU reality, not a bug.
+- Requires **qwen `--ctx-size` ≥ ~24K** (bumped to 32768) so the agent prompt fits — an 8K window overflows.
+- A 0.8B is weak at multi-step tool-calling. Great for learning OpenClaw's mechanics; for real agent work, point the config at a bigger model (ideally on a GPU).
+- If a turn errors mid-way (e.g. a timeout), the session can get a dangling message → `Cannot continue from message role: assistant`. Start fresh with `/reset` (or `/new`) in the TUI.

--- a/base-apps/openclaw-qwen/docs/runbook.md
+++ b/base-apps/openclaw-qwen/docs/runbook.md
@@ -10,39 +10,46 @@ last_reviewed: 2026-07-22
 status: current
 tags: [llm, agent, coding-agent, local, gpu-optional]
 sources:
-  - base-apps/openclaw-qwen/configmap.yaml
   - base-apps/openclaw-qwen/deployment.yaml
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/secret.yaml
 ---
 
 # openclaw-qwen runbook
 
 ## Failure modes
 
-### Symptom: `[assistant turn failed before producing content]` / turns never reach qwen
-- **Check:** from inside the pod, `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- curl -sS -m10 http://qwen.qwen.svc.cluster.local:8080/health` (expect `{"status":"ok"}`), and `kubectl -n qwen logs deploy/qwen -c llama-server --since=2m | grep task` to see if requests land.
-- **Fix:** if the health check fails, qwen is down (see `base-apps/qwen`) or network policy is blocking. If health is OK but no requests land, confirm `HOME=/state` and that `/state/.openclaw/openclaw.json` exists and points at the qwen baseUrl (`exec ... -- cat /state/.openclaw/openclaw.json`). Unlike the openshell harness, this pod has no egress proxy, so proxy interception is not a factor here.
+### Symptom: TUI connects but sending fails with `missing scope: operator.write`
+- **Cause:** the gateway is not using token auth, or the client isn't presenting the token.
+- **Check:** `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- sh -c 'echo $OPENCLAW_GATEWAY_TOKEN | head -c8'` (should be non-empty) and confirm `configmap.yaml` has `gateway.auth.mode: token`.
+- **Fix:** ensure `secret.yaml` exists and the deployment mounts `OPENCLAW_GATEWAY_TOKEN`. Token (shared-secret) auth auto-approves the client as **operator**; `mode: none` leaves it read-only.
 
-### Symptom: TUI shows model `gpt-5.5` instead of `openai/Qwen3.5-0.8B`
-- **Check:** the config wasn't loaded — `exec ... -- sh -c 'HOME=/state openclaw config validate'` and inspect `/state/.openclaw/openclaw.json`.
-- **Fix:** ensure `HOME=/state` is set (env in `deployment.yaml`) and the init container seeded the config. Delete the pod to re-seed. `gpt-5.5` is OpenClaw's built-in fallback when it can't resolve the configured provider.
+### Symptom: agent turns fail — `exceeds context size` / `[assistant turn failed before producing content]`
+- **Cause:** OpenClaw's agent system prompt (~20K tokens) is larger than qwen's context window.
+- **Check:** `kubectl -n qwen logs deploy/qwen -c llama-server --tail=60 | grep n_ctx_slot` (needs to be ≥ ~24K) and grep for `exceeds the available context size`.
+- **Fix:** qwen must run `--ctx-size` ≥ ~24K (set to 32768 in `base-apps/qwen/deployments.yaml`). If it reverted to 8192, re-sync `base-apps/qwen`.
 
-### Symptom: pod CrashLoop / liveness failing
-- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen` and `kubectl -n openclaw-qwen describe pod -l app=openclaw-qwen`. The liveness probe greps `/proc/net/tcp` for the gateway port (18800 = `:4970`); if the gateway never binds, the probe fails.
-- **Fix:** check the gateway startup logs for config errors; verify the pinned image still ships `openclaw`. Raise `initialDelaySeconds` if the gateway is slow to bind on first start.
+### Symptom: `Cannot continue from message role: assistant`
+- **Cause:** a previous turn errored mid-way and left a dangling assistant message in the session.
+- **Fix:** start a fresh session — `/reset` (or `/new`) in the TUI, or clear the session file: `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- rm -f /home/node/.openclaw/agents/default/sessions/*.jsonl`.
+
+### Symptom: pod CrashLoop / not ready
+- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen -c gateway` and `-c init-config`. Readiness hits `127.0.0.1:18789/readyz`.
+- **Fix:** verify the pinned image still exposes `gateway run`; check the init container seeded `/home/node/.openclaw/openclaw.json` (the PVC must be writable, fsGroup 1000).
 
 ## How-to
 
 ### Deploy / update
-Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`strategy: Recreate`) so the init container re-seeds `openclaw.json`.
+Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`Recreate`) so the init container re-seeds `openclaw.json`.
 
 ### Smoke test (does qwen answer?)
 ```bash
 kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
-  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: what color is grass?" --local
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: grass color?" --local
 ```
 
 ### Point at a bigger / different model
-Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. (A larger model is the real fix for weak agent behavior.)
+Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. A larger model (ideally on a GPU) is the real fix for slow/weak agent behavior.
 
 ### Note on performance
-Inference runs on the CPU-only qwen pod (Qwen3.5-0.8B). Agent turns are slow and the model is weak at tool-calling — expected, not a bug.
+The agent's ~20K-token prompt runs on the CPU-only qwen pod at ~50 tok/s prompt-eval, so the first turn takes minutes. Expected for a 0.8B on CPU, not a bug.

--- a/base-apps/openclaw-qwen/pvc.yaml
+++ b/base-apps/openclaw-qwen/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-qwen-home
+  namespace: openclaw-qwen
+  labels:
+    app: openclaw-qwen
+    app.kubernetes.io/name: openclaw-qwen
+spec:
+  # OpenClaw's writable home: config, sessions, workspace. local-path has
+  # allowVolumeExpansion=false, so size up front; 5Gi is ample for agent state.
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/base-apps/openclaw-qwen/runbook.md
+++ b/base-apps/openclaw-qwen/runbook.md
@@ -10,39 +10,46 @@ last_reviewed: 2026-07-22
 status: current
 tags: [llm, agent, coding-agent, local, gpu-optional]
 sources:
-  - base-apps/openclaw-qwen/configmap.yaml
   - base-apps/openclaw-qwen/deployment.yaml
+  - base-apps/openclaw-qwen/configmap.yaml
+  - base-apps/openclaw-qwen/secret.yaml
 ---
 
 # openclaw-qwen runbook
 
 ## Failure modes
 
-### Symptom: `[assistant turn failed before producing content]` / turns never reach qwen
-- **Check:** from inside the pod, `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- curl -sS -m10 http://qwen.qwen.svc.cluster.local:8080/health` (expect `{"status":"ok"}`), and `kubectl -n qwen logs deploy/qwen -c llama-server --since=2m | grep task` to see if requests land.
-- **Fix:** if the health check fails, qwen is down (see `base-apps/qwen`) or network policy is blocking. If health is OK but no requests land, confirm `HOME=/state` and that `/state/.openclaw/openclaw.json` exists and points at the qwen baseUrl (`exec ... -- cat /state/.openclaw/openclaw.json`). Unlike the openshell harness, this pod has no egress proxy, so proxy interception is not a factor here.
+### Symptom: TUI connects but sending fails with `missing scope: operator.write`
+- **Cause:** the gateway is not using token auth, or the client isn't presenting the token.
+- **Check:** `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- sh -c 'echo $OPENCLAW_GATEWAY_TOKEN | head -c8'` (should be non-empty) and confirm `configmap.yaml` has `gateway.auth.mode: token`.
+- **Fix:** ensure `secret.yaml` exists and the deployment mounts `OPENCLAW_GATEWAY_TOKEN`. Token (shared-secret) auth auto-approves the client as **operator**; `mode: none` leaves it read-only.
 
-### Symptom: TUI shows model `gpt-5.5` instead of `openai/Qwen3.5-0.8B`
-- **Check:** the config wasn't loaded — `exec ... -- sh -c 'HOME=/state openclaw config validate'` and inspect `/state/.openclaw/openclaw.json`.
-- **Fix:** ensure `HOME=/state` is set (env in `deployment.yaml`) and the init container seeded the config. Delete the pod to re-seed. `gpt-5.5` is OpenClaw's built-in fallback when it can't resolve the configured provider.
+### Symptom: agent turns fail — `exceeds context size` / `[assistant turn failed before producing content]`
+- **Cause:** OpenClaw's agent system prompt (~20K tokens) is larger than qwen's context window.
+- **Check:** `kubectl -n qwen logs deploy/qwen -c llama-server --tail=60 | grep n_ctx_slot` (needs to be ≥ ~24K) and grep for `exceeds the available context size`.
+- **Fix:** qwen must run `--ctx-size` ≥ ~24K (set to 32768 in `base-apps/qwen/deployments.yaml`). If it reverted to 8192, re-sync `base-apps/qwen`.
 
-### Symptom: pod CrashLoop / liveness failing
-- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen` and `kubectl -n openclaw-qwen describe pod -l app=openclaw-qwen`. The liveness probe greps `/proc/net/tcp` for the gateway port (18800 = `:4970`); if the gateway never binds, the probe fails.
-- **Fix:** check the gateway startup logs for config errors; verify the pinned image still ships `openclaw`. Raise `initialDelaySeconds` if the gateway is slow to bind on first start.
+### Symptom: `Cannot continue from message role: assistant`
+- **Cause:** a previous turn errored mid-way and left a dangling assistant message in the session.
+- **Fix:** start a fresh session — `/reset` (or `/new`) in the TUI, or clear the session file: `kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- rm -f /home/node/.openclaw/agents/default/sessions/*.jsonl`.
+
+### Symptom: pod CrashLoop / not ready
+- **Check:** `kubectl -n openclaw-qwen logs deploy/openclaw-qwen -c gateway` and `-c init-config`. Readiness hits `127.0.0.1:18789/readyz`.
+- **Fix:** verify the pinned image still exposes `gateway run`; check the init container seeded `/home/node/.openclaw/openclaw.json` (the PVC must be writable, fsGroup 1000).
 
 ## How-to
 
 ### Deploy / update
-Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`strategy: Recreate`) so the init container re-seeds `openclaw.json`.
+Edit manifests here and PR; Argo CD syncs on merge. Config changes require a pod restart (`Recreate`) so the init container re-seeds `openclaw.json`.
 
 ### Smoke test (does qwen answer?)
 ```bash
 kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
-  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: what color is grass?" --local
+  openclaw infer model run --model openai/Qwen3.5-0.8B --prompt "Reply with one word: grass color?" --local
 ```
 
 ### Point at a bigger / different model
-Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. (A larger model is the real fix for weak agent behavior.)
+Edit `configmap.yaml`: change `models.providers.openai.baseUrl` + `models[].id` and `agents.defaults.model.primary`, then PR. A larger model (ideally on a GPU) is the real fix for slow/weak agent behavior.
 
 ### Note on performance
-Inference runs on the CPU-only qwen pod (Qwen3.5-0.8B). Agent turns are slow and the model is weak at tool-calling — expected, not a bug.
+The agent's ~20K-token prompt runs on the CPU-only qwen pod at ~50 tok/s prompt-eval, so the first turn takes minutes. Expected for a 0.8B on CPU, not a bug.

--- a/base-apps/openclaw-qwen/secret.yaml
+++ b/base-apps/openclaw-qwen/secret.yaml
@@ -1,0 +1,18 @@
+# Gateway operator token for the loopback OpenClaw gateway. Shared-secret (token)
+# auth is what grants the client the OPERATOR role/scopes (incl. operator.write)
+# — this is the fix for the "missing scope: operator.write" wall that `--auth none`
+# hit. The gateway binds loopback (not network-exposed) and is reached via
+# `kubectl exec`/port-forward, so this token sits behind kubectl access as
+# defense-in-depth. Committed for GitOps simplicity; move to ESO/Vault if you'd
+# rather keep it out of git. Rotate with: openssl rand -hex 32
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-qwen-secrets
+  namespace: openclaw-qwen
+  labels:
+    app: openclaw-qwen
+    app.kubernetes.io/name: openclaw-qwen
+type: Opaque
+stringData:
+  OPENCLAW_GATEWAY_TOKEN: "55e60f4990bfc7aabf32758470f1057f1527b1810b4580484c2749be96f5c6d6"

--- a/base-apps/openclaw-qwen/service.yaml
+++ b/base-apps/openclaw-qwen/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-qwen
+  namespace: openclaw-qwen
+  labels:
+    app: openclaw-qwen
+    app.kubernetes.io/name: openclaw-qwen
+spec:
+  selector:
+    app: openclaw-qwen
+  ports:
+    - name: gateway
+      port: 18789
+      targetPort: 18789
+  # ClusterIP for `kubectl port-forward` access (the gateway binds loopback in
+  # the pod; port-forward tunnels to it). Primary access is `kubectl exec`.
+  type: ClusterIP

--- a/base-apps/qwen/deployments.yaml
+++ b/base-apps/qwen/deployments.yaml
@@ -75,10 +75,11 @@ spec:
             - 0.0.0.0
             - --port
             - "8080"
-            # Modest context: the model supports 262K, but a large KV cache is
-            # impractical on CPU. Raise if you need longer prompts.
+            # 32K context: fits agent frameworks' large system prompts (OpenClaw's
+            # is ~20K tokens). The model supports 262K, but a bigger KV cache is
+            # impractical on CPU; 32K balances headroom vs memory on the 0.8B.
             - --ctx-size
-            - "8192"
+            - "32768"
             - --threads
             - "6"
             # Default thinking OFF: this GGUF's chat template defaults to reasoning,


### PR DESCRIPTION
## What
Rebuilds `openclaw-qwen` to OpenClaw's **official Kubernetes pattern** ([docs.openclaw.ai/install/kubernetes](https://docs.openclaw.ai/install/kubernetes)) and fixes the two walls that stopped the in-cluster TUI from working.

## Root cause of the "TUI can't send" wall
The earlier deployment used `gateway.auth.mode: none` → the client was **read-only** (`missing scope: operator.write`). Per OpenClaw's [operator-scopes docs](https://docs.openclaw.ai/gateway/operator-scopes), **shared-secret (token) auth auto-approves the client as `operator`**. Switching to token auth fixes it — **verified** in a throwaway namespace:
```
[gateway] device pairing auto-approved role=operator     ← sending now authorized
[agent/embedded] ... model=Qwen3.5-0.8B  (reaches the model)
```

## Changes
- **`deployment.yaml`** — official image `ghcr.io/openclaw/openclaw:slim` + `gateway run`, hardened securityContext (non-root, read-only rootfs, dropped caps), init container seeds config into a PVC home.
- **`secret.yaml`** — `OPENCLAW_GATEWAY_TOKEN` (the operator token).
- **`configmap.yaml`** — `gateway.auth.mode: token`, `openai` provider → qwen, `timeoutSeconds: 1200`.
- **`pvc.yaml` / `service.yaml`** — 5Gi home + ClusterIP 18789.
- **`base-apps/qwen/deployments.yaml`** — `--ctx-size 8192 → 32768` (OpenClaw's ~20K agent prompt overflowed 8K; verified `status=200` at 32K).

## How to use (after merge)
```bash
kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui
```
The `OPENCLAW_GATEWAY_TOKEN` env in the pod authenticates you as operator, so you can send.

## ⚠️ Honest caveat — it's SLOW
Config-wise everything is solved and verified (auth ✅, context ✅). But a **0.8B on the CPU-only Sandy-Bridge nodes** processes OpenClaw's ~20K-token agent prompt at **~40 tok/s → ~8 min of prompt-eval per model call**. `timeoutSeconds: 1200` lets a turn grind to completion, but a multi-call agent turn can take 10–30+ minutes. **Usable for learning OpenClaw's mechanics; not for real work.** For a usable agent, point the config at a bigger model (ideally a GPU) — one line in `configmap.yaml`.

## Validation
`yamllint` clean · `kubeconform` 6/6 · JSON valid · token-auth + 32K-context both verified live before teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns
