### PR TITLE
T36 step 1: pin vault-0 to k3s-worker-01 (merge at the start of the migration window)

### DIFF
--- a/base-apps/openclaw-qwen/docs.md
+++ b/base-apps/openclaw-qwen/docs.md
@@ -51,3 +51,4 @@ kubectl -n openclaw-qwen exec deploy/openclaw-qwen -- \
 - The model reasons (`reasoning_content`) before answering; OpenClaw handles this, and it's fast on the GPU.
 - To switch models, edit the `openai` provider `baseUrl`/`models[].id` and `agents.defaults.model.primary` here.
 - Earlier history: this app previously pointed at the in-cluster CPU `Qwen3.5-0.8B` (`base-apps/qwen`), which worked but was too slow (~8 min/turn) for interactive use.
+- If a turn errors mid-way (e.g. a timeout), the session can get a dangling message → `Cannot continue from message role: assistant`. Start fresh with `/reset` (or `/new`) in the TUI.

--- a/base-apps/vault/statefulsets.yaml
+++ b/base-apps/vault/statefulsets.yaml
@@ -31,11 +31,23 @@ spec:
         component: server
         helm.sh/chart: vault-0.29.1
     spec:
+      # Pinned to k3s-worker-01, off the control plane (SPEC.md §T.27, §T.36).
+      #
+      # This previously selected `node.kubernetes.io/workload: infrastructure`, a label
+      # only k3s-control-01 carries — so Vault ran on the single control-plane node,
+      # alongside postgresql-cluster-1, on a local-path volume hard-pinned there. Every
+      # control-plane upgrade hop therefore took out the API, every secret in the cluster,
+      # and both application databases together, and neither workload could reschedule.
+      #
+      # Pinned by hostname rather than `workload: application` on purpose: local-path
+      # volumes are node-bound, so a selector matching both workers would only pretend
+      # this is schedulable. worker-01 is the target for its disk headroom.
+      #
+      # The control-plane toleration is gone — worker-01 carries no taints, and keeping it
+      # would imply Vault may still land on the control plane, which is the arrangement
+      # this change exists to end.
       nodeSelector:
-        node.kubernetes.io/workload: infrastructure
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        effect: NoSchedule
+        kubernetes.io/hostname: k3s-worker-01
       containers:
         - args:
             - |
@@ -169,7 +181,7 @@ spec:
   - metadata:
       name: vault-data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
+      accessModes: ["ReadWriteOnce"]
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
Step 1 of T36 (relocating Vault off the control plane). **Do not merge this and walk away** — see the timing note below.

## What it changes

Vault's `nodeSelector` moves from `node.kubernetes.io/workload: infrastructure` to `kubernetes.io/hostname: k3s-worker-01`, and the control-plane toleration is dropped.

That `infrastructure` label is carried by exactly one node, `k3s-control-01`. It is why Vault has been running on the single control-plane node all along, on a local-path volume hard-pinned there, next to `postgresql-cluster-1`.

## Timing — this must be merged at the *start* of the T36 window

The StatefulSet uses `updateStrategy: OnDelete`, so syncing this change does **not** move the pod. Vault keeps running on `k3s-control-01` until the pod is deleted.

That is the safe behaviour, but it opens a window: from the moment Argo syncs this until T36 completes, any unplanned restart of `vault-0` (node reboot, eviction, OOM) will try to schedule it on `k3s-worker-01`, where it cannot bind the control-plane-pinned PVC. The pod would sit `Pending` and Vault would stay down until T36 is finished or this is reverted.

Existing Kubernetes Secrets survive that — ESO materialises them and `refreshInterval` is 1h — so apps keep working; only secret *refreshes* stall. Still: merge this when you are ready to run T36 immediately after, not days ahead.

## Why hostname rather than `workload: application`

`application` matches both workers. local-path volumes are node-bound, so a selector suggesting Vault could live on either would be fiction. worker-01 is chosen for headroom: 114GB free versus 8.8GB on worker-02.

## What follows

Per §V.40, the rest of T36 is: suspend the Argo app → back up (`scripts/vault-backup.sh`, drill-proven) → scale to 0 → delete the PVC → helper pod with the nodeSelector and §V.34 toleration provisions the new volume and receives the restore → delete helper → scale to 1, where the StatefulSet adopts `vault-data-vault-0` → prove unseal and a real secret read → resume Argo.

The PVC spec is unchanged here (`vault-data-vault-0`, 1Gi, `ReadWriteOnce`), so adoption works.

## Note for T37

`base-apps/postgresql/cnpg-cluster.yaml` uses the same `workload: infrastructure` selector — that is why `postgresql-cluster-1` is also on the control plane. T37 needs the equivalent change, though CNPG gets there by scale-to-2 and switchover rather than by deleting a volume.

## Verification

yamllint clean (CI-pinned 1.35.1). No test changes — this is a placement change whose effect is only observable during T36 itself.