### PR TITLE
T42: ignoreDifferences for the three apps with confirmed causes

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -19,6 +19,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: istio-system
+  # istiod injects a ~1460-byte caBundle into this webhook at runtime; the chart
+  # ships it empty because the CA is generated in-cluster. Nothing can reconcile
+  # that, so the app sat permanently OutOfSync (SPEC.md §V.47, and
+  # docs/plans/argocd-drift-diagnosis.md for the evidence).
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: istiod-default-validator
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
   syncPolicy:
     automated:
       prune: true

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -34,6 +34,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: istio-system
+  # istiod injects a ~1460-byte caBundle into this webhook at runtime; the chart
+  # ships it empty because the CA is generated in-cluster. Nothing can reconcile
+  # that, so the app sat permanently OutOfSync (SPEC.md §V.47, and
+  # docs/plans/argocd-drift-diagnosis.md for the evidence).
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: istio-validator-istio-system
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
   syncPolicy:
     automated:
       prune: true

--- a/base-apps/openshell-secrets.yaml
+++ b/base-apps/openshell-secrets.yaml
@@ -28,6 +28,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: openshell
+  # The External Secrets admission webhook stamps defaults onto every remoteRef
+  # (conversionStrategy, decodingStrategy, metadataPolicy) and sets
+  # target.deletionPolicy. None of them are in git, so this app sat permanently
+  # OutOfSync (SPEC.md §V.47, docs/plans/argocd-drift-diagnosis.md).
+  #
+  # Note for §T.31: this is the same ESO webhook that will rewrite v1beta1 objects
+  # to v1 during the migration. Expect more of this then, not less.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
+        - .spec.target.deletionPolicy
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Each rule targets a specific field a controller writes that git cannot represent, per `docs/plans/argocd-drift-diagnosis.md`. §V.47 requires exactly this — a documented cause plus a rule covering it — rather than apps sitting `OutOfSync` forever and blocking every hop.

## The three

**istio-base / istio-istiod** — istiod injects a ~1460-byte `caBundle` into each `ValidatingWebhookConfiguration` at runtime. The chart ships it empty because the CA is generated in-cluster. Rules are scoped **by webhook name**, so they can't silently swallow drift on some other webhook.

**openshell-secrets** — the ESO admission webhook stamps `conversionStrategy`, `decodingStrategy` and `metadataPolicy` onto every `remoteRef`, and sets `target.deletionPolicy`. Four jq expressions, each naming one defaulted field, rather than ignoring the whole spec.

`jqPathExpressions` rather than `jsonPointers` throughout — the array-index form breaks the moment a webhook or data entry is reordered, and then silently ignores the *wrong* field instead of failing.

## Deliberately not included

**kagent-secrets** needs a different fix. The operator copies Argo's `tracking-id` onto a ServiceAccount it generates, so Argo tracks a resource it never applied and that isn't in git. Ignoring fields would paper over that rather than fix it.

**argo-rollouts** and **kyverno** CRDs remain unexplained — annotation size isn't the cause and kyverno already runs SSA. Closing them needs `argocd app diff`.

## Verification

195 tests pass, yamllint clean, Application schema validated. Expect `istio-base`, `istio-istiod` and `openshell-secrets` to go `Synced` after this lands — I'll confirm and report rather than assume, given §B.6.