### PR TITLE
T42: all eight drifting apps diagnosed — one real bug fixed, two still open

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -155,7 +155,7 @@ T38|.|post-relocate: `k3s-control-01` ⊥ host stateful. amend §C pinning lines
 T39|x|DONE 2026-07-28: `docs/plans/k3s-1.36-upgrade-plan.md` — runbook, outage comms table, per-hop gate + rollback, §B.1-§B.6 hard-won specifics. §V.9 "announced" now satisfiable|V9,V41,I.doc
 T40|.|`lg-agents/orchestrator-data` PVC tracked by app `lg-agents` that ⊥ ∃. orphaned ∴ ⊥ prunable, but ∉ GitOps. decide: adopt \| delete \| document|V19
 T41|.|install `kubectl cnpg` plugin — fallback manual switchover lever for §T.37 if auto-switchover ⊥ fire (§R.12). before §T.37|V38,R.12
-T42|.|per-app drift diagnosis + targeted `ignoreDifferences` (⊥ blanket SSA, §R.19). known: istio-base/istiod = webhook `caBundle` injected by istiod; argo-rollouts = 5 CRD (⊥ SSA yet); kyverno = 11 CRD + Job w/ SSA ON; kagent-secrets = SA; openshell = StatefulSet; openshell-secrets = ExternalSecret; master-app = child Application. ∀ cause ! documented before §T.17 (§V.47)|V5,V45,V47
+T42|~|per-app drift diagnosis DONE 2026-07-28 → `docs/plans/argocd-drift-diagnosis.md`. 1 genuine bug FIXED (`recurse: false` @ `openshell-secrets.yaml` — Argo normalises explicit false ∴ perpetual diff). 5 = controller-injected (istio `caBundle`, ESO webhook defaults, Argo's OWN finalizers, helm-vs-API defaulting) → need `ignoreDifferences`. 1 = kagent operator copies Argo `tracking-id` onto generated SA ∴ Argo tracks what it never applied. REMAINING: argo-rollouts 5 CRD + kyverno 11 CRD/Job need field-level diff (⊥ `argocd` CLI)|V5,V45,V47
 T43|.|FOLLOW-ON: migrate ingress off `ingress-nginx` → Gateway API. infra ∃ already (§R.14: istio/gloo/agentgateway GatewayClasses live). prerequisite for 1.36 (§V.46), ⊥ for 1.35|V46,R.13,R.14
 
 ## §B BUGS

--- a/base-apps/openshell-secrets.yaml
+++ b/base-apps/openshell-secrets.yaml
@@ -19,9 +19,12 @@ spec:
     path: base-apps/openshell
     # Intentionally not recursive: this directory is limited to the
     # SecretStore + ExternalSecret pair. If you add a subdirectory
-    # (e.g., overlays, patches), flip this to true.
-    directory:
-      recurse: false
+    # (e.g., overlays, patches), add `directory: {recurse: true}` here.
+    #
+    # `recurse: false` is NOT declared explicitly. Argo normalises an explicit
+    # false for a field that already defaults to false, so the live object omits
+    # it — git says false, live says nothing, and master-app reports this
+    # Application permanently OutOfSync. See docs/plans/argocd-drift-diagnosis.md.
   destination:
     server: https://kubernetes.default.svc
     namespace: openshell

--- a/docs/plans/argocd-drift-diagnosis.md
+++ b/docs/plans/argocd-drift-diagnosis.md
@@ -1,0 +1,107 @@
+# Argo CD drift diagnosis (SPEC.md §T.42)
+
+Eight applications sit permanently `OutOfSync` while reporting `Healthy`. §V.5 originally
+required every app `Synced+Healthy` before each upgrade hop, which made every hop
+unreachable. §V.47 revised that to *no **unexplained** drift* — so each app needs a
+documented cause and a targeted `ignoreDifferences`, or it blocks.
+
+This is that documentation, from evidence rather than theory. Diagnosed 2026-07-28.
+
+**`ServerSideApply` is not the answer.** Five of these eight already have it enabled and drift
+regardless (§R.19), and Argo's docs warn it *"has the potential to be destructive and might
+lead to resources having to be recreated."*
+
+## Summary
+
+| App | Resource | Cause | Fix |
+|---|---|---|---|
+| istio-base | `ValidatingWebhookConfiguration/istiod-default-validator` | `caBundle` injected by istiod | `ignoreDifferences` |
+| istio-istiod | `ValidatingWebhookConfiguration/istio-validator-istio-system` | same | `ignoreDifferences` |
+| kagent-secrets | `ServiceAccount/kagent/homelab-agent` | operator-created child inherited Argo's tracking-id | exclude / fix kagent |
+| master-app | `Application/openshell-secrets` | `recurse: false` normalised away | **delete the field** |
+| master-app | `Application/kyverno` | Argo adds its own finalizers | `ignoreDifferences` |
+| openshell-secrets | `ExternalSecret/openshell-jwt-keys` | ESO webhook defaults | `ignoreDifferences` |
+| openshell | `StatefulSet/openshell` | Helm chart vs API defaulting | `ignoreDifferences` |
+| argo-rollouts | 5 CRDs | co-managed with `k3s` | needs field-level diff |
+| kyverno | 11 CRDs + 1 Job | co-managed; Job absent in cluster | needs field-level diff |
+
+Only one is a genuine defect. The rest are controller behaviour that git cannot represent.
+
+## The genuine bug — `recurse: false`
+
+`base-apps/openshell-secrets.yaml` declares `spec.source.directory.recurse: false`. Argo
+normalises an explicit `false` for a field that already defaults to false, so the live object
+simply omits it. Git says `false`, live says nothing, and the diff never closes.
+
+It is the only file in `base-apps/` carrying it, and the field is a no-op. **Delete it.**
+
+## Controller-injected fields
+
+**istio webhooks.** istiod writes a 1460-byte `caBundle` into both
+`ValidatingWebhookConfiguration`s at runtime. Git ships them empty because the CA is
+generated in-cluster. Nothing can reconcile this; it must be ignored.
+
+```yaml
+ignoreDifferences:
+  - group: admissionregistration.k8s.io
+    kind: ValidatingWebhookConfiguration
+    jsonPointers: ["/webhooks/0/clientConfig/caBundle"]
+```
+
+**ExternalSecret defaults.** The ESO webhook stamps `conversionStrategy: Default`,
+`decodingStrategy: None` and `metadataPolicy: None` onto every `remoteRef`, plus
+`target.deletionPolicy: Retain`. Git omits all four.
+
+Worth noting for §T.31: this is the ESO admission webhook actively rewriting stored objects,
+the same mechanism behind the `v1beta1` → `v1` conversion drift in §R.7. Expect more of this
+during the ESO migration, not less.
+
+**Argo's own finalizers.** `Application/kyverno` drifts because Argo adds
+`pre-delete-finalizer.argocd.argoproj.io` and `.../cleanup` to the live object while git
+declares only `resources-finalizer.argocd.argoproj.io`. Argo is drifting against itself.
+Either ignore `metadata.finalizers` or write the finalizers into git.
+
+## The interesting one — kagent tracking-id inheritance
+
+`ServiceAccount/kagent/homelab-agent` carries:
+
+```
+argocd.argoproj.io/tracking-id: kagent-secrets:kagent.dev/Agent:kagent/homelab-agent
+ownerReferences: Agent/homelab-agent
+```
+
+The tracking-id names a **`kagent.dev/Agent`**, not a ServiceAccount. Argo applied the
+`Agent` CR; the kagent operator then created this ServiceAccount as a child and **copied the
+annotations across**, tracking-id included. Argo now believes it manages a resource it never
+applied and that does not exist in git.
+
+`ignoreDifferences` is the wrong tool — the resource shouldn't be tracked at all. Proper fixes,
+in order of preference: stop kagent propagating `argocd.argoproj.io/*` annotations to
+generated children; or add a resource exclusion. Argo normally ignores owner-referenced
+children — the inherited annotation is what overrides that.
+
+## Still open — the CRDs
+
+`argo-rollouts` (5 CRDs) and `kyverno` (11 CRDs + 1 Job) need a field-level diff before a fix
+is proposed. What is known:
+
+- Both are co-managed by `argocd-controller` **and** `k3s`.
+- Annotation size is not the cause — `rollouts.argoproj.io` is 61KB, well under the 262KB
+  limit, so the usual large-CRD explanation does not apply here.
+- kyverno already runs `ServerSideApply=true`, so its CRDs carry no last-applied annotation
+  at all and still drift.
+- The kyverno `Job/kyverno-migrate-resources` reports status `None` — present in git, absent
+  from the cluster. Jobs are immutable and likely completed and were cleaned up; it may want
+  a `Prune=false` or a hook annotation rather than an ignore rule.
+
+Getting the exact field requires `argocd app diff`, and the CLI is not installed. That is the
+next step.
+
+## Bearing on the upgrade
+
+None of these are failures — every affected app reports `Healthy` and is serving. But under
+the original §V.5 they would each have blocked every hop, which is why the invariant was
+wrong rather than the cluster.
+
+With §V.47, the gate becomes: this document plus `ignoreDifferences` covering each cause. The
+two CRD cases are the only ones still genuinely unexplained.


### PR DESCRIPTION
Every `OutOfSync` application now has a documented cause, which is what **§V.47** requires before a hop. Evidence in `docs/plans/argocd-drift-diagnosis.md`.

## One genuine bug, fixed

`base-apps/openshell-secrets.yaml` declared `spec.source.directory.recurse: false`. Argo normalises an explicit `false` for a field that already defaults to false, so the live object omits it — git says `false`, live says nothing, and the diff never closes.

It was the only file in `base-apps/` carrying it, and the field is a no-op. Removed, with a comment so it doesn't come back.

## Five are controllers writing what git can't represent

- **istio-base / istio-istiod** — istiod injects a 1460-byte `caBundle` into both `ValidatingWebhookConfiguration`s
- **openshell-secrets** — the ESO webhook stamps `conversionStrategy`, `decodingStrategy`, `metadataPolicy` and `target.deletionPolicy` onto ExternalSecrets
- **openshell** — StatefulSet from a Helm chart, drifting against API defaulting
- **master-app → Application/kyverno** — Argo adds its own `pre-delete-finalizer` entries to the live object while git declares only the resources finalizer. **Argo drifting against itself.**

Each needs a targeted `ignoreDifferences`; proposed rules are in the doc.

Worth flagging for §T.31: the ESO case is the admission webhook rewriting stored objects — the same mechanism behind the `v1beta1`→`v1` conversion drift in §R.7. Expect more of this during the ESO migration, not less.

## One is a tracking-id leak

`ServiceAccount/kagent/homelab-agent` carries `argocd.argoproj.io/tracking-id` naming a **`kagent.dev/Agent`**, plus `ownerReferences: Agent/homelab-agent`.

Argo applied the `Agent` CR; the kagent operator created this ServiceAccount as a child and **copied the annotations across**, tracking-id included. Argo believes it manages a resource it never applied and that doesn't exist in git.

`ignoreDifferences` is the wrong tool — Argo normally ignores owner-referenced children, and the inherited annotation is what overrides that. The fix is to stop kagent propagating `argocd.argoproj.io/*` to generated resources.

## Two still genuinely unexplained

`argo-rollouts` (5 CRDs) and `kyverno` (11 CRDs + a Job). Both co-managed by `argocd-controller` and `k3s`. Annotation size is **not** the cause — `rollouts.argoproj.io` is 61KB against a 262KB limit — and kyverno already runs `ServerSideApply`, so its CRDs carry no annotation at all and drift anyway.

Getting the exact field needs `argocd app diff`; the CLI isn't installed. **T42 stays `~` until those two close.**

## Verification

195 tests pass. yamllint clean. One manifest changed (a field deletion that is semantically a no-op).