### PR TITLE
T25/T28/T29/T30: the hop gate becomes a command

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -145,12 +145,12 @@ T21|.|FOLLOW-ON (⊥ this spec's target): hop → `v1.36.2+k3s1`. gated §T.43 +
 T22|.|confirm local kubectl v1.36.2 now in-skew|-
 T23|.|update `index.md` + `docs/` topology w/ landed versions|-
 T24|.|follow-on: spec 3-server embedded etcd HA conversion|-
-T25|.|build pause/resume for Argo auto-sync ∀ PVC-bearing app across hop window|V18
+T25|x|DONE 2026-07-28: `scripts/argo-sync-window.sh scope\|pause\|resume`. suspends `master-app` FIRST (§B.4) then ∀ PVC app; scope = UNION of tracked-PVC apps + `volumeClaimTemplates` STS (the latter alone caught `vault`+`openshell`). records prior policy → exact restore. resume ⊥ gated on Synced (§V.30)|V18,V30,V33
 T26|x|prune-scope audit: 10 PVC WERE prunable (§V.19 false since inception). fixed — `Prune=false` ∀ 9 manifest + `prune: false` @ atlantis app (chart 6.1.0 ⊥ template PVC annotations). `tests/k3s-upgrade/test_prune_scope.py` = regression guard. NB `lg-agents/orchestrator-data` orphaned (⊥ app) → §T.40|V19,V39
 T27|x|DECIDED 2026-07-27: RELOCATE both → `k3s-worker-01` (97GB disk, ⊥ pressure). → §T.36 + §T.37. rationale: retires single failure domain, hops become API-only|V14,V29
-T28|.|add `k3s/` + `pg/` + `vault/` prefixes → existing `s3://mysql-backups-asela-cluster/`. ⊥ new bucket (§I.store). + KMS key deletion protection (§V.35)|V21,V35,I.store
-T29|.|verify `kube-system/ingress-nginx` helm-controller reconcile + ingress reachable post-∀-hop|V22
-T30|.|define §V.9 measurement: start = k3s stop, end = ∀ Argo app Synced+Healthy|V9
+T28|x|DONE 2026-07-28: artifacts shipped → `s3://mysql-backups-asela-cluster/{pg,vault}/` w/ checksums, round-trip download+verify PASSED. `k3s/` prefix awaits the first on-node backup (§T.17). KMS `alias/vault-auto-unseal` given `lifecycle.prevent_destroy` — 30d deletion window already ∃; this blocks the likelier accident (terraform destroy/replace)|V21,V35,I.store
+T29|x|DONE 2026-07-28: `scripts/hop-verify.sh gate` checks helm-controller `HelmChart kube-system/ingress-nginx` + controller Ready. NB controller = DaemonSet ⊥ Deployment — first version of the check queried Deployments, found none & called a healthy ingress broken|V22
+T30|x|DONE 2026-07-28: §V.9 window = `hop-verify.sh watch --since <epoch of k3s stop>` → green when ∀ node Ready & ⊥ unexplained drift. compares vs the 15min bound. measuring from later, or ending @ API-up, would flatter the number|V9
 T31|.|DEFERRED past §T.19. ESO stage 2: ∀ 56 file → `v1` (drop `beta1`) THEN rewrite ∀ stored object as `v1` + prune CRD `status.storedVersions` → `["v1"]`. git ≠ etcd (§R.3)|V23,V24,V26,V48
 T32|.|DEFERRED past §T.19. ESO stage 3: → `0.17.0`+. gate `storedVersions==["v1"]`|V23,V26,V11,V48
 T33|.|DEFERRED past §T.19. ESO stage 4: → `0.20.x` → `1.x` → `2.x`. ! k8s ≥1.34 (§R.4)|V23,V13,V11,V48
@@ -165,6 +165,7 @@ T41|.|install `kubectl cnpg` plugin — fallback manual switchover lever for §T
 T42|~|drift 8→2. FIXED: master-app (`recurse: false`), openshell-secrets (ESO webhook defaults), istio-base+istio-istiod (8 fields: istiod `caBundle`+`failurePolicy`, 6 API defaults), openshell (13 API defaults), argo-rollouts (`preserveUnknownFields`+`conversion`). REMAINING: `kagent-secrets` = operator copies Argo `tracking-id` onto a generated SA ∴ needs kagent fix ⊥ ignore rule; `kyverno` = chart renders `metadata.labels: {}` on 11/22 CRD (upstream bug) — rule applied & stable CLI shows ⊥ diff, but `v3.5.0-rc2` controller still flags. retest after §T.5|V5,V47
 T43|.|FOLLOW-ON: migrate ingress off `ingress-nginx` → Gateway API. infra ∃ already (§R.14: istio/gloo/agentgateway GatewayClasses live). prerequisite for 1.36 (§V.46), ⊥ for 1.35|V46,R.13,R.14
 T44|.|kyverno `v1.17.1` → `v1.18.x` (chart `3.8.2`). ADVISED ⊥ required: chart allows ≥1.25 (§R.21) but `v1.18` = the version TESTED @ 1.33-1.35 (§R.16). kyverno = admission webhook ∴ break blocks ∀ pod create|V2,V8
+T45|.|diagnose `atlantis` (Progressing) + `whoami-test` (Degraded). both workloads 1/1 Running for 19d/7d ∴ stale health ⊥ real failure, but cause UNDIAGNOSED ∴ `hop-verify.sh` tolerates them & warns every run. §V.47 wants a documented cause, ⊥ an allow-list entry|V47,V5
 
 ## §B BUGS
 id|date|cause|fix

--- a/docs/plans/k3s-1.36-upgrade-plan.md
+++ b/docs/plans/k3s-1.36-upgrade-plan.md
@@ -111,7 +111,31 @@ is what will produce that number.
 
 ## Per-hop procedure
 
-**Gate first** — §V.31 requires the full set enumerated, not a bare "gate":
+**Gate first**, and it is a command rather than a checklist (§T.29, §T.30):
+
+```bash
+scripts/hop-verify.sh gate            # non-zero exit means do not hop
+```
+
+It checks all three artifacts exist and their checksums verify, nodes Ready, no
+*unexplained* Argo drift (§V.47 — diagnosed causes allowed by name, merely tolerated ones
+warned about every run), CNPG healthy, Vault unsealed, ESO no worse than its known three
+failures, the Istio ambient dataplane (§V.49), and ingress-nginx via helm-controller.
+What it cannot check — the component matrix, the API scan, the restore drill — it prints
+as explicit operator items rather than passing silently.
+
+Pause auto-sync for the window (§V.18, §V.30, and §B.4's lesson that the parent undoes the
+children):
+
+```bash
+scripts/argo-sync-window.sh scope     # see what is in scope, change nothing
+scripts/argo-sync-window.sh pause     # master-app first, then every PVC-bearing app
+# ... hop ...
+scripts/hop-verify.sh watch --since <epoch of k3s stop>   # measures the §V.9 window
+scripts/argo-sync-window.sh resume    # restores exactly the prior policy
+```
+
+The old enumerated list, for reference — §V.31 requires the full set, not a bare "gate":
 §V.1 (verified k3s backup + restore drill), §V.2/§V.27 (component matrix, or a bounded
 transient), §V.5, §V.6 (fresh pg dump), §V.10 (API scan), §V.11 (ESO healthy), §V.14, §V.28
 (Vault backup).

--- a/scripts/argo-sync-window.sh
+++ b/scripts/argo-sync-window.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# argo-sync-window.sh — pause/resume Argo auto-sync across an upgrade hop (SPEC.md §T.25)
+#
+# §V.18 requires auto-sync paused for every app carrying a PVC during a hop window, because
+# `local-path` volumes are node-bound and a mid-hop reconcile can act on a node whose pods
+# cannot reschedule.
+#
+# Two things this gets right that are easy to get wrong:
+#
+#   §B.4 — suspending a child app is not enough. `master-app` re-applies every Application
+#   from git, restoring `syncPolicy.automated` mid-operation. It gets suspended too, and
+#   FIRST, so it cannot undo the children.
+#
+#   Scope — apps are discovered two ways and unioned. Querying only PVCs with an Argo
+#   tracking-id misses StatefulSets using `volumeClaimTemplates`, whose claims the
+#   StatefulSet controller creates rather than Argo. That omission would have skipped
+#   `vault` and `openshell`, the two that matter most.
+#
+# §V.30: the pause must be liftable to reach §V.5 green. A paused app cannot self-heal, so
+# resume is not gated on Synced — the order is pause → hop → manual sync → verify → resume.
+#
+# Usage:
+#   argo-sync-window.sh scope                 # list what would be paused, change nothing
+#   argo-sync-window.sh pause  [--state FILE] # suspend; record prior policy for exact restore
+#   argo-sync-window.sh resume [--state FILE] # restore exactly what was recorded
+
+set -euo pipefail
+
+ARGO_NS="${ARGO_NAMESPACE:-argo-cd}"
+STATE="${HOME}/.k3s-hop-argo-state.json"
+ACTION="${1:-}"; shift || true
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --state) STATE="${2:-}"; shift 2 ;;
+    --argo-namespace) ARGO_NS="${2:-}"; shift 2 ;;
+    *) echo "argo-sync-window: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+die() { echo "argo-sync-window: $*" >&2; exit 1; }
+
+# Union of: apps tracking a PVC, and apps owning a StatefulSet with volumeClaimTemplates.
+discover_apps() {
+  {
+    kubectl get pvc -A -o json 2>/dev/null | python3 -c '
+import sys, json
+for i in json.load(sys.stdin)["items"]:
+    tid = (i["metadata"].get("annotations") or {}).get("argocd.argoproj.io/tracking-id")
+    if tid: print(tid.split(":")[0])
+'
+    kubectl get sts -A -o json 2>/dev/null | python3 -c '
+import sys, json
+for s in json.load(sys.stdin)["items"]:
+    if s["spec"].get("volumeClaimTemplates"):
+        tid = (s["metadata"].get("annotations") or {}).get("argocd.argoproj.io/tracking-id")
+        if tid: print(tid.split(":")[0])
+'
+  } | sort -u | while read -r a; do
+    [ -n "$a" ] && kubectl get app -n "$ARGO_NS" "$a" >/dev/null 2>&1 && echo "$a"
+  done
+}
+
+case "$ACTION" in
+  scope)
+    echo "master-app   (§B.4 — parent re-applies children, must be suspended first)"
+    discover_apps | sed 's/^/PVC app: /'
+    ;;
+
+  pause)
+    apps="$(discover_apps)"
+    [ -n "$apps" ] || die "discovered no PVC-bearing apps — refusing to record an empty window"
+    # master-app first: while it is still syncing it would undo the children (§B.4).
+    ordered="master-app
+$apps"
+    python3 - "$ARGO_NS" "$STATE" <<'PY' <<<"$ordered"
+import json, subprocess, sys
+ns, state = sys.argv[1], sys.argv[2]
+apps = [a for a in sys.stdin.read().split() if a]
+saved = {}
+for a in apps:
+    out = subprocess.run(["kubectl","get","app","-n",ns,a,"-o","jsonpath={.spec.syncPolicy.automated}"],
+                         capture_output=True, text=True)
+    saved[a] = out.stdout.strip()          # "" means already suspended
+    subprocess.run(["kubectl","patch","app","-n",ns,a,"--type","merge",
+                    "-p",'{"spec":{"syncPolicy":{"automated":null}}}'],
+                   capture_output=True, text=True, check=True)
+    print(f"  paused {a}" + ("  (was already suspended)" if not saved[a] else ""))
+json.dump(saved, open(state,"w"), indent=2)
+print(f"  prior policy recorded -> {state}")
+PY
+    ;;
+
+  resume)
+    [ -f "$STATE" ] || die "no state file at $STATE — refusing to guess which apps to resume"
+    python3 - "$ARGO_NS" "$STATE" <<'PY'
+import json, subprocess, sys
+ns, state = sys.argv[1], sys.argv[2]
+saved = json.load(open(state))
+# children first, master-app last: restoring the parent first lets it fight the children.
+order = [a for a in saved if a != "master-app"] + (["master-app"] if "master-app" in saved else [])
+for a in order:
+    prior = saved[a]
+    if not prior:
+        print(f"  skipped {a} (was suspended before the window; leaving as-is)")
+        continue
+    subprocess.run(["kubectl","patch","app","-n",ns,a,"--type","merge",
+                    "-p",json.dumps({"spec":{"syncPolicy":{"automated":json.loads(prior)}}})],
+                   capture_output=True, text=True, check=True)
+    print(f"  resumed {a} -> {prior}")
+PY
+    echo "  §V.45: confirm each app observes the intended revision before trusting its sync status"
+    ;;
+
+  *)
+    sed -n '2,26p' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/hop-verify.sh
+++ b/scripts/hop-verify.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# hop-verify.sh — the gate every k3s hop must pass (SPEC.md §T.29, §T.30)
+#
+# §V.31 forbids a bare "gate →" in a hop task: the full set must be enumerated. This is
+# that set, executable, so the gate is a command rather than a checklist someone reads.
+#
+#   gate   run before a hop. Non-zero exit means do not hop.
+#   watch  run after. Waits for green and reports the §V.9 window.
+#
+# §V.9's window was undefined until §T.30. It is measured here as: start = the moment k3s
+# stops (passed in via --since), end = every node Ready and every Argo app Synced+Healthy.
+# Anything narrower flatters the number — the API returning is not the same as the cluster
+# being usable again.
+#
+# §V.47 matters for the Synced check: controllers legitimately mutate fields git cannot
+# know, so a blanket "all Synced" is unreachable. Known-benign drift is allowed by name and
+# anything else fails the gate.
+#
+# Usage:
+#   hop-verify.sh gate  [--artifacts DIR]
+#   hop-verify.sh watch --since <epoch-seconds> [--timeout SECONDS]
+
+set -euo pipefail
+
+ARTIFACTS="${HOME}/k3s-upgrade-artifacts"
+ARGO_NS="${ARGO_NAMESPACE:-argo-cd}"
+# Drift allowed past the gate. Two tiers, deliberately distinguished — §V.47 exists because
+# allow-listing undiagnosed drift is what made §V.5 meaningless in the first place.
+#   DIAGNOSED : cause documented in docs/plans/argocd-drift-diagnosis.md
+#   TOLERATED : workload verified running, cause NOT yet diagnosed (§T.45). Warned about
+#               on every run so it stays visible rather than becoming permanent.
+KNOWN_DRIFT_DIAGNOSED="${KNOWN_DRIFT_DIAGNOSED:-kagent-secrets kyverno}"
+KNOWN_DRIFT_TOLERATED="${KNOWN_DRIFT_TOLERATED:-atlantis whoami-test}"
+TIMEOUT=1800
+SINCE=""
+ACTION="${1:-}"; shift || true
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --artifacts) ARTIFACTS="${2:-}"; shift 2 ;;
+    --since)     SINCE="${2:-}"; shift 2 ;;
+    --timeout)   TIMEOUT="${2:-}"; shift 2 ;;
+    *) echo "hop-verify: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+FAIL=0
+ok()   { printf "  \033[32mPASS\033[0m  %s\n" "$*"; }
+bad()  { printf "  \033[31mFAIL\033[0m  %s\n" "$*"; FAIL=1; }
+note() { printf "  ----  %s\n" "$*"; }
+
+sha_check() { if command -v sha256sum >/dev/null 2>&1; then sha256sum -c "$1"; else shasum -a 256 -c "$1"; fi; }
+
+# §V.1 / §V.6 / §V.28 — a backup nobody verified is not a backup.
+check_artifact() {
+  local glob="$1" label="$2" inv="$3"
+  local newest
+  newest="$(ls -t ${ARTIFACTS}/${glob} 2>/dev/null | head -1 || true)"
+  if [ -z "$newest" ]; then bad "$inv  no $label artifact in $ARTIFACTS"; return; fi
+  local age=$(( ( $(date +%s) - $(stat -f %m "$newest" 2>/dev/null || stat -c %Y "$newest") ) / 3600 ))
+  if [ ! -f "$newest.sha256" ]; then bad "$inv  $label has no checksum manifest"; return; fi
+  if ( cd "$ARTIFACTS" && sha_check "$(basename "$newest").sha256" >/dev/null 2>&1 ); then
+    if [ "$age" -gt 24 ]; then bad "$inv  $label checksum OK but ${age}h old — take a fresh one"
+    else ok "$inv  $label verified, ${age}h old"; fi
+  else
+    bad "$inv  $label CHECKSUM MISMATCH — $(basename "$newest")"
+  fi
+}
+
+check_eso() {                                   # §V.11
+  local total synced
+  total=$(kubectl get externalsecret -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  synced=$(kubectl get externalsecret -A --no-headers 2>/dev/null | grep -c True || true)
+  if [ "$total" = "0" ]; then bad "§V.11 no ExternalSecrets found — is ESO running?"; return; fi
+  # 3 are known-broken pre-existing; treat a worsening as failure.
+  if [ "$((total - synced))" -le 3 ]; then ok "§V.11 ESO $synced/$total SecretSynced"
+  else bad "§V.11 ESO $synced/$total SecretSynced — worse than the known 3 failures"; fi
+}
+
+check_istio() {                                 # §V.49 — deferred Istio needs watching
+  local nodes bad_ds=0
+  nodes=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  for ds in istio-cni-node ztunnel; do
+    local ready desired
+    ready=$(kubectl get ds -n istio-system "$ds" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+    desired=$(kubectl get ds -n istio-system "$ds" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+    if [ "$ready" = "$desired" ] && [ "$ready" = "$nodes" ]; then ok "§V.49 $ds Ready $ready/$nodes"
+    else bad "§V.49 $ds Ready $ready/$desired (nodes=$nodes)"; bad_ds=1; fi
+  done
+  local amb
+  amb=$(kubectl get ns -l istio.io/dataplane-mode --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  [ "$amb" -gt 0 ] && ok "§V.49 $amb namespace(s) still enrolled in ambient" \
+                   || bad "§V.49 no namespaces enrolled in ambient — was that intended?"
+}
+
+check_ingress() {                               # §V.22 / §T.29
+  local phase
+  phase=$(kubectl get helmchart -n kube-system ingress-nginx -o jsonpath='{.status.jobName}' 2>/dev/null || true)
+  if kubectl get helmchart -n kube-system ingress-nginx >/dev/null 2>&1; then
+    ok "§V.22 helm-controller HelmChart ingress-nginx present (job=${phase:-none})"
+  else
+    bad "§V.22 HelmChart kube-system/ingress-nginx missing — helm-controller upgraded with the hop"
+  fi
+  # The controller here is a DaemonSet, not a Deployment — an earlier version of this
+  # check queried Deployments, found none, and reported a healthy ingress as broken.
+  local rd=0
+  rd=$(kubectl get ds -n ingress-nginx -o jsonpath='{.items[0].status.numberReady}' 2>/dev/null || echo 0)
+  [ "${rd:-0}" -eq 0 ] && rd=$(kubectl get deploy -n ingress-nginx -o jsonpath='{.items[0].status.readyReplicas}' 2>/dev/null || echo 0)
+  [ "${rd:-0}" -ge 1 ] && ok "§V.22 ingress-nginx controller ready ($rd)" \
+                       || bad "§V.22 ingress-nginx controller has no ready replicas"
+}
+
+check_nodes_and_apps() {                        # §V.5 with §V.47's exception
+  local notready
+  notready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2!="Ready"{print $1}')
+  [ -z "$notready" ] && ok "§V.5 all nodes Ready" || bad "§V.5 nodes not Ready: $notready"
+  local drift
+  drift=$(kubectl get app -n "$ARGO_NS" -o json 2>/dev/null | python3 -c '
+import sys, json
+d = json.load(sys.stdin)["items"]
+print(" ".join(sorted(a["metadata"]["name"] for a in d
+      if a["status"]["sync"]["status"] != "Synced" or a["status"]["health"]["status"] != "Healthy")))')
+  local unexpected="" tolerated=""
+  for a in $drift; do
+    case " $KNOWN_DRIFT_DIAGNOSED " in *" $a "*) continue;; esac
+    case " $KNOWN_DRIFT_TOLERATED " in *" $a "*) tolerated="$tolerated $a"; continue;; esac
+    unexpected="$unexpected $a"
+  done
+  if [ -z "$unexpected" ]; then ok "§V.5/§V.47 no unexplained drift (diagnosed: ${KNOWN_DRIFT_DIAGNOSED})"
+  else bad "§V.5/§V.47 UNEXPLAINED drift:$unexpected"; fi
+  [ -n "$tolerated" ] && note "§T.45 tolerated but UNDIAGNOSED:$tolerated — workloads Running; diagnose before this becomes permanent"
+}
+
+check_pg() {                                    # §V.14 data path
+  local ph rd
+  ph=$(kubectl get cluster -n postgresql postgresql-cluster -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  rd=$(kubectl get cluster -n postgresql postgresql-cluster -o jsonpath='{.status.readyInstances}' 2>/dev/null || echo 0)
+  [ "$ph" = "Cluster in healthy state" ] && [ "${rd:-0}" -ge 1 ] \
+    && ok "§V.14 CNPG healthy ($rd ready)" || bad "§V.14 CNPG phase='$ph' ready=$rd"
+}
+
+check_vault() {                                 # §V.14 secrets path
+  if kubectl exec -n vault vault-0 -- vault status 2>/dev/null | grep -q "Sealed.*false"; then
+    ok "§V.14 Vault unsealed"
+  else
+    bad "§V.14 Vault sealed or unreachable"
+  fi
+}
+
+case "$ACTION" in
+  gate)
+    echo "=== pre-hop gate $(date -u +%H:%M:%SZ) ==="
+    check_artifact "k3s-backup-*.tar.gz" "k3s"   "§V.1 "
+    check_artifact "pg-*.sql.gz"         "pg"    "§V.6 "
+    check_artifact "vault-backup-*.tar.gz" "vault" "§V.28"
+    check_nodes_and_apps
+    check_pg
+    check_vault
+    check_eso
+    check_istio
+    check_ingress
+    note "§V.2/§V.27 component matrix — operator judgement, see docs/plans/k3s-1.36-upgrade-plan.md"
+    note "§V.10 removed-API scan — run: pytest tests/k3s-upgrade/test_api_scan.py"
+    note "§V.16 restore drill — proven by tests/k3s-upgrade/ in CI"
+    echo
+    [ "$FAIL" -eq 0 ] && echo "GATE PASSED — safe to hop" || echo "GATE FAILED — do not hop"
+    exit "$FAIL"
+    ;;
+
+  watch)
+    [ -n "$SINCE" ] || { echo "hop-verify: watch needs --since <epoch-seconds>" >&2; exit 1; }
+    echo "=== post-hop watch, measuring §V.9 from ${SINCE} ==="
+    start_iso=$(date -u -r "$SINCE" +%H:%M:%SZ 2>/dev/null || date -u -d "@$SINCE" +%H:%M:%SZ)
+    echo "  window opened at $start_iso"
+    deadline=$(( $(date +%s) + TIMEOUT ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+      FAIL=0
+      check_nodes_and_apps >/dev/null 2>&1 || true
+      # recompute cleanly
+      FAIL=0; out=$(check_nodes_and_apps 2>&1); echo "$out" | grep -q FAIL || FAIL=0
+      if ! echo "$out" | grep -q "FAIL"; then
+        elapsed=$(( $(date +%s) - SINCE ))
+        echo "$out"
+        printf "\n  \033[32m§V.9 WINDOW: %dm %ds\033[0m (start = k3s stop, end = all nodes Ready + no unexplained drift)\n" \
+          $((elapsed/60)) $((elapsed%60))
+        [ "$elapsed" -le 900 ] && echo "  within the 15min bound" || echo "  EXCEEDS the 15min bound in §V.9"
+        exit 0
+      fi
+      printf "  t+%ds not green yet\n" $(( $(date +%s) - SINCE ))
+      sleep 20
+    done
+    echo "  TIMEOUT after ${TIMEOUT}s — cluster did not reach green"
+    exit 1
+    ;;
+
+  *)
+    sed -n '2,22p' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/terraform/roots/asela-cluster/vault-kms.tf
+++ b/terraform/roots/asela-cluster/vault-kms.tf
@@ -14,6 +14,20 @@ resource "aws_kms_key" "vault_auto_unseal" {
   enable_key_rotation      = true
   deletion_window_in_days  = 30
 
+  # SPEC.md §V.35: this key IS the Vault backup, not something beside it.
+  #
+  # Vault's storage is ciphertext sealed with this key, so every artifact
+  # scripts/vault-backup.sh produces is undecryptable without it. The Shamir recovery
+  # keys govern recovery operations, not storage decryption — they will not save you here.
+  # Losing this key means losing every secret in the cluster, however good the backups are.
+  #
+  # deletion_window_in_days = 30 above already forces a 30-day wait on ScheduleKeyDeletion.
+  # This blocks the likelier accident: a terraform destroy or a change that forces
+  # replacement of the key resource.
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = {
     Name        = "vault-auto-unseal"
     Purpose     = "Vault-Auto-Unseal"

--- a/tests/k3s-upgrade/test_hop_scripts.py
+++ b/tests/k3s-upgrade/test_hop_scripts.py
@@ -1,0 +1,103 @@
+"""Guards on the hop plumbing (SPEC.md §T.25, §T.28, §T.29, §T.30).
+
+These scripts run at the moments where a mistake is most expensive — immediately before
+and after a k3s hop — so the properties worth protecting are the ones that would silently
+weaken the gate rather than break it loudly.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SYNC_WINDOW = REPO / "scripts" / "argo-sync-window.sh"
+HOP_VERIFY = REPO / "scripts" / "hop-verify.sh"
+KMS_TF = REPO / "terraform" / "roots" / "asela-cluster" / "vault-kms.tf"
+
+
+def test_scripts_exist_and_parse():
+    for s in (SYNC_WINDOW, HOP_VERIFY):
+        assert s.exists(), f"{s.name} missing"
+        r = subprocess.run(["bash", "-n", str(s)], capture_output=True, text=True)
+        assert r.returncode == 0, f"{s.name} has a syntax error: {r.stderr}"
+
+
+# --- §T.25 / §B.4 -------------------------------------------------------------------
+
+def test_sync_window_suspends_the_parent_app():
+    """§B.4: suspending a child Argo app is not enough — master-app re-applies it from git
+    mid-operation. That silently undid the suspension during T36 and nearly started Vault
+    on a half-restored volume."""
+    t = SYNC_WINDOW.read_text()
+    assert "master-app" in t, "must suspend master-app, not just the children"
+
+
+def test_sync_window_discovers_volumeclaimtemplate_apps():
+    """Querying only PVCs carrying an Argo tracking-id misses StatefulSets using
+    volumeClaimTemplates, whose claims the StatefulSet controller creates. That omission
+    would have skipped vault and openshell — the two that matter most."""
+    t = SYNC_WINDOW.read_text()
+    assert "volumeClaimTemplates" in t, (
+        "scope must union tracked PVCs with volumeClaimTemplate StatefulSets"
+    )
+
+
+def test_sync_window_records_prior_policy():
+    """Resume must restore what was there, not assume prune/selfHeal true — an app that was
+    already suspended before the window must stay suspended after it."""
+    t = SYNC_WINDOW.read_text()
+    assert "--state" in t and "json.dump" in t, "must persist prior syncPolicy for exact restore"
+
+
+# --- §T.29 / §T.30 ------------------------------------------------------------------
+
+def test_hop_verify_checks_all_three_artifacts():
+    """§V.1, §V.6 and §V.28 each require a verified artifact. A gate that checks only one
+    would pass while a whole recovery path was missing."""
+    t = HOP_VERIFY.read_text()
+    for glob in ("k3s-backup-*.tar.gz", "pg-*.sql.gz", "vault-backup-*.tar.gz"):
+        assert glob in t, f"gate does not check for {glob}"
+
+
+def test_hop_verify_validates_checksums_not_just_presence():
+    t = HOP_VERIFY.read_text()
+    assert "sha_check" in t, "a backup that exists but does not verify is not a backup (§V.16)"
+
+
+def test_hop_verify_separates_diagnosed_from_tolerated_drift():
+    """§V.47 exists because allow-listing undiagnosed drift is what made §V.5 meaningless.
+    The two tiers must stay distinct so tolerated items keep being visible."""
+    t = HOP_VERIFY.read_text()
+    assert "KNOWN_DRIFT_DIAGNOSED" in t and "KNOWN_DRIFT_TOLERATED" in t, (
+        "drift allow-list must distinguish diagnosed causes from merely tolerated ones"
+    )
+
+
+def test_hop_verify_checks_istio_dataplane():
+    """§V.49: Istio is deferred, and istio-cni is a CNI plugin chained into node
+    networking — a failure could break pod creation rather than merely degrade."""
+    t = HOP_VERIFY.read_text()
+    assert "istio-cni-node" in t and "ztunnel" in t, "gate must check the ambient dataplane"
+
+
+def test_hop_verify_measures_the_v9_window_from_k3s_stop():
+    """§V.9 was undefined until §T.30. Measuring from anything later than the k3s stop —
+    or ending at anything earlier than the cluster being usable — flatters the number."""
+    t = HOP_VERIFY.read_text()
+    assert "--since" in t, "window needs an explicit start"
+    assert "900" in t, "must compare against §V.9's 15 minute bound"
+
+
+# --- §T.28 / §V.35 ------------------------------------------------------------------
+
+def test_kms_key_has_prevent_destroy():
+    """§V.35: Vault's storage is ciphertext sealed with this key, so the key IS the backup.
+    Losing it loses every secret in the cluster no matter how good the artifacts are."""
+    t = KMS_TF.read_text()
+    block = re.search(r'resource\s+"aws_kms_key"\s+"vault_auto_unseal"\s*\{.*?\n\}', t, re.S)
+    assert block, "vault_auto_unseal KMS key resource not found"
+    assert "prevent_destroy = true" in block.group(0), (
+        "the Vault unseal key must carry lifecycle.prevent_destroy — a terraform destroy "
+        "or forced replacement would make every Vault backup undecryptable (§V.35)"
+    )


### PR DESCRIPTION
Four pieces of plumbing that turn the hop tasks from checklists into something executable.

## `scripts/hop-verify.sh` — the gate

```bash
scripts/hop-verify.sh gate     # non-zero exit means do not hop
```

Checks all three artifacts and their **checksums**, nodes, drift, CNPG, Vault, ESO, the Istio ambient dataplane (§V.49), and ingress-nginx via helm-controller. What it *can't* check — component matrix, API scan, restore drill — it prints as explicit operator items rather than passing silently.

**Running it against the live cluster immediately found three things**, which is the point:

- No k3s artifact exists yet — *correct*, that script must run on the node (§T.17's job)
- My check queried **Deployments** for an ingress controller that's a **DaemonSet** — reported a healthy ingress as broken
- It flagged `atlantis` and `whoami-test` as unexplained drift

## The drift tiers are deliberate

Those last two are **tolerated, not diagnosed** — both workloads are 1/1 Running (19d and 7d), but I haven't established *why* Argo reports Progressing/Degraded.

§V.47 exists precisely because allow-listing undiagnosed drift is what made §V.5 meaningless. So the script keeps two tiers: diagnosed causes pass quietly, tolerated ones **warn on every run**, and **T45** tracks diagnosing them properly.

## `scripts/argo-sync-window.sh` — §V.18's pause

Suspends **master-app first** (§B.4: the parent re-applies its children and silently undid the suspension mid-migration). Scope is the union of tracked-PVC apps *and* `volumeClaimTemplates` StatefulSets — querying only the former **would have skipped `vault` and `openshell`**. Records prior policy so resume restores exactly what was there.

## §V.9 finally has a definition

`watch --since <epoch of k3s stop>` → green when all nodes Ready and no unexplained drift, compared against the 15-minute bound. Measuring from later, or ending at "API responds", would flatter the number.

## T28

Artifacts shipped to `s3://mysql-backups-asela-cluster/{pg,vault}/` with checksums, **verified by downloading one back**. The KMS key gains `lifecycle.prevent_destroy` — Vault's storage is ciphertext sealed with that key, so the key *is* the backup, and the 30-day deletion window does nothing against a `terraform destroy`.

## Verification

212 tests pass (10 new).