### PR TITLE
T42: CRD conversion defaults — the last two drift cases explained

### DIFF
--- a/base-apps/argo-rollouts.yaml
+++ b/base-apps/argo-rollouts.yaml
@@ -31,6 +31,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: argo-rollouts
+  # The API server rewrites every CRD the chart ships, so Argo can never converge:
+  #   preserveUnknownFields  chart sets false; the API strips it (v1beta1 field,
+  #                          removed in apiextensions.k8s.io/v1)
+  #   conversion             chart omits it; the API defaults {strategy: None}
+  # Verified against all five CRDs by rendering argo-rollouts 2.40.5 and diffing.
+  # See docs/plans/argocd-drift-diagnosis.md (SPEC.md §V.47).
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.preserveUnknownFields
+        - .spec.conversion
   syncPolicy:
     automated:
       prune: true

--- a/base-apps/kyverno.yaml
+++ b/base-apps/kyverno.yaml
@@ -61,6 +61,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kyverno
+  # The API server defaults spec.conversion to {strategy: None} on every CRD the
+  # chart ships, which the chart itself omits — Argo can never converge on it.
+  # Verified across all 11 drifting CRDs against kyverno 3.7.1.
+  #
+  # Note: preserveUnknownFields is NOT listed. Unlike argo-rollouts, this chart
+  # does not set it, so there is nothing to ignore. Only evidenced fields here.
+  # See docs/plans/argocd-drift-diagnosis.md (SPEC.md §V.47).
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.conversion
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Both apps drift because the API server rewrites every CRD their charts ship. Neither had anything to do with `ServerSideApply` or annotation size, which is what I originally assumed.

**argo-rollouts** — verified across all 5 CRDs against chart 2.40.5:

| Field | Chart | Live |
|---|---|---|
| `preserveUnknownFields` | `false` | **absent** — v1beta1 field, doesn't exist in `apiextensions.k8s.io/v1` |
| `conversion` | **absent** | `{strategy: None}` — API default |

**kyverno** — verified across all 11 drifting CRDs against chart 3.7.1: `conversion` only.

kyverno deliberately gets *only* the conversion rule. Its chart doesn't set `preserveUnknownFields`, so there's nothing to ignore and adding it would be a rule with no evidence behind it. That distinction is the entire reason the first istio attempt failed — it ignored one field out of eight because I'd observed rather than diffed.

## The Job isn't drift

`kyverno-migrate-resources` is a Helm `post-upgrade` hook. It completed 124 days ago and still exists; Argo lists hook resources with status `None` by design.

## Method

Render the exact chart and version Argo renders, diff against live, and **distinguish absent from null explicitly**. That last part matters more than it sounds — a naive comparison reports `chart='None' live='None'` for a field that's present in one and missing in the other, which is how I nearly wrote the wrong rule again.

## Verification

195 tests pass, yamllint clean, syncPolicy asserted intact. Expect both to reach `Synced`; I'll confirm rather than assume.