### PR TITLE
T18: the agent Plan goes live at 1.34.9, worker-02 only

### DIFF
--- a/base-apps/system-upgrade-controller/plan-agent.yaml
+++ b/base-apps/system-upgrade-controller/plan-agent.yaml
@@ -5,11 +5,26 @@
 # by the very API server it would be restarting. §V.17 forbids ever pointing this
 # controller at k3s-control-01, and §T.15 forbids labelling it.
 #
-# CURRENTLY A NO-OP DRY RUN (§T.16). `version` is pinned to v1.33.5+k3s1 — the version
-# already running — so this exercises the whole mechanism (node selection, cordon, the
-# privileged upgrade job, uncordon) without changing anything. Only k3s-worker-02
-# carries the k3s-upgrade label for now; worker-01 hosts Vault and postgresql-cluster
-# after §T.36/§T.37 and is deliberately left out until the real hop.
+# LIVE as of §T.18: `version` is v1.34.9+k3s1, matching the control plane hopped manually
+# in §T.17. The §T.16 dry run (pinned to the running v1.33.5+k3s1) already proved the
+# mechanism end to end — node selection, cordon, the privileged upgrade job, uncordon.
+#
+# Only k3s-worker-02 carries the k3s-upgrade label. worker-01 hosts Vault and
+# postgresql-cluster after §T.36/§T.37, so hopping it is a real outage and stays a
+# deliberate, attended step (§T.15).
+#
+# ! §V.50 — THIS PLAN DOES NOT FINISH THE JOB. When k3s restarts on a node it extracts
+# into a new /var/lib/rancher/k3s/data/<hash>/ and repoints data/current, orphaning the
+# istio-cni binary installed under it. The istio-cni DaemonSet cannot heal itself: the
+# kubelet resolved its hostPath at pod-create, so the running pod reinstalls into the
+# OLD directory. containerd then fails every NEW pod sandbox on that node. Existing pods
+# keep running, which is what makes it easy to miss, and the DaemonSet stays Ready 3/3
+# throughout (§B.7). After this Plan completes on a node, run:
+#
+#   kubectl delete pod -n istio-system -l k8s-app=istio-cni-node \
+#     --field-selector spec.nodeName=<node>
+#
+# §T.46 tracks the durable fix (point cniBinDir at the stable data/cni directory).
 #
 # drain is INTENTIONALLY UNSET. Per the Plan CRD: "If left unspecified, no drain will
 # be performed." That is required here, not merely convenient — local-path is the only
@@ -28,7 +43,7 @@ spec:
   # Pinned, not a channel. A channel resolves to "latest stable" via HTTP redirect,
   # which would silently retarget this Plan when upstream cuts a release — the walk
   # must move one deliberate minor at a time (§V.3).
-  version: v1.33.5+k3s1
+  version: v1.34.9+k3s1
 
   # One node at a time. With two workers, concurrency 2 would take both out together.
   concurrency: 1


### PR DESCRIPTION
Points the system-upgrade-controller agent Plan at `v1.34.9+k3s1`, matching the control
plane hopped manually in T17 (#462). The T16 dry run — pinned to the already-running
version — already exercised node selection, cordon, the privileged upgrade job and
uncordon end to end.

**This hops one node.** Only `k3s-worker-02` carries the `k3s-upgrade` label. `worker-01`
hosts Vault and the CNPG primary after T36/T37, so hopping it takes both down; that stays
a deliberate, attended step (T15). `drain` remains unset — `local-path` is the only
StorageClass and its PVs carry hard node affinity, so a drain would evict pods that cannot
come back. Cordon alone is what we want.

## The Plan does not finish the job (§V.50)

The comment now says so explicitly. When k3s restarts on a node it extracts into a new
`data/<hash>/` and repoints `data/current`, orphaning the istio-cni binary installed under
it. The DaemonSet cannot heal itself — the kubelet resolved its hostPath at pod-create, so
the running pod reinstalls into the *old* directory. containerd then fails every **new**
pod sandbox on that node.

What makes this hard to catch: existing pods keep running, and the DaemonSet stays
`Ready 3/3` for the whole outage. On the control plane it took out coredns and with it
cluster DNS (§B.7). After the Plan completes on a node:

```bash
kubectl delete pod -n istio-system -l k8s-app=istio-cni-node \
  --field-selector spec.nodeName=<node>
```

T46 tracks the durable fix — point `cniBinDir` at the stable `data/cni` directory, which
k3s does not rotate.

Gate passes before the hop. `test_suc_plan.py` green (it asserts a version is pinned rather
than which one, so the bump is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hMqm2okNKhHVXoDhX2Cb