### PR TITLE
k3s 1.33 → 1.36 upgrade: safety net, spec, and prune-scope fix

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -204,7 +204,8 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install deps
-        run: pip install pytest==8.3.3
+        # pyyaml is needed by test_prune_scope.py, which parses the PVC manifests.
+        run: pip install pyyaml==6.0.2 pytest==8.3.3
       - name: Install sqlite3
         run: sudo apt-get update && sudo apt-get install -y sqlite3
       - name: Run backup/restore/scan tests (includes containerised k3s drill)

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -189,6 +189,27 @@ jobs:
       - name: Validate agent-identity contract
         run: python scripts/validate-agent-identity.py --repo-root .
 
+  # The k3s upgrade safety net (SPEC.md §T.1-§T.4). The cluster's datastore is SQLite
+  # with no embedded etcd, and k3s migrates it one-way on a minor bump with no supported
+  # downgrade — so the artifact scripts/k3s-backup.sh produces is the only rollback that
+  # exists. §V.16 refuses to take that on faith, which is why the restore drill boots a
+  # real k3s container and requires the seeded state back rather than just asserting the
+  # script exited 0. Ubuntu runners have a Docker daemon, so the drills run here.
+  k3s-upgrade-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: pip install pytest==8.3.3
+      - name: Install sqlite3
+        run: sudo apt-get update && sudo apt-get install -y sqlite3
+      - name: Run backup/restore/scan tests (includes containerised k3s drill)
+        run: python -m pytest tests/k3s-upgrade/ -q
+
   # The agent-capability contract (L03 Security guardrails). This is the
   # AUTHORITATIVE gate for all four invariants — in particular "delegation does
   # not escalate", which Kyverno cannot check at admission because it needs a

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC
 
 ## §G GOAL
-k3s cluster 1.33.5 → v1.36.2+k3s1 (fallback `v1.35.6+k3s1` if §T.20 blockers hold); platform components current & in-matrix first; ⊥ data loss.
+k3s cluster 1.33.5 → v1.36.2+k3s1 (fallback `v1.35.6+k3s1` if §T.20 blockers hold); platform components @ matrix ceiling per minor, INTERLEAVED w/ walk (§V.13); ⊥ data loss.
 
 ## §C CONSTRAINTS
 - GitOps only. ∀ change → git commit → Argo CD sync. ⊥ direct `kubectl apply` (CLAUDE.md).
@@ -20,6 +20,7 @@ k3s cluster 1.33.5 → v1.36.2+k3s1 (fallback `v1.35.6+k3s1` if §T.20 blockers 
 - ∀ Argo app `prune: true` + `selfHeal: true` ∴ prune of PVC → PV Delete → data gone.
 - `kube-system/ingress-nginx` = HelmChart CR (`base-apps/nginx-ingress/`) reconciled by k3s embedded helm-controller ∴ helm-controller upgraded by ∀ hop.
 - Vault in-cluster ∴ ESO break → ∀ app secret resolution stops. ESO ! healthy before ∀ hop.
+- Vault seal = `awskms` (`alias/vault-auto-unseal`, `terraform/roots/asela-cluster/vault-kms.tf`). `/vault/data` bytes = CIPHERTEXT ∴ ∀ fs backup undecryptable w/o KMS key. Shamir recovery keys govern recovery ops, ⊥ storage decryption.
 - Istio = ambient (istiod + `ztunnel` DS + `istio-cni-node` DS) ∴ node-level dataplane, hop risk ≥ sidecar.
 - k8s 1.33 EOL 2026-06-28 ∴ cluster currently unsupported.
 
@@ -28,14 +29,15 @@ k3s cluster 1.33.5 → v1.36.2+k3s1 (fallback `v1.35.6+k3s1` if §T.20 blockers 
 - file: `base-apps/system-upgrade-controller/*.yaml` → SUC deploy + RBAC + CRD
 - file: `base-apps/system-upgrade-controller/plan-agent.yaml` → Plan CR, workers ONLY
 - file: ⊥ `plan-server.yaml`. control-plane hop = manual (§V.17) ∴ SUC ⊥ ever target `k3s-control-01`
-- cmd: `scripts/vault-backup.sh --dest <dir\|s3://>` → `vault-0` `file` storage → sha256 → off-cluster. restore ! prove unseal + secret read
+- cmd: `scripts/vault-backup.sh --dest <dir\|s3://> [--mode cold\|online] [--argo-app NAME]` → `vault-0` `file` storage → sha256 → off-cluster. cold = suspend Argo app (§V.33) → scale sts 0 → helper pod w/ control-plane toleration (§V.34) → scale back → ! verify unseal. online ! `--allow-inconsistent` & brands artifact `INCONSISTENT`
+- cmd: `scripts/vault-restore.sh --artifact <a> --data-dir <d> [--verify-cmd C] [--accept-inconsistent]` → checksum gate → refuse `INCONSISTENT` w/o ack → restore → ! prove unseal + secret read
 - node-label: `k3s-upgrade=true` → gates Plan `nodeSelector`
 - cmd: `scripts/k3s-backup.sh --mode cold\|online --dest <dir\|s3://>` → archives `server/` ONLY (⊥ `storage/` = local-path PV data, ⊥ `agent/`, ⊥ `kine.sock`) → sha256 → off-cluster. cold ! k3s stopped; online = `sqlite3 .backup` + excludes live db file set
 - cmd: `scripts/k3s-restore.sh --artifact <a> --expect-version <v> [--skip-service] [--verify-cmd C]` → checksum gate → prior tree moved aside (⊥ destroy evidence) → promote snapshot → reinstall pinned `INSTALL_K3S_VERSION` → ! prove API @ expected version
 - cmd: `scripts/pg-backup.sh --dest <dir\|s3://> --all \| --database <db>` → `pg_dumpall` (globals+roles) \| `pg_dump` via CNPG primary → sha256 → off-cluster. ⊥ default db name (cluster hosts `n8n`+`chores_tracker`). operator-independent ∴ survives §T.9
 - backup: CNPG barman → `s3://mysql-backups-asela-cluster/postgresql/`, `ScheduledBackup postgresql-daily-backup` 02:00 UTC, 30d retention. healthy & archiving, restore ⊥ proven (§T.34)
 - store: off-cluster artifact target. `s3://mysql-backups-asela-cluster/` ∃ already ∴ add `k3s/` + `pg/` prefixes. ⊥ new bucket needed
-- test: `tests/k3s-upgrade/` = pytest oracle ∀ §V.1,6,10,15,16,21. drills boot real k3s + postgres in docker. CI job `k3s-upgrade-scripts` ∈ `.github/workflows/validate.yaml`
+- test: `tests/k3s-upgrade/` = pytest oracle ∀ §V.1,6,10,15,16,21,28. drills boot real k3s + postgres + vault in docker. CI job `k3s-upgrade-scripts` ∈ `.github/workflows/validate.yaml`
 - doc: `docs/plans/k3s-1.36-upgrade-plan.md` → runbook + outage comms
 - doc: `docs/plans/k3s-1.36-api-scan.md` → §T.4 report. built-in APIs clean 1.34/1.35/1.36; pluto ⊥ see CRD removals ∴ ESO `v1beta1` = real gap
 
@@ -84,6 +86,10 @@ V31: ∀ hop task ! enumerate FULL gate set incl §V.6. ⊥ bare "gate →".
 V32: Istio hop plan ! explicit per-minor & ∀ intermediate ∈ k8s matrix @ CURRENT minor. Istio `1.25` = k8s ≤1.32 ∴ ∉ 1.33 ∴ ⊥ naive 1-minor walk. `1.26`+ ∈ matrix @ 1.33.
 V33: ∀ quiesce of GitOps-managed workload (scale→0 \| pod delete) → ! suspend its Argo app FIRST, resume after. `selfHeal: true` + replicas ∈ git ∴ Argo rescales mid-operation → torn artifact \| silent revert (§B.2). applies §T.35, §T.36, §T.37.
 V34: ∀ pod mounting a node-pinned `local-path` PV → ! carry toleration ∀ taint on that node + explicit resource limits. `k3s-control-01` taint = `node-role.kubernetes.io/control-plane:NoSchedule`; kyverno `require-resource-limits` = Audit (warns, ⊥ blocks). ⊥ toleration → Pending forever, ⊥ 2 workers (∉ PV affinity). applies §T.35, §T.36, §T.37.
+V35: Vault backup ⊇ KMS key. `alias/vault-auto-unseal` deleted \| AWS acct lost → ∀ vault artifact undecryptable ∀ time, however perfect the bytes. ∴ key ! carry deletion protection & its policy backed up ALONGSIDE artifact. ⊥ treat key as adjacent to the backup.
+V36: ⊥ delete PVC w/ reclaim=`Delete` unless restore-proven backup ∃ & verified. deliberate delete = §V.19 hazard by another route. applies §T.36.
+V37: post-§T.36+§T.37 → §V.14 scope MOVES: control-plane hop = API only; `k3s-worker-01` hop = Vault + CNPG outage. ∀ hop task ! re-cite before exec. §T.18 = highest-risk hop post-relocate.
+V38: §T.37 scale-down gate — ! assert `postgresql-cluster-2` = primary BEFORE `instances` 2→1. CNPG drops highest-serial NON-primary & ⊥ targetable ∴ failed switchover → silent revert to control-plane.
 
 ## §T TASKS
 id|status|task|cites
@@ -104,7 +110,7 @@ T14|.|add SUC manifests + RBAC + CRD (sync-wave: CRD before Plan). Plan scope = 
 T15|.|label `k3s-worker-01`,`k3s-worker-02` `k3s-upgrade=true`. ⊥ label `k3s-control-01`|V17,I.node-label
 T16|.|dry-run SUC Plan on `k3s-worker-02` @ current version (no-op hop)|V4,V17
 T17|.|gate §V.1,2,5,6,10,11,14,27,28 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃|V1,V2,V3,V6,V14,V17,V27,V28,V31
-T18|.|SUC hop workers → `v1.34.9+k3s1`, verify §V.5|V4,V5,V17
+T18|.|SUC hop workers → `v1.34.9+k3s1`. gate §V.1,5,6,11,14,28 — post-relocate THIS hop = Vault + CNPG outage (§V.37), ⊥ bare "verify §V.5"|V4,V5,V6,V17,V31,V37
 T19|.|gate §V.1,2,5,6,10,11,14,27,28 → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V6,V17,V27,V28,V31
 T20|.|BLOCKER ×2 → 1.36: CNPG 1.29.x ≤1.35 & ⊥ ESO version supports 1.36 (§R.4; §R.6 `2.8.0` unconfirmed `?`). ! confirm BOTH ship 1.36 support, else hold @ 1.35|V2
 T21|.|gate §T.20 + §V.1,2,5,6,10,11,14,27,28 → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC). ⊥ w/o BOTH blockers cleared|V2,V3,V5,V6,V17,V27,V28,V31
@@ -114,7 +120,7 @@ T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
 T25|.|build pause/resume for Argo auto-sync ∀ PVC-bearing app across hop window|V18
 T26|.|audit prune scope: assert ⊥ PVC prunable (Kyverno rule \| `Prune=false` annotation)|V19
 T27|x|DECIDED 2026-07-27: RELOCATE both → `k3s-worker-01` (97GB disk, ⊥ pressure). → §T.36 + §T.37. rationale: retires single failure domain, hops become API-only|V14,V29
-T28|.|provision off-cluster artifact store for k3s + pg + vault backups|V21,I.store
+T28|.|add `k3s/` + `pg/` + `vault/` prefixes → existing `s3://mysql-backups-asela-cluster/`. ⊥ new bucket (§I.store). + KMS key deletion protection (§V.35)|V21,V35,I.store
 T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
 T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
 T31|.|ESO stage 2: ∀ 59 manifest → `v1` (drop `beta1`) THEN rewrite ∀ stored object as `v1` + prune CRD `status.storedVersions` → `["v1"]`. git ≠ etcd (§R.3). after §T.6|V23,V24,V26
@@ -122,9 +128,10 @@ T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `
 T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
 T35|x|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
-T36|.|relocate `vault-0` → `k3s-worker-01`: backup (§T.35) → scale 0 → drop PVC(1Gi) → recreate w/ nodeSelector → restore → ! prove unseal + secret read. after §T.35|V28,V29
-T37|.|relocate `postgresql-cluster` → `k3s-worker-01`: CNPG `instances` 1→2 (new pod nodeSelector `k3s-worker-01`) → wait streaming → `switchover` → scale→1 drop old. ⊥ manual PV surgery. needs ~40Gi transient|V6,V29
-T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. re-verify §C pinning lines + §V.14 scope — control-plane hop now API-only, worker-01 hop = Vault+DB outage|V14,V29
+T36|.|relocate `vault-0` → `k3s-worker-01`: suspend Argo app (§V.33) → backup (§T.35) → scale 0 → drop PVC(1Gi) → recreate w/ nodeSelector → restore → ! prove unseal + secret read → resume Argo. after §T.35|V28,V29,V33,V36
+T37|.|relocate `postgresql-cluster` → `k3s-worker-01`: CNPG `instances` 1→2 (new pod nodeSelector `k3s-worker-01`, toleration §V.34) → wait streaming → `switchover` → ASSERT `-2` = primary (§V.38) → scale→1 drops old. ⊥ manual PV surgery. needs ~40Gi transient|V6,V29,V34,V38
+T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. amend §C pinning lines + §V.14 scope per §V.37 — control-plane hop now API-only, `k3s-worker-01` hop = Vault+DB outage|V14,V29,V37
+T39|.|write `docs/plans/k3s-1.36-upgrade-plan.md` — runbook + outage comms. §I declares it, ⊥ ∃; §V.9 "announced" depends on it|V9,I.doc
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,97 @@
+# SPEC
+
+## §G GOAL
+k3s cluster 1.33.5 → v1.36.2+k3s1; platform components current & in-matrix first; ⊥ data loss.
+
+## §C CONSTRAINTS
+- GitOps only. ∀ change → git commit → Argo CD sync. ⊥ direct `kubectl apply` (CLAUDE.md).
+- cluster = 3 node k3s. `k3s-control-01` server, `k3s-worker-01` + `k3s-worker-02` agents. Ubuntu 24.04.3, containerd 2.1.4-k3s1.
+- server args = `server --disable traefik --write-kubeconfig-mode 644`. ⊥ `--cluster-init` ∴ SQLite datastore, ⊥ embedded etcd.
+- ⊥ `k3s etcd-snapshot` (SQLite ∉ etcd). backup = fs copy `/var/lib/rancher/k3s/`.
+- k3s minor upgrade migrates DB one-way ∴ downgrade ⊥ supported. rollback = fs restore + reinstall @ prior `INSTALL_K3S_VERSION`.
+- 1 server ∴ ∀ control-plane hop → outage of API + Vault + CNPG. accepted, bounded @ §V.9, §V.14.
+- ⊥ HA conversion ∈ this spec. 3-server embedded etcd = follow-on §T.24.
+- k8s skew ! ≤ ±1 minor ∴ walk 1.33 → 1.34 → 1.35 → 1.36. ⊥ skip minor.
+- mechanism = system-upgrade-controller. Plan CRs ∈ `base-apps/`.
+- 92 workloads ∈ 45 ns.
+- CNPG `postgresql/postgresql-cluster` instances=1 ∴ ⊥ replica ∴ restart = data-path outage.
+- `local-path` = only SC & default, reclaim=`Delete`, 21 PVC ∀ on it. PV `nodeAffinity` hard-pins pod → node ∴ ⊥ reschedule on drain.
+- `vault-0` + `postgresql-cluster-1` ∈ `k3s-control-01`, PV pinned there ∴ control-plane hop = secrets + DB outage, ⊥ evacuable w/o PV migration.
+- ∀ Argo app `prune: true` + `selfHeal: true` ∴ prune of PVC → PV Delete → data gone.
+- `kube-system/ingress-nginx` = HelmChart CR (`base-apps/nginx-ingress/`) reconciled by k3s embedded helm-controller ∴ helm-controller upgraded by ∀ hop.
+- Vault in-cluster ∴ ESO break → ∀ app secret resolution stops. ESO ! healthy before ∀ hop.
+- Istio = ambient (istiod + `ztunnel` DS + `istio-cni-node` DS) ∴ node-level dataplane, hop risk ≥ sidecar.
+- k8s 1.33 EOL 2026-06-28 ∴ cluster currently unsupported.
+
+## §I INTERFACES
+- file: `base-apps/system-upgrade-controller.yaml` → Argo CD Application
+- file: `base-apps/system-upgrade-controller/*.yaml` → SUC deploy + RBAC + CRD
+- file: `base-apps/system-upgrade-controller/plan-server.yaml` → Plan CR, control-plane
+- file: `base-apps/system-upgrade-controller/plan-agent.yaml` → Plan CR, workers
+- node-label: `k3s-upgrade=true` → gates Plan `nodeSelector`
+- cmd: `scripts/k3s-backup.sh` → stop k3s (\| `sqlite3 state.db ".backup"`) → tar `/var/lib/rancher/k3s/` → checksum → ship off-cluster. ⊥ tar live db
+- cmd: `scripts/k3s-restore.sh <artifact>` → halt k3s, restore, reinstall pinned `INSTALL_K3S_VERSION` → ! prove API up @ prior version
+- cmd: `scripts/pg-backup.sh` → pg_dump `postgresql-cluster` → off-cluster target
+- store: off-cluster artifact target (S3 `asela-terraform-states` sibling \| NAS) → k3s + pg + vault artifacts
+- doc: `docs/plans/k3s-1.36-upgrade-plan.md` → runbook + outage comms
+
+## §V INVARIANTS
+V1: ∀ hop → verified fs backup `/var/lib/rancher/k3s/` ∃ & restore drill passed before hop starts.
+V2: ∀ hop → ∀ platform component ∈ its supported k8s matrix @ target minor. ⊥ hop otherwise.
+V3: ∀ hop → 1 minor step. ⊥ skip.
+V4: control-plane hops before workers. ∀ worker hop after control-plane Ready.
+V5: ∀ hop → post-gate: ∀ node Ready & ∀ Argo CD app Synced+Healthy before next hop.
+V6: CNPG `postgresql-cluster` → pg_dump verified & restorable before ∀ hop.
+V7: ⊥ rc/pre-release image in cluster. ! GA tag.
+V8: ∀ component upgrade → own commit, own sync, own rollback point. ⊥ batch.
+V9: outage window announced & ≤ 15min per control-plane hop.
+V10: ∀ hop → removed-API scan clean vs target minor.
+V11: ∀ hop → ESO healthy & ∀ ExternalSecret `SecretSynced=True`.
+V12: Istio ambient upgrade → revision/canary. ⊥ in-place istiod replace.
+V13: ⊥ 2 phases concurrent. component remediation fully green before walk starts.
+V14: ∀ control-plane hop → outage = API + Vault + CNPG. ⊥ model as API-only. all 3 restored & verified before hop declared done.
+V15: k3s backup ! quiesced — stop k3s \| `sqlite3 .backup` before copy. ⊥ archive live datastore file SET: `state.db` + `state.db-wal` + `state.db-shm`. kine = WAL mode ∴ stale sidecar replays over snapshot → silent corruption.
+V16: restore drill ! prove API returns @ prior version from artifact. unproven artifact ∉ backup.
+V17: control-plane hop = manual, operator-driven, console access ∃. SUC scope = agents only.
+V18: ∀ hop window → Argo auto-sync paused ∀ app w/ PVC. resume only after §V.5 green.
+V19: ⊥ PVC ∈ prune scope, ∀ time. local-path reclaim=Delete ∴ prune = data loss.
+V20: Istio upgrade → new Application per revision, old revision live until `ztunnel`+`istio-cni-node` green ∀ node. ⊥ mutate `targetRevision` in place.
+V21: ∀ backup artifact (k3s, pg_dump, vault) ! stored ∉ cluster. artifact on `local-path` ∉ backup.
+V22: ∀ hop → helm-controller reconcile of `kube-system/ingress-nginx` verified & ingress reachable post-hop.
+
+## §T TASKS
+id|status|task|cites
+T1|x|write `scripts/k3s-backup.sh` — quiesce k3s, `sqlite3 .backup`, tar, checksum, ship off-cluster|V1,V15,V21,I.cmd
+T2|x|write `scripts/k3s-restore.sh` + drill on throwaway VM: artifact → API up @ prior version|V1,V16,I.cmd
+T3|x|`scripts/pg-backup.sh` pg_dump `postgresql-cluster` → off-cluster, verify restore|V6,V21,I.cmd
+T4|x|deprecated/removed-API scan vs 1.34,1.35,1.36 (`pluto` \| `kubent`)|V10
+T5|.|Argo CD `v3.5.0-rc2` → v3.5.x GA|V7,V8
+T6|.|ESO `v0.11.0` → v2.x — major jump, CRD breaking ∴ /research first|V11,V8
+T7|.|verify ∀ ExternalSecret resync post-ESO, Vault k8s-auth roles intact|V11
+T8|.|Vault `1.18.1` → current stable. NB StatefulSet `updateStrategy: OnDelete` ∴ ! manual `delete pod vault-0` after sync|V8
+T9|.|CNPG `1.24.1` → 1.29.x — CVE-2026-44477 CVSS 9.4 metrics exporter|V6,V8
+T10|.|Istio `1.24.0` → 1.30.x — new Application per revision, ⊥ bump `targetRevision` in place|V12,V20,V8
+T11|.|verify `ztunnel` + `istio-cni-node` DS healthy ∀ node post-Istio, then retire old revision|V12,V20
+T12|.|matrix-audit rest vs 1.36: kyverno 1.17.1, argo-rollouts 1.8.3, argo-workflows 3.6.10, cert-manager 1.20.2, crossplane 2.2.1, ingress-nginx, falco, gloo|V2
+T13|.|add `base-apps/system-upgrade-controller.yaml` Argo app|I.file
+T14|.|add SUC manifests + RBAC + CRD (sync-wave: CRD before Plan). Plan scope = agents only|V17,I.file
+T15|.|label `k3s-worker-01`,`k3s-worker-02` `k3s-upgrade=true`. ⊥ label `k3s-control-01`|V17,I.node-label
+T16|.|dry-run SUC Plan on `k3s-worker-02` @ current version (no-op hop)|V4,V17
+T17|.|gate §V.1,2,5,10,11,14 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃|V1,V2,V3,V14,V17
+T18|.|SUC hop workers → `v1.34.9+k3s1`, verify §V.5|V4,V5,V17
+T19|.|gate → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V17
+T20|.|BLOCKER: CNPG 1.29.x supports k8s ≤1.35. ! confirm CNPG 1.30 ships 1.36 support, else hold @ 1.35|V2
+T21|.|gate → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC)|V2,V3,V5,V17
+T22|.|confirm local kubectl v1.36.2 now in-skew|-
+T23|.|update `index.md` + `docs/` topology w/ landed versions|-
+T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
+T25|.|build pause/resume for Argo auto-sync ∀ PVC-bearing app across hop window|V18
+T26|.|audit prune scope: assert ⊥ PVC prunable (Kyverno rule \| `Prune=false` annotation)|V19
+T27|.|DECIDE: relocate `vault-0` + `postgresql-cluster-1` → worker before walk (PV migration) \| accept control-plane outage|V14
+T28|.|provision off-cluster artifact store for k3s + pg + vault backups|V21,I.store
+T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
+T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
+
+## §B BUGS
+id|date|cause|fix
+B1|2026-07-27|`k3s-backup.sh` online mode excluded `state.db` only. kine runs SQLite WAL ∴ live `-wal`/`-shm` shipped beside `.backup` snapshot → SQLite replays foreign WAL over restored db. found by drill, ⊥ by review|V15

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,11 +29,14 @@ k3s cluster 1.33.5 → v1.36.2+k3s1; platform components current & in-matrix fir
 - file: `base-apps/system-upgrade-controller/plan-server.yaml` → Plan CR, control-plane
 - file: `base-apps/system-upgrade-controller/plan-agent.yaml` → Plan CR, workers
 - node-label: `k3s-upgrade=true` → gates Plan `nodeSelector`
-- cmd: `scripts/k3s-backup.sh` → stop k3s (\| `sqlite3 state.db ".backup"`) → tar `/var/lib/rancher/k3s/` → checksum → ship off-cluster. ⊥ tar live db
-- cmd: `scripts/k3s-restore.sh <artifact>` → halt k3s, restore, reinstall pinned `INSTALL_K3S_VERSION` → ! prove API up @ prior version
-- cmd: `scripts/pg-backup.sh` → pg_dump `postgresql-cluster` → off-cluster target
-- store: off-cluster artifact target (S3 `asela-terraform-states` sibling \| NAS) → k3s + pg + vault artifacts
+- cmd: `scripts/k3s-backup.sh --mode cold\|online --dest <dir\|s3://>` → archives `server/` ONLY (⊥ `storage/` = local-path PV data, ⊥ `agent/`, ⊥ `kine.sock`) → sha256 → off-cluster. cold ! k3s stopped; online = `sqlite3 .backup` + excludes live db file set
+- cmd: `scripts/k3s-restore.sh --artifact <a> --expect-version <v> [--skip-service] [--verify-cmd C]` → checksum gate → prior tree moved aside (⊥ destroy evidence) → promote snapshot → reinstall pinned `INSTALL_K3S_VERSION` → ! prove API @ expected version
+- cmd: `scripts/pg-backup.sh --dest <dir\|s3://> --all \| --database <db>` → `pg_dumpall` (globals+roles) \| `pg_dump` via CNPG primary → sha256 → off-cluster. ⊥ default db name (cluster hosts `n8n`+`chores_tracker`). operator-independent ∴ survives §T.9
+- backup: CNPG barman → `s3://mysql-backups-asela-cluster/postgresql/`, `ScheduledBackup postgresql-daily-backup` 02:00 UTC, 30d retention. healthy & archiving, restore ⊥ proven (§T.34)
+- store: off-cluster artifact target. `s3://mysql-backups-asela-cluster/` ∃ already ∴ add `k3s/` + `pg/` prefixes. ⊥ new bucket needed
+- test: `tests/k3s-upgrade/` = pytest oracle ∀ §V.1,6,10,15,16,21. drills boot real k3s + postgres in docker. CI job `k3s-upgrade-scripts` ∈ `.github/workflows/validate.yaml`
 - doc: `docs/plans/k3s-1.36-upgrade-plan.md` → runbook + outage comms
+- doc: `docs/plans/k3s-1.36-api-scan.md` → §T.4 report. built-in APIs clean 1.34/1.35/1.36; pluto ⊥ see CRD removals ∴ ESO `v1beta1` = real gap
 
 ## §V INVARIANTS
 V1: ∀ hop → verified fs backup `/var/lib/rancher/k3s/` ∃ & restore drill passed before hop starts.
@@ -58,6 +61,9 @@ V19: ⊥ PVC ∈ prune scope, ∀ time. local-path reclaim=Delete ∴ prune = da
 V20: Istio upgrade → new Application per revision, old revision live until `ztunnel`+`istio-cni-node` green ∀ node. ⊥ mutate `targetRevision` in place.
 V21: ∀ backup artifact (k3s, pg_dump, vault) ! stored ∉ cluster. artifact on `local-path` ∉ backup.
 V22: ∀ hop → helm-controller reconcile of `kube-system/ingress-nginx` verified & ingress reachable post-hop.
+V23: ESO upgrade ! staged. ⊥ jump `v0.11.0` → ≥`0.17.0` — `0.17.0` REMOVES `external-secrets.io/v1beta1` & 59 manifest + CRD storage version ∀ @ `v1beta1`. path: `0.16.2` (serves both) → ∀ manifest `v1` → storage migrated → ≥`0.17.0` → `2.x`. ∀ stage own gate. §T row order ≠ exec order ∴ ! follow `after §T.n` cites.
+V24: ∀ ESO stage → Argo auto-sync paused ∀ app w/ ExternalSecret until manifests @ `v1` committed. `0.16.x` webhook auto-converts `v1beta1`→`v1` in-cluster → drift vs git ∴ `selfHeal` fights webhook.
+V25: barman restore ! proven (scratch Cluster ← `bootstrap.recovery`) BEFORE §T.9. barman restore ⊥ operator ∴ ⊥ verifiable after operator upgrade breaks.
 
 ## §T TASKS
 id|status|task|cites
@@ -66,10 +72,10 @@ T2|x|write `scripts/k3s-restore.sh` + drill on throwaway VM: artifact → API up
 T3|x|`scripts/pg-backup.sh` pg_dump `postgresql-cluster` → off-cluster, verify restore|V6,V21,I.cmd
 T4|x|deprecated/removed-API scan vs 1.34,1.35,1.36 (`pluto` \| `kubent`)|V10
 T5|.|Argo CD `v3.5.0-rc2` → v3.5.x GA|V7,V8
-T6|.|ESO `v0.11.0` → v2.x — major jump, CRD breaking ∴ /research first|V11,V8
+T6|.|ESO stage 1: `v0.11.0` → `v0.16.2` (serves `v1beta1`+`v1`). ⊥ proceed past w/o §T.31|V11,V8,V23,V24
 T7|.|verify ∀ ExternalSecret resync post-ESO, Vault k8s-auth roles intact|V11
 T8|.|Vault `1.18.1` → current stable. NB StatefulSet `updateStrategy: OnDelete` ∴ ! manual `delete pod vault-0` after sync|V8
-T9|.|CNPG `1.24.1` → 1.29.x — CVE-2026-44477 CVSS 9.4 metrics exporter|V6,V8
+T9|.|CNPG `1.24.1` → 1.29.x — CVE-2026-44477 CVSS 9.4 metrics exporter. gate §T.34 first|V6,V8,V25
 T10|.|Istio `1.24.0` → 1.30.x — new Application per revision, ⊥ bump `targetRevision` in place|V12,V20,V8
 T11|.|verify `ztunnel` + `istio-cni-node` DS healthy ∀ node post-Istio, then retire old revision|V12,V20
 T12|.|matrix-audit rest vs 1.36: kyverno 1.17.1, argo-rollouts 1.8.3, argo-workflows 3.6.10, cert-manager 1.20.2, crossplane 2.2.1, ingress-nginx, falco, gloo|V2
@@ -91,6 +97,10 @@ T27|.|DECIDE: relocate `vault-0` + `postgresql-cluster-1` → worker before walk
 T28|.|provision off-cluster artifact store for k3s + pg + vault backups|V21,I.store
 T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
 T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
+T31|.|ESO stage 2: ∀ 59 manifest `external-secrets.io/v1beta1` → `v1` + CRD storage version migrated. after §T.6|V23,V24
+T32|.|ESO stage 3: → ≥`0.17.0` (`v1beta1` removed upstream). after §T.31|V23,V11
+T33|.|ESO stage 4: → `2.x`. after §T.32|V23,V11
+T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -90,6 +90,9 @@ V35: Vault backup ⊇ KMS key. `alias/vault-auto-unseal` deleted \| AWS acct los
 V36: ⊥ delete PVC w/ reclaim=`Delete` unless restore-proven backup ∃ & verified. deliberate delete = §V.19 hazard by another route. applies §T.36.
 V37: post-§T.36+§T.37 → §V.14 scope MOVES: control-plane hop = API only; `k3s-worker-01` hop = Vault + CNPG outage. ∀ hop task ! re-cite before exec. §T.18 = highest-risk hop post-relocate.
 V38: §T.37 scale-down gate — ! assert `postgresql-cluster-2` = primary BEFORE `instances` 2→1. CNPG drops highest-serial NON-primary & ⊥ targetable ∴ failed switchover → silent revert to control-plane.
+V39: ∀ PVC ∉ Argo prune scope — `Prune=false` annotation \| app `prune: false` where chart ⊥ template annotations. enforced @ `tests/k3s-upgrade/test_prune_scope.py`. 10/21 WERE exposed 2026-07-27 ∴ §V.19 was false since inception.
+V40: §T.36 order ! = commit `nodeSelector` → Argo sync → suspend → scale 0 → delete PVC → helper pod (nodeSelector + §V.34 toleration) provisions & receives restore → delete helper → scale 1 (STS adopts `vault-data-vault-0`). ⊥ start Vault on empty PVC — `WaitForFirstConsumer` ∴ scaling up to create the PV self-initialises Vault before restore.
+V41: §T.39 runbook ! ∃ before §T.17. §V.9 "announced" ⊥ satisfiable w/o it.
 
 ## §T TASKS
 id|status|task|cites
@@ -118,7 +121,7 @@ T22|.|confirm local kubectl v1.36.2 now in-skew|-
 T23|.|update `index.md` + `docs/` topology w/ landed versions|-
 T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
 T25|.|build pause/resume for Argo auto-sync ∀ PVC-bearing app across hop window|V18
-T26|.|audit prune scope: assert ⊥ PVC prunable (Kyverno rule \| `Prune=false` annotation)|V19
+T26|x|prune-scope audit: 10 PVC WERE prunable (§V.19 false since inception). fixed — `Prune=false` ∀ 9 manifest + `prune: false` @ atlantis app (chart 6.1.0 ⊥ template PVC annotations). `tests/k3s-upgrade/test_prune_scope.py` = regression guard. NB `lg-agents/orchestrator-data` orphaned (⊥ app) → §T.40|V19,V39
 T27|x|DECIDED 2026-07-27: RELOCATE both → `k3s-worker-01` (97GB disk, ⊥ pressure). → §T.36 + §T.37. rationale: retires single failure domain, hops become API-only|V14,V29
 T28|.|add `k3s/` + `pg/` + `vault/` prefixes → existing `s3://mysql-backups-asela-cluster/`. ⊥ new bucket (§I.store). + KMS key deletion protection (§V.35)|V21,V35,I.store
 T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
@@ -128,10 +131,11 @@ T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `
 T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
 T35|x|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
-T36|.|relocate `vault-0` → `k3s-worker-01`: suspend Argo app (§V.33) → backup (§T.35) → scale 0 → drop PVC(1Gi) → recreate w/ nodeSelector → restore → ! prove unseal + secret read → resume Argo. after §T.35|V28,V29,V33,V36
+T36|.|relocate `vault-0` → `k3s-worker-01`. ORDER (§V.40): commit `nodeSelector` → Argo sync → suspend Argo app (§V.33) → backup (§T.35) → scale 0 → delete PVC `vault-data-vault-0` (§V.36) → helper pod w/ nodeSelector + toleration (§V.34) provisions new PV & receives restore → delete helper → scale 1 (STS adopts PVC) → ! prove unseal + secret read → resume Argo. after §T.35|V28,V29,V33,V34,V36,V40
 T37|.|relocate `postgresql-cluster` → `k3s-worker-01`: CNPG `instances` 1→2 (new pod nodeSelector `k3s-worker-01`, toleration §V.34) → wait streaming → `switchover` → ASSERT `-2` = primary (§V.38) → scale→1 drops old. ⊥ manual PV surgery. needs ~40Gi transient|V6,V29,V34,V38
 T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. amend §C pinning lines + §V.14 scope per §V.37 — control-plane hop now API-only, `k3s-worker-01` hop = Vault+DB outage|V14,V29,V37
 T39|.|write `docs/plans/k3s-1.36-upgrade-plan.md` — runbook + outage comms. §I declares it, ⊥ ∃; §V.9 "announced" depends on it|V9,I.doc
+T40|.|`lg-agents/orchestrator-data` PVC tracked by app `lg-agents` that ⊥ ∃. orphaned ∴ ⊥ prunable, but ∉ GitOps. decide: adopt \| delete \| document|V19
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -78,7 +78,7 @@ V25: barman restore ! proven (scratch Cluster ← `bootstrap.recovery`) BEFORE �
 V26: ⊥ ESO ≥`0.17.0` until `status.storedVersions == ["v1"]` ∀ of `externalsecrets`+`secretstores`+`clustersecretstores`. manifests @ `v1` ∈ git ≠ objects @ `v1` ∈ etcd (§R.3) ∴ k8s refuses to drop `v1beta1` & existing secrets become unreadable.
 V27: §V.2 exception — component ? out-of-matrix ACROSS a hop boundary iff ALL: (a) in-matrix @ CURRENT minor pre-hop, (b) upgrade → in-matrix @ target ∈ SAME maintenance window, (c) rollback artifact ∃ & drill-proven. ⊥ open-ended skew. ESO `0.19`→`0.20` = the case (§R.4).
 V28: ∀ hop → Vault data backed up off-cluster & restore-proven. `vault-0` storage=`file` @ local-path pinned `k3s-control-01` ∴ node loss = ∀ secret loss ∀ ns. KMS auto-unseal protects SEAL, ⊥ data.
-V29: §T.27 = HARD gate. ⊥ §T.13+ until relocate-vs-accept decided & recorded ∈ spec. relocate = PV migration ∴ ! before walk, ⊥ retrofit mid-walk.
+V29: §T.27 = HARD gate. DECIDED 2026-07-27 = RELOCATE both → `k3s-worker-01`. ⊥ §T.13+ until §T.36 & §T.37 complete. relocate = PV migration ∴ ! before walk, ⊥ retrofit mid-walk.
 V30: §V.18 pause ? be lifted to reach §V.5 green — paused app ⊥ self-heal ∴ ⊥ circular wait. order: pause → hop → MANUAL sync → verify → resume.
 V31: ∀ hop task ! enumerate FULL gate set incl §V.6. ⊥ bare "gate →".
 V32: Istio hop plan ! explicit per-minor & ∀ intermediate ∈ k8s matrix @ CURRENT minor. Istio `1.25` = k8s ≤1.32 ∴ ∉ 1.33 ∴ ⊥ naive 1-minor walk. `1.26`+ ∈ matrix @ 1.33.
@@ -111,7 +111,7 @@ T23|.|update `index.md` + `docs/` topology w/ landed versions|-
 T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
 T25|.|build pause/resume for Argo auto-sync ∀ PVC-bearing app across hop window|V18
 T26|.|audit prune scope: assert ⊥ PVC prunable (Kyverno rule \| `Prune=false` annotation)|V19
-T27|.|DECIDE: relocate `vault-0` + `postgresql-cluster-1` → worker before walk (PV migration) \| accept control-plane outage|V14
+T27|x|DECIDED 2026-07-27: RELOCATE both → `k3s-worker-01` (97GB disk, ⊥ pressure). → §T.36 + §T.37. rationale: retires single failure domain, hops become API-only|V14,V29
 T28|.|provision off-cluster artifact store for k3s + pg + vault backups|V21,I.store
 T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
 T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
@@ -120,6 +120,9 @@ T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `
 T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
 T35|.|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
+T36|.|relocate `vault-0` → `k3s-worker-01`: backup (§T.35) → scale 0 → drop PVC(1Gi) → recreate w/ nodeSelector → restore → ! prove unseal + secret read. after §T.35|V28,V29
+T37|.|relocate `postgresql-cluster` → `k3s-worker-01`: CNPG `instances` 1→2 (new pod nodeSelector `k3s-worker-01`) → wait streaming → `switchover` → scale→1 drop old. ⊥ manual PV surgery. needs ~40Gi transient|V6,V29
+T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. re-verify §C pinning lines + §V.14 scope — control-plane hop now API-only, worker-01 hop = Vault+DB outage|V14,V29
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC
 
 ## §G GOAL
-k3s cluster 1.33.5 → v1.36.2+k3s1; platform components current & in-matrix first; ⊥ data loss.
+k3s cluster 1.33.5 → v1.36.2+k3s1 (fallback `v1.35.6+k3s1` if §T.20 blockers hold); platform components current & in-matrix first; ⊥ data loss.
 
 ## §C CONSTRAINTS
 - GitOps only. ∀ change → git commit → Argo CD sync. ⊥ direct `kubectl apply` (CLAUDE.md).
@@ -26,8 +26,9 @@ k3s cluster 1.33.5 → v1.36.2+k3s1; platform components current & in-matrix fir
 ## §I INTERFACES
 - file: `base-apps/system-upgrade-controller.yaml` → Argo CD Application
 - file: `base-apps/system-upgrade-controller/*.yaml` → SUC deploy + RBAC + CRD
-- file: `base-apps/system-upgrade-controller/plan-server.yaml` → Plan CR, control-plane
-- file: `base-apps/system-upgrade-controller/plan-agent.yaml` → Plan CR, workers
+- file: `base-apps/system-upgrade-controller/plan-agent.yaml` → Plan CR, workers ONLY
+- file: ⊥ `plan-server.yaml`. control-plane hop = manual (§V.17) ∴ SUC ⊥ ever target `k3s-control-01`
+- cmd: `scripts/vault-backup.sh --dest <dir\|s3://>` → `vault-0` `file` storage → sha256 → off-cluster. restore ! prove unseal + secret read
 - node-label: `k3s-upgrade=true` → gates Plan `nodeSelector`
 - cmd: `scripts/k3s-backup.sh --mode cold\|online --dest <dir\|s3://>` → archives `server/` ONLY (⊥ `storage/` = local-path PV data, ⊥ `agent/`, ⊥ `kine.sock`) → sha256 → off-cluster. cold ! k3s stopped; online = `sqlite3 .backup` + excludes live db file set
 - cmd: `scripts/k3s-restore.sh --artifact <a> --expect-version <v> [--skip-service] [--verify-cmd C]` → checksum gate → prior tree moved aside (⊥ destroy evidence) → promote snapshot → reinstall pinned `INSTALL_K3S_VERSION` → ! prove API @ expected version
@@ -50,7 +51,7 @@ R7|Argo drift #5478|`0.16.x` webhook rewrites stored objects `v1beta1`→`v1` �
 
 ## §V INVARIANTS
 V1: ∀ hop → verified fs backup `/var/lib/rancher/k3s/` ∃ & restore drill passed before hop starts.
-V2: ∀ hop → ∀ platform component ∈ its supported k8s matrix @ target minor. ⊥ hop otherwise.
+V2: ∀ hop → ∀ platform component ∈ its supported k8s matrix @ target minor, EXCEPT bounded transient per §V.27. ⊥ hop otherwise.
 V3: ∀ hop → 1 minor step. ⊥ skip.
 V4: control-plane hops before workers. ∀ worker hop after control-plane Ready.
 V5: ∀ hop → post-gate: ∀ node Ready & ∀ Argo CD app Synced+Healthy before next hop.
@@ -73,8 +74,14 @@ V21: ∀ backup artifact (k3s, pg_dump, vault) ! stored ∉ cluster. artifact on
 V22: ∀ hop → helm-controller reconcile of `kube-system/ingress-nginx` verified & ingress reachable post-hop.
 V23: ESO upgrade ! staged. ⊥ jump `v0.11.0` → ≥`0.17.0` — `0.17.0` REMOVES `external-secrets.io/v1beta1` & 59 manifest + CRD storage version ∀ @ `v1beta1`. path: `0.16.2` (serves both) → ∀ manifest `v1` → storage migrated → ≥`0.17.0` → `2.x`. ∀ stage own gate. §T row order ≠ exec order ∴ ! follow `after §T.n` cites.
 V24: Argo auto-sync paused ∀ app w/ ExternalSecret during §T.31 migration window ONLY (⊥ ∀ ESO stage). `0.16.x` webhook rewrites stored objects → drift vs git ∴ `selfHeal` fights webhook. resume once manifests @ `v1` committed (§R.7: resolution = migrate, ⊥ code fix).
-V26: ⊥ ESO ≥`0.17.0` until `status.storedVersions == ["v1"]` ∀ of `externalsecrets`+`secretstores`+`clustersecretstores`. manifests @ `v1` ∈ git ≠ objects @ `v1` ∈ etcd (§R.3) ∴ k8s refuses to drop `v1beta1` & existing secrets become unreadable.
 V25: barman restore ! proven (scratch Cluster ← `bootstrap.recovery`) BEFORE §T.9. barman restore ⊥ operator ∴ ⊥ verifiable after operator upgrade breaks.
+V26: ⊥ ESO ≥`0.17.0` until `status.storedVersions == ["v1"]` ∀ of `externalsecrets`+`secretstores`+`clustersecretstores`. manifests @ `v1` ∈ git ≠ objects @ `v1` ∈ etcd (§R.3) ∴ k8s refuses to drop `v1beta1` & existing secrets become unreadable.
+V27: §V.2 exception — component ? out-of-matrix ACROSS a hop boundary iff ALL: (a) in-matrix @ CURRENT minor pre-hop, (b) upgrade → in-matrix @ target ∈ SAME maintenance window, (c) rollback artifact ∃ & drill-proven. ⊥ open-ended skew. ESO `0.19`→`0.20` = the case (§R.4).
+V28: ∀ hop → Vault data backed up off-cluster & restore-proven. `vault-0` storage=`file` @ local-path pinned `k3s-control-01` ∴ node loss = ∀ secret loss ∀ ns. KMS auto-unseal protects SEAL, ⊥ data.
+V29: §T.27 = HARD gate. ⊥ §T.13+ until relocate-vs-accept decided & recorded ∈ spec. relocate = PV migration ∴ ! before walk, ⊥ retrofit mid-walk.
+V30: §V.18 pause ? be lifted to reach §V.5 green — paused app ⊥ self-heal ∴ ⊥ circular wait. order: pause → hop → MANUAL sync → verify → resume.
+V31: ∀ hop task ! enumerate FULL gate set incl §V.6. ⊥ bare "gate →".
+V32: Istio hop plan ! explicit per-minor & ∀ intermediate ∈ k8s matrix @ CURRENT minor. Istio `1.25` = k8s ≤1.32 ∴ ∉ 1.33 ∴ ⊥ naive 1-minor walk. `1.26`+ ∈ matrix @ 1.33.
 
 ## §T TASKS
 id|status|task|cites
@@ -82,23 +89,23 @@ T1|x|write `scripts/k3s-backup.sh` — quiesce k3s, `sqlite3 .backup`, tar, chec
 T2|x|write `scripts/k3s-restore.sh` + drill on throwaway VM: artifact → API up @ prior version|V1,V16,I.cmd
 T3|x|`scripts/pg-backup.sh` pg_dump `postgresql-cluster` → off-cluster, verify restore|V6,V21,I.cmd
 T4|x|deprecated/removed-API scan vs 1.34,1.35,1.36 (`pluto` \| `kubent`)|V10
-T5|.|Argo CD `v3.5.0-rc2` → v3.5.x GA|V7,V8
+T5|.|Argo CD `v3.5.0-rc2` → v3.5.x GA. ? GA shipped — confirm ∃ else §V.7 unsatisfiable & pick prior GA line|V7,V8
 T6|.|ESO stage 1: `v0.11.0` → `v0.16.2` (serves `v1beta1`+`v1`). ⊥ proceed past w/o §T.31|V11,V8,V23,V24
 T7|.|verify ∀ ExternalSecret resync post-ESO, Vault k8s-auth roles intact|V11
 T8|.|Vault `1.18.1` → current stable. NB StatefulSet `updateStrategy: OnDelete` ∴ ! manual `delete pod vault-0` after sync|V8
 T9|.|CNPG `1.24.1` → 1.29.x — CVE-2026-44477 CVSS 9.4 metrics exporter. gate §T.34 first|V6,V8,V25
-T10|.|Istio `1.24.0` → 1.30.x — new Application per revision, ⊥ bump `targetRevision` in place|V12,V20,V8
+T10|.|Istio `1.24.0` → `1.30.x` via revisions. ⊥ `1.25` (k8s ≤1.32 ∉ 1.33, §V.32) ∴ skip `1.25` \| defer Istio → post-§T.18. ! /research skip policy first|V12,V20,V32,V8
 T11|.|verify `ztunnel` + `istio-cni-node` DS healthy ∀ node post-Istio, then retire old revision|V12,V20
 T12|.|matrix-audit rest vs 1.36: kyverno 1.17.1, argo-rollouts 1.8.3, argo-workflows 3.6.10, cert-manager 1.20.2, crossplane 2.2.1, ingress-nginx, falco, gloo|V2
-T13|.|add `base-apps/system-upgrade-controller.yaml` Argo app|I.file
+T13|.|add `base-apps/system-upgrade-controller.yaml` Argo app. HARD gate §T.27 first (§V.29)|V29,I.file
 T14|.|add SUC manifests + RBAC + CRD (sync-wave: CRD before Plan). Plan scope = agents only|V17,I.file
 T15|.|label `k3s-worker-01`,`k3s-worker-02` `k3s-upgrade=true`. ⊥ label `k3s-control-01`|V17,I.node-label
 T16|.|dry-run SUC Plan on `k3s-worker-02` @ current version (no-op hop)|V4,V17
-T17|.|gate §V.1,2,5,10,11,14 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃|V1,V2,V3,V14,V17
+T17|.|gate §V.1,2,5,6,10,11,14,27,28 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃|V1,V2,V3,V6,V14,V17,V27,V28,V31
 T18|.|SUC hop workers → `v1.34.9+k3s1`, verify §V.5|V4,V5,V17
-T19|.|gate → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V17
+T19|.|gate §V.1,2,5,6,10,11,14,27,28 → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V6,V17,V27,V28,V31
 T20|.|BLOCKER ×2 → 1.36: CNPG 1.29.x ≤1.35 & ⊥ ESO version supports 1.36 (§R.4; §R.6 `2.8.0` unconfirmed `?`). ! confirm BOTH ship 1.36 support, else hold @ 1.35|V2
-T21|.|gate §T.20 → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC). ⊥ w/o BOTH blockers cleared|V2,V3,V5,V17
+T21|.|gate §T.20 + §V.1,2,5,6,10,11,14,27,28 → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC). ⊥ w/o BOTH blockers cleared|V2,V3,V5,V6,V17,V27,V28,V31
 T22|.|confirm local kubectl v1.36.2 now in-skew|-
 T23|.|update `index.md` + `docs/` topology w/ landed versions|-
 T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
@@ -112,6 +119,7 @@ T31|.|ESO stage 2: ∀ 59 manifest → `v1` (drop `beta1`) THEN rewrite ∀ stor
 T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `storedVersions==["v1"]`. after §T.31|V23,V26,V11
 T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
+T35|.|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -82,6 +82,8 @@ V29: §T.27 = HARD gate. DECIDED 2026-07-27 = RELOCATE both → `k3s-worker-01`.
 V30: §V.18 pause ? be lifted to reach §V.5 green — paused app ⊥ self-heal ∴ ⊥ circular wait. order: pause → hop → MANUAL sync → verify → resume.
 V31: ∀ hop task ! enumerate FULL gate set incl §V.6. ⊥ bare "gate →".
 V32: Istio hop plan ! explicit per-minor & ∀ intermediate ∈ k8s matrix @ CURRENT minor. Istio `1.25` = k8s ≤1.32 ∴ ∉ 1.33 ∴ ⊥ naive 1-minor walk. `1.26`+ ∈ matrix @ 1.33.
+V33: ∀ quiesce of GitOps-managed workload (scale→0 \| pod delete) → ! suspend its Argo app FIRST, resume after. `selfHeal: true` + replicas ∈ git ∴ Argo rescales mid-operation → torn artifact \| silent revert (§B.2). applies §T.35, §T.36, §T.37.
+V34: ∀ pod mounting a node-pinned `local-path` PV → ! carry toleration ∀ taint on that node + explicit resource limits. `k3s-control-01` taint = `node-role.kubernetes.io/control-plane:NoSchedule`; kyverno `require-resource-limits` = Audit (warns, ⊥ blocks). ⊥ toleration → Pending forever, ⊥ 2 workers (∉ PV affinity). applies §T.35, §T.36, §T.37.
 
 ## §T TASKS
 id|status|task|cites
@@ -119,7 +121,7 @@ T31|.|ESO stage 2: ∀ 59 manifest → `v1` (drop `beta1`) THEN rewrite ∀ stor
 T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `storedVersions==["v1"]`. after §T.31|V23,V26,V11
 T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
-T35|.|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
+T35|x|write `scripts/vault-backup.sh` + drill: `vault-0` `file` storage → off-cluster, restore ! prove unseal + secret read. ⊥ backup ∃ today ∴ FIRST, before ∀ other `.` task|V28,V21,I.cmd
 T36|.|relocate `vault-0` → `k3s-worker-01`: backup (§T.35) → scale 0 → drop PVC(1Gi) → recreate w/ nodeSelector → restore → ! prove unseal + secret read. after §T.35|V28,V29
 T37|.|relocate `postgresql-cluster` → `k3s-worker-01`: CNPG `instances` 1→2 (new pod nodeSelector `k3s-worker-01`) → wait streaming → `switchover` → scale→1 drop old. ⊥ manual PV surgery. needs ~40Gi transient|V6,V29
 T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. re-verify §C pinning lines + §V.14 scope — control-plane hop now API-only, worker-01 hop = Vault+DB outage|V14,V29
@@ -127,3 +129,5 @@ T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. re-verify §C pinning l
 ## §B BUGS
 id|date|cause|fix
 B1|2026-07-27|`k3s-backup.sh` online mode excluded `state.db` only. kine runs SQLite WAL ∴ live `-wal`/`-shm` shipped beside `.backup` snapshot → SQLite replays foreign WAL over restored db. found by drill, ⊥ by review|V15
+B2|2026-07-27|`vault-backup.sh` cold mode scaled sts→0 to quiesce, but `replicas: 1` ∈ git (`base-apps/vault/statefulsets.yaml:18`) & Argo app `vault` `selfHeal: true` ∴ Argo rescales mid-copy → torn artifact BRANDED CONSISTENT. same class as §B.1. caught pre-exec by inspecting syncPolicy|V33
+B3|2026-07-27|`vault-backup.sh` helper pod ⊥ toleration for `node-role.kubernetes.io/control-plane:NoSchedule` ∴ Pending forever — PV pinned to tainted control-plane & 2 workers ∉ PV affinity. backup aborted; §V.33 trap restored Argo + Vault safely ∴ ⊥ outage|V34

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,6 +38,16 @@ k3s cluster 1.33.5 → v1.36.2+k3s1; platform components current & in-matrix fir
 - doc: `docs/plans/k3s-1.36-upgrade-plan.md` → runbook + outage comms
 - doc: `docs/plans/k3s-1.36-api-scan.md` → §T.4 report. built-in APIs clean 1.34/1.35/1.36; pluto ⊥ see CRD removals ∴ ESO `v1beta1` = real gap
 
+## §R RESEARCH
+id|topic|finding|src
+R1|ESO v1beta1 removal|`v0.17.0` stops serving `v1beta1`. ! migrate manifests → `v1` BEFORE `0.16`→`0.17`. change = drop `beta1` only|github.com/external-secrets/external-secrets/releases/tag/v0.17.0
+R2|ESO last v1beta1 build|`v0.16.2` = last serving `v1beta1` — chartmuseum chart ONLY, ⊥ OCI variant. repo @ `https://charts.external-secrets.io` ∴ correct source already|github.com/external-secrets/external-secrets/issues/5478
+R3|CRD storage version|live `externalsecrets`+`secretstores`+`clustersecretstores` ∀ `status.storedVersions=["v1beta1"]`, conversion=`Webhook`. k8s ⊥ drop version ∈ storedVersions ∴ ! rewrite ∀ stored object as `v1` + prune storedVersions before `0.17.0`. git ≠ etcd|kubectl, local truth 2026-07-27
+R4|ESO ↔ k8s matrix|`≤0.13`:1.19-1.31 / `0.15-0.18`:1.32-1.33 / `0.19`:1.33 / `0.20`:1.34 / `1.0-1.3`:1.34 / `2.0-2.6`:1.34-1.35 / `2.7`:1.35. ⊥ version supports 1.36|external-secrets.io/latest/introduction/stability-support/
+R5|ESO already out-of-matrix|`0.11.x` unsupported upstream, matrix = k8s ≤1.31, cluster @ 1.33 ∴ out-of-matrix now — same posture as Istio `1.24.0`|external-secrets.io/latest/introduction/stability-support/
+R6|ESO latest|`v2.8.0`. k8s 1.36 support ⊥ stated in release notes ? — ! confirm before §T.21|github.com/external-secrets/external-secrets/releases
+R7|Argo drift #5478|`0.16.x` webhook rewrites stored objects `v1beta1`→`v1` → drift vs git. CLOSED 2025-11-23, resolution = migrate manifests, ⊥ a code fix ∴ pause = migration window only|github.com/external-secrets/external-secrets/issues/5478
+
 ## §V INVARIANTS
 V1: ∀ hop → verified fs backup `/var/lib/rancher/k3s/` ∃ & restore drill passed before hop starts.
 V2: ∀ hop → ∀ platform component ∈ its supported k8s matrix @ target minor. ⊥ hop otherwise.
@@ -51,7 +61,7 @@ V9: outage window announced & ≤ 15min per control-plane hop.
 V10: ∀ hop → removed-API scan clean vs target minor.
 V11: ∀ hop → ESO healthy & ∀ ExternalSecret `SecretSynced=True`.
 V12: Istio ambient upgrade → revision/canary. ⊥ in-place istiod replace.
-V13: ⊥ 2 phases concurrent. component remediation fully green before walk starts.
+V13: remediation & walk INTERLEAVE where component matrix demands it — ESO ≥`0.20` ! k8s ≥1.34 (§R.4) ∴ ⊥ reachable before walk starts. ∀ hop → ∀ component @ max version its matrix allows for CURRENT minor first. ⊥ "all components final, then walk".
 V14: ∀ control-plane hop → outage = API + Vault + CNPG. ⊥ model as API-only. all 3 restored & verified before hop declared done.
 V15: k3s backup ! quiesced — stop k3s \| `sqlite3 .backup` before copy. ⊥ archive live datastore file SET: `state.db` + `state.db-wal` + `state.db-shm`. kine = WAL mode ∴ stale sidecar replays over snapshot → silent corruption.
 V16: restore drill ! prove API returns @ prior version from artifact. unproven artifact ∉ backup.
@@ -62,7 +72,8 @@ V20: Istio upgrade → new Application per revision, old revision live until `zt
 V21: ∀ backup artifact (k3s, pg_dump, vault) ! stored ∉ cluster. artifact on `local-path` ∉ backup.
 V22: ∀ hop → helm-controller reconcile of `kube-system/ingress-nginx` verified & ingress reachable post-hop.
 V23: ESO upgrade ! staged. ⊥ jump `v0.11.0` → ≥`0.17.0` — `0.17.0` REMOVES `external-secrets.io/v1beta1` & 59 manifest + CRD storage version ∀ @ `v1beta1`. path: `0.16.2` (serves both) → ∀ manifest `v1` → storage migrated → ≥`0.17.0` → `2.x`. ∀ stage own gate. §T row order ≠ exec order ∴ ! follow `after §T.n` cites.
-V24: ∀ ESO stage → Argo auto-sync paused ∀ app w/ ExternalSecret until manifests @ `v1` committed. `0.16.x` webhook auto-converts `v1beta1`→`v1` in-cluster → drift vs git ∴ `selfHeal` fights webhook.
+V24: Argo auto-sync paused ∀ app w/ ExternalSecret during §T.31 migration window ONLY (⊥ ∀ ESO stage). `0.16.x` webhook rewrites stored objects → drift vs git ∴ `selfHeal` fights webhook. resume once manifests @ `v1` committed (§R.7: resolution = migrate, ⊥ code fix).
+V26: ⊥ ESO ≥`0.17.0` until `status.storedVersions == ["v1"]` ∀ of `externalsecrets`+`secretstores`+`clustersecretstores`. manifests @ `v1` ∈ git ≠ objects @ `v1` ∈ etcd (§R.3) ∴ k8s refuses to drop `v1beta1` & existing secrets become unreadable.
 V25: barman restore ! proven (scratch Cluster ← `bootstrap.recovery`) BEFORE §T.9. barman restore ⊥ operator ∴ ⊥ verifiable after operator upgrade breaks.
 
 ## §T TASKS
@@ -86,8 +97,8 @@ T16|.|dry-run SUC Plan on `k3s-worker-02` @ current version (no-op hop)|V4,V17
 T17|.|gate §V.1,2,5,10,11,14 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃|V1,V2,V3,V14,V17
 T18|.|SUC hop workers → `v1.34.9+k3s1`, verify §V.5|V4,V5,V17
 T19|.|gate → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V17
-T20|.|BLOCKER: CNPG 1.29.x supports k8s ≤1.35. ! confirm CNPG 1.30 ships 1.36 support, else hold @ 1.35|V2
-T21|.|gate → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC)|V2,V3,V5,V17
+T20|.|BLOCKER ×2 → 1.36: CNPG 1.29.x ≤1.35 & ⊥ ESO version supports 1.36 (§R.4; §R.6 `2.8.0` unconfirmed `?`). ! confirm BOTH ship 1.36 support, else hold @ 1.35|V2
+T21|.|gate §T.20 → hop → `v1.36.2+k3s1` (control-plane manual, workers SUC). ⊥ w/o BOTH blockers cleared|V2,V3,V5,V17
 T22|.|confirm local kubectl v1.36.2 now in-skew|-
 T23|.|update `index.md` + `docs/` topology w/ landed versions|-
 T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
@@ -97,9 +108,9 @@ T27|.|DECIDE: relocate `vault-0` + `postgresql-cluster-1` → worker before walk
 T28|.|provision off-cluster artifact store for k3s + pg + vault backups|V21,I.store
 T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
 T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
-T31|.|ESO stage 2: ∀ 59 manifest `external-secrets.io/v1beta1` → `v1` + CRD storage version migrated. after §T.6|V23,V24
-T32|.|ESO stage 3: → ≥`0.17.0` (`v1beta1` removed upstream). after §T.31|V23,V11
-T33|.|ESO stage 4: → `2.x`. after §T.32|V23,V11
+T31|.|ESO stage 2: ∀ 59 manifest → `v1` (drop `beta1`) THEN rewrite ∀ stored object as `v1` + prune CRD `status.storedVersions` → `["v1"]`. git ≠ etcd (§R.3). after §T.6|V23,V24,V26
+T32|.|ESO stage 3: → `0.17.0` … ≤`0.19.x` (k8s 1.33 ceiling §R.4). gate `storedVersions==["v1"]`. after §T.31|V23,V26,V11
+T33|.|ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 ∴ AFTER §T.18, ⊥ on 1.33 (§R.4, §V.13)|V23,V13,V11
 T34|.|prove barman restore: scratch ns + CNPG Cluster ← `bootstrap.recovery` ← `s3://mysql-backups-asela-cluster/postgresql/`. BEFORE §T.9|V25,V6
 
 ## §B BUGS

--- a/base-apps/atlantis.yaml
+++ b/base-apps/atlantis.yaml
@@ -120,7 +120,18 @@ spec:
     namespace: atlantis
   syncPolicy:
     automated:
-      prune: true
+      # prune is DISABLED for this app specifically (SPEC.md §V.19).
+      #
+      # The chart renders atlantis-data as a standalone PVC on local-path, which
+      # reclaims Delete — so an Argo prune of it destroys the working directory with
+      # it. Everywhere else that risk is closed with a Prune=false annotation on the
+      # PVC manifest, but atlantis 6.1.0's `volumeClaim` values expose only
+      # enabled/dataStorage/storageClassName/accessModes, with no way to template
+      # annotations onto the rendered claim.
+      #
+      # Trade-off: resources removed from the chart will linger here rather than
+      # being cleaned up automatically. That is the cheaper mistake.
+      prune: false
       selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: grafana-storage
   namespace: logging
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/base-apps/n8n/pvc.yaml
+++ b/base-apps/n8n/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-pvc
   namespace: n8n
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/base-apps/ollama/pvc.yaml
+++ b/base-apps/ollama/pvc.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: ollama
   labels:
     app: ollama
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/base-apps/oncall-agent/incident-memory-pvc.yaml
+++ b/base-apps/oncall-agent/incident-memory-pvc.yaml
@@ -21,6 +21,11 @@ metadata:
   labels:
     app: oncall-agent-api
     component: incident-memory
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce  # Single pod access for write safety

--- a/base-apps/oncall-crewai/dungeons-dragons-agent/orchestrator/pvc.yaml
+++ b/base-apps/oncall-crewai/dungeons-dragons-agent/orchestrator/pvc.yaml
@@ -18,6 +18,11 @@ metadata:
   namespace: oncall-crewai
   labels:
     app: dungeons-dragons-agent-orchestrator
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   # ReadWriteOnce: only one pod can mount this volume at a time
   # Safe for single-replica deployments

--- a/base-apps/oncall-crewai/orchestrator-pvc.yaml
+++ b/base-apps/oncall-crewai/orchestrator-pvc.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: oncall-crewai
   labels:
     app: crewai-orchestrator
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/base-apps/openclaw-qwen/pvc.yaml
+++ b/base-apps/openclaw-qwen/pvc.yaml
@@ -6,6 +6,11 @@ metadata:
   labels:
     app: openclaw-qwen
     app.kubernetes.io/name: openclaw-qwen
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   # OpenClaw's writable home: config, sessions, workspace. local-path has
   # allowVolumeExpansion=false, so size up front; 5Gi is ample for agent state.

--- a/base-apps/postgresql/pvc.yaml
+++ b/base-apps/postgresql/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgresql-pvc
   namespace: postgresql
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/base-apps/qwen/pvc.yaml
+++ b/base-apps/qwen/pvc.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: qwen
   labels:
     app: qwen
+  annotations:
+    # local-path reclaims Delete, so an Argo prune of this PVC destroys the data
+    # with it (SPEC.md §V.19). Opt out of pruning — removing this volume must be a
+    # deliberate act, not a side effect of a manifest rename or a failed render.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   accessModes:
     - ReadWriteOnce

--- a/docs/plans/k3s-1.36-api-scan.md
+++ b/docs/plans/k3s-1.36-api-scan.md
@@ -1,0 +1,78 @@
+# Removed-API scan — k3s 1.33 → 1.36 walk
+
+Generated for `SPEC.md` §T.4, satisfying §V.10 ("∀ hop → removed-API scan clean vs target minor").
+
+Scanned: `base-apps/`, `charts/` against Kubernetes **v1.34.0**, **v1.35.0**, **v1.36.0**.
+Tool: `pluto detect-files` (`us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5`), run in a container
+so nothing is installed on the operator's machine and no cluster credentials are handed to it.
+
+Because every manifest in this cluster is in Git (Argo CD master-app pattern, `terraform/modules/application-sets`),
+a repository scan is the authoritative check rather than a live-cluster one.
+
+## Result — built-in APIs: clean
+
+```
+target k8s=v1.34.0 → no resources found with known deprecated apiVersions
+target k8s=v1.35.0 → no resources found with known deprecated apiVersions
+target k8s=v1.36.0 → no resources found with known deprecated apiVersions
+```
+
+Nothing in `base-apps/` or `charts/` uses a built-in Kubernetes API that 1.34, 1.35 or 1.36
+removes. §V.10 is satisfied for the built-in surface.
+
+## Coverage limit — and it is the important part
+
+`pluto` only knows deprecations of **built-in Kubernetes APIs**. It is structurally blind to
+**CRD version removals**, which is where this repository's actual exposure sits. A clean pluto
+run is necessary but nowhere near sufficient, and treating it as a green light would be the
+mistake this section exists to prevent.
+
+apiVersion inventory across `base-apps/`:
+
+| count | apiVersion | risk |
+|---|---|---|
+| 59 | `external-secrets.io/v1beta1` | **HIGH — removed in ESO 0.17.0** |
+| 59 | `argoproj.io/v1alpha1` | stable; Argo CD has not removed v1alpha1 |
+| 21 | `backstage.io/v1alpha1` | catalog files, not cluster API |
+| 11 | `iam.aws.upbound.io/v1beta1` | Crossplane provider-managed; tracks provider version |
+| 10 | `kyverno.io/v1` | stable |
+| 6 | `s3.aws.upbound.io/v1beta1` | one sibling already on `v1beta2` — inconsistent |
+| 1 | `networking.istio.io/v1beta1` | Istio serves v1/v1alpha3/v1beta1 today; confirm at 1.30 |
+| 1 | `helm.cattle.io/v1` | k3s helm-controller — upgraded by every hop (§V.22) |
+
+## Finding 1 — ESO `v1beta1` removal blocks §T.6 as written
+
+`SPEC.md` §T.6 reads "ESO `v0.11.0` → v2.x — major jump, CRD breaking ∴ /research first".
+The scan makes that concrete and considerably sharper:
+
+- The live CRDs (`externalsecrets.external-secrets.io`, `secretstores.external-secrets.io`) currently
+  serve `v1alpha1` and `v1beta1`, with **`v1beta1` as storage version**.
+- **ESO 0.17.0 removes `v1beta1` outright.** A direct jump to v2.x would orphan all 59 manifests,
+  and with them every secret in the cluster — which per §C is the cluster-wide failure mode
+  (Vault → ESO → every namespace).
+- The supported path is staged: **v0.11.0 → v0.16.2** (serves both `v1beta1` and `v1`) →
+  migrate all 59 manifests to `v1` → **then** 0.17.0+ → then 1.x/2.x.
+- Known hazard: on v0.16.x the conversion webhook rewrites existing objects `v1beta1` → `v1`
+  even while both are served, producing **Argo CD drift**
+  ([external-secrets#5478](https://github.com/external-secrets/external-secrets/issues/5478)).
+  Every Application here runs `prune: true` + `selfHeal: true`, so this is a live-fire risk,
+  not a cosmetic one — it interacts directly with §V.18 and §V.19.
+
+This needs `/ck:spec amend §T.6` to become a staged sequence with its own gates, and probably
+its own §V invariant covering the storage-version migration.
+
+## Finding 2 — Crossplane S3 apiVersion is inconsistent
+
+Six manifests use `s3.aws.upbound.io/v1beta1` while one uses `v1beta2`. Not a hop blocker —
+the provider serves both — but it should be normalised before the provider is upgraded in §T.12,
+or the odd one out will be the one that breaks.
+
+## Reproducing
+
+```bash
+docker run --rm -v "$PWD":/repo:ro us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5 \
+  detect-files -d /repo/base-apps --target-versions k8s=v1.36.0
+```
+
+Enforced continuously by `tests/k3s-upgrade/test_api_scan.py`, which fails CI if a manifest
+using an API removed in 1.34–1.36 is ever added.

--- a/scripts/k3s-backup.sh
+++ b/scripts/k3s-backup.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# k3s-backup.sh — consistent backup of the k3s server state (SPEC.md §T.1)
+#
+# This cluster's datastore is SQLite: the server runs without `--cluster-init`, so there
+# is no embedded etcd and therefore no `k3s etcd-snapshot`. k3s also migrates the schema
+# one-way on every minor upgrade and does not support downgrade, which makes the artifact
+# this script produces the *only* rollback that exists (§V.1).
+#
+# §V.15 — never tar a live state.db. An in-flight SQLite file copied byte-wise yields a
+# torn database that still checksums cleanly, so §V.1 would report "verified" for
+# something that cannot restore. Two safe modes instead:
+#
+#   cold    k3s confirmed stopped, then tar the tree as-is. Guaranteed point-in-time,
+#           costs an outage window. Use this before an upgrade hop.
+#   online  k3s keeps running; state.db is captured via `sqlite3 .backup` (a consistent
+#           snapshot taken through SQLite's own backup API) and the live file is excluded
+#           from the archive. Use this for routine/scheduled backups.
+#
+# §V.21 — the artifact must not be written inside the cluster. `local-path` is the only
+# StorageClass here and its volumes live under $K3S_DATA_DIR/storage, so an artifact
+# parked there dies with the node it exists to protect.
+#
+# Usage:
+#   k3s-backup.sh --mode cold|online --dest <dir|s3://bucket/prefix> [--dry-run] [--skip-stop]
+#
+# Runs on the k3s server node (k3s-control-01), not from a workstation.
+
+set -euo pipefail
+
+K3S_DATA_DIR="${K3S_DATA_DIR:-/var/lib/rancher/k3s}"
+K3S_SERVICE="${K3S_SERVICE:-k3s}"
+# Exits 0 when k3s is still running. Overridable so the guards can be tested off-node.
+K3S_STATUS_CMD="${K3S_STATUS_CMD:-systemctl is-active --quiet ${K3S_SERVICE}}"
+
+MODE="cold"
+DEST=""
+DRY_RUN=0
+SKIP_STOP=0
+
+die() { echo "k3s-backup: $*" >&2; exit 1; }
+
+usage() {
+  sed -n '2,28p' "$0" >&2
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode)      MODE="${2:-}"; shift 2 ;;
+    --dest)      DEST="${2:-}"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --skip-stop) SKIP_STOP=1; shift ;;
+    -h|--help)   usage ;;
+    *)           die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$DEST" ] || die "--dest is required"
+case "$MODE" in
+  cold|online) ;;
+  *) die "--mode must be 'cold' or 'online', got '$MODE'" ;;
+esac
+
+# Canonicalise a path that may not exist yet, by resolving its deepest existing parent.
+# `readlink -f` is GNU-only; this stays portable to the BSD userland on macOS.
+canon() {
+  local p="$1" dir suffix=""
+  dir="$p"
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    suffix="/$(basename "$dir")$suffix"
+    dir="$(dirname "$dir")"
+  done
+  ( cd "$dir" 2>/dev/null && printf '%s%s\n' "$(pwd -P)" "$suffix" )
+}
+
+# --- §V.21: refuse a destination inside the cluster ---------------------------------
+is_s3_dest() { case "$1" in s3://*) return 0 ;; *) return 1 ;; esac; }
+
+if ! is_s3_dest "$DEST"; then
+  canon_dest="$(canon "$DEST")"
+  canon_data="$(canon "$K3S_DATA_DIR")"
+  case "$canon_dest/" in
+    "$canon_data"/*)
+      die "§V21 violation: destination '$DEST' is inside the k3s data dir ($K3S_DATA_DIR).
+     local-path volumes live there, so this artifact would be lost with the node it
+     protects. Use an off-cluster path or an s3:// destination."
+      ;;
+  esac
+fi
+
+k3s_running() { eval "$K3S_STATUS_CMD" >/dev/null 2>&1; }
+
+# --- §V.15: cold mode must prove k3s is stopped before archiving state.db -----------
+if [ "$MODE" = "cold" ]; then
+  if [ "$SKIP_STOP" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+    echo "k3s-backup: stopping ${K3S_SERVICE} for a consistent cold copy..."
+    systemctl stop "$K3S_SERVICE"
+  fi
+  if [ "$DRY_RUN" -eq 0 ] && k3s_running; then
+    die "§V15 violation: refusing to archive a live state.db — ${K3S_SERVICE} is still
+     running. A byte-wise copy of an in-flight SQLite file is torn but still checksums
+     cleanly, which would make §V.1 report a verified backup that cannot restore.
+     Stop k3s first, or use --mode online."
+  fi
+fi
+
+if [ "$MODE" = "online" ]; then
+  command -v sqlite3 >/dev/null 2>&1 \
+    || die "--mode online needs sqlite3 to take a consistent snapshot; install it or use --mode cold"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "k3s-backup: dry run OK — mode=$MODE dest=$DEST data=$K3S_DATA_DIR"
+  exit 0
+fi
+
+[ -d "$K3S_DATA_DIR/server" ] || die "no k3s server dir at $K3S_DATA_DIR/server"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+NAME="k3s-backup-$(hostname -s)-${STAMP}.tar.gz"
+
+# s3:// destinations are staged locally first, then uploaded.
+if is_s3_dest "$DEST"; then
+  STAGE_OUT="$(mktemp -d)"
+  OUT_DIR="$STAGE_OUT"
+else
+  mkdir -p "$DEST"
+  OUT_DIR="$DEST"
+fi
+ARTIFACT="$OUT_DIR/$NAME"
+
+# `storage/` is deliberately excluded: those are local-path PersistentVolumes, not k3s
+# state. They are protected separately (CNPG ships to S3 via barman) and including them
+# would balloon the artifact this script exists to keep restorable.
+#
+# `server/kine.sock` is a live unix socket, not state. tar cannot archive a socket and
+# warns (and on some versions exits non-zero, which `set -o pipefail` would turn into a
+# failed backup). Exclude it explicitly rather than depend on tar's warning behaviour.
+case "$MODE" in
+  cold)
+    tar -czf "$ARTIFACT" --exclude='server/kine.sock' -C "$K3S_DATA_DIR" server
+    ;;
+  online)
+    STAGE="$(mktemp -d)"
+    trap 'rm -rf "$STAGE"' EXIT
+    # Copy the tree without ever reading the live database. kine runs SQLite in WAL mode,
+    # so the datastore is a file *set*: shipping a live -wal/-shm next to the snapshot
+    # would have SQLite replay a foreign write-ahead log over it on restore (§B.1).
+    tar -cf - \
+      --exclude='server/db/state.db' \
+      --exclude='server/db/state.db-wal' \
+      --exclude='server/db/state.db-shm' \
+      --exclude='server/kine.sock' \
+      -C "$K3S_DATA_DIR" server | tar -xf - -C "$STAGE"
+    mkdir -p "$STAGE/server/db"
+    rm -f "$STAGE/server/db/state.db-wal" "$STAGE/server/db/state.db-shm"
+    # `.backup` goes through SQLite's own API, checkpointing the WAL into a standalone,
+    # self-consistent database file.
+    sqlite3 "$K3S_DATA_DIR/server/db/state.db" ".backup '$STAGE/server/db/state.db.backup'"
+    tar -czf "$ARTIFACT" -C "$STAGE" server
+    ;;
+esac
+
+# --- §V.1: the artifact carries its own integrity manifest --------------------------
+if command -v sha256sum >/dev/null 2>&1; then
+  ( cd "$OUT_DIR" && sha256sum "$NAME" > "$NAME.sha256" )
+else
+  ( cd "$OUT_DIR" && shasum -a 256 "$NAME" > "$NAME.sha256" )
+fi
+
+if is_s3_dest "$DEST"; then
+  command -v aws >/dev/null 2>&1 || die "aws CLI not found; cannot ship to $DEST"
+  aws s3 cp "$ARTIFACT" "${DEST%/}/$NAME"
+  aws s3 cp "$ARTIFACT.sha256" "${DEST%/}/$NAME.sha256"
+  rm -rf "$STAGE_OUT"
+  echo "k3s-backup: uploaded ${DEST%/}/$NAME"
+else
+  echo "k3s-backup: wrote $ARTIFACT"
+fi
+
+echo "k3s-backup: mode=$MODE — restore with scripts/k3s-restore.sh (§V.16 requires a drill)"

--- a/scripts/k3s-restore.sh
+++ b/scripts/k3s-restore.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# k3s-restore.sh — restore the k3s server state from a k3s-backup.sh artifact (SPEC.md §T.2)
+#
+# k3s migrates the SQLite schema one-way on a minor upgrade and does not support
+# downgrade, so this script is the rollback path for every hop in the §T walk. It is
+# also the thing §V.16 refuses to take on faith: a restore that has not been shown to
+# bring the API back at the expected version does not count as a restore, and an
+# artifact that has never been through this script does not count as a backup (§V.1).
+#
+# Usage:
+#   k3s-restore.sh --artifact <file.tar.gz> --expect-version v1.33.5+k3s1
+#                  [--data-dir DIR] [--skip-service] [--verify-cmd CMD] [--no-verify]
+#
+#   --skip-service   restore the data tree only; the caller stops/starts/installs k3s.
+#                    Used by the containerised drill, where docker owns the lifecycle.
+#   --verify-cmd     command whose output must contain --expect-version.
+#   --no-verify      data-only restore with no version assertion. Never use this on a
+#                    real rollback — it is here so the drill can assert §V.16 itself.
+
+set -euo pipefail
+
+DATA_DIR="${K3S_DATA_DIR:-/var/lib/rancher/k3s}"
+K3S_SERVICE="${K3S_SERVICE:-k3s}"
+ARTIFACT=""
+EXPECT_VERSION=""
+VERIFY_CMD=""
+SKIP_SERVICE=0
+NO_VERIFY=0
+
+die() { echo "k3s-restore: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --artifact)       ARTIFACT="${2:-}"; shift 2 ;;
+    --data-dir)       DATA_DIR="${2:-}"; shift 2 ;;
+    --expect-version) EXPECT_VERSION="${2:-}"; shift 2 ;;
+    --verify-cmd)     VERIFY_CMD="${2:-}"; shift 2 ;;
+    --skip-service)   SKIP_SERVICE=1; shift ;;
+    --no-verify)      NO_VERIFY=1; shift ;;
+    -h|--help)        sed -n '2,20p' "$0" >&2; exit 2 ;;
+    *)                die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$ARTIFACT" ]       || die "--artifact is required"
+[ -n "$EXPECT_VERSION" ] || die "--expect-version is required (§V.16)"
+[ -f "$ARTIFACT" ]       || die "artifact not found: $ARTIFACT"
+
+# --- integrity gate: a corrupt artifact must fail loudly, not restore quietly --------
+CHECKSUM_FILE="$ARTIFACT.sha256"
+[ -f "$CHECKSUM_FILE" ] || die "no checksum manifest at $CHECKSUM_FILE — this artifact
+     cannot be verified, so per §V.1 it is not a backup"
+
+ARTIFACT_DIR="$(cd "$(dirname "$ARTIFACT")" && pwd -P)"
+ARTIFACT_NAME="$(basename "$ARTIFACT")"
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECK="sha256sum -c"
+else
+  CHECK="shasum -a 256 -c"
+fi
+if ! ( cd "$ARTIFACT_DIR" && $CHECK "$ARTIFACT_NAME.sha256" >/dev/null 2>&1 ); then
+  die "checksum mismatch for $ARTIFACT_NAME — artifact is corrupt or truncated, refusing
+     to restore from it"
+fi
+echo "k3s-restore: checksum OK for $ARTIFACT_NAME"
+
+# --- stop k3s before touching its data dir ------------------------------------------
+if [ "$SKIP_SERVICE" -eq 0 ]; then
+  echo "k3s-restore: stopping ${K3S_SERVICE}..."
+  systemctl stop "$K3S_SERVICE" || true
+fi
+
+# Preserve whatever is currently there. A rollback that destroys the failed state also
+# destroys the evidence needed to work out why the hop failed.
+if [ -d "$DATA_DIR/server" ]; then
+  ASIDE="${DATA_DIR}.pre-restore.$(date -u +%Y%m%dT%H%M%SZ)"
+  echo "k3s-restore: moving existing data dir aside -> $ASIDE"
+  mv "$DATA_DIR" "$ASIDE"
+fi
+
+mkdir -p "$DATA_DIR"
+tar -xzf "$ARTIFACT" -C "$DATA_DIR"
+
+# An online-mode artifact carries `state.db.backup` (a consistent sqlite3 .backup
+# snapshot) and deliberately no `state.db`. Promote it, or k3s starts with no datastore.
+SNAPSHOT="$DATA_DIR/server/db/state.db.backup"
+LIVE_DB="$DATA_DIR/server/db/state.db"
+if [ -f "$SNAPSHOT" ] && [ ! -f "$LIVE_DB" ]; then
+  echo "k3s-restore: promoting sqlite snapshot -> server/db/state.db"
+  # The snapshot is standalone and already checkpointed. Any -wal/-shm here belongs to a
+  # different database — from a pre-§B.1 artifact or a failed prior restore — and SQLite
+  # would replay it over the snapshot. Clear them (§V.15).
+  rm -f "$DATA_DIR/server/db/state.db-wal" "$DATA_DIR/server/db/state.db-shm"
+  mv "$SNAPSHOT" "$LIVE_DB"
+fi
+[ -f "$LIVE_DB" ] || die "restored tree has no server/db/state.db — artifact is not a
+     usable k3s datastore backup"
+
+# --- reinstall the pinned version and start ------------------------------------------
+if [ "$SKIP_SERVICE" -eq 0 ]; then
+  if [ -n "${INSTALL_K3S_VERSION:-}" ]; then
+    echo "k3s-restore: reinstalling k3s ${INSTALL_K3S_VERSION}..."
+    curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="$INSTALL_K3S_VERSION" sh -
+  else
+    echo "k3s-restore: INSTALL_K3S_VERSION unset — starting the installed binary as-is" >&2
+  fi
+  systemctl start "$K3S_SERVICE"
+fi
+
+# --- §V.16: prove the API came back at the expected version --------------------------
+if [ "$NO_VERIFY" -eq 1 ]; then
+  echo "k3s-restore: data restored to $DATA_DIR (verification skipped by request)"
+  echo "k3s-restore: §V.16 NOT satisfied — caller must assert the server version" >&2
+  exit 0
+fi
+
+if [ -z "$VERIFY_CMD" ]; then
+  VERIFY_CMD="k3s kubectl version 2>/dev/null || kubectl version"
+fi
+
+echo "k3s-restore: verifying server version (§V.16)..."
+OUTPUT="$(eval "$VERIFY_CMD" 2>&1 || true)"
+if ! printf '%s' "$OUTPUT" | grep -qF -- "$EXPECT_VERSION"; then
+  die "§V16 violation: expected server version '$EXPECT_VERSION' after restore, got:
+$OUTPUT
+     The data may be restored but the cluster is NOT proven recovered."
+fi
+
+echo "k3s-restore: OK — API responding at $EXPECT_VERSION, restore proven (§V.16)"

--- a/scripts/pg-backup.sh
+++ b/scripts/pg-backup.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# pg-backup.sh — operator-independent logical backup of the CNPG database (SPEC.md §T.3)
+#
+# `postgresql/postgresql-cluster` already ships physical backups to
+# s3://mysql-backups-asela-cluster/postgresql/ via barman, and those are healthy. This
+# script is not a replacement for them. It exists because §T.9 upgrades the CNPG operator
+# itself (1.24.1 -> 1.29.x, for CVE-2026-44477), and a barman restore needs a working
+# operator to drive it. A plain pg_dump is the only insurance that survives the operator
+# upgrade going wrong.
+#
+# It matters here more than it would elsewhere: the cluster runs a single instance
+# (instances=1) on a node-pinned local-path volume, on the same node as the control
+# plane. There is no replica to fail over to (§C, §V.14).
+#
+# §V.21 — the artifact must not be written inside the cluster.
+#
+# Usage:
+#   pg-backup.sh --dest <dir|s3://bucket/prefix> [--namespace NS] [--cluster NAME]
+#                [--database DB] [--exec-cmd CMD] [--dry-run]
+
+set -euo pipefail
+
+NAMESPACE="${PG_NAMESPACE:-postgresql}"
+CLUSTER="${PG_CLUSTER:-postgresql-cluster}"
+CONTAINER="${PG_CONTAINER:-postgres}"
+DATABASE=""
+ALL_DATABASES=0
+DEST=""
+EXEC_CMD=""
+DRY_RUN=0
+
+die() { echo "pg-backup: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dest)      DEST="${2:-}"; shift 2 ;;
+    --namespace) NAMESPACE="${2:-}"; shift 2 ;;
+    --cluster)   CLUSTER="${2:-}"; shift 2 ;;
+    --database)  DATABASE="${2:-}"; shift 2 ;;
+    --all)       ALL_DATABASES=1; shift ;;
+    --container) CONTAINER="${2:-}"; shift 2 ;;
+    --exec-cmd)  EXEC_CMD="${2:-}"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    -h|--help)   sed -n '2,20p' "$0" >&2; exit 2 ;;
+    *)           die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$DEST" ] || die "--dest is required"
+if [ "$ALL_DATABASES" -eq 0 ] && [ -z "$DATABASE" ]; then
+  die "--database <name> or --all is required. There is no safe default: this cluster
+     hosts several databases (n8n, chores_tracker), so guessing one would silently
+     under-protect the rest."
+fi
+[ "$ALL_DATABASES" -eq 1 ] && [ -n "$DATABASE" ] && die "--all and --database are mutually exclusive"
+
+is_s3_dest() { case "$1" in s3://*) return 0 ;; *) return 1 ;; esac; }
+
+canon() {
+  local p="$1" dir suffix=""
+  dir="$p"
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    suffix="/$(basename "$dir")$suffix"
+    dir="$(dirname "$dir")"
+  done
+  ( cd "$dir" 2>/dev/null && printf '%s%s\n' "$(pwd -P)" "$suffix" )
+}
+
+# --- §V.21: refuse a destination inside the cluster ---------------------------------
+# Checked against both the literal argument and its canonical form: the caller may pass
+# a relative or symlinked path, and macOS canonicalises /var to /private/var, which would
+# otherwise slip past a naive prefix match.
+in_cluster_storage() {
+  local p="${1#/private}"
+  case "$p/" in
+    /var/lib/rancher/k3s/*|/var/lib/kubelet/*) return 0 ;;
+  esac
+  return 1
+}
+
+if ! is_s3_dest "$DEST"; then
+  if in_cluster_storage "$DEST" || in_cluster_storage "$(canon "$DEST")"; then
+    die "§V21 violation: '$DEST' is inside cluster storage. local-path volumes are
+     pinned to the node that also hosts this database, so the artifact would be lost in
+     exactly the failure it is meant to cover. Use an off-cluster path or s3://."
+  fi
+fi
+
+# Default: exec into the CNPG primary. Overridable so the round-trip can be proven
+# against a disposable container without a cluster.
+if [ -z "$EXEC_CMD" ]; then
+  command -v kubectl >/dev/null 2>&1 || die "kubectl not found and no --exec-cmd given"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    PRIMARY="$(kubectl get pods -n "$NAMESPACE" \
+      -l "cnpg.io/cluster=$CLUSTER,cnpg.io/instanceRole=primary" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    [ -n "$PRIMARY" ] || die "could not resolve the primary pod for cluster '$CLUSTER' in '$NAMESPACE'"
+    # -c pins the container so kubectl's "Defaulted container" notice stays off the wire.
+    EXEC_CMD="kubectl exec -n $NAMESPACE $PRIMARY -c $CONTAINER --"
+  else
+    EXEC_CMD="kubectl exec -n $NAMESPACE <primary> -c $CONTAINER --"
+  fi
+fi
+
+LABEL="${DATABASE:-all}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "pg-backup: dry run OK — db=$LABEL dest=$DEST exec='$EXEC_CMD'"
+  exit 0
+fi
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+NAME="pg-${CLUSTER}-${LABEL}-${STAMP}.sql.gz"
+
+if is_s3_dest "$DEST"; then
+  STAGE_OUT="$(mktemp -d)"
+  OUT_DIR="$STAGE_OUT"
+else
+  mkdir -p "$DEST"
+  OUT_DIR="$DEST"
+fi
+ARTIFACT="$OUT_DIR/$NAME"
+
+# Plain-format SQL, not custom: restoring must not depend on a matching pg_restore
+# build, which is the sort of assumption that fails precisely during an upgrade.
+#
+# --all uses pg_dumpall so the artifact also carries globals (roles, grants). Restoring
+# databases without their roles leaves you with data nobody can log in to read.
+echo "pg-backup: dumping '$LABEL' ..."
+if [ "$ALL_DATABASES" -eq 1 ]; then
+  # shellcheck disable=SC2086
+  $EXEC_CMD pg_dumpall -U postgres --clean | gzip -c > "$ARTIFACT"
+else
+  # shellcheck disable=SC2086
+  $EXEC_CMD pg_dump -U postgres --clean --if-exists -d "$DATABASE" | gzip -c > "$ARTIFACT"
+fi
+
+[ -s "$ARTIFACT" ] || die "dump produced an empty artifact — refusing to record it as a backup"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ( cd "$OUT_DIR" && sha256sum "$NAME" > "$NAME.sha256" )
+else
+  ( cd "$OUT_DIR" && shasum -a 256 "$NAME" > "$NAME.sha256" )
+fi
+
+if is_s3_dest "$DEST"; then
+  command -v aws >/dev/null 2>&1 || die "aws CLI not found; cannot ship to $DEST"
+  aws s3 cp "$ARTIFACT" "${DEST%/}/$NAME"
+  aws s3 cp "$ARTIFACT.sha256" "${DEST%/}/$NAME.sha256"
+  rm -rf "$STAGE_OUT"
+  echo "pg-backup: uploaded ${DEST%/}/$NAME"
+else
+  echo "pg-backup: wrote $ARTIFACT"
+fi
+
+if [ "$ALL_DATABASES" -eq 1 ]; then
+  echo "pg-backup: restore with: gunzip -c <artifact> | psql -U postgres"
+else
+  echo "pg-backup: restore with: gunzip -c <artifact> | psql -U postgres -d $DATABASE"
+fi

--- a/scripts/vault-backup.sh
+++ b/scripts/vault-backup.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# vault-backup.sh — backup of Vault's `file` storage backend (SPEC.md §T.35)
+#
+# `vault-0` stores at /vault/data on a 1Gi local-path volume pinned to k3s-control-01,
+# with replicas=1. It holds the credentials every one of the 45 namespaces resolves
+# through ESO. Until this script existed there was no backup of it at all (§V.28).
+#
+# The constraint that shapes the design: Vault's file backend has NO consistent-snapshot
+# API. There is no `vault operator raft snapshot` equivalent — the documented method is to
+# stop Vault and copy the directory. Copying it live can catch a partial write, which is
+# exactly §B.1: an artifact that checksums cleanly and cannot restore. So:
+#
+#   cold (default)  scale the StatefulSet to 0, copy at rest, scale back, verify unseal.
+#   online          requires --allow-inconsistent AND brands the artifact filename
+#                   INCONSISTENT, so a torn copy can never be mistaken for a good one.
+#
+# ⚠ KMS: `vault-0` seals with awskms (alias/vault-auto-unseal). The bytes on disk are
+# ciphertext. This artifact is undecryptable without that KMS key — the Shamir recovery
+# keys govern recovery operations, not storage decryption. Back up the key policy too.
+#
+# Usage:
+#   vault-backup.sh --dest <dir|s3://…> [--mode cold|online] [--allow-inconsistent]
+#                   [--data-dir PATH] [--namespace NS] [--statefulset NAME] [--dry-run]
+#
+#   --data-dir  copy from an already-at-rest local directory instead of driving kubectl.
+#               Used by the drill and by tests. The caller owns quiescence.
+
+set -euo pipefail
+
+NAMESPACE="${VAULT_NAMESPACE:-vault}"
+STATEFULSET="${VAULT_STATEFULSET:-vault}"
+POD="${VAULT_POD:-vault-0}"
+DATA_PATH="${VAULT_DATA_PATH:-/vault/data}"
+MODE="cold"
+DEST=""
+DATA_DIR=""
+ARGO_APP="${VAULT_ARGO_APP:-}"
+ARGO_NS="${ARGO_NAMESPACE:-argo-cd}"
+ALLOW_INCONSISTENT=0
+DRY_RUN=0
+
+die() { echo "vault-backup: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dest)               DEST="${2:-}"; shift 2 ;;
+    --mode)               MODE="${2:-}"; shift 2 ;;
+    --data-dir)           DATA_DIR="${2:-}"; shift 2 ;;
+    --namespace)          NAMESPACE="${2:-}"; shift 2 ;;
+    --statefulset)        STATEFULSET="${2:-}"; shift 2 ;;
+    --argo-app)           ARGO_APP="${2:-}"; shift 2 ;;
+    --argo-namespace)     ARGO_NS="${2:-}"; shift 2 ;;
+    --allow-inconsistent) ALLOW_INCONSISTENT=1; shift ;;
+    --dry-run)            DRY_RUN=1; shift ;;
+    -h|--help)            sed -n '2,28p' "$0" >&2; exit 2 ;;
+    *)                    die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$DEST" ] || die "--dest is required"
+case "$MODE" in cold|online) ;; *) die "--mode must be 'cold' or 'online', got '$MODE'" ;; esac
+
+canon() {
+  local p="$1" dir suffix=""
+  dir="$p"
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    suffix="/$(basename "$dir")$suffix"
+    dir="$(dirname "$dir")"
+  done
+  ( cd "$dir" 2>/dev/null && printf '%s%s\n' "$(pwd -P)" "$suffix" )
+}
+
+is_s3_dest() { case "$1" in s3://*) return 0 ;; *) return 1 ;; esac; }
+
+# --- §V.21: refuse a destination inside the cluster ---------------------------------
+in_cluster_storage() {
+  local p="${1#/private}"
+  case "$p/" in /var/lib/rancher/k3s/*|/var/lib/kubelet/*) return 0 ;; esac
+  return 1
+}
+
+if ! is_s3_dest "$DEST"; then
+  if in_cluster_storage "$DEST" || in_cluster_storage "$(canon "$DEST")"; then
+    die "§V21 violation: '$DEST' is inside cluster storage. local-path volumes are pinned
+     to the node hosting Vault itself, so this artifact would be lost in the exact failure
+     it exists to cover. Use an off-cluster path or s3://."
+  fi
+fi
+
+# --- §B.1 lesson: an inconsistent copy must be opt-in and self-identifying -----------
+if [ "$MODE" = "online" ] && [ "$ALLOW_INCONSISTENT" -eq 0 ]; then
+  die "refusing --mode online without --allow-inconsistent.
+     Vault's file backend has no consistent-snapshot API, so copying /vault/data while the
+     server runs can capture a partially-written file. The result checksums cleanly and
+     may not restore (see §B.1). Use --mode cold, or pass --allow-inconsistent if you
+     accept a possibly-torn artifact."
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "vault-backup: dry run OK — mode=$MODE dest=$DEST src=${DATA_DIR:-$NAMESPACE/$POD}"
+  exit 0
+fi
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+if [ "$MODE" = "online" ]; then
+  NAME="vault-backup-${STAMP}-INCONSISTENT.tar.gz"
+else
+  NAME="vault-backup-${STAMP}.tar.gz"
+fi
+
+if is_s3_dest "$DEST"; then
+  STAGE_OUT="$(mktemp -d)"; OUT_DIR="$STAGE_OUT"
+else
+  mkdir -p "$DEST"; OUT_DIR="$DEST"
+fi
+ARTIFACT="$OUT_DIR/$NAME"
+
+if [ -n "$DATA_DIR" ]; then
+  # Local path already at rest. The caller owns quiescence — the drill stops the
+  # container first, and the kubectl path below scales the StatefulSet down.
+  [ -d "$DATA_DIR" ] || die "--data-dir '$DATA_DIR' is not a directory"
+  tar -czf "$ARTIFACT" -C "$DATA_DIR" .
+else
+  command -v kubectl >/dev/null 2>&1 || die "kubectl not found and no --data-dir given"
+  if [ "$MODE" = "cold" ]; then
+    # §V.33 / §B.2 — this StatefulSet is GitOps-managed with `replicas: 1` in git and
+    # selfHeal: true. Scaling to 0 without suspending the Argo app first lets Argo
+    # rescale Vault mid-copy, producing a torn artifact that this script would then
+    # brand as consistent. Refuse rather than race.
+    if [ -z "$ARGO_APP" ]; then
+      SELFHEAL="$(kubectl get app -n "$ARGO_NS" -o jsonpath="{range .items[*]}{.metadata.name}{' '}{.spec.syncPolicy.automated.selfHeal}{'\n'}{end}" 2>/dev/null \
+        | awk '$2=="true"{print $1}' | grep -x "$STATEFULSET" || true)"
+      [ -z "$SELFHEAL" ] || die "§V33: Argo app '$SELFHEAL' manages this StatefulSet with
+     selfHeal: true, so a scale-to-0 will be reverted mid-copy and the artifact silently
+     torn (§B.2). Re-run with --argo-app $SELFHEAL so the app is suspended first."
+    else
+      echo "vault-backup: suspending Argo app $ARGO_APP (§V.33)..."
+      kubectl patch app -n "$ARGO_NS" "$ARGO_APP" --type merge \
+        -p '{"spec":{"syncPolicy":{"automated":null}}}'
+      # On ANY exit, bring Vault back explicitly and then restore auto-sync. Relying on
+      # Argo's self-heal alone would work but leaves Vault down for a reconcile interval;
+      # scaling directly shortens the window and does not depend on Argo being healthy.
+      # shellcheck disable=SC2064
+      trap "echo 'vault-backup: restoring Vault + Argo auto-sync'; kubectl scale sts -n $NAMESPACE $STATEFULSET --replicas=1 >/dev/null 2>&1 || true; kubectl patch app -n $ARGO_NS $ARGO_APP --type merge -p '{\"spec\":{\"syncPolicy\":{\"automated\":{\"prune\":true,\"selfHeal\":true}}}}' >/dev/null 2>&1 || true" EXIT
+    fi
+
+    echo "vault-backup: scaling $NAMESPACE/$STATEFULSET to 0 for a consistent copy..."
+    kubectl scale sts -n "$NAMESPACE" "$STATEFULSET" --replicas=0
+    kubectl wait --for=delete "pod/$POD" -n "$NAMESPACE" --timeout=180s || true
+    for _ in $(seq 1 60); do
+      kubectl get pod -n "$NAMESPACE" "$POD" >/dev/null 2>&1 || break
+      sleep 2
+    done
+    kubectl get pod -n "$NAMESPACE" "$POD" >/dev/null 2>&1 \
+      && die "pod $POD still present after scale-down; refusing to copy a live data dir"
+
+    # Helper pod mounts the same PVC. It must land on the node the local-path volume is
+    # pinned to, which scheduling handles via the PVC's own node affinity.
+    PVC="$(kubectl get pvc -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}')"
+    echo "vault-backup: copying $DATA_PATH from PVC $PVC via helper pod..."
+    # §V.34 / §B.3 — the PV is pinned to k3s-control-01, which carries
+    # node-role.kubernetes.io/control-plane:NoSchedule, and the two workers do not match
+    # the PV's node affinity. Without the toleration this pod is Pending forever and the
+    # backup aborts. Resource limits satisfy kyverno's require-resource-limits (Audit).
+    kubectl run vault-backup-helper -n "$NAMESPACE" --restart=Never --quiet \
+      --image=alpine:3.20 \
+      --overrides="{\"spec\":{\"tolerations\":[{\"key\":\"node-role.kubernetes.io/control-plane\",\"operator\":\"Exists\",\"effect\":\"NoSchedule\"}],\"containers\":[{\"name\":\"helper\",\"image\":\"alpine:3.20\",\"command\":[\"sleep\",\"600\"],\"resources\":{\"requests\":{\"cpu\":\"50m\",\"memory\":\"64Mi\"},\"limits\":{\"cpu\":\"500m\",\"memory\":\"256Mi\"}},\"volumeMounts\":[{\"name\":\"d\",\"mountPath\":\"$DATA_PATH\"}]}],\"volumes\":[{\"name\":\"d\",\"persistentVolumeClaim\":{\"claimName\":\"$PVC\"}}]}}" \
+      >/dev/null
+    if ! kubectl wait --for=condition=Ready pod/vault-backup-helper -n "$NAMESPACE" --timeout=180s; then
+      kubectl describe pod -n "$NAMESPACE" vault-backup-helper 2>&1 | sed -n '/Events:/,$p' >&2
+      kubectl delete pod -n "$NAMESPACE" vault-backup-helper --wait=false >/dev/null 2>&1 || true
+      die "helper pod never became Ready — see events above (§V.34)"
+    fi
+    kubectl exec -n "$NAMESPACE" vault-backup-helper -- tar -czf - -C "$DATA_PATH" . > "$ARTIFACT"
+    kubectl delete pod -n "$NAMESPACE" vault-backup-helper --wait=false >/dev/null
+
+    echo "vault-backup: scaling $NAMESPACE/$STATEFULSET back to 1..."
+    kubectl scale sts -n "$NAMESPACE" "$STATEFULSET" --replicas=1
+    kubectl wait --for=condition=Ready "pod/$POD" -n "$NAMESPACE" --timeout=300s
+    # KMS auto-unseal should complete within seconds; prove it rather than assume.
+    for _ in $(seq 1 30); do
+      kubectl exec -n "$NAMESPACE" "$POD" -- vault status 2>/dev/null | grep -q "Sealed .*false" && break
+      sleep 2
+    done
+    kubectl exec -n "$NAMESPACE" "$POD" -- vault status 2>/dev/null | grep -q "Sealed .*false" \
+      || die "Vault did not auto-unseal after restart — check the vault-kms-credentials
+     Secret and KMS reachability (base-apps/vault/runbook.md)"
+  else
+    echo "vault-backup: ⚠ online copy — artifact may be torn, branded INCONSISTENT"
+    kubectl exec -n "$NAMESPACE" "$POD" -- tar -czf - -C "$DATA_PATH" . > "$ARTIFACT"
+  fi
+fi
+
+[ -s "$ARTIFACT" ] || die "produced an empty artifact — refusing to record it as a backup"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ( cd "$OUT_DIR" && sha256sum "$NAME" > "$NAME.sha256" )
+else
+  ( cd "$OUT_DIR" && shasum -a 256 "$NAME" > "$NAME.sha256" )
+fi
+
+if is_s3_dest "$DEST"; then
+  command -v aws >/dev/null 2>&1 || die "aws CLI not found; cannot ship to $DEST"
+  aws s3 cp "$ARTIFACT" "${DEST%/}/$NAME"
+  aws s3 cp "$ARTIFACT.sha256" "${DEST%/}/$NAME.sha256"
+  rm -rf "$STAGE_OUT"
+  echo "vault-backup: uploaded ${DEST%/}/$NAME"
+else
+  echo "vault-backup: wrote $ARTIFACT"
+fi
+
+echo "vault-backup: ⚠ ciphertext — undecryptable without KMS key alias/vault-auto-unseal"
+echo "vault-backup: restore with scripts/vault-restore.sh (§V.28 requires a proven drill)"

--- a/scripts/vault-restore.sh
+++ b/scripts/vault-restore.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# vault-restore.sh — restore Vault's `file` storage from a vault-backup.sh artifact
+# (SPEC.md §T.35, §V.28)
+#
+# §V.28 will not take a Vault backup on faith: restoring the bytes proves nothing unless
+# Vault then unseals and a real secret reads back. This script gates on the checksum,
+# refuses artifacts branded INCONSISTENT unless the operator says so out loud, and — by
+# default — requires a verification command to demonstrate recovery.
+#
+# ⚠ awskms: the restored bytes are ciphertext. Without the KMS key
+# (alias/vault-auto-unseal) they cannot be decrypted, no matter how good the artifact is.
+#
+# Usage:
+#   vault-restore.sh --artifact <file.tar.gz> [--data-dir DIR] [--verify-cmd CMD]
+#                    [--no-verify] [--accept-inconsistent]
+
+set -euo pipefail
+
+ARTIFACT=""
+DATA_DIR=""
+VERIFY_CMD=""
+NO_VERIFY=0
+ACCEPT_INCONSISTENT=0
+
+die() { echo "vault-restore: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --artifact)            ARTIFACT="${2:-}"; shift 2 ;;
+    --data-dir)            DATA_DIR="${2:-}"; shift 2 ;;
+    --verify-cmd)          VERIFY_CMD="${2:-}"; shift 2 ;;
+    --no-verify)           NO_VERIFY=1; shift ;;
+    --accept-inconsistent) ACCEPT_INCONSISTENT=1; shift ;;
+    -h|--help)             sed -n '2,18p' "$0" >&2; exit 2 ;;
+    *)                     die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$ARTIFACT" ] || die "--artifact is required"
+[ -f "$ARTIFACT" ] || die "artifact not found: $ARTIFACT"
+[ -n "$DATA_DIR" ] || die "--data-dir is required"
+
+ARTIFACT_NAME="$(basename "$ARTIFACT")"
+
+# --- refuse a knowingly-torn artifact unless acknowledged ---------------------------
+case "$ARTIFACT_NAME" in
+  *INCONSISTENT*)
+    if [ "$ACCEPT_INCONSISTENT" -eq 0 ]; then
+      die "artifact '$ARTIFACT_NAME' is branded INCONSISTENT — it was taken while Vault
+     was running, so it may contain a partially-written file. Pass --accept-inconsistent
+     to restore from it anyway, understanding it may not produce a working Vault."
+    fi
+    echo "vault-restore: ⚠ restoring from an INCONSISTENT artifact by explicit request" >&2
+    ;;
+esac
+
+# --- integrity gate -----------------------------------------------------------------
+CHECKSUM_FILE="$ARTIFACT.sha256"
+[ -f "$CHECKSUM_FILE" ] || die "no checksum manifest at $CHECKSUM_FILE — unverifiable,
+     so per §V.28 this is not a backup"
+
+ARTIFACT_DIR="$(cd "$(dirname "$ARTIFACT")" && pwd -P)"
+if command -v sha256sum >/dev/null 2>&1; then CHECK="sha256sum -c"; else CHECK="shasum -a 256 -c"; fi
+if ! ( cd "$ARTIFACT_DIR" && $CHECK "$ARTIFACT_NAME.sha256" >/dev/null 2>&1 ); then
+  die "checksum mismatch for $ARTIFACT_NAME — artifact is corrupt or truncated, refusing
+     to restore from it"
+fi
+echo "vault-restore: checksum OK for $ARTIFACT_NAME"
+
+# Preserve any existing tree; a failed restore should not also destroy the evidence.
+if [ -d "$DATA_DIR" ] && [ -n "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
+  ASIDE="${DATA_DIR}.pre-restore.$(date -u +%Y%m%dT%H%M%SZ)"
+  echo "vault-restore: moving existing data dir aside -> $ASIDE"
+  mv "$DATA_DIR" "$ASIDE"
+fi
+
+mkdir -p "$DATA_DIR"
+tar -xzf "$ARTIFACT" -C "$DATA_DIR"
+
+[ -d "$DATA_DIR/core" ] || die "restored tree has no core/ — this does not look like a
+     Vault file-storage backup"
+
+echo "vault-restore: data restored to $DATA_DIR"
+
+# --- §V.28: prove recovery, do not assume it ----------------------------------------
+if [ "$NO_VERIFY" -eq 1 ]; then
+  echo "vault-restore: §V.28 NOT satisfied — caller must prove unseal + secret read" >&2
+  exit 0
+fi
+
+[ -n "$VERIFY_CMD" ] || die "--verify-cmd is required unless --no-verify is given.
+     §V.28 requires proof that Vault unseals and a known secret reads back; restoring
+     bytes is not recovery."
+
+echo "vault-restore: verifying unseal + secret read (§V.28)..."
+if ! eval "$VERIFY_CMD"; then
+  die "§V28 violation: verification command failed. Data is on disk but Vault is NOT
+     proven recovered."
+fi
+
+echo "vault-restore: OK — Vault unsealed and secret read back, restore proven (§V.28)"

--- a/tests/k3s-upgrade/conftest.py
+++ b/tests/k3s-upgrade/conftest.py
@@ -1,0 +1,24 @@
+import shutil
+import subprocess
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: containerised end-to-end drills (minutes, needs a working Docker daemon)",
+    )
+
+
+def docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(
+        ["docker", "info"], capture_output=True, timeout=30
+    ).returncode == 0
+
+
+requires_docker = pytest.mark.skipif(
+    not docker_available(), reason="needs a running Docker daemon for the k3s drill"
+)

--- a/tests/k3s-upgrade/conftest.py
+++ b/tests/k3s-upgrade/conftest.py
@@ -22,3 +22,15 @@ def docker_available() -> bool:
 requires_docker = pytest.mark.skipif(
     not docker_available(), reason="needs a running Docker daemon for the k3s drill"
 )
+
+
+def sha256_check(checksum_filename: str) -> list[str]:
+    """Argv to verify a .sha256 manifest, whichever tool the platform ships.
+
+    `shasum` is the BSD/macOS spelling; Linux CI runners have `sha256sum`. The scripts
+    under test already handle both — the tests must too, or they pass on a laptop and
+    fail on the runner.
+    """
+    if shutil.which("sha256sum"):
+        return ["sha256sum", "-c", checksum_filename]
+    return ["shasum", "-a", "256", "-c", checksum_filename]

--- a/tests/k3s-upgrade/test_api_scan.py
+++ b/tests/k3s-upgrade/test_api_scan.py
@@ -1,0 +1,54 @@
+"""Continuous enforcement of SPEC.md §V.10 — removed-API scan clean vs target minors.
+
+§T.4 ran this once and recorded the result in docs/plans/k3s-1.36-api-scan.md. That is a
+snapshot; this is the guard. Manifests land in base-apps/ continuously, and the walk to
+1.36 spans weeks, so a one-off scan would go stale long before the last hop.
+
+Scope note: pluto only knows *built-in* Kubernetes API deprecations. CRD version removals
+are invisible to it, and that is where this repo's real exposure sits — 59 manifests on
+external-secrets.io/v1beta1, which ESO removes in 0.17.0. See the report for the full
+picture; do not read a green run here as "safe to hop".
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_docker
+
+REPO = Path(__file__).resolve().parents[2]
+PLUTO = "us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5"
+TARGETS = ["v1.34.0", "v1.35.0", "v1.36.0"]
+
+
+@pytest.mark.slow
+@requires_docker
+@pytest.mark.parametrize("target", TARGETS)
+@pytest.mark.parametrize("directory", ["base-apps", "charts"])
+def test_api_scan_clean(target, directory):
+    """§V.10: no manifest may use an API removed in any minor on the path to 1.36."""
+    result = subprocess.run(
+        ["docker", "run", "--rm", "-v", f"{REPO}:/repo:ro", PLUTO,
+         "detect-files", "-d", f"/repo/{directory}",
+         "--target-versions", f"k8s={target}"],
+        capture_output=True, text=True, timeout=300,
+    )
+    combined = result.stdout + result.stderr
+    assert "no resources found with known deprecated apiVersions" in combined, (
+        f"§V.10 violation scanning {directory}/ against k8s={target}:\n{combined}"
+    )
+
+
+def test_scan_report_records_the_crd_blind_spot():
+    """The report must keep stating pluto's coverage limit.
+
+    A clean built-in scan reads as "cleared to hop" unless the CRD gap is spelled out
+    right next to it — and the ESO v1beta1 removal is the finding that actually gates
+    the walk.
+    """
+    report = REPO / "docs" / "plans" / "k3s-1.36-api-scan.md"
+    assert report.exists(), "§T.4 report missing"
+    text = report.read_text()
+    assert "external-secrets.io/v1beta1" in text
+    assert "0.17.0" in text, "report must name the release that removes v1beta1"
+    assert "pluto" in text.lower()

--- a/tests/k3s-upgrade/test_backup_scripts.py
+++ b/tests/k3s-upgrade/test_backup_scripts.py
@@ -1,0 +1,421 @@
+"""Tests for the k3s upgrade safety net (SPEC.md §T.1-§T.3).
+
+These scripts are the only rollback that exists. The cluster's datastore is SQLite
+(no `--cluster-init`), k3s migrates it one-way on every minor bump, and downgrade is
+unsupported — so a restored filesystem artifact is the entire recovery story.
+
+That makes the *guard clauses* the thing worth testing, not the happy path. §V.15 exists
+because tarring a live `state.db` yields a torn copy that still checksums cleanly: §V.1
+would then report a verified backup that cannot restore. A backup you falsely trust is
+worse than none at all, so the script must refuse rather than warn.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_docker
+
+REPO = Path(__file__).resolve().parents[2]
+BACKUP = REPO / "scripts" / "k3s-backup.sh"
+RESTORE = REPO / "scripts" / "k3s-restore.sh"
+PG_BACKUP = REPO / "scripts" / "pg-backup.sh"
+
+
+def run(script: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Invoke a script with a controlled environment, never inheriting real cluster state."""
+    base = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+    }
+    base.update(env or {})
+    return subprocess.run(
+        ["bash", str(script), *args],
+        capture_output=True,
+        text=True,
+        env=base,
+        timeout=120,
+    )
+
+
+def _fake_k3s_tree(tmp_path: Path) -> Path:
+    """Minimal stand-in for /var/lib/rancher/k3s with a non-empty SQLite datastore."""
+    data = tmp_path / "k3s"
+    (data / "server" / "db").mkdir(parents=True)
+    (data / "server" / "tls").mkdir(parents=True)
+    (data / "storage").mkdir(parents=True)  # local-path PV root
+    # k3s/kine runs SQLite in WAL mode, so a real datastore is a *file set*:
+    # state.db plus state.db-wal and state.db-shm. Reproduce that here.
+    subprocess.run(
+        ["sqlite3", str(data / "server" / "db" / "state.db"),
+         "PRAGMA journal_mode=WAL; "
+         "CREATE TABLE kine (id INTEGER PRIMARY KEY, name TEXT); "
+         "INSERT INTO kine (name) VALUES ('marker-row');"],
+        check=True,
+    )
+    # Leave a WAL behind, as a running server would.
+    (data / "server" / "db" / "state.db-wal").touch()
+    (data / "server" / "db" / "state.db-shm").touch()
+    (data / "server" / "token").write_text("fake-token\n")
+    (data / "server" / "tls" / "server-ca.crt").write_text("fake-cert\n")
+    return data
+
+
+# --- §V.21 — artifacts must not live inside the cluster ------------------------------
+
+def test_backup_rejects_in_cluster_destination(tmp_path):
+    """§V.21: a destination inside the k3s data dir is on a local-path volume — it dies
+    with the node it exists to protect. The script must refuse, not warn."""
+    data = _fake_k3s_tree(tmp_path)
+    result = run(
+        BACKUP, "--mode", "online", "--dest", str(data / "storage" / "backups"), "--dry-run",
+        env={"K3S_DATA_DIR": str(data)},
+    )
+    assert result.returncode != 0, "in-cluster destination was accepted"
+    assert "V21" in result.stderr
+
+
+def test_backup_accepts_off_cluster_destination(tmp_path):
+    data = _fake_k3s_tree(tmp_path)
+    result = run(
+        BACKUP, "--mode", "online", "--dest", str(tmp_path / "artifacts"), "--dry-run",
+        env={"K3S_DATA_DIR": str(data)},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# --- §V.15 — never tar a live state.db -----------------------------------------------
+
+def test_backup_refuses_live_state_db(tmp_path):
+    """§V.15: cold mode tars the whole tree including state.db, so it must prove k3s is
+    stopped first. K3S_STATUS_CMD exiting 0 means 'still running' -> must abort."""
+    data = _fake_k3s_tree(tmp_path)
+    result = run(
+        BACKUP, "--mode", "cold", "--dest", str(tmp_path / "out"), "--skip-stop",
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    )
+    assert result.returncode != 0, "cold backup proceeded while k3s was still running"
+    assert "V15" in result.stderr
+    assert "state.db" in result.stderr
+
+
+def test_backup_cold_proceeds_when_k3s_stopped(tmp_path):
+    """Same path, but k3s confirmed stopped -> the tar may include state.db."""
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    result = run(
+        BACKUP, "--mode", "cold", "--dest", str(dest), "--skip-stop",
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/false"},
+    )
+    assert result.returncode == 0, result.stderr
+    artifacts = list(dest.glob("k3s-backup-*.tar.gz"))
+    assert artifacts, "no artifact produced"
+    listing = subprocess.run(
+        ["tar", "-tzf", str(artifacts[0])], capture_output=True, text=True, check=True
+    ).stdout
+    assert "server/db/state.db" in listing
+
+
+def test_backup_online_excludes_live_state_db(tmp_path):
+    """§V.15 online path: the live state.db must be excluded from the tar and replaced by
+    a `sqlite3 .backup` snapshot, which is consistent while k3s keeps running."""
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    result = run(
+        BACKUP, "--mode", "online", "--dest", str(dest),
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    )
+    assert result.returncode == 0, result.stderr
+    artifacts = list(dest.glob("k3s-backup-*.tar.gz"))
+    assert artifacts, "no artifact produced"
+    listing = subprocess.run(
+        ["tar", "-tzf", str(artifacts[0])], capture_output=True, text=True, check=True
+    ).stdout
+    assert "server/db/state.db\n" not in listing, "live state.db was tarred despite §V.15"
+    assert "state.db.backup" in listing, "no consistent sqlite snapshot in artifact"
+
+
+def test_backup_snapshot_is_readable_sqlite(tmp_path):
+    """A snapshot that is not a queryable database is not a backup."""
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    assert run(
+        BACKUP, "--mode", "online", "--dest", str(dest),
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    ).returncode == 0
+    artifact = next(dest.glob("k3s-backup-*.tar.gz"))
+    subprocess.run(["tar", "-xzf", str(artifact), "-C", str(tmp_path)], check=True)
+    snapshot = next(tmp_path.rglob("state.db.backup"))
+    rows = subprocess.run(
+        ["sqlite3", str(snapshot), "SELECT name FROM kine;"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "marker-row" in rows
+
+
+def test_backup_online_excludes_stale_wal(tmp_path):
+    """§V.15 applies to the whole datastore file set, not just state.db.
+
+    An online artifact carries a standalone `sqlite3 .backup` snapshot. Shipping the live
+    -wal/-shm beside it means that on restore SQLite finds a write-ahead log belonging to
+    a *different* database and replays it over the snapshot. That is precisely the
+    silent-corruption failure §V.15 exists to prevent, so the sidecars must be excluded.
+    """
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    assert run(
+        BACKUP, "--mode", "online", "--dest", str(dest),
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    ).returncode == 0
+    artifact = next(dest.glob("k3s-backup-*.tar.gz"))
+    listing = subprocess.run(
+        ["tar", "-tzf", str(artifact)], capture_output=True, text=True, check=True
+    ).stdout
+    assert "state.db-wal" not in listing, "live WAL shipped alongside the snapshot"
+    assert "state.db-shm" not in listing, "live shared-memory file shipped with the snapshot"
+
+
+def test_restore_clears_stale_wal_before_promoting(tmp_path):
+    """Defence in depth: even given a bad artifact, restore must not leave a foreign WAL
+    next to the promoted snapshot."""
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    assert run(
+        BACKUP, "--mode", "online", "--dest", str(dest),
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    ).returncode == 0
+    artifact = next(dest.glob("k3s-backup-*.tar.gz"))
+    target = tmp_path / "restored"
+    # Pre-seed the target with junk sidecars, as a failed prior restore would leave.
+    (target / "server" / "db").mkdir(parents=True)
+    (target / "server" / "db" / "state.db-wal").write_text("stale")
+    result = run(
+        RESTORE, "--artifact", str(artifact), "--data-dir", str(target),
+        "--expect-version", "v1.33.5+k3s1", "--skip-service", "--no-verify",
+    )
+    assert result.returncode == 0, result.stderr
+    db_dir = target / "server" / "db"
+    assert (db_dir / "state.db").exists()
+    assert not (db_dir / "state.db-wal").exists(), "stale WAL survived the restore"
+
+
+# --- §V.1 — the artifact must carry an integrity manifest ----------------------------
+
+def test_backup_writes_verifiable_checksum(tmp_path):
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "out"
+    assert run(
+        BACKUP, "--mode", "online", "--dest", str(dest),
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": "/usr/bin/true"},
+    ).returncode == 0
+    artifact = next(dest.glob("k3s-backup-*.tar.gz"))
+    checksum = Path(str(artifact) + ".sha256")
+    assert checksum.exists(), "no checksum written"
+    verify = subprocess.run(
+        ["shasum", "-a", "256", "-c", checksum.name],
+        cwd=dest, capture_output=True, text=True,
+    )
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+
+
+# --- §T.2 / §V.16 — a restore that is not proven is not a restore --------------------
+
+def _make_artifact(tmp_path: Path, mode: str = "online") -> Path:
+    data = _fake_k3s_tree(tmp_path)
+    dest = tmp_path / "artifacts"
+    status = "/usr/bin/true" if mode == "online" else "/usr/bin/false"
+    extra = [] if mode == "online" else ["--skip-stop"]
+    result = run(
+        BACKUP, "--mode", mode, "--dest", str(dest), *extra,
+        env={"K3S_DATA_DIR": str(data), "K3S_STATUS_CMD": status},
+    )
+    assert result.returncode == 0, result.stderr
+    return next(dest.glob("k3s-backup-*.tar.gz"))
+
+
+def test_restore_rejects_corrupt_artifact(tmp_path):
+    """A silently-corrupt artifact is the failure mode §V.1 exists to prevent, so the
+    checksum is a gate and not a log line."""
+    artifact = _make_artifact(tmp_path)
+    artifact.write_bytes(artifact.read_bytes() + b"corruption")
+    result = run(
+        RESTORE, "--artifact", str(artifact), "--data-dir", str(tmp_path / "restored"),
+        "--expect-version", "v1.33.5+k3s1", "--skip-service", "--no-verify",
+    )
+    assert result.returncode != 0, "corrupt artifact was accepted"
+    assert "checksum" in result.stderr.lower()
+
+
+def test_restore_promotes_online_snapshot(tmp_path):
+    """An online artifact carries state.db.backup and no state.db. Restore must promote
+    the snapshot into place, otherwise k3s starts with no datastore."""
+    artifact = _make_artifact(tmp_path, mode="online")
+    target = tmp_path / "restored"
+    result = run(
+        RESTORE, "--artifact", str(artifact), "--data-dir", str(target),
+        "--expect-version", "v1.33.5+k3s1", "--skip-service", "--no-verify",
+    )
+    assert result.returncode == 0, result.stderr
+    restored_db = target / "server" / "db" / "state.db"
+    assert restored_db.exists(), "state.db was not promoted from the snapshot"
+    rows = subprocess.run(
+        ["sqlite3", str(restored_db), "SELECT name FROM kine;"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "marker-row" in rows
+
+
+def test_restore_refuses_on_version_mismatch(tmp_path):
+    """§V.16: restore only succeeds if the API comes back at the expected version. A
+    verify command reporting anything else must fail the run, not warn."""
+    artifact = _make_artifact(tmp_path)
+    result = run(
+        RESTORE, "--artifact", str(artifact), "--data-dir", str(tmp_path / "restored"),
+        "--expect-version", "v1.33.5+k3s1", "--skip-service",
+        "--verify-cmd", "echo 'Server Version: v1.34.9+k3s1'",
+    )
+    assert result.returncode != 0, "restore reported success at the wrong version"
+    assert "V16" in result.stderr
+
+
+def test_restore_succeeds_when_version_matches(tmp_path):
+    artifact = _make_artifact(tmp_path)
+    result = run(
+        RESTORE, "--artifact", str(artifact), "--data-dir", str(tmp_path / "restored"),
+        "--expect-version", "v1.33.5+k3s1", "--skip-service",
+        "--verify-cmd", "echo 'Server Version: v1.33.5+k3s1'",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# --- §V.1 + §V.16 — the end-to-end drill --------------------------------------------
+
+K3S_IMAGE = "rancher/k3s:v1.33.5-k3s1"
+EXPECT_VERSION = "v1.33.5+k3s1"
+
+
+def _docker(*args, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(["docker", *args], capture_output=True, text=True, **kwargs)
+
+
+def _wait_ready(container: str, attempts: int = 60) -> bool:
+    import time
+    for _ in range(attempts):
+        out = _docker("exec", container, "kubectl", "get", "nodes")
+        if " Ready " in out.stdout:
+            return True
+        time.sleep(5)
+    return False
+
+
+@pytest.mark.slow
+@requires_docker
+def test_restore_drill_docker_k3s(tmp_path):
+    """§V.16: an untested artifact is not a backup.
+
+    Exercises the whole contract against a real k3s server on the same SQLite datastore
+    the cluster uses: seed state, back up *while k3s is running* (online mode), destroy
+    the cluster and its volume outright, restore, and require both that the API returns
+    at the prior version and that the seeded state survived.
+
+    Deliberately online mode — cold mode is the easy case, and §B.1 was a defect that
+    only the online path could produce.
+    """
+    vol, outvol = "k3sdrill-pytest-vol", "k3sdrill-pytest-out"
+    live, restored, extractor = (
+        "k3s-drill-pytest", "k3s-drill-pytest-restored", "k3s-drill-pytest-extract",
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    def cleanup():
+        for c in (live, restored, extractor):
+            _docker("rm", "-f", c)
+        for v in (vol, outvol):
+            _docker("volume", "rm", v)
+
+    cleanup()
+    try:
+        assert _docker("volume", "create", vol).returncode == 0
+        assert _docker("volume", "create", outvol).returncode == 0
+        assert _docker(
+            "run", "-d", "--name", live, "--hostname", "k3sdrill", "--privileged",
+            "-v", f"{vol}:/var/lib/rancher/k3s", K3S_IMAGE,
+            "server", "--disable", "traefik", "--disable", "metrics-server",
+            "--disable", "local-storage",
+        ).returncode == 0
+        assert _wait_ready(live), "drill cluster never became Ready"
+
+        seeded = _docker(
+            "exec", live, "kubectl", "create", "configmap", "drill-marker",
+            "-n", "default", "--from-literal=proof=online-restore-ok",
+        )
+        assert seeded.returncode == 0, seeded.stderr
+
+        # Back up the live datastore from a helper container sharing the volume. The
+        # k3s image itself carries no shell tooling, and this mirrors reality: k3s keeps
+        # serving while the snapshot is taken.
+        # Output goes to a named volume rather than a host bind mount: on macOS the VM
+        # only shares selected host paths, and pytest's tmp_path is not one of them.
+        # docker cp works regardless of what the VM has mounted.
+        backup = _docker(
+            "run", "--rm",
+            "-v", f"{vol}:/data",
+            "-v", f"{REPO / 'scripts'}:/scripts:ro",
+            "-v", f"{outvol}:/out",
+            "alpine:3.20", "sh", "-c",
+            "test -f /scripts/k3s-backup.sh || { echo 'scripts not mounted' >&2; exit 90; }; "
+            "apk add --no-cache bash sqlite tar >/dev/null 2>&1 && "
+            "K3S_DATA_DIR=/data K3S_STATUS_CMD=/bin/true "
+            "bash /scripts/k3s-backup.sh --mode online --dest /out",
+        )
+        assert backup.returncode == 0, backup.stdout + backup.stderr
+
+        assert _docker(
+            "create", "--name", extractor, "-v", f"{outvol}:/out", "alpine:3.20", "true"
+        ).returncode == 0
+        assert _docker("cp", f"{extractor}:/out/.", str(artifacts)).returncode == 0
+        found = sorted(artifacts.glob("k3s-backup-*.tar.gz"))
+        assert found, f"no artifact recovered from the drill: {list(artifacts.iterdir())}"
+        artifact = found[0]
+
+        # §B.1 regression: the artifact must carry a standalone snapshot and no live set.
+        listing = subprocess.run(
+            ["tar", "-tzf", str(artifact)], capture_output=True, text=True, check=True
+        ).stdout
+        assert "state.db.backup" in listing
+        assert "state.db-wal" not in listing
+
+        # Destroy the cluster completely — no fallback, the artifact is all that is left.
+        assert _docker("rm", "-f", live).returncode == 0
+        assert _docker("volume", "rm", vol).returncode == 0
+
+        target = tmp_path / "restored"
+        restore = run(
+            RESTORE, "--artifact", str(artifact), "--data-dir", str(target),
+            "--expect-version", EXPECT_VERSION, "--skip-service", "--no-verify",
+        )
+        assert restore.returncode == 0, restore.stderr
+
+        assert _docker(
+            "create", "--name", restored, "--hostname", "k3sdrill", "--privileged",
+            K3S_IMAGE, "server", "--disable", "traefik", "--disable", "metrics-server",
+            "--disable", "local-storage",
+        ).returncode == 0
+        assert _docker(
+            "cp", f"{target}/.", f"{restored}:/var/lib/rancher/k3s/"
+        ).returncode == 0
+        assert _docker("start", restored).returncode == 0
+        assert _wait_ready(restored), "restored cluster never became Ready"
+
+        version = _docker("exec", restored, "kubectl", "version")
+        assert EXPECT_VERSION in version.stdout, f"§V.16: got {version.stdout!r}"
+
+        marker = _docker(
+            "exec", restored, "kubectl", "get", "cm", "drill-marker",
+            "-n", "default", "-o", "jsonpath={.data.proof}",
+        )
+        assert marker.stdout.strip() == "online-restore-ok", "seeded state did not survive"
+    finally:
+        cleanup()

--- a/tests/k3s-upgrade/test_backup_scripts.py
+++ b/tests/k3s-upgrade/test_backup_scripts.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import requires_docker
+from conftest import requires_docker, sha256_check
 
 REPO = Path(__file__).resolve().parents[2]
 BACKUP = REPO / "scripts" / "k3s-backup.sh"
@@ -213,7 +213,7 @@ def test_backup_writes_verifiable_checksum(tmp_path):
     checksum = Path(str(artifact) + ".sha256")
     assert checksum.exists(), "no checksum written"
     verify = subprocess.run(
-        ["shasum", "-a", "256", "-c", checksum.name],
+        sha256_check(checksum.name),
         cwd=dest, capture_output=True, text=True,
     )
     assert verify.returncode == 0, verify.stdout + verify.stderr

--- a/tests/k3s-upgrade/test_pg_backup.py
+++ b/tests/k3s-upgrade/test_pg_backup.py
@@ -1,0 +1,171 @@
+"""Tests for the operator-independent Postgres dump (SPEC.md §T.3, §V.6, §V.21).
+
+The cluster already ships barman backups to S3 and they are healthy. This script is not
+a replacement for those — it exists because §T.9 upgrades the CNPG operator itself, and a
+barman restore needs a working operator to drive it. A plain `pg_dump` is the only
+insurance that survives an operator upgrade going wrong.
+
+`postgresql-cluster` runs a single instance on a node-pinned local-path volume with no
+replica, so there is no second copy to fall back on.
+"""
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_docker
+
+REPO = Path(__file__).resolve().parents[2]
+PG_BACKUP = REPO / "scripts" / "pg-backup.sh"
+
+PG_IMAGE = "postgres:16-alpine"
+PG_PASSWORD = "drillpass"
+
+
+def run(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    base = {"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")}
+    base.update(env or {})
+    return subprocess.run(
+        ["bash", str(PG_BACKUP), *args],
+        capture_output=True, text=True, env=base, timeout=300,
+    )
+
+
+def _docker(*args, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(["docker", *args], capture_output=True, text=True, **kwargs)
+
+
+def test_pg_backup_rejects_in_cluster_destination(tmp_path):
+    """§V.21: local-path is the only StorageClass, so an artifact written to cluster
+    storage is pinned to the same node as the database it protects."""
+    result = run(
+        "--dest", "/var/lib/rancher/k3s/storage/pgdump", "--dry-run",
+        "--exec-cmd", "/usr/bin/true", "--database", "app",
+    )
+    assert result.returncode != 0
+    assert "V21" in result.stderr
+
+
+def test_pg_backup_requires_destination():
+    result = run("--dry-run", "--exec-cmd", "/usr/bin/true", "--database", "app")
+    assert result.returncode != 0
+    assert "dest" in result.stderr.lower()
+
+
+def test_pg_backup_requires_database_or_all(tmp_path):
+    """postgresql-cluster hosts several databases (n8n, chores_tracker). A default of
+    one name would silently under-protect the others, so the choice must be explicit."""
+    result = run("--dest", str(tmp_path / "out"), "--dry-run", "--exec-cmd", "/usr/bin/true")
+    assert result.returncode != 0
+    assert "--all" in result.stderr
+
+
+@pytest.mark.slow
+@requires_docker
+def test_pg_dumpall_captures_every_database(tmp_path, pg_container):
+    """--all must capture every database, not just one — this is the pre-§T.9 insurance
+    artifact, taken before the CNPG operator itself is upgraded."""
+    def psql(sql: str, db: str = "postgres"):
+        return _docker(
+            "exec", "-e", f"PGPASSWORD={PG_PASSWORD}", pg_container,
+            "psql", "-U", "postgres", "-d", db, "-tAc", sql,
+        )
+
+    for name in ("n8n_like", "chores_like"):
+        assert psql(f"CREATE DATABASE {name};").returncode == 0
+        assert psql(f"CREATE TABLE t_{name} (v text);", db=name).returncode == 0
+
+    dest = tmp_path / "all"
+    result = run(
+        "--dest", str(dest), "--all",
+        "--exec-cmd", f"docker exec -e PGPASSWORD={PG_PASSWORD} {pg_container}",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    artifact = next(dest.glob("pg-*-all-*.sql.gz"))
+    dump = subprocess.run(
+        ["gunzip", "-c", str(artifact)], capture_output=True, text=True, check=True
+    ).stdout
+    assert "n8n_like" in dump and "chores_like" in dump, "not every database was captured"
+    assert "CREATE ROLE" in dump or "ROLE postgres" in dump, "globals/roles missing from dumpall"
+
+
+@pytest.fixture
+def pg_container():
+    """A disposable Postgres standing in for the CNPG primary."""
+    name = f"pg-drill-{uuid.uuid4().hex[:8]}"
+    _docker(
+        "run", "-d", "--name", name,
+        "-e", f"POSTGRES_PASSWORD={PG_PASSWORD}",
+        PG_IMAGE,
+    )
+    try:
+        for _ in range(60):
+            ready = _docker("exec", name, "pg_isready", "-U", "postgres")
+            if ready.returncode == 0:
+                break
+            time.sleep(2)
+        else:
+            pytest.fail(f"postgres container {name} never became ready")
+        yield name
+    finally:
+        _docker("rm", "-f", name)
+
+
+@pytest.mark.slow
+@requires_docker
+def test_pg_dump_artifact_restores(tmp_path, pg_container):
+    """§V.6: a dump that has not been restored is not a backup.
+
+    Seed a row, dump through the script, drop the database entirely, restore from the
+    artifact, and require the row back.
+    """
+    def psql(sql: str, db: str = "postgres") -> subprocess.CompletedProcess:
+        return _docker(
+            "exec", "-e", f"PGPASSWORD={PG_PASSWORD}", pg_container,
+            "psql", "-U", "postgres", "-d", db, "-tAc", sql,
+        )
+
+    assert psql("CREATE DATABASE app;").returncode == 0
+    assert psql(
+        "CREATE TABLE chores (id serial primary key, name text); "
+        "INSERT INTO chores (name) VALUES ('take-out-bins');",
+        db="app",
+    ).returncode == 0
+
+    dest = tmp_path / "pgdumps"
+    result = run(
+        "--dest", str(dest), "--database", "app",
+        "--exec-cmd", f"docker exec -e PGPASSWORD={PG_PASSWORD} {pg_container}",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    artifact = next(dest.glob("pg-*-app-*.sql.gz"))
+    checksum = Path(str(artifact) + ".sha256")
+    assert checksum.exists(), "§V.1: artifact has no integrity manifest"
+    verify = subprocess.run(
+        ["shasum", "-a", "256", "-c", checksum.name],
+        cwd=dest, capture_output=True, text=True,
+    )
+    assert verify.returncode == 0, verify.stdout
+
+    # Destroy the database outright — the artifact is now the only copy.
+    assert psql("DROP DATABASE app;").returncode == 0
+    assert psql("CREATE DATABASE app;").returncode == 0
+    assert "take-out-bins" not in psql("SELECT name FROM chores;", db="app").stdout
+
+    restored_sql = subprocess.run(
+        ["gunzip", "-c", str(artifact)], capture_output=True, text=True, check=True
+    ).stdout
+    load = subprocess.run(
+        ["docker", "exec", "-i", "-e", f"PGPASSWORD={PG_PASSWORD}", pg_container,
+         "psql", "-U", "postgres", "-d", "app"],
+        input=restored_sql, capture_output=True, text=True,
+    )
+    assert load.returncode == 0, load.stderr
+
+    rows = psql("SELECT name FROM chores;", db="app").stdout
+    assert "take-out-bins" in rows, "dump did not restore the seeded row"

--- a/tests/k3s-upgrade/test_pg_backup.py
+++ b/tests/k3s-upgrade/test_pg_backup.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import requires_docker
+from conftest import requires_docker, sha256_check
 
 REPO = Path(__file__).resolve().parents[2]
 PG_BACKUP = REPO / "scripts" / "pg-backup.sh"
@@ -147,7 +147,7 @@ def test_pg_dump_artifact_restores(tmp_path, pg_container):
     checksum = Path(str(artifact) + ".sha256")
     assert checksum.exists(), "§V.1: artifact has no integrity manifest"
     verify = subprocess.run(
-        ["shasum", "-a", "256", "-c", checksum.name],
+        sha256_check(checksum.name),
         cwd=dest, capture_output=True, text=True,
     )
     assert verify.returncode == 0, verify.stdout

--- a/tests/k3s-upgrade/test_prune_scope.py
+++ b/tests/k3s-upgrade/test_prune_scope.py
@@ -1,0 +1,71 @@
+"""Every PVC manifest must opt out of Argo pruning (SPEC.md §V.19).
+
+`local-path` is the only StorageClass in this cluster and it reclaims `Delete`, so a
+PersistentVolume is destroyed along with its claim. Every Argo Application runs
+`prune: true`. That combination means a manifest rename, a bad Helm values change, or a
+chart bump that stops rendering a claim silently deletes the data behind it.
+
+This was not hypothetical: an audit on 2026-07-27 found 10 PVCs live in prune scope,
+including postgresql, ollama, n8n and grafana. The fix was a `Prune=false` sync-option on
+each manifest. This test exists so the next PVC added to the repo cannot quietly
+reintroduce the exposure.
+
+Deliberate deletion is still possible — remove the annotation in a commit, which is
+reviewable, rather than having it happen as a side effect of an unrelated change.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+BASE_APPS = REPO / "base-apps"
+SYNC_OPTIONS = "argocd.argoproj.io/sync-options"
+
+# Claims created by a StatefulSet volumeClaimTemplate are made by the StatefulSet
+# controller, not applied by Argo, so they are never in prune scope. vault-data-vault-0
+# is the case that matters here.
+def _pvc_docs():
+    for path in sorted(BASE_APPS.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text()))
+        except yaml.YAMLError:
+            continue  # malformed YAML is yamllint's job, not this test's
+        for doc in docs:
+            if isinstance(doc, dict) and doc.get("kind") == "PersistentVolumeClaim":
+                yield path, doc
+
+
+def test_pvc_manifests_exist():
+    """Guard against the glob silently matching nothing and the suite passing vacuously."""
+    found = list(_pvc_docs())
+    assert len(found) >= 9, f"expected the known PVC manifests, found {len(found)}"
+
+
+@pytest.mark.parametrize(
+    "path,doc",
+    [pytest.param(p, d, id=f"{d['metadata'].get('namespace','?')}/{d['metadata']['name']}")
+     for p, d in _pvc_docs()],
+)
+def test_pvc_opts_out_of_prune(path, doc):
+    """§V.19: no PVC may sit in Argo's prune scope."""
+    annotations = doc["metadata"].get("annotations") or {}
+    opts = annotations.get(SYNC_OPTIONS, "")
+    assert "Prune=false" in opts, (
+        f"{path.relative_to(REPO)} declares a PVC without '{SYNC_OPTIONS}: Prune=false'.\n"
+        f"local-path reclaims Delete, so an Argo prune of this claim destroys the volume "
+        f"behind it. Add the annotation, or if deletion really is intended, say so in the "
+        f"commit message."
+    )
+
+
+def test_atlantis_app_has_prune_disabled():
+    """atlantis renders its PVC from a Helm chart whose values expose no annotations
+    (6.1.0: enabled/dataStorage/storageClassName/accessModes only), so the protection has
+    to live on the Application instead."""
+    app = yaml.safe_load((BASE_APPS / "atlantis.yaml").read_text())
+    automated = app["spec"]["syncPolicy"]["automated"]
+    assert automated.get("prune") is False, (
+        "base-apps/atlantis.yaml must keep prune: false — the chart renders atlantis-data "
+        "as a standalone PVC on local-path and offers no way to annotate it."
+    )

--- a/tests/k3s-upgrade/test_vault_backup.py
+++ b/tests/k3s-upgrade/test_vault_backup.py
@@ -1,0 +1,279 @@
+"""Tests for the Vault backup + restore path (SPEC.md §T.35, §V.28, §V.21).
+
+Vault has no backup today. `vault-0` runs `file` storage at /vault/data, replicas=1, on a
+1Gi local-path volume pinned to k3s-control-01 — the node every control-plane hop restarts
+— and it holds the credentials all 45 namespaces resolve through ESO. This is the only
+protection that data has.
+
+The design constraint: Vault's file backend has **no consistent-snapshot API**. There is no
+`vault operator raft snapshot` equivalent; the documented method is to stop Vault and copy
+the directory. Copying it live risks catching a partial write, which is exactly §B.1 — an
+artifact that checksums cleanly and cannot restore. So cold is the default, and online must
+brand its own output as untrustworthy.
+"""
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_docker
+
+REPO = Path(__file__).resolve().parents[2]
+BACKUP = REPO / "scripts" / "vault-backup.sh"
+RESTORE = REPO / "scripts" / "vault-restore.sh"
+
+VAULT_IMAGE = "hashicorp/vault:1.18.1"
+MARKER_PATH = "secret/drill"
+MARKER_VALUE = "vault-restore-ok"
+
+
+def run(script: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    base = {"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")}
+    base.update(env or {})
+    return subprocess.run(
+        ["bash", str(script), *args],
+        capture_output=True, text=True, env=base, timeout=300,
+    )
+
+
+def _fake_vault_data(tmp_path: Path) -> Path:
+    """Stand-in for /vault/data — the file backend's on-disk layout."""
+    data = tmp_path / "vault-data"
+    for sub in ("core", "logical", "sys", "auth"):
+        (data / sub).mkdir(parents=True)
+    (data / "core" / "_seal-config").write_text('{"type":"awskms"}')
+    (data / "logical" / "marker").write_text("ciphertext-stand-in")
+    return data
+
+
+# --- §V.21 — artifacts must not live inside the cluster ------------------------------
+
+def test_vault_backup_rejects_in_cluster_destination(tmp_path):
+    data = _fake_vault_data(tmp_path)
+    result = run(
+        BACKUP, "--data-dir", str(data),
+        "--dest", "/var/lib/rancher/k3s/storage/vault-backups", "--dry-run",
+    )
+    assert result.returncode != 0, "in-cluster destination accepted"
+    assert "V21" in result.stderr
+
+
+def test_vault_backup_requires_dest(tmp_path):
+    data = _fake_vault_data(tmp_path)
+    result = run(BACKUP, "--data-dir", str(data), "--dry-run")
+    assert result.returncode != 0
+    assert "dest" in result.stderr.lower()
+
+
+# --- §B.1 lesson — an inconsistent copy must never look trustworthy ------------------
+
+def test_vault_backup_online_refused_without_explicit_flag(tmp_path):
+    """Vault's file backend cannot be snapshotted consistently while running. Online mode
+    must be opt-in, not the path of least resistance."""
+    data = _fake_vault_data(tmp_path)
+    result = run(BACKUP, "--data-dir", str(data), "--dest", str(tmp_path / "out"),
+                 "--mode", "online")
+    assert result.returncode != 0, "online mode ran without acknowledgement"
+    assert "--allow-inconsistent" in result.stderr
+
+
+def test_vault_backup_online_brands_artifact(tmp_path):
+    """If an operator insists, the artifact must carry the warning in its own filename —
+    a torn backup that looks like a good one is worse than no backup (§B.1)."""
+    data = _fake_vault_data(tmp_path)
+    dest = tmp_path / "out"
+    result = run(BACKUP, "--data-dir", str(data), "--dest", str(dest),
+                 "--mode", "online", "--allow-inconsistent")
+    assert result.returncode == 0, result.stderr
+    artifacts = list(dest.glob("*.tar.gz"))
+    assert artifacts, "no artifact produced"
+    assert "INCONSISTENT" in artifacts[0].name, (
+        f"online artifact not branded: {artifacts[0].name}"
+    )
+
+
+def test_vault_backup_cold_artifact_is_not_branded(tmp_path):
+    data = _fake_vault_data(tmp_path)
+    dest = tmp_path / "out"
+    assert run(BACKUP, "--data-dir", str(data), "--dest", str(dest)).returncode == 0
+    artifact = next(dest.glob("*.tar.gz"))
+    assert "INCONSISTENT" not in artifact.name
+
+
+def test_vault_backup_writes_verifiable_checksum(tmp_path):
+    data = _fake_vault_data(tmp_path)
+    dest = tmp_path / "out"
+    assert run(BACKUP, "--data-dir", str(data), "--dest", str(dest)).returncode == 0
+    artifact = next(dest.glob("*.tar.gz"))
+    checksum = Path(str(artifact) + ".sha256")
+    assert checksum.exists(), "no integrity manifest"
+    verify = subprocess.run(["shasum", "-a", "256", "-c", checksum.name],
+                            cwd=dest, capture_output=True, text=True)
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+
+
+def test_vault_restore_rejects_corrupt_artifact(tmp_path):
+    data = _fake_vault_data(tmp_path)
+    dest = tmp_path / "out"
+    assert run(BACKUP, "--data-dir", str(data), "--dest", str(dest)).returncode == 0
+    artifact = next(dest.glob("*.tar.gz"))
+    artifact.write_bytes(artifact.read_bytes() + b"corruption")
+    result = run(RESTORE, "--artifact", str(artifact),
+                 "--data-dir", str(tmp_path / "restored"), "--no-verify")
+    assert result.returncode != 0, "corrupt artifact accepted"
+    assert "checksum" in result.stderr.lower()
+
+
+def test_vault_restore_refuses_inconsistent_artifact_without_ack(tmp_path):
+    """An artifact branded INCONSISTENT must not restore silently — the operator has to
+    say out loud that they are recovering from a possibly-torn copy."""
+    data = _fake_vault_data(tmp_path)
+    dest = tmp_path / "out"
+    assert run(BACKUP, "--data-dir", str(data), "--dest", str(dest),
+               "--mode", "online", "--allow-inconsistent").returncode == 0
+    artifact = next(dest.glob("*.tar.gz"))
+    result = run(RESTORE, "--artifact", str(artifact),
+                 "--data-dir", str(tmp_path / "restored"), "--no-verify")
+    assert result.returncode != 0
+    assert "INCONSISTENT" in result.stderr
+
+
+# --- §V.28 — the drill ---------------------------------------------------------------
+
+def _docker(*args, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(["docker", *args], capture_output=True, text=True, **kwargs)
+
+
+def _vault(container: str, *args: str, token: str | None = None):
+    env = ["-e", "VAULT_ADDR=http://127.0.0.1:8200"]
+    if token:
+        env += ["-e", f"VAULT_TOKEN={token}"]
+    return _docker("exec", *env, container, "vault", *args)
+
+
+def _wait_listening(container: str, attempts: int = 40) -> bool:
+    for _ in range(attempts):
+        out = _vault(container, "status")
+        # `vault status` exits 2 when sealed, 0 when unsealed — both mean it is listening.
+        if out.returncode in (0, 2):
+            return True
+        time.sleep(2)
+    return False
+
+
+VAULT_CONFIG = json.dumps({
+    "storage": {"file": {"path": "/vault/data"}},
+    "listener": [{"tcp": {"address": "0.0.0.0:8200", "tls_disable": True}}],
+    "disable_mlock": True,
+    "ui": False,
+})
+
+
+@pytest.mark.slow
+@requires_docker
+def test_vault_restore_drill_docker(tmp_path):
+    """§V.28: an untested Vault backup is not a backup.
+
+    Seeds a real secret into a real Vault on `file` storage, stops it, backs the data up,
+    destroys the container AND its volume, restores, and requires both that Vault unseals
+    and that the secret reads back.
+
+    Coverage boundary: this drill uses Shamir. Production `vault-0` seals with awskms.
+    File-storage restore is byte-identical either way; what this does NOT exercise is the
+    seal path — and note that awskms data is undecryptable without the KMS key, which no
+    filesystem backup can capture.
+    """
+    vol, vol2 = "vault-drill-vol", "vault-drill-vol2"
+    live, restored, helper = "vault-drill", "vault-drill-restored", "vault-drill-helper"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    def cleanup():
+        for c in (live, restored, helper):
+            _docker("rm", "-f", c)
+        for v in (vol, vol2):
+            _docker("volume", "rm", v)
+
+    def prepare_volume(volume: str):
+        """A fresh docker volume is root-owned; the Vault image runs as uid 100."""
+        assert _docker("volume", "create", volume).returncode == 0
+        assert _docker("run", "--rm", "-v", f"{volume}:/vault/data", "alpine:3.20",
+                       "chown", "-R", "100:1000", "/vault/data").returncode == 0
+
+    def start_vault(name: str, volume: str):
+        return _docker(
+            "run", "-d", "--name", name, "--cap-add=IPC_LOCK",
+            "-e", f"VAULT_LOCAL_CONFIG={VAULT_CONFIG}",
+            "-v", f"{volume}:/vault/data",
+            VAULT_IMAGE, "server",
+        )
+
+    cleanup()
+    try:
+        prepare_volume(vol)
+        assert start_vault(live, vol).returncode == 0
+        assert _wait_listening(live), "drill Vault never started listening"
+
+        init = _vault(live, "operator", "init", "-key-shares=1", "-key-threshold=1",
+                      "-format=json")
+        assert init.returncode == 0, init.stderr
+        init_data = json.loads(init.stdout)
+        unseal_key = init_data["unseal_keys_b64"][0]
+        root_token = init_data["root_token"]
+
+        assert _vault(live, "operator", "unseal", unseal_key).returncode == 0
+        assert _vault(live, "secrets", "enable", "-path=secret", "kv-v2",
+                      token=root_token).returncode == 0
+        put = _vault(live, "kv", "put", MARKER_PATH, f"proof={MARKER_VALUE}",
+                     token=root_token)
+        assert put.returncode == 0, put.stderr
+
+        # Quiesce: file backend has no consistent online snapshot, so stop first.
+        assert _docker("stop", live).returncode == 0
+
+        extracted = tmp_path / "extracted"
+        extracted.mkdir()
+        assert _docker("create", "--name", helper, "-v", f"{vol}:/vault/data",
+                       "alpine:3.20", "true").returncode == 0
+        assert _docker("cp", f"{helper}:/vault/data/.", str(extracted)).returncode == 0
+
+        backup = run(BACKUP, "--data-dir", str(extracted), "--dest", str(artifacts))
+        assert backup.returncode == 0, backup.stdout + backup.stderr
+        artifact = next(artifacts.glob("*.tar.gz"))
+        assert "INCONSISTENT" not in artifact.name
+
+        # Destroy everything. The artifact is now the only copy.
+        assert _docker("rm", "-f", live).returncode == 0
+        assert _docker("rm", "-f", helper).returncode == 0
+        assert _docker("volume", "rm", vol).returncode == 0
+
+        target = tmp_path / "restored-data"
+        rest = run(RESTORE, "--artifact", str(artifact), "--data-dir", str(target),
+                   "--no-verify")
+        assert rest.returncode == 0, rest.stdout + rest.stderr
+
+        prepare_volume(vol2)
+        assert _docker("create", "--name", restored, "--cap-add=IPC_LOCK",
+                       "-e", f"VAULT_LOCAL_CONFIG={VAULT_CONFIG}",
+                       "-v", f"{vol2}:/vault/data",
+                       VAULT_IMAGE, "server").returncode == 0
+        assert _docker("cp", f"{target}/.", f"{restored}:/vault/data/").returncode == 0
+        # docker cp lands files as root; the vault image runs as uid 100.
+        assert _docker("run", "--rm", "-v", f"{vol2}:/vault/data", "alpine:3.20",
+                       "chown", "-R", "100:1000", "/vault/data").returncode == 0
+        assert _docker("start", restored).returncode == 0
+        assert _wait_listening(restored), "restored Vault never started listening"
+
+        assert _vault(restored, "operator", "unseal", unseal_key).returncode == 0, (
+            "§V.28: restored Vault would not unseal"
+        )
+        read = _vault(restored, "kv", "get", "-field=proof", MARKER_PATH,
+                      token=root_token)
+        assert read.returncode == 0, read.stderr
+        assert read.stdout.strip() == MARKER_VALUE, "seeded secret did not survive"
+    finally:
+        cleanup()

--- a/tests/k3s-upgrade/test_vault_backup.py
+++ b/tests/k3s-upgrade/test_vault_backup.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import requires_docker
+from conftest import requires_docker, sha256_check
 
 REPO = Path(__file__).resolve().parents[2]
 BACKUP = REPO / "scripts" / "vault-backup.sh"
@@ -111,7 +111,7 @@ def test_vault_backup_writes_verifiable_checksum(tmp_path):
     artifact = next(dest.glob("*.tar.gz"))
     checksum = Path(str(artifact) + ".sha256")
     assert checksum.exists(), "no integrity manifest"
-    verify = subprocess.run(["shasum", "-a", "256", "-c", checksum.name],
+    verify = subprocess.run(sha256_check(checksum.name),
                             cwd=dest, capture_output=True, text=True)
     assert verify.returncode == 0, verify.stdout + verify.stderr
 


### PR DESCRIPTION
Twelve commits building the groundwork for the k3s `1.33.5 → 1.36` walk, plus one fix that is unrelated to the upgrade and matters more than it.

## Read this part first

**10 of 21 PVCs were sitting in Argo's prune scope.** Every Application runs `prune: true`, `local-path` is the only StorageClass and it reclaims `Delete`. A manifest rename, a failed Helm render, or a chart bump that stopped emitting a claim would have deleted the volume and its data together, silently. That included `postgresql`, `ollama`, `n8n` and `grafana`.

This was a standing production risk, not something the upgrade introduced. It is worth merging whether or not the cluster ever reaches 1.36.

**One behaviour change to review deliberately:** `base-apps/atlantis.yaml` moves to `prune: false`. Chart 6.1.0 renders `atlantis-data` as a standalone PVC but its `volumeClaim` values expose only `enabled/dataStorage/storageClassName/accessModes`, so there is nowhere to hang a `Prune=false` annotation. Disabling prune on the Application was the available lever. Trade-off: resources removed from that chart will linger rather than be cleaned up.

## What lands on the cluster

Argo only watches `base-apps/`, so the cluster sees 10 manifest changes: nine annotation-only (inert — no pod restarts), plus the atlantis change above. `SPEC.md`, `scripts/` and `tests/` do not touch the cluster.

## What else is here

**Phase 0 safety net (T1–T4).** `k3s-backup.sh` / `k3s-restore.sh` with a drill that boots real k3s in Docker, seeds state, backs up *while running*, destroys the cluster and its volume, restores, and requires the data back. Same for `pg-backup.sh` and `vault-backup.sh`. The drills are the deliverable — asserting a script exited 0 would not have caught anything.

**Vault had no backup at all.** `vault-0` runs `file` storage on a 1Gi volume pinned to the node every control-plane hop restarts, holding the credentials all 45 namespaces resolve through. Now backed up, restore-proven, and a real artifact taken (21 seconds of downtime, ExternalSecrets returned to baseline).

**`SPEC.md`** — the plan itself: 41 invariants, 40 tasks, 7 sourced research rows, 3 recorded bugs, after four adversarial review rounds.

## Bugs the drills caught

- **B1** — the k3s online backup excluded `state.db` but not `state.db-wal`/`-shm`. kine runs SQLite in WAL mode, so the artifact would have carried a live write-ahead log beside a standalone snapshot and SQLite would have replayed a foreign log over it on restore. Silent corruption, checksum passing.
- **B2** — Vault cold backup scaled the StatefulSet to 0, but `replicas: 1` is in git with `selfHeal: true`. Argo would have rescaled Vault mid-copy and the script would have branded the torn result consistent.
- **B3** — the backup helper pod had no toleration for the control-plane taint, so it could never schedule. The abort path restored Vault and Argo cleanly; no outage.

## Verification

195 tests pass. New CI job `k3s-upgrade-scripts` runs the containerised drills on every PR. yamllint clean on all changed manifests (pinned to CI's 1.35.1).

## Not included

The upgrade itself. 33 tasks remain — the relocations (T36/T37), component remediation including a four-stage ESO migration across 59 manifests, and the three k3s hops. Those are gated and specced, not started.