### PR TITLE
T16: dry run passed — rig proven, outage window still unmeasured

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -126,10 +126,10 @@ T9|.|CNPG `1.24.1` → 1.29.x — CVE-2026-44477 CVSS 9.4 metrics exporter. gate
 T10|.|Istio `1.24.0` → `1.30.x` via revisions. ⊥ `1.25` (k8s ≤1.32 ∉ 1.33, §V.32) ∴ skip `1.25` \| defer Istio → post-§T.18. ! /research skip policy first|V12,V20,V32,V8
 T11|.|verify `ztunnel` + `istio-cni-node` DS healthy ∀ node post-Istio, then retire old revision|V12,V20
 T12|x|DONE 2026-07-28 matrix audit → §R.13-§R.18. blockers: ingress-nginx TERMINAL, kyverno ≤1.35, ArgoCD ⊥ 3.5 GA. clear: cert-manager→v1.21, Istio→1.30|V2,V46
-T13|.|add `base-apps/system-upgrade-controller.yaml` Argo app. HARD gate §T.27 first (§V.29)|V29,I.file
-T14|.|add SUC manifests + RBAC + CRD (sync-wave: CRD before Plan). Plan scope = agents only|V17,I.file
-T15|.|label `k3s-worker-01`,`k3s-worker-02` `k3s-upgrade=true`. ⊥ label `k3s-control-01`|V17,I.node-label
-T16|.|dry-run SUC Plan on `k3s-worker-02` @ current version (no-op hop)|V4,V17
+T13|x|DONE 2026-07-28: `base-apps/system-upgrade-controller.yaml` Argo app. SUC `v0.20.1`, Synced/Healthy|V29,I.file
+T14|x|DONE 2026-07-28: official v0.20.1 manifests + CRD, sync-wave -2/-1/0. `plan-agent.yaml` agents ONLY, ⊥ `plan-server.yaml`. `drain` ABSENT (local-path node-pinned), `cordon: true`, `concurrency: 1`, `version` pinned ⊥ channel. guards @ `tests/k3s-upgrade/test_suc_plan.py`|V3,V17,I.file
+T15|~|`k3s-worker-02` labelled `k3s-upgrade=true` for §T.16. `k3s-worker-01` deliberately UNLABELLED until the real hop (hosts Vault+CNPG). `k3s-control-01` ⊥ labelled ∀ time (§V.17)|V17,I.node-label
+T16|x|DONE 2026-07-28 dry run on `k3s-worker-02`: job created t+0s → cordon t+15s → Complete + uncordon t+31s. ⊥ NotReady ∀ moment. 21 workloads survived, other nodes untouched. NB job logged "Binary already been replaced" & exit 0 ∴ k3s never restarted — mechanism proven, real hop NotReady window still UNMEASURED|V4,V17
 T17|.|gate §V.1,2,5,6,10,11,14,27,28 → MANUAL hop control-plane → `v1.34.9+k3s1`, console access ∃. ⊥ drainable until §T.37 done — PDB blocks it (§R.10, §V.42)|V1,V2,V3,V6,V14,V17,V27,V28,V31
 T18|.|SUC hop workers → `v1.34.9+k3s1`. gate §V.1,5,6,11,14,28 — post-relocate THIS hop = Vault + CNPG outage (§V.37), ⊥ bare "verify §V.5". NB post-§T.37 the CNPG PDB blocks draining `k3s-worker-01` (§V.42) — scale→2 \| disable PDB for the hop|V4,V5,V6,V17,V31,V37,V42
 T19|.|gate §V.1,2,5,6,10,11,14,27,28 → hop → `v1.35.6+k3s1` (control-plane manual, workers SUC)|V3,V5,V6,V17,V27,V28,V31

--- a/docs/plans/k3s-1.36-upgrade-plan.md
+++ b/docs/plans/k3s-1.36-upgrade-plan.md
@@ -54,6 +54,26 @@ Still outstanding, and all three gate §T.17:
 Announce before a control-plane hop; the API being down means Argo and `kubectl` are too, so
 anything you need for diagnosis must be in hand beforehand.
 
+## What the §T.16 dry run established
+
+Run 2026-07-28 on `k3s-worker-02`, with the Plan pinned to the version already running:
+
+```
+t+0s    upgrade job created and scheduled on the node
+t+15s   node Ready,SchedulingDisabled  (cordon applied)
+t+31s   job Complete, node Ready       (uncordon)
+```
+
+The node **never went NotReady**, all 21 workloads survived, and the other two nodes
+were untouched. Node selection worked exactly as scoped — only worker-02, never the
+control plane, and not worker-01 (unlabelled, since it hosts Vault and CNPG).
+
+**What this does not tell us.** The job logged `Binary already been replaced` and exited
+0 without restarting k3s, because the binary checksums matched. So the machinery is
+proven end to end, but the NotReady window for a *real* hop remains unmeasured — the
+worker figures in the table above are still estimates. The first genuine hop (§T.18)
+is what will produce that number.
+
 ## Per-hop procedure
 
 **Gate first** — §V.31 requires the full set enumerated, not a bare "gate":


### PR DESCRIPTION
Labelled `k3s-worker-02` and watched.

```
t+0s    upgrade job created and scheduled
t+15s   node Ready,SchedulingDisabled   (cordon)
t+31s   job Complete, node Ready        (uncordon)
```

Node **never went NotReady**. All 21 workloads survived. `k3s-control-01` and `k3s-worker-01` untouched throughout.

Node selection behaved exactly as scoped — only worker-02, never the control plane, and not worker-01, which stays unlabelled until the real hop because it now hosts Vault and Postgres.

## What it does *not* establish

The job logged:

```
[INFO]  Comparing old and new binaries
[INFO]  Binary already been replaced
exit 0
```

Checksums matched, so k3s never restarted — exactly what a same-version Plan should do. **The machinery is proven end to end; the NotReady window for a real hop is still an estimate.** T18 will produce that number, and the runbook now says so rather than implying the estimate was validated.

That's worth being explicit about, because "dry run passed, node never went NotReady" reads like good news about hop duration and isn't.

## T15 stays partial

Its text says label both workers. Only worker-02 carries the label; worker-01 gets it at hop time. Recording that as `~` rather than quietly redefining the task to match what I did.

## State

```
15 tasks done · 2 in progress · 26 open
202 tests pass
```

## Verification

202 tests pass. Spec and runbook updated with measurements, not impressions.