### PR TITLE
fix(openclaw-qwen): force Slack channel replies (silentReply.group=disallow)

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -39,7 +39,7 @@ data:
         }
       },
       "agents": {
-        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen2.5-coder-14b-instruct" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" } },
+        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen2.5-coder-14b-instruct" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" }, "silentReply": { "group": "disallow" } },
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "/workspace" } ]
       },
       "cron": { "enabled": false },


### PR DESCRIPTION
The bot connected to Slack but never answered channel @mentions. Traced it: in group chats OpenClaw tells the model to reply with the `NO_REPLY` sentinel when it has 'nothing to say', and the coder model was choosing `NO_REPLY` even on a direct mention. Setting `agents.defaults.silentReply.group: disallow` drops that guidance so the model must reply. Proven by replaying the exact prompt against LM Studio (with the section → `NO_REPLY`; without → `Hi!`). DMs already always reply (`direct` is hardcoded disallow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx3qXP9BxHXrPayUYxRFns