### PR TITLE
feat(openclaw-qwen): point at GPU-served Qwen3.5-9B (LM Studio)

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -12,8 +12,10 @@ data:
   # gateway.auth.mode "token" — shared-secret auth that grants the OPERATOR role,
   # so the TUI can actually send (unlike "none", which is read-only). The token
   # comes from the OPENCLAW_GATEWAY_TOKEN env (secret.yaml). The `openai` provider
-  # points at the in-cluster qwen model; a plain Deployment has no egress proxy,
-  # so it reaches qwen directly.
+  # points at Qwen3.5-9B served by LM Studio on the gaming PC's GPU
+  # (http://10.0.1.200:1234, same LAN subnet as the nodes) — a GPU 9B answers in
+  # seconds vs. minutes for the CPU 0.8B, and it's the ~20K agent prompt's real
+  # home. Requires LM Studio to load the model with context length >= ~24K.
   openclaw.json: |
     {
       "gateway": {
@@ -27,17 +29,17 @@ data:
         "mode": "merge",
         "providers": {
           "openai": {
-            "baseUrl": "http://qwen.qwen.svc.cluster.local:8080/v1",
+            "baseUrl": "http://10.0.1.200:1234/v1",
             "apiKey": "not-needed",
             "auth": "api-key",
             "api": "openai-completions",
-            "timeoutSeconds": 1200,
-            "models": [ { "id": "Qwen3.5-0.8B", "name": "Qwen3.5-0.8B" } ]
+            "timeoutSeconds": 600,
+            "models": [ { "id": "qwen/qwen3.5-9b", "name": "Qwen3.5-9B (LM Studio, GPU)" } ]
           }
         }
       },
       "agents": {
-        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/Qwen3.5-0.8B" }, "timeoutSeconds": 1200 },
+        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600 },
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "~/.openclaw/workspace" } ]
       },
       "cron": { "enabled": false }
@@ -45,6 +47,5 @@ data:
   AGENTS.md: |
     # OpenClaw Assistant
 
-    You are a helpful AI assistant running in Kubernetes, backed by a local
-    Qwen3.5-0.8B model. Keep answers short and direct — the model is small and
-    runs on CPU, so brevity matters.
+    You are a helpful AI assistant running in Kubernetes, backed by a
+    Qwen3.5-9B model served on a GPU (LM Studio). Be clear and concise.

--- a/base-apps/openclaw-qwen/docs.md
+++ b/base-apps/openclaw-qwen/docs.md
@@ -18,7 +18,7 @@ sources:
 # openclaw-qwen
 
 ## What it is
-A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
+A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by **Qwen3.5-9B served on a GPU** (LM Studio on the gaming PC at `http://10.0.1.200:1234`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
 
 ## Why this shape (two things that matter)
 1. **Token auth, not `--auth none`.** OpenClaw gates `operator.write` (the ability to *send*) behind an operator identity. Shared-secret **token** auth auto-approves the connecting client as **operator**; `none` leaves it read-only. The gateway reads `OPENCLAW_GATEWAY_TOKEN` (from `secret.yaml`); a client that inherits that env authenticates as operator.
@@ -45,7 +45,9 @@ kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
 - `secret.yaml` — `OPENCLAW_GATEWAY_TOKEN` (operator token).
 - `pvc.yaml` — 5Gi writable home (sessions/workspace). `service.yaml` — ClusterIP 18789 (for port-forward).
 
-## Caveats (the honest part)
-- **It is slow.** OpenClaw's agent system prompt is ~20K tokens; qwen runs it on **CPU** at ~50 tok/s prompt-eval, so the *first* turn takes minutes. This is the 0.8B/CPU reality, not a bug.
-- Requires **qwen `--ctx-size` ≥ ~24K** (bumped to 32768) so the agent prompt fits — an 8K window overflows.
-- A 0.8B is weak at multi-step tool-calling. Great for learning OpenClaw's mechanics; for real agent work, point the config at a bigger model (ideally on a GPU).
+## Notes
+- **Model runs off-cluster on the gaming PC's GPU** (LM Studio, `10.0.1.200:1234`, same LAN subnet as the nodes). Verified reachable from a cluster pod; a full turn returns in **seconds** (vs. ~8 min on the old CPU 0.8B).
+- **LM Studio must load the model with context length ≥ ~24K** — OpenClaw's agent prompt is ~20K tokens; the default 4K overflows.
+- The model reasons (`reasoning_content`) before answering; OpenClaw handles this, and it's fast on the GPU.
+- To switch models, edit the `openai` provider `baseUrl`/`models[].id` and `agents.defaults.model.primary` here.
+- Earlier history: this app previously pointed at the in-cluster CPU `Qwen3.5-0.8B` (`base-apps/qwen`), which worked but was too slow (~8 min/turn) for interactive use.

--- a/base-apps/openclaw-qwen/docs/index.md
+++ b/base-apps/openclaw-qwen/docs/index.md
@@ -18,7 +18,7 @@ sources:
 # openclaw-qwen
 
 ## What it is
-A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by the in-cluster **Qwen3.5-0.8B** model (`base-apps/qwen`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
+A standalone [OpenClaw](https://docs.openclaw.ai) agent running as a plain `Deployment`, driven by **Qwen3.5-9B served on a GPU** (LM Studio on the gaming PC at `http://10.0.1.200:1234`). Follows OpenClaw's [official Kubernetes pattern](https://docs.openclaw.ai/install/kubernetes): the `ghcr.io/openclaw/openclaw:slim` image running `gateway run`, hardened securityContext, and **token auth**.
 
 ## Why this shape (two things that matter)
 1. **Token auth, not `--auth none`.** OpenClaw gates `operator.write` (the ability to *send*) behind an operator identity. Shared-secret **token** auth auto-approves the connecting client as **operator**; `none` leaves it read-only. The gateway reads `OPENCLAW_GATEWAY_TOKEN` (from `secret.yaml`); a client that inherits that env authenticates as operator.
@@ -45,8 +45,10 @@ kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
 - `secret.yaml` — `OPENCLAW_GATEWAY_TOKEN` (operator token).
 - `pvc.yaml` — 5Gi writable home (sessions/workspace). `service.yaml` — ClusterIP 18789 (for port-forward).
 
-## Caveats (the honest part)
-- **It is slow.** OpenClaw's agent system prompt is ~20K tokens; qwen runs it on **CPU** at ~50 tok/s prompt-eval, so the *first* turn takes minutes. This is the 0.8B/CPU reality, not a bug.
-- Requires **qwen `--ctx-size` ≥ ~24K** (bumped to 32768) so the agent prompt fits — an 8K window overflows.
-- A 0.8B is weak at multi-step tool-calling. Great for learning OpenClaw's mechanics; for real agent work, point the config at a bigger model (ideally on a GPU).
+## Notes
+- **Model runs off-cluster on the gaming PC's GPU** (LM Studio, `10.0.1.200:1234`, same LAN subnet as the nodes). Verified reachable from a cluster pod; a full turn returns in **seconds** (vs. ~8 min on the old CPU 0.8B).
+- **LM Studio must load the model with context length ≥ ~24K** — OpenClaw's agent prompt is ~20K tokens; the default 4K overflows.
+- The model reasons (`reasoning_content`) before answering; OpenClaw handles this, and it's fast on the GPU.
+- To switch models, edit the `openai` provider `baseUrl`/`models[].id` and `agents.defaults.model.primary` here.
+- Earlier history: this app previously pointed at the in-cluster CPU `Qwen3.5-0.8B` (`base-apps/qwen`), which worked but was too slow (~8 min/turn) for interactive use.
 - If a turn errors mid-way (e.g. a timeout), the session can get a dangling message → `Cannot continue from message role: assistant`. Start fresh with `/reset` (or `/new`) in the TUI.


### PR DESCRIPTION
## What
Repoints the in-cluster OpenClaw agent from the **CPU Qwen3.5-0.8B** (~8 min/turn) to **Qwen3.5-9B on the gaming PC's GPU** via LM Studio (`http://10.0.1.200:1234`, same LAN subnet as the nodes). OpenClaw itself is unchanged (token auth, official pattern) — only the model endpoint moves.

## Verified from the cluster before switching
- `/v1/models` reachable → `qwen/qwen3.5-9b`
- A **20.7K-token** agent-sized prompt → real content, `finish_reason: stop`, **~5s** (vs ~8 min on the 0.8B)
- Required fix on the LM Studio side: load the model with **context length ≥ ~24K** (default 4K overflowed OpenClaw's ~20K prompt) — done + confirmed.

## Change
`configmap.yaml`: `openai` provider `baseUrl` → `http://10.0.1.200:1234/v1`, model `qwen/qwen3.5-9b`, `agents.defaults.model.primary` → `openai/qwen/qwen3.5-9b`.

## After merge
`kubectl -n openclaw-qwen exec -it deploy/openclaw-qwen -- openclaw tui` → now answers in **seconds**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns