### PR TITLE
docs(openclaw-qwen): record 32K context + KV-quant for Devstral

### DIFF
--- a/base-apps/openclaw-qwen/configmap.yaml
+++ b/base-apps/openclaw-qwen/configmap.yaml
@@ -15,8 +15,11 @@ data:
   # points at Devstral Small 2 24B (agentic coding model) served by LM Studio on the
   # gaming PC's GPU (http://10.0.1.200:1234, same LAN subnet as the nodes). Load it in
   # LM Studio with Max Concurrent Predictions = 1 (so a single request gets the whole
-  # context window, not context/N) and context length >= ~16K — the agent prompt plus
-  # the trimmed GitHub toolset fits comfortably at 16K once Parallel=1.
+  # context window, not context/N) and context length 32768 with K/V cache quantization
+  # (Q8_0, or Q4_0 if VRAM is tight) enabled + Flash Attention on. The agent prompt +
+  # trimmed GitHub toolset runs ~22K tokens, which overflows a 16K window; 32K + a
+  # quantized KV cache keeps it inside the 16GB card. (n_keep 22416 >= n_ctx 16384 was
+  # the overflow error before this.)
   openclaw.json: |
     {
       "gateway": {


### PR DESCRIPTION
Comment-only runbook update: Devstral needs context 32768 + KV-cache quantization (the ~22K agent prompt overflows 16K). Verified LM Studio now reports loaded_context_length: 32768. No runtime change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)