### PR TITLE
T9 step 2/5: CNPG operator 1.25.1 → 1.26.1

### DIFF
--- a/base-apps/cnpg-system.yaml
+++ b/base-apps/cnpg-system.yaml
@@ -23,14 +23,14 @@ spec:
     chart: cloudnative-pg
     # STEP 1 of 5 (SPEC.md §T.9, §R.22). CloudNativePG documents that operator minors
     # must not be skipped, so 1.24.1 -> 1.29.1 is a sequence, not a jump:
-    #   0.23.2 -> 1.25.1  <- here
-    #   0.25.0 -> 1.26.1
+    #   0.23.2 -> 1.25.1  (done)
+    #   0.25.0 -> 1.26.1  <- here
     #   0.26.1 -> 1.27.1
     #   0.27.1 -> 1.28.1
     #   0.28.3 -> 1.29.1  (target: covers k8s 1.33-1.35, fixes CVE-2026-44477)
     # Each step restarts the single Postgres pod -- instances=1 leaves no replica to
     # switch over to -- so expect ~30-60s of database downtime per step.
-    targetRevision: 0.23.2
+    targetRevision: 0.25.0
     helm:
       releaseName: cnpg
       values: |


### PR DESCRIPTION
Step 1 verified — operator 1.25.1, pod recreated as expected, cluster healthy in ~10s, data matched baseline (n8n 55 tables, chores_tracker 7, chores 3 rows).

This is step 2 of 5: chart `0.23.2` → `0.25.0`, operator 1.25.1 → 1.26.1. Same expectation: brief pod restart, verify before step 3.

Note for §V.45 checks on this app: `cnpg-system` is Helm-sourced, so `status.sync.revision` reports the *chart* version, not a git SHA. The signal to watch is the Application's `targetRevision` flipping.