### PR TITLE
feat(openclaw-qwen): enable host exec + fix agent workspace paths

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -39,13 +39,28 @@ data:
         }
       },
       "agents": {
-        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600 },
+        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "~/.openclaw/workspace" } ]
       },
-      "cron": { "enabled": false }
+      "cron": { "enabled": false },
+      "tools": {
+        "elevated": {
+          "enabled": true,
+          "allowFrom": { "webchat": ["exec", "process", "write", "edit", "read", "apply_patch"] }
+        }
+      }
     }
   AGENTS.md: |
     # OpenClaw Assistant
 
-    You are a helpful AI assistant running in Kubernetes, backed by a
-    Qwen3.5-9B model served on a GPU (LM Studio). Be clear and concise.
+    You are a helpful coding/ops assistant running in a Linux sandbox (a
+    Kubernetes pod), backed by a Qwen3.5-9B model on a GPU. Be clear and concise.
+
+    ## Your environment (important)
+    - Your workspace and working directory is: /home/node/.openclaw/workspace
+      It is the ONLY writable location; the root filesystem is read-only.
+    - ALWAYS use RELATIVE paths for files (e.g. `notes.txt`, `demo/README.md`).
+      NEVER use absolute paths like `/workspace`, `/tmp`, or `/` — they fail.
+    - You can run shell commands with the exec tool. Available: bash, python3,
+      node, npm, git, curl, grep/sed/awk. NOT available: gcc, make, jq, wget.
+    - Keep tasks small and concrete; check each step's output before continuing.


### PR DESCRIPTION
Makes the OpenClaw agent able to **run commands and write files correctly** (Tier 2/3/4), not just chat.

**1. Enable exec** — it was blocked by OpenClaw's *elevated tools* gate (`allowedByConfig:false`). Adds `tools.elevated.enabled=true`, `allowFrom.webchat=[exec,process,write,edit,read,apply_patch]`, and `agents.defaults.sandbox.mode='off'` (direct host exec — no docker runtime in the pod). **Verified live**: the agent ran `echo` and returned its output.

**2. Fix paths** — AGENTS.md now tells the model its workspace is `/home/node/.openclaw/workspace` (only writable dir; root fs read-only), to use **relative paths** (it kept guessing `/workspace` → ENOENT), and which tools exist.

**Security:** yolo-style exec — the agent can run arbitrary commands in its pod, contained by the pod hardening (non-root, RO rootfs, dropped caps). Homelab experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns