### PR TITLE
feat(openclaw-qwen): add Slack channel (Socket Mode)

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -43,10 +43,21 @@ data:
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "/workspace" } ]
       },
       "cron": { "enabled": false },
+      "channels": {
+        "slack": {
+          "enabled": true,
+          "mode": "socket",
+          "appToken": { "source": "env", "provider": "default", "id": "SLACK_APP_TOKEN" },
+          "botToken": { "source": "env", "provider": "default", "id": "SLACK_BOT_TOKEN" }
+        }
+      },
       "tools": {
         "elevated": {
           "enabled": true,
-          "allowFrom": { "webchat": ["exec", "process", "write", "edit", "read", "apply_patch"] }
+          "allowFrom": {
+            "webchat": ["exec", "process", "write", "edit", "read", "apply_patch"],
+            "slack": ["exec", "process", "write", "edit", "read", "apply_patch"]
+          }
         }
       }
     }

--- a/base-apps/openclaw-qwen/deployment.yaml
+++ b/base-apps/openclaw-qwen/deployment.yaml
@@ -80,6 +80,19 @@ spec:
                 secretKeyRef:
                   name: openclaw-qwen-secrets
                   key: OPENCLAW_GATEWAY_TOKEN
+            # Slack Socket-Mode tokens (channels.slack SecretRefs point at these).
+            # The openclaw-slack Secret is created out-of-band (not in git) so the
+            # real tokens never touch the repo.
+            - name: SLACK_APP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-slack
+                  key: SLACK_APP_TOKEN
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-slack
+                  key: SLACK_BOT_TOKEN
           resources:
             requests:
               memory: 512Mi


### PR DESCRIPTION
Adds a Slack channel so you can talk to the agent from Slack. Tokens come from the out-of-band `openclaw-slack` Secret (never in git) via env vars; `channels.slack` references them with SecretRef. Slack channel can use tools like the TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns