### PR TITLE
T42: istio webhook rules cover all eight differing fields, not one

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -28,7 +28,18 @@ spec:
       kind: ValidatingWebhookConfiguration
       name: istiod-default-validator
       jqPathExpressions:
+        # istiod writes these two at runtime. caBundle is the in-cluster CA the
+        # chart cannot know; failurePolicy is flipped Ignore -> Fail once istiod
+        # is ready, so Argo can never win this one.
         - .webhooks[].clientConfig.caBundle
+        - .webhooks[].failurePolicy
+        # The remainder are API-server defaults absent from the rendered chart.
+        - .webhooks[].clientConfig.service.port
+        - .webhooks[].matchPolicy
+        - .webhooks[].namespaceSelector
+        - .webhooks[].objectSelector
+        - .webhooks[].timeoutSeconds
+        - .webhooks[].rules[].scope
   syncPolicy:
     automated:
       prune: true

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -43,7 +43,18 @@ spec:
       kind: ValidatingWebhookConfiguration
       name: istio-validator-istio-system
       jqPathExpressions:
+        # istiod writes these two at runtime. caBundle is the in-cluster CA the
+        # chart cannot know; failurePolicy is flipped Ignore -> Fail once istiod
+        # is ready, so Argo can never win this one.
         - .webhooks[].clientConfig.caBundle
+        - .webhooks[].failurePolicy
+        # The remainder are API-server defaults absent from the rendered chart.
+        - .webhooks[].clientConfig.service.port
+        - .webhooks[].matchPolicy
+        - .webhooks[].namespaceSelector
+        - .webhooks[].objectSelector
+        - .webhooks[].timeoutSeconds
+        - .webhooks[].rules[].scope
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
My first rule ignored only `caBundle` and the apps stayed `OutOfSync`. I'd diagnosed by *observing* a caBundle in the cluster rather than diffing against what the chart renders — the same shortcut that caused §B.5.

Rendering `base-1.24.0` with helm and comparing shows **eight** differences:

| Field | Chart | Live | Source |
|---|---|---|---|
| `caBundle` | empty | set | istiod injects the in-cluster CA |
| `failurePolicy` | `Ignore` | `Fail` | istiod flips it once ready |
| `clientConfig.service.port` | — | `443` | API default |
| `matchPolicy` | — | `Equivalent` | API default |
| `namespaceSelector` | — | `{}` | API default |
| `objectSelector` | — | `{}` | API default |
| `rules[].scope` | — | `*` | API default |
| `timeoutSeconds` | — | `10` | API default |

Two are istiod writing at runtime; six are API-server defaults absent from the rendered chart. Argo can never win any of them.

## One cost worth naming

`failurePolicy` is security-relevant — ignoring it means a chart-side change to that field would no longer be reconciled. That's a genuine tradeoff, accepted because istiod actively owns the field and the alternative is an app that blocks every upgrade hop. It's called out in the manifest comment so the next reader sees it.

Listed field by field rather than ignoring the `webhooks` array wholesale, so genuine drift on anything else still surfaces.

## Verification

195 tests pass, yamllint clean, syncPolicy asserted intact on both. I'll confirm both apps reach `Synced` after merge rather than assume it — that's what caught this one.