### PR TITLE
fix(openclaw-qwen): make Slack durable (install plugin + enable in config)

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -51,6 +51,10 @@ data:
           "botToken": { "source": "env", "provider": "default", "id": "SLACK_BOT_TOKEN" }
         }
       },
+      "plugins": {
+        "allow": ["slack"],
+        "entries": { "slack": { "enabled": true } }
+      },
       "tools": {
         "elevated": {
           "enabled": true,

--- a/base-apps/openclaw-qwen/deployment.yaml
+++ b/base-apps/openclaw-qwen/deployment.yaml
@@ -54,6 +54,51 @@ spec:
               mountPath: /home/node/.openclaw
             - name: config
               mountPath: /config
+        # Slack is a channel plugin (@openclaw/slack) NOT bundled in the slim
+        # image; install it from npm into the persistent PVC on first boot.
+        # Idempotent: skipped when already present, so warm restarts stay fast and
+        # only a fresh/lost PVC triggers a re-download. npm cache -> /tmp because
+        # the container rootfs is read-only. openclaw.json (with plugins.entries.
+        # slack.enabled + channels.slack) is seeded by init-config, which runs first.
+        - name: init-slack-plugin
+          image: ghcr.io/openclaw/openclaw:slim
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              if ls -d /home/node/.openclaw/npm/projects/openclaw-slack-* >/dev/null 2>&1; then
+                echo "slack plugin already installed; skipping"
+              else
+                echo "installing @openclaw/slack from npm..."
+                openclaw plugins install @openclaw/slack
+              fi
+          env:
+            - name: HOME
+              value: /home/node
+            - name: npm_config_cache
+              value: /tmp/.npm
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: "1"
+          volumeMounts:
+            - name: home
+              mountPath: /home/node/.openclaw
+            - name: tmp
+              mountPath: /tmp
       containers:
         - name: gateway
           # Official OpenClaw image + command (docs.openclaw.ai/install/kubernetes).


### PR DESCRIPTION
Follow-up to #422. The Slack channel worked live but depended on state that lived only in the pod's PVC. This bakes both pieces into git so a fresh pod/PVC comes up with Slack:

- **init-slack-plugin** container installs `@openclaw/slack` from npm into the PVC (idempotent; skips if present).
- **plugins.entries.slack.enabled + plugins.allow** added to `openclaw.json` so the gateway loads/trusts the external channel at boot.

Verified live: `[slack] socket mode connected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns