### PR TITLE
T42: openshell StatefulSet — 13 confirmed API defaults, one deliberate unknown

### DIFF
--- a/base-apps/openshell.yaml
+++ b/base-apps/openshell.yaml
@@ -102,6 +102,34 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: openshell
+  # The chart omits fields the API server then defaults, and StatefulSet spec is
+  # largely immutable, so Argo can never reconcile them and the app sat permanently
+  # OutOfSync. Evidence: rendering helm-chart 0.0.49 and diffing against live gave
+  # 14 differing paths; the 13 below are all API defaults.
+  # See docs/plans/argocd-drift-diagnosis.md (SPEC.md §V.47).
+  #
+  # NOT included: template.metadata.annotations."checksum/gateway-config". That one
+  # may be a real difference or an artifact of a local helm version rendering
+  # differently from Argo's bundled one — it needs `argocd app diff` to settle.
+  # If this app is still OutOfSync after these rules, the checksum is the cause.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: openshell
+      jqPathExpressions:
+        - .spec.podManagementPolicy
+        - .spec.revisionHistoryLimit
+        - .spec.updateStrategy
+        - .spec.persistentVolumeClaimRetentionPolicy
+        - .spec.volumeClaimTemplates
+        - .spec.template.spec.dnsPolicy
+        - .spec.template.spec.restartPolicy
+        - .spec.template.spec.schedulerName
+        - .spec.template.spec.serviceAccount
+        - .spec.template.spec.volumes[].configMap.defaultMode
+        - .spec.template.spec.volumes[].secret.defaultMode
+        - .spec.template.spec.containers[].terminationMessagePath
+        - .spec.template.spec.containers[].terminationMessagePolicy
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Rendering `helm-chart` 0.0.49 and diffing against live gives **14** differing spec paths.

**Thirteen** are fields the chart omits and the API server defaults: `podManagementPolicy`, `revisionHistoryLimit`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`, `dnsPolicy`, `restartPolicy`, `schedulerName`, `serviceAccount`, volume `defaultMode`s, container `terminationMessage*`, and the `apiVersion`/`kind`/`status` the API adds to `volumeClaimTemplates`. StatefulSet spec is largely immutable, so Argo can never reconcile any of them.

## The fourteenth is deliberately left alone

`template.metadata.annotations."checksum/gateway-config"` differs between my render and live.

I haven't ignored it, because I can't tell what it means. The ConfigMap it checksums reports `Synced`, and the app's last sync **succeeded** — so either it's a real pending change, or my local helm renders differently from Argo's bundled version. Guessing is what produced §B.5 and the first istio rule, which ignored one field out of eight.

**So this is a test with a stated prediction:**

- If `openshell` reaches `Synced` → the checksum was an artifact of my tooling
- If it stays `OutOfSync` → the checksum is the real cause and needs `argocd app diff`

Either outcome is informative, and the manifest comment records it for whoever reads this next.

## Verification

195 tests pass, yamllint clean, syncPolicy asserted intact. I'll report which way it went rather than assume.