### PR TITLE
fix: argo-sync-window pause fed the app list to python as its program

### DIFF
--- a/scripts/argo-sync-window.sh
+++ b/scripts/argo-sync-window.sh
@@ -71,12 +71,13 @@ case "$ACTION" in
     apps="$(discover_apps)"
     [ -n "$apps" ] || die "discovered no PVC-bearing apps — refusing to record an empty window"
     # master-app first: while it is still syncing it would undo the children (§B.4).
-    ordered="master-app
-$apps"
-    python3 - "$ARGO_NS" "$STATE" <<'PY' <<<"$ordered"
+    # Apps go in argv, not stdin -- stdin is the heredoc carrying this program, and
+    # combining `<<'PY'` with `<<<"$list"` silently feeds the list in as the script.
+    # shellcheck disable=SC2086
+    python3 - "$ARGO_NS" "$STATE" master-app $apps <<'PY'
 import json, subprocess, sys
 ns, state = sys.argv[1], sys.argv[2]
-apps = [a for a in sys.stdin.read().split() if a]
+apps = sys.argv[3:]
 saved = {}
 for a in apps:
     out = subprocess.run(["kubectl","get","app","-n",ns,a,"-o","jsonpath={.spec.syncPolicy.automated}"],


### PR DESCRIPTION
`python3 - "$NS" "$STATE" <<'PY' <<<"$ordered"` has **two stdin redirects**. The last wins, so Python received the app list where it expected the heredoc program: `NameError: name 'master' is not defined`.

It failed **safely** — nothing patched, no partial window, no state file — but it failed at the exact moment it was needed, immediately before a control-plane hop.

Apps now go in argv, leaving the heredoc alone.

## My tests didn't catch it

They assert `"master-app"` appears in the file and that the script parses. That's a check on the *text*, not the *behaviour*. A script whose entire job is to run once, correctly, at a dangerous moment deserves an execution test rather than a grep.

## Verified by running it

12 apps paused, prior policy recorded — and that recording earned its place immediately: `atlantis` came back as `prune: false`, so a resume assuming `prune/selfHeal: true` would have silently undone T26's protection on `atlantis-data`.