### PR TITLE
fix(openclaw-qwen): mount workspace at /workspace so agent writes land

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -39,8 +39,8 @@ data:
         }
       },
       "agents": {
-        "defaults": { "workspace": "~/.openclaw/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
-        "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "~/.openclaw/workspace" } ]
+        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
+        "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "/workspace" } ]
       },
       "cron": { "enabled": false },
       "tools": {
@@ -57,10 +57,9 @@ data:
     Kubernetes pod), backed by a Qwen3.5-9B model on a GPU. Be clear and concise.
 
     ## Your environment (important)
-    - Your workspace and working directory is: /home/node/.openclaw/workspace
-      It is the ONLY writable location; the root filesystem is read-only.
-    - ALWAYS use RELATIVE paths for files (e.g. `notes.txt`, `demo/README.md`).
-      NEVER use absolute paths like `/workspace`, `/tmp`, or `/` — they fail.
+    - Your workspace and working directory is: /workspace
+      Create and edit files there (e.g. /workspace/notes.txt, or just notes.txt).
+      Do NOT write outside /workspace — the rest of the filesystem is read-only.
     - You can run shell commands with the exec tool. Available: bash, python3,
       node, npm, git, curl, grep/sed/awk. NOT available: gcc, make, jq, wget.
     - Keep tasks small and concrete; check each step's output before continuing.

--- a/base-apps/openclaw-qwen/deployment.yaml
+++ b/base-apps/openclaw-qwen/deployment.yaml
@@ -108,6 +108,12 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/node/.openclaw
+            # Also expose the workspace at /workspace — the model hard-assumes
+            # that path for file writes. Same PVC dir as ~/.openclaw/workspace
+            # (subPath), so /workspace and the configured workspace are identical.
+            - name: home
+              mountPath: /workspace
+              subPath: workspace
             - name: tmp
               mountPath: /tmp
           securityContext:


### PR DESCRIPTION
The 9B hard-assumes `/workspace` for file writes and ignored the AGENTS.md relative-path hint → `/workspace/... ENOENT`. Rather than fight the model, this makes `/workspace` real: mounts the PVC workspace subdir at `/workspace` and points OpenClaw's agent workspace there. Model writes land in the persistent PVC; exec cwd=/workspace so `python3 hello.py` finds the file. exec itself was enabled in #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns