### PR TITLE
feat(openclaw-qwen): switch model to Devstral Small 2 24B

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -12,10 +12,11 @@ data:
   # gateway.auth.mode "token" — shared-secret auth that grants the OPERATOR role,
   # so the TUI can actually send (unlike "none", which is read-only). The token
   # comes from the OPENCLAW_GATEWAY_TOKEN env (secret.yaml). The `openai` provider
-  # points at Qwen2.5-Coder-14B served by LM Studio on the gaming PC's GPU
-  # (http://10.0.1.200:1234, same LAN subnet as the nodes) — a GPU model answers in
-  # seconds vs. minutes for the CPU 0.8B, and it's the ~20K agent prompt's real
-  # home. Requires LM Studio to load the model with context length >= ~24K.
+  # points at Devstral Small 2 24B (agentic coding model) served by LM Studio on the
+  # gaming PC's GPU (http://10.0.1.200:1234, same LAN subnet as the nodes). Load it in
+  # LM Studio with Max Concurrent Predictions = 1 (so a single request gets the whole
+  # context window, not context/N) and context length >= ~16K — the agent prompt plus
+  # the trimmed GitHub toolset fits comfortably at 16K once Parallel=1.
   openclaw.json: |
     {
       "gateway": {
@@ -34,12 +35,12 @@ data:
             "auth": "api-key",
             "api": "openai-completions",
             "timeoutSeconds": 600,
-            "models": [ { "id": "qwen2.5-coder-14b-instruct", "name": "Qwen2.5-Coder-14B (LM Studio, GPU)" } ]
+            "models": [ { "id": "devstral-small-2-24b-instruct-2512", "name": "Devstral Small 2 24B (LM Studio, GPU)" } ]
           }
         }
       },
       "agents": {
-        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/qwen2.5-coder-14b-instruct" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" }, "silentReply": { "group": "disallow" } },
+        "defaults": { "workspace": "/workspace", "model": { "primary": "openai/devstral-small-2-24b-instruct-2512" }, "timeoutSeconds": 600, "sandbox": { "mode": "off" }, "silentReply": { "group": "disallow" } },
         "list": [ { "id": "default", "name": "OpenClaw Assistant", "workspace": "/workspace" } ]
       },
       "cron": { "enabled": false },
@@ -69,7 +70,7 @@ data:
     # OpenClaw Assistant
 
     You are a helpful coding/ops assistant running in a Linux sandbox (a
-    Kubernetes pod), backed by a Qwen2.5-Coder-14B model on a GPU. Be clear and concise.
+    Kubernetes pod), backed by a Devstral Small 2 24B model on a GPU. Be clear and concise.
 
     ## Your environment (important)
     - Your workspace and working directory is: /workspace


### PR DESCRIPTION
Points OpenClaw at `devstral-small-2-24b-instruct-2512` (agentic coding model) instead of Qwen2.5-Coder-14B. Verified reachable + responding from the pod. Loaded at ctx 16384, Parallel=1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)