### PR TITLE
feat(openclaw-qwen): switch model to Qwen2.5-Coder-14B-Instruct

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -12,8 +12,8 @@ data:
   # gateway.auth.mode "token" — shared-secret auth that grants the OPERATOR role,
   # so the TUI can actually send (unlike "none", which is read-only). The token
   # comes from the OPENCLAW_GATEWAY_TOKEN env (secret.yaml). The `openai` provider
-  # points at Qwen3.5-9B served by LM Studio on the gaming PC's GPU
-  # (http://10.0.1.200:1234, same LAN subnet as the nodes) — a GPU 9B answers in
+  # points at Qwen2.5-Coder-14B served by LM Studio on the gaming PC's GPU
+  # (http://10.0.1.200:1234, same LAN subnet as the nodes) — a GPU model answers in
   # seconds vs. minutes for the CPU 0.8B, and it's the ~20K agent prompt's real
   # home. Requires LM Studio to load the model with context length >= ~24K.
   openclaw.json: |
@@ -34,12 +34,12 @@ data:
             "auth": "api-key",
             "api": "openai-completions",
             "timeoutSeconds": 600,
-            "models": [ { "id": "qwen/qwen3.5-9b", "name": "Qwen3.5-9B (LM Studio, GPU)" } ]
+            "models": [ { "id": "qwen2.5-coder-14b-instruct", "name": "Qwen2.5-Coder-14B (LM Studio, GPU)" } ]
           }
         }
       },
       "agents": {
-        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen/qwen3.5-9b" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
+        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen2.5-coder-14b-instruct" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "/workspace" } ]
       },
       "cron": { "enabled": false },
@@ -54,7 +54,7 @@ data:
     # OpenClaw Assistant
 
     You are a helpful coding/ops assistant running in a Linux sandbox (a
-    Kubernetes pod), backed by a Qwen3.5-9B model on a GPU. Be clear and concise.
+    Kubernetes pod), backed by a Qwen2.5-Coder-14B model on a GPU. Be clear and concise.
 
     ## Your environment (important)
     - Your workspace and working directory is: /workspace


### PR DESCRIPTION
Swaps the reasoning `qwen3.5-9b` (which made tool calls but never closed the turn → `incomplete turn` errors) for **Qwen2.5-Coder-14B-Instruct** — a non-reasoning instruct/coder model (verified `reasoning_content=''`) with stable tool-calling, on the GPU via LM Studio. Fits 16GB at Q4_K_M. Only the model id changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns