### PR TITLE
T42: kyverno drift is an empty labels map — and my diff script was lying

### DIFF
--- a/base-apps/kyverno.yaml
+++ b/base-apps/kyverno.yaml
@@ -73,6 +73,12 @@ spec:
       kind: CustomResourceDefinition
       jqPathExpressions:
         - .spec.conversion
+        # The real cause, per `argocd app diff`: kyverno 3.7.1 renders
+        # `metadata.labels: {}` on exactly 11 of its 22 CRDs — an empty map the
+        # API server drops, so Argo diffs {} against absent forever. Those 11 are
+        # precisely the CRDs that were OutOfSync. An upstream chart bug; nothing
+        # here can reconcile it.
+        - .metadata.labels
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Three rounds of inference failed to explain kyverno, so I ran `argocd app diff` via the CLI in `--core` mode. The answer, identical on all eleven CRDs:

```
metadata.labels: {}
```

kyverno 3.7.1 renders an **empty labels map** on exactly 11 of its 22 CRDs. The API server drops empty maps, so Argo compares `{}` against absent forever. Those 11 are precisely the CRDs that were `OutOfSync` — and argo-rollouts, whose chart gives its CRDs real labels, went `Synced` with no such rule. It's an upstream chart bug.

## I reported the wrong cause earlier

I told you `conversion` was the only differing path across all eleven. That was wrong, and it was wrong **because of a bug in my own diff script** — it normalised "absent" to `{}` before comparing, so `{}` versus absent compared equal and the real difference was invisible.

The tool I wrote to stop myself guessing was itself guessing.

## Method note

Rendering charts and diffing by hand got four of five cases right and silently mangled the fifth. `argocd app diff --core` needs only a kubeconfig with the context namespace pointed at the Argo install namespace, runs fine in Docker with no install, and would have answered this in one step. Worth reaching for first next time.

I've kept the `.spec.conversion` expression. Argo's diff no longer shows it, and I can't distinguish "my rule is working" from "Argo normalises it" — but it's a genuine API default either way.

## Verification

195 tests pass, yamllint clean, syncPolicy intact. Expect kyverno to reach `Synced`; I'll confirm.