### PR TITLE
T9 step 5/5: CNPG operator 1.28.1 → 1.29.1 — CVE fix lands

### DIFF
--- a/base-apps/cnpg-system.yaml
+++ b/base-apps/cnpg-system.yaml
@@ -26,11 +26,11 @@ spec:
     #   0.23.2 -> 1.25.1  (done)
     #   0.25.0 -> 1.26.1  (done)
     #   0.26.1 -> 1.27.1  (done)
-    #   0.27.1 -> 1.28.1  <- here
-    #   0.28.3 -> 1.29.1  (target: covers k8s 1.33-1.35, fixes CVE-2026-44477)
+    #   0.27.1 -> 1.28.1  (done)
+    #   0.28.3 -> 1.29.1  <- here (target: covers k8s 1.33-1.35, fixes CVE-2026-44477)
     # Each step restarts the single Postgres pod -- instances=1 leaves no replica to
     # switch over to -- so expect ~30-60s of database downtime per step.
-    targetRevision: 0.27.1
+    targetRevision: 0.28.3
     helm:
       releaseName: cnpg
       values: |


### PR DESCRIPTION
Final step of five. Operator reaches **1.29.1**, which covers k8s 1.33–1.35 and carries the fix for **CVE-2026-44477** — the CVSS 9.4 metrics-exporter flaw that's been open on this cluster all along.

Steps 1–4 all verified clean (1.25.1 → 1.26.1 → 1.27.1 → 1.28.1), each with the cluster returning healthy and data unchanged: n8n 55 tables, chores_tracker 7 tables, chores 3 rows.

Restarts were consistently far shorter than the 30–60s estimated — the cluster was back healthy within a single 15s poll each time.