### PR TITLE
T13-T16: system-upgrade-controller rig, wired as a no-op dry run

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -48,6 +48,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | openshell |  |  |  |  |  |
 | postgresql | Shared PostgreSQL + pgvector instance (root DB, kagent DB) + CNPG cluster for chores-tracker (daily S3 backups) | postgresql | [docs.md](postgresql/docs.md) | [runbook.md](postgresql/runbook.md) | [catalog-info.yaml](postgresql/catalog-info.yaml) |
 | qwen | Self-hosted multimodal (text+vision) LLM server via llama.cpp, CPU-only, PVC-backed | qwen | [docs.md](qwen/docs.md) | [runbook.md](qwen/runbook.md) | [catalog-info.yaml](qwen/catalog-info.yaml) |
+| system-upgrade-controller |  |  |  |  |  |
 | vault | In-cluster secret backend (KV v2) | vault | [docs.md](vault/docs.md) | [runbook.md](vault/runbook.md) | [catalog-info.yaml](vault/catalog-info.yaml) |
 | vcluster-sandbox-1 |  |  |  |  |  |
 | weather-kitchen-backend | Backend API for Weather Kitchen (likely FastAPI, JWT, Vault-backed DB) | weather-kitchen | [docs.md](weather-kitchen-backend/docs.md) | [runbook.md](weather-kitchen-backend/runbook.md) | [catalog-info.yaml](weather-kitchen-backend/catalog-info.yaml) |

--- a/base-apps/system-upgrade-controller.yaml
+++ b/base-apps/system-upgrade-controller.yaml
@@ -1,0 +1,44 @@
+# system-upgrade-controller — drives the k3s WORKER hops (SPEC.md §T.13).
+#
+# Gated on §T.27's relocation completing (§V.29): Vault and postgresql-cluster both
+# moved to k3s-worker-01 first, so a node hop no longer takes secrets and databases
+# with it.
+#
+# Scope is agents only (§V.17). The control-plane hop is manual — a single-server k3s
+# cannot safely be upgraded by a Job its own API server schedules.
+#
+# Sync waves: CRD (-2) must exist before the controller (-1), and both before any Plan
+# (0), or the first sync fails on an unknown kind.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: system-upgrade-controller
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/system-upgrade-controller
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: system-upgrade
+  syncPolicy:
+    automated:
+      # prune is ON here. Unlike the apps carrying data volumes, everything in this
+      # directory is disposable controller machinery — no PVCs, nothing that
+      # reclaim=Delete could destroy (§V.19).
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  ignoreDifferences:
+    # The API server defaults spec.conversion to {strategy: None} on every CRD, and
+    # the upstream manifest omits it — the same permanent diff diagnosed on
+    # argo-rollouts and kyverno. See docs/plans/argocd-drift-diagnosis.md.
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.conversion

--- a/base-apps/system-upgrade-controller/controller.yaml
+++ b/base-apps/system-upgrade-controller/controller.yaml
@@ -1,0 +1,343 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - system-upgrade-controller
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - upgrade.cattle.io
+  resources:
+  - plans
+  - plans/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-drainer
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade-drainer
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-drainer
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: v1
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: 'false'
+  SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT: 'true'
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: '2'
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: '900'
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: '99'
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: Always
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: rancher/kubectl:v1.30.3
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE_WINDOWS: ''
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: 'true'
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: '900'
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: 15m
+kind: ConfigMap
+metadata:
+  name: default-controller-env
+  namespace: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+spec:
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: system-upgrade-controller
+        upgrade.cattle.io/controller: system-upgrade-controller
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - system-upgrade-controller
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - env:
+        - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['upgrade.cattle.io/controller']
+        - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SYSTEM_UPGRADE_CONTROLLER_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - configMapRef:
+            name: default-controller-env
+        image: rancher/system-upgrade-controller:v0.20.1
+        imagePullPolicy: IfNotPresent
+        name: system-upgrade-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/ssl
+          name: etc-ssl
+          readOnly: true
+        - mountPath: /etc/pki
+          name: etc-pki
+          readOnly: true
+        - mountPath: /etc/ca-certificates
+          name: etc-ca-certificates
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+      serviceAccountName: system-upgrade
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/controlplane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: node-role.kubernetes.io/etcd
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/ssl
+          type: DirectoryOrCreate
+        name: etc-ssl
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: etc-pki
+      - hostPath:
+          path: /etc/ca-certificates
+          type: DirectoryOrCreate
+        name: etc-ca-certificates
+      - emptyDir: {}
+        name: tmp

--- a/base-apps/system-upgrade-controller/crd.yaml
+++ b/base-apps/system-upgrade-controller/crd.yaml
@@ -1,0 +1,1695 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+    argocd.argoproj.io/sync-wave: '-2'
+  name: plans.upgrade.cattle.io
+spec:
+  group: upgrade.cattle.io
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.upgrade.image
+      name: Image
+      type: string
+    - jsonPath: .spec.channel
+      name: Channel
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Complete')].status
+      name: Complete
+      type: string
+    - jsonPath: .status.conditions[?(@.message!='')].message
+      name: Message
+      type: string
+    - jsonPath: .status.applying
+      name: Applying
+      priority: 10
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Plan represents a set of Jobs to apply an upgrade (or other operation)
+          to set of Nodes.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlanSpec represents the user-configurable details of a Plan.
+            properties:
+              channel:
+                description: A URL that returns HTTP 302 with the last path element
+                  of the value returned in the Location header assumed to be an image
+                  tag (after munging "+" to "-").
+                type: string
+              concurrency:
+                description: The maximum number of concurrent nodes to apply this
+                  update on.
+                format: int64
+                type: integer
+              cordon:
+                description: 'If Cordon is true, the node is cordoned before the upgrade
+                  container is run.
+
+                  If drain is specified, the value for cordon is ignored, and the
+                  node is cordoned.
+
+                  If neither drain nor cordon are specified and the node is marked
+                  as schedulable=false it will not be marked as schedulable=true when
+                  the Job completes.'
+                type: boolean
+              drain:
+                description: Configuration for draining nodes prior to upgrade. If
+                  left unspecified, no drain will be performed.
+                properties:
+                  deleteEmptydirData:
+                    type: boolean
+                  deleteLocalData:
+                    type: boolean
+                  disableEviction:
+                    type: boolean
+                  force:
+                    type: boolean
+                  gracePeriod:
+                    format: int32
+                    type: integer
+                  ignoreDaemonSets:
+                    type: boolean
+                  podSelector:
+                    description: 'A label selector is a label query over a set of
+                      resources. The result of matchLabels and
+
+                      matchExpressions are ANDed. An empty label selector matches
+                      all objects. A null
+
+                      label selector matches no objects.'
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: 'A label selector requirement is a selector
+                            that contains values, a key, and an operator that
+
+                            relates the key and values.'
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: 'operator represents a key''s relationship
+                                to a set of values.
+
+                                Valid operators are In, NotIn, Exists and DoesNotExist.'
+                              type: string
+                            values:
+                              description: 'values is an array of string values. If
+                                the operator is In or NotIn,
+
+                                the values array must be non-empty. If the operator
+                                is Exists or DoesNotExist,
+
+                                the values array must be empty. This array is replaced
+                                during a strategic
+
+                                merge patch.'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: 'matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels
+
+                          map is equivalent to an element of matchExpressions, whose
+                          key field is "key", the
+
+                          operator is "In", and the values array contains only "value".
+                          The requirements are ANDed.'
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  skipWaitForDeleteTimeout:
+                    type: integer
+                  timeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'If a string, this is passed through directly to
+                      the `kubectl drain` command.
+
+                      If an int, this represents the duration as a count of nanoseconds,
+                      and will be converted to a duration string when passed to the
+                      `kubectl drain` command.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              exclusive:
+                description: Jobs for exclusive plans cannot be run alongside any
+                  other exclusive plan.
+                type: boolean
+              imagePullSecrets:
+                description: Image Pull Secrets, used to pull images for the Job.
+                items:
+                  description: 'LocalObjectReference contains enough information to
+                    let you locate the
+
+                    referenced object inside the same namespace.'
+                  properties:
+                    name:
+                      default: ''
+                      description: 'Name of the referent.
+
+                        This field is effectively required, but due to backwards compatibility
+                        is
+
+                        allowed to be empty. Instances of this type with an empty
+                        value here are
+
+                        almost certainly wrong.
+
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobActiveDeadlineSecs:
+                description: 'Sets ActiveDeadlineSeconds on Jobs generated to apply
+                  this Plan.
+
+                  If the Job does not complete within this time, the Plan will stop
+                  processing until it is updated to trigger a redeploy.
+
+                  If set to 0, Jobs have no deadline. If not set, the controller default
+                  value is used.'
+                format: int64
+                type: integer
+              nodeSelector:
+                description: Select which nodes this plan can be applied to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: 'A label selector requirement is a selector that
+                        contains values, a key, and an operator that
+
+                        relates the key and values.'
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: 'operator represents a key''s relationship
+                            to a set of values.
+
+                            Valid operators are In, NotIn, Exists and DoesNotExist.'
+                          type: string
+                        values:
+                          description: 'values is an array of string values. If the
+                            operator is In or NotIn,
+
+                            the values array must be non-empty. If the operator is
+                            Exists or DoesNotExist,
+
+                            the values array must be empty. This array is replaced
+                            during a strategic
+
+                            merge patch.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: 'matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels
+
+                      map is equivalent to an element of matchExpressions, whose key
+                      field is "key", the
+
+                      operator is "In", and the values array contains only "value".
+                      The requirements are ANDed.'
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              postCompleteDelay:
+                description: Time after a Job for one Node is complete before a new
+                  Job will be created for the next Node.
+                type: string
+              postCompleteLabels:
+                additionalProperties:
+                  type: string
+                description: 'Label key-value pairs to apply to a node when the job
+                  for this plan completes successfully.
+
+                  Values may contain `$(LATEST_HASH)` or `$(LATEST_VERSION)`, which
+                  will be expanded from the plan status.'
+                type: object
+              prepare:
+                description: The prepare init container, if specified, is run before
+                  cordon/drain which is run before the upgrade container.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ''
+                              description: 'Name of the referent.
+
+                                This field is effectively required, but due to backwards
+                                compatibility is
+
+                                allowed to be empty. Instances of this type with an
+                                empty value here are
+
+                                almost certainly wrong.
+
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: 'Optional text to prepend to the name of each
+                            environment variable.
+
+                            May consist of any printable ASCII characters except ''=''.'
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ''
+                              description: 'Name of the referent.
+
+                                This field is effectively required, but due to backwards
+                                compatibility is
+
+                                allowed to be empty. Instances of this type with an
+                                empty value here are
+
+                                almost certainly wrong.
+
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: 'Name of the environment variable.
+
+                            May consist of any printable ASCII characters except ''=''.'
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+
+                            using the previously defined environment variables in
+                            the container and
+
+                            any service environment variables. If a variable cannot
+                            be resolved,
+
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced
+
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e.
+
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+
+                            Escaped references will never be expanded, regardless
+                            of whether the variable
+
+                            exists or not.
+
+                            Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ''
+                                  description: 'Name of the referent.
+
+                                    This field is effectively required, but due to
+                                    backwards compatibility is
+
+                                    allowed to be empty. Instances of this type with
+                                    an empty value here are
+
+                                    almost certainly wrong.
+
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`,
+
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: 'FileKeyRef selects a key of the env file.
+
+                                Requires the EnvFiles feature gate to be enabled.'
+                              properties:
+                                key:
+                                  description: 'The key within the env file. An invalid
+                                    key will prevent the pod from starting.
+
+                                    The keys defined within a source may consist of
+                                    any printable ASCII characters except ''=''.
+
+                                    During Alpha stage of the EnvFiles feature gate,
+                                    the key size is limited to 128 characters.'
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: 'Specify whether the file or its key
+                                    must be defined. If the file or key
+
+                                    does not exist, then the env var is not published.
+
+                                    If optional is set to true and the specified key
+                                    does not exist,
+
+                                    the environment variable will not be set in the
+                                    Pod''s containers.
+
+
+                                    If optional is set to false and the specified
+                                    key does not exist,
+
+                                    an error will be returned during Pod creation.'
+                                  type: boolean
+                                path:
+                                  description: 'The path within the volume from which
+                                    to select the file.
+
+                                    Must be relative and may not contain the ''..''
+                                    path or start with ''..''.'
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests
+
+                                (limits.cpu, limits.memory, limits.ephemeral-storage,
+                                requests.cpu, requests.memory and requests.ephemeral-storage)
+                                are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ''
+                                  description: 'Name of the referent.
+
+                                    This field is effectively required, but due to
+                                    backwards compatibility is
+
+                                    allowed to be empty. Instances of this type with
+                                    an empty value here are
+
+                                    almost certainly wrong.
+
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds security configuration that
+                      will be applied to a container.
+
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When
+                      both
+
+                      are set, the values in SecurityContext take precedence.'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more
+
+                          privileges than its parent process. This bool directly controls
+                          if
+
+                          the no_new_privs flag will be set on the container process.
+
+                          AllowPrivilegeEscalation is true always when the container
+                          is:
+
+                          1) run as Privileged
+
+                          2) has CAP_SYS_ADMIN
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      appArmorProfile:
+                        description: 'appArmorProfile is the AppArmor options to use
+                          by this container. If set, this profile
+
+                          overrides the pod''s appArmorProfile.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          localhostProfile:
+                            description: 'localhostProfile indicates a profile loaded
+                              on the node that should be used.
+
+                              The profile must be preconfigured on the node to work.
+
+                              Must match the loaded name of the profile.
+
+                              Must be set if and only if type is "Localhost".'
+                            type: string
+                          type:
+                            description: "type indicates which kind of AppArmor profile\
+                              \ will be applied.\nValid options are:\n  Localhost\
+                              \ - a profile pre-loaded on the node.\n  RuntimeDefault\
+                              \ - the container runtime's default profile.\n  Unconfined\
+                              \ - no AppArmor enforcement."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: 'The capabilities to add/drop when running containers.
+
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: 'Run container in privileged mode.
+
+                          Processes in privileged containers are essentially equivalent
+                          to root on the host.
+
+                          Defaults to false.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      procMount:
+                        description: 'procMount denotes the type of proc mount to
+                          use for the containers.
+
+                          The default value is Default which uses the container runtime
+                          defaults for
+
+                          readonly paths and masked paths.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: 'Whether this container has a read-only root
+                          filesystem.
+
+                          Default is false.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      runAsGroup:
+                        description: 'The GID to run the entrypoint of the container
+                          process.
+
+                          Uses runtime default if unset.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: 'Indicates that the container must run as a non-root
+                          user.
+
+                          If true, the Kubelet will validate the image at runtime
+                          to ensure that it
+
+                          does not run as UID 0 (root) and fail to start the container
+                          if it does.
+
+                          If unset or false, no such validation will be performed.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.'
+                        type: boolean
+                      runAsUser:
+                        description: 'The UID to run the entrypoint of the container
+                          process.
+
+                          Defaults to user specified in image metadata if unspecified.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: 'The SELinux context to be applied to the container.
+
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each
+
+                          container.  May also be set in PodSecurityContext.  If set
+                          in both SecurityContext and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: 'The seccomp options to use by this container.
+                          If seccomp options are
+
+                          provided at both the pod & container level, the container
+                          options
+
+                          override the pod options.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          localhostProfile:
+                            description: 'localhostProfile indicates a profile defined
+                              in a file on the node should be used.
+
+                              The profile must be preconfigured on the node to work.
+
+                              Must be a descending path, relative to the kubelet''s
+                              configured seccomp profile location.
+
+                              Must be set if type is "Localhost". Must NOT be set
+                              for any other type.'
+                            type: string
+                          type:
+                            description: 'type indicates which kind of seccomp profile
+                              will be applied.
+
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node
+                              should be used.
+
+                              RuntimeDefault - the container runtime default profile
+                              should be used.
+
+                              Unconfined - no profile should be applied.'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: 'The Windows specific settings applied to all
+                          containers.
+
+                          If unspecified, the options from the PodSecurityContext
+                          will be used.
+
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          linux.'
+                        properties:
+                          gmsaCredentialSpec:
+                            description: 'GMSACredentialSpec is where the GMSA admission
+                              webhook
+
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines
+                              the contents of the
+
+                              GMSA credential spec named by the GMSACredentialSpecName
+                              field.'
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: 'HostProcess determines if a container should
+                              be run as a ''Host Process'' container.
+
+                              All of a Pod''s containers must have the same effective
+                              HostProcess value
+
+                              (it is not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).
+
+                              In addition, if HostProcess is true then HostNetwork
+                              must also be set to true.'
+                            type: boolean
+                          runAsUserName:
+                            description: 'The UserName in Windows to run the entrypoint
+                              of the container process.
+
+                              Defaults to the user specified in image metadata if
+                              unspecified.
+
+                              May also be set in PodSecurityContext. If set in both
+                              SecurityContext and
+
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.'
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              priorityClassName:
+                description: Priority Class Name of Job, if specified.
+                type: string
+              secrets:
+                description: Secrets to be mounted into the Job Pod.
+                items:
+                  description: SecretSpec describes a Secret to be mounted for prepare/upgrade
+                    containers.
+                  properties:
+                    defaultMode:
+                      description: Mode to mount the Secret volume with.
+                      format: int32
+                      type: integer
+                    ignoreUpdates:
+                      description: If set to true, the Secret contents will not be
+                        hashed, and changes to the Secret will not trigger new application
+                        of the Plan.
+                      type: boolean
+                    name:
+                      description: Secret name
+                      type: string
+                    path:
+                      description: Path to mount the Secret volume within the Pod.
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+              serviceAccountName:
+                description: The service account for the pod to use. As with normal
+                  pods, if not specified the default service account from the namespace
+                  will be assigned.
+                type: string
+              tolerations:
+                description: 'Specify which node taints should be tolerated by pods
+                  applying the upgrade.
+
+                  Anything specified here is appended to the default of:
+
+                  - `{key: node.kubernetes.io/unschedulable, effect: NoSchedule, operator:
+                  Exists}`'
+                items:
+                  description: 'The pod this Toleration is attached to tolerates any
+                    taint that matches
+
+                    the triple <key,value,effect> using the matching operator <operator>.'
+                  properties:
+                    effect:
+                      description: 'Effect indicates the taint effect to match. Empty
+                        means match all taint effects.
+
+                        When specified, allowed values are NoSchedule, PreferNoSchedule
+                        and NoExecute.'
+                      type: string
+                    key:
+                      description: 'Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys.
+
+                        If the key is empty, operator must be Exists; this combination
+                        means to match all values and all keys.'
+                      type: string
+                    operator:
+                      description: 'Operator represents a key''s relationship to the
+                        value.
+
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to
+                        Equal.
+
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can
+
+                        tolerate all taints of a particular category.
+
+                        Lt and Gt perform numeric comparisons (requires feature gate
+                        TaintTolerationComparisonOperators).'
+                      type: string
+                    tolerationSeconds:
+                      description: 'TolerationSeconds represents the period of time
+                        the toleration (which must be
+
+                        of effect NoExecute, otherwise this field is ignored) tolerates
+                        the taint. By default,
+
+                        it is not set, which means tolerate the taint forever (do
+                        not evict). Zero and
+
+                        negative values will be treated as 0 (evict immediately) by
+                        the system.'
+                      format: int64
+                      type: integer
+                    value:
+                      description: 'Value is the taint value the toleration matches
+                        to.
+
+                        If the operator is Exists, the value should be empty, otherwise
+                        just a regular string.'
+                      type: string
+                  type: object
+                type: array
+              upgrade:
+                description: The upgrade container; must be specified.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ''
+                              description: 'Name of the referent.
+
+                                This field is effectively required, but due to backwards
+                                compatibility is
+
+                                allowed to be empty. Instances of this type with an
+                                empty value here are
+
+                                almost certainly wrong.
+
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: 'Optional text to prepend to the name of each
+                            environment variable.
+
+                            May consist of any printable ASCII characters except ''=''.'
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ''
+                              description: 'Name of the referent.
+
+                                This field is effectively required, but due to backwards
+                                compatibility is
+
+                                allowed to be empty. Instances of this type with an
+                                empty value here are
+
+                                almost certainly wrong.
+
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: 'Name of the environment variable.
+
+                            May consist of any printable ASCII characters except ''=''.'
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+
+                            using the previously defined environment variables in
+                            the container and
+
+                            any service environment variables. If a variable cannot
+                            be resolved,
+
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced
+
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e.
+
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+
+                            Escaped references will never be expanded, regardless
+                            of whether the variable
+
+                            exists or not.
+
+                            Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ''
+                                  description: 'Name of the referent.
+
+                                    This field is effectively required, but due to
+                                    backwards compatibility is
+
+                                    allowed to be empty. Instances of this type with
+                                    an empty value here are
+
+                                    almost certainly wrong.
+
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`,
+
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: 'FileKeyRef selects a key of the env file.
+
+                                Requires the EnvFiles feature gate to be enabled.'
+                              properties:
+                                key:
+                                  description: 'The key within the env file. An invalid
+                                    key will prevent the pod from starting.
+
+                                    The keys defined within a source may consist of
+                                    any printable ASCII characters except ''=''.
+
+                                    During Alpha stage of the EnvFiles feature gate,
+                                    the key size is limited to 128 characters.'
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: 'Specify whether the file or its key
+                                    must be defined. If the file or key
+
+                                    does not exist, then the env var is not published.
+
+                                    If optional is set to true and the specified key
+                                    does not exist,
+
+                                    the environment variable will not be set in the
+                                    Pod''s containers.
+
+
+                                    If optional is set to false and the specified
+                                    key does not exist,
+
+                                    an error will be returned during Pod creation.'
+                                  type: boolean
+                                path:
+                                  description: 'The path within the volume from which
+                                    to select the file.
+
+                                    Must be relative and may not contain the ''..''
+                                    path or start with ''..''.'
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests
+
+                                (limits.cpu, limits.memory, limits.ephemeral-storage,
+                                requests.cpu, requests.memory and requests.ephemeral-storage)
+                                are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ''
+                                  description: 'Name of the referent.
+
+                                    This field is effectively required, but due to
+                                    backwards compatibility is
+
+                                    allowed to be empty. Instances of this type with
+                                    an empty value here are
+
+                                    almost certainly wrong.
+
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds security configuration that
+                      will be applied to a container.
+
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When
+                      both
+
+                      are set, the values in SecurityContext take precedence.'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more
+
+                          privileges than its parent process. This bool directly controls
+                          if
+
+                          the no_new_privs flag will be set on the container process.
+
+                          AllowPrivilegeEscalation is true always when the container
+                          is:
+
+                          1) run as Privileged
+
+                          2) has CAP_SYS_ADMIN
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      appArmorProfile:
+                        description: 'appArmorProfile is the AppArmor options to use
+                          by this container. If set, this profile
+
+                          overrides the pod''s appArmorProfile.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          localhostProfile:
+                            description: 'localhostProfile indicates a profile loaded
+                              on the node that should be used.
+
+                              The profile must be preconfigured on the node to work.
+
+                              Must match the loaded name of the profile.
+
+                              Must be set if and only if type is "Localhost".'
+                            type: string
+                          type:
+                            description: "type indicates which kind of AppArmor profile\
+                              \ will be applied.\nValid options are:\n  Localhost\
+                              \ - a profile pre-loaded on the node.\n  RuntimeDefault\
+                              \ - the container runtime's default profile.\n  Unconfined\
+                              \ - no AppArmor enforcement."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: 'The capabilities to add/drop when running containers.
+
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: 'Run container in privileged mode.
+
+                          Processes in privileged containers are essentially equivalent
+                          to root on the host.
+
+                          Defaults to false.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      procMount:
+                        description: 'procMount denotes the type of proc mount to
+                          use for the containers.
+
+                          The default value is Default which uses the container runtime
+                          defaults for
+
+                          readonly paths and masked paths.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: 'Whether this container has a read-only root
+                          filesystem.
+
+                          Default is false.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        type: boolean
+                      runAsGroup:
+                        description: 'The GID to run the entrypoint of the container
+                          process.
+
+                          Uses runtime default if unset.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: 'Indicates that the container must run as a non-root
+                          user.
+
+                          If true, the Kubelet will validate the image at runtime
+                          to ensure that it
+
+                          does not run as UID 0 (root) and fail to start the container
+                          if it does.
+
+                          If unset or false, no such validation will be performed.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.'
+                        type: boolean
+                      runAsUser:
+                        description: 'The UID to run the entrypoint of the container
+                          process.
+
+                          Defaults to user specified in image metadata if unspecified.
+
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: 'The SELinux context to be applied to the container.
+
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each
+
+                          container.  May also be set in PodSecurityContext.  If set
+                          in both SecurityContext and
+
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: 'The seccomp options to use by this container.
+                          If seccomp options are
+
+                          provided at both the pod & container level, the container
+                          options
+
+                          override the pod options.
+
+                          Note that this field cannot be set when spec.os.name is
+                          windows.'
+                        properties:
+                          localhostProfile:
+                            description: 'localhostProfile indicates a profile defined
+                              in a file on the node should be used.
+
+                              The profile must be preconfigured on the node to work.
+
+                              Must be a descending path, relative to the kubelet''s
+                              configured seccomp profile location.
+
+                              Must be set if type is "Localhost". Must NOT be set
+                              for any other type.'
+                            type: string
+                          type:
+                            description: 'type indicates which kind of seccomp profile
+                              will be applied.
+
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node
+                              should be used.
+
+                              RuntimeDefault - the container runtime default profile
+                              should be used.
+
+                              Unconfined - no profile should be applied.'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: 'The Windows specific settings applied to all
+                          containers.
+
+                          If unspecified, the options from the PodSecurityContext
+                          will be used.
+
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+
+                          Note that this field cannot be set when spec.os.name is
+                          linux.'
+                        properties:
+                          gmsaCredentialSpec:
+                            description: 'GMSACredentialSpec is where the GMSA admission
+                              webhook
+
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines
+                              the contents of the
+
+                              GMSA credential spec named by the GMSACredentialSpecName
+                              field.'
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: 'HostProcess determines if a container should
+                              be run as a ''Host Process'' container.
+
+                              All of a Pod''s containers must have the same effective
+                              HostProcess value
+
+                              (it is not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).
+
+                              In addition, if HostProcess is true then HostNetwork
+                              must also be set to true.'
+                            type: boolean
+                          runAsUserName:
+                            description: 'The UserName in Windows to run the entrypoint
+                              of the container process.
+
+                              Defaults to the user specified in image metadata if
+                              unspecified.
+
+                              May also be set in PodSecurityContext. If set in both
+                              SecurityContext and
+
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.'
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              version:
+                description: Providing a value for version will prevent polling/resolution
+                  of the channel if specified.
+                type: string
+              window:
+                description: 'A time window in which to execute Jobs for this Plan.
+
+                  Jobs will not be generated outside this time window, but may continue
+                  executing into the window once started.'
+                properties:
+                  days:
+                    description: Days that this time window is valid for
+                    items:
+                      enum:
+                      - '0'
+                      - su
+                      - sun
+                      - sunday
+                      - '1'
+                      - mo
+                      - mon
+                      - monday
+                      - '2'
+                      - tu
+                      - tue
+                      - tuesday
+                      - '3'
+                      - we
+                      - wed
+                      - wednesday
+                      - '4'
+                      - th
+                      - thu
+                      - thursday
+                      - '5'
+                      - fr
+                      - fri
+                      - friday
+                      - '6'
+                      - sa
+                      - sat
+                      - saturday
+                      type: string
+                    minItems: 1
+                    type: array
+                  endTime:
+                    description: End of the time window.
+                    type: string
+                  startTime:
+                    description: Start of the time window.
+                    type: string
+                  timeZone:
+                    description: Time zone for the time window; if not specified UTC
+                      will be used.
+                    type: string
+                type: object
+            required:
+            - upgrade
+            type: object
+          status:
+            description: PlanStatus represents the resulting state from processing
+              Plan events.
+            properties:
+              applying:
+                description: List of Node names that the Plan is currently being applied
+                  on.
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: '`LatestResolved` indicates that the latest version as
+                  per the spec has been determined.
+
+                  `Validated` indicates that the plan spec has been validated.
+
+                  `Complete` indicates that the latest version of the plan has completed
+                  on all selected nodes. If any Jobs for the Plan fail to complete,
+                  this condition will remain false, and the reason and message will
+                  reflect the source of the error.'
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              latestHash:
+                description: The hash of the most recently applied plan .spec.
+                type: string
+              latestVersion:
+                description: The latest version, as resolved from .spec.version, or
+                  the channel server.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/base-apps/system-upgrade-controller/plan-agent.yaml
+++ b/base-apps/system-upgrade-controller/plan-agent.yaml
@@ -1,0 +1,51 @@
+# k3s agent upgrade Plan — workers ONLY (SPEC.md §T.14, §T.16, §V.17).
+#
+# There is deliberately no plan-server.yaml. The control-plane hop is manual: this
+# cluster runs a single server, and SUC drives upgrades as a privileged Job scheduled
+# by the very API server it would be restarting. §V.17 forbids ever pointing this
+# controller at k3s-control-01, and §T.15 forbids labelling it.
+#
+# CURRENTLY A NO-OP DRY RUN (§T.16). `version` is pinned to v1.33.5+k3s1 — the version
+# already running — so this exercises the whole mechanism (node selection, cordon, the
+# privileged upgrade job, uncordon) without changing anything. Only k3s-worker-02
+# carries the k3s-upgrade label for now; worker-01 hosts Vault and postgresql-cluster
+# after §T.36/§T.37 and is deliberately left out until the real hop.
+#
+# drain is INTENTIONALLY UNSET. Per the Plan CRD: "If left unspecified, no drain will
+# be performed." That is required here, not merely convenient — local-path is the only
+# StorageClass and its PVs carry hard node affinity, so a drain cannot reschedule
+# anything with a volume. It would evict pods that can never come back until the node
+# returns (§C, §V.42). Cordon alone gives the safety we want: no new scheduling during
+# the upgrade, existing pods left alone.
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: k3s-agent
+  namespace: system-upgrade
+  labels:
+    k3s-upgrade: agent
+spec:
+  # Pinned, not a channel. A channel resolves to "latest stable" via HTTP redirect,
+  # which would silently retarget this Plan when upstream cuts a release — the walk
+  # must move one deliberate minor at a time (§V.3).
+  version: v1.33.5+k3s1
+
+  # One node at a time. With two workers, concurrency 2 would take both out together.
+  concurrency: 1
+
+  nodeSelector:
+    matchExpressions:
+      - key: k3s-upgrade
+        operator: In
+        values: ["true"]
+      # Belt and braces alongside §T.15: even if the control plane were ever labelled
+      # by mistake, this Plan still refuses to select it.
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+
+  serviceAccountName: system-upgrade
+
+  cordon: true
+
+  upgrade:
+    image: rancher/k3s-upgrade

--- a/tests/k3s-upgrade/test_suc_plan.py
+++ b/tests/k3s-upgrade/test_suc_plan.py
@@ -1,0 +1,110 @@
+"""Guards on the system-upgrade-controller rig (SPEC.md §T.13-§T.16).
+
+Two of these properties are safety-critical and easy to undo by accident.
+
+**No drain.** `local-path` is the only StorageClass and its PersistentVolumes carry
+hard node affinity, so a drained pod with a volume cannot reschedule anywhere — it
+sits Pending until the node returns. The Plan CRD documents that omitting `drain`
+performs no drain, so the guard is that the key stays absent. Adding `drain: {}`
+would look harmless and would strand Vault, Postgres, and every other stateful pod.
+
+**Never the control plane.** §V.17 keeps SUC away from `k3s-control-01`: this is a
+single-server cluster, and SUC runs upgrades as a privileged Job scheduled by the very
+API server it would restart. That is enforced twice — by not labelling the node
+(§T.15) and by the Plan's own nodeSelector — because the label is cluster state that
+no test can see, while the selector lives in git where this test can.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SUC_DIR = REPO / "base-apps" / "system-upgrade-controller"
+APP = REPO / "base-apps" / "system-upgrade-controller.yaml"
+
+
+def _docs(path: Path):
+    return [d for d in yaml.safe_load_all(path.read_text()) if d]
+
+
+def _plans():
+    return [d for f in SUC_DIR.glob("*.yaml") for d in _docs(f) if d.get("kind") == "Plan"]
+
+
+def test_rig_exists():
+    """Guard against the globs silently matching nothing and the suite passing vacuously."""
+    assert APP.exists(), "system-upgrade-controller Application missing"
+    assert _plans(), "no Plan manifests found"
+
+
+def test_no_plan_targets_the_control_plane():
+    """§V.17: SUC scope is agents only."""
+    for plan in _plans():
+        exprs = plan["spec"].get("nodeSelector", {}).get("matchExpressions", [])
+        guarded = any(
+            e.get("key") == "node-role.kubernetes.io/control-plane"
+            and e.get("operator") == "DoesNotExist"
+            for e in exprs
+        )
+        assert guarded, (
+            f"Plan {plan['metadata']['name']} does not exclude the control plane. "
+            f"SUC on a single-server cluster can strand it (§V.17)."
+        )
+
+
+def test_no_plan_server_manifest_exists():
+    """§I declares plan-server.yaml must never exist."""
+    assert not (SUC_DIR / "plan-server.yaml").exists(), (
+        "plan-server.yaml would point SUC at k3s-control-01 (§V.17)."
+    )
+
+
+@pytest.mark.parametrize("plan", _plans(), ids=lambda p: p["metadata"]["name"])
+def test_plan_does_not_drain(plan):
+    """Draining strands every pod with a node-pinned local-path volume."""
+    assert "drain" not in plan["spec"], (
+        f"Plan {plan['metadata']['name']} sets `drain`. local-path PVs have hard node "
+        f"affinity, so drained stateful pods cannot reschedule and sit Pending until "
+        f"the node returns. Omit the key entirely — the CRD treats absent as no-drain."
+    )
+
+
+@pytest.mark.parametrize("plan", _plans(), ids=lambda p: p["metadata"]["name"])
+def test_plan_pins_a_version_not_a_channel(plan):
+    """§V.3: one deliberate minor at a time.
+
+    A `channel` resolves to whatever upstream calls latest via HTTP redirect, so a Plan
+    using one silently retargets when a release is cut.
+    """
+    spec = plan["spec"]
+    assert spec.get("version"), f"Plan {plan['metadata']['name']} must pin `version`"
+    assert "channel" not in spec, (
+        f"Plan {plan['metadata']['name']} uses `channel`, which follows upstream "
+        f"releases automatically and would skip the deliberate one-minor walk."
+    )
+
+
+@pytest.mark.parametrize("plan", _plans(), ids=lambda p: p["metadata"]["name"])
+def test_plan_upgrades_one_node_at_a_time(plan):
+    """There are only two workers; concurrency 2 would take both out together."""
+    assert plan["spec"].get("concurrency") == 1, (
+        f"Plan {plan['metadata']['name']} must set concurrency: 1"
+    )
+
+
+def test_sync_waves_order_crd_before_controller():
+    """The Plan CRD must exist before the controller, and both before any Plan, or the
+    first sync fails on an unknown kind."""
+    waves = {}
+    for f in SUC_DIR.glob("*.yaml"):
+        for d in _docs(f):
+            w = int(d.get("metadata", {}).get("annotations", {})
+                    .get("argocd.argoproj.io/sync-wave", 0))
+            waves.setdefault(d["kind"], w)
+    assert waves.get("CustomResourceDefinition", 0) < waves.get("Deployment", 0), (
+        f"CRD must sync before the controller: {waves}"
+    )
+    assert waves.get("Deployment", 0) < waves.get("Plan", 0), (
+        f"controller must sync before any Plan: {waves}"
+    )


### PR DESCRIPTION
Unblocked by §V.29 now that T36/T37 moved Vault and Postgres off the control plane.

Official **v0.20.1** manifests, unmodified except for sync-wave annotations: CRD at `-2`, controller at `-1`, Plan at default `0` — a Plan applied before its CRD fails the first sync on an unknown kind.

## It ships as a genuine no-op

`version: v1.33.5+k3s1` — exactly what all three nodes run. Applying it exercises node selection, cordon, the privileged upgrade job and uncordon **without changing a version**. That's §T.16's dry run, and it's the point of building the rig before the walk rather than discovering its behaviour mid-hop.

**No node carries the `k3s-upgrade` label yet**, so on merge the Plan matches nothing. Labelling `k3s-worker-02` is the deliberate trigger, done under observation — and worker-02 is the right choice because worker-01 now hosts Vault and Postgres.

## Three deliberate safety properties

**`drain` is absent, not empty.** The CRD documents that omitting it performs no drain. That's *required* here, not convenient: `local-path` is the only StorageClass and its PVs carry hard node affinity, so a drained pod with a volume cannot reschedule — it sits `Pending` until the node returns. Cordon gives what we want: no new scheduling, existing pods untouched.

**The control plane is excluded twice** — §T.15 keeps the label off `k3s-control-01`, *and* the Plan's nodeSelector carries a `DoesNotExist` guard on the control-plane role label. Belt and braces, because the label is cluster state no test can see while the selector lives in git where tests can.

**`version` pinned, never `channel`.** A channel resolves to upstream's latest via HTTP redirect and would silently retarget the Plan when a release is cut, skipping the deliberate one-minor walk §V.3 requires.

## Guards

`tests/k3s-upgrade/test_suc_plan.py` covers all of the above plus the absence of `plan-server.yaml` and the sync-wave ordering. 202 tests pass, yamllint clean.

## After merge

I'll label `k3s-worker-02` to trigger the dry run and report what the upgrade job actually does — including whether the node goes NotReady and for how long, which is the number that sizes the real hop windows.