### PR TITLE
T19: control plane is on 1.35.6, point the agent Plan at it

### DIFF
--- a/base-apps/system-upgrade-controller/plan-agent.yaml
+++ b/base-apps/system-upgrade-controller/plan-agent.yaml
@@ -5,13 +5,13 @@
 # by the very API server it would be restarting. §V.17 forbids ever pointing this
 # controller at k3s-control-01, and §T.15 forbids labelling it.
 #
-# LIVE as of §T.18: `version` is v1.34.9+k3s1, matching the control plane hopped manually
-# in §T.17. The §T.16 dry run (pinned to the running v1.33.5+k3s1) already proved the
+# LIVE as of §T.19: `version` is v1.35.6+k3s1, matching the control plane hopped manually
+# in §T.19. The §T.16 dry run (pinned to the then-running version) already proved the
 # mechanism end to end — node selection, cordon, the privileged upgrade job, uncordon.
 #
-# Only k3s-worker-02 carries the k3s-upgrade label. worker-01 hosts Vault and
-# postgresql-cluster after §T.36/§T.37, so hopping it is a real outage and stays a
-# deliberate, attended step (§T.15).
+# BOTH workers now carry the k3s-upgrade label — §T.18 proved a worker hop does not
+# disturb Vault or CNPG (pods survive a k3s agent restart; the containerd shims outlive
+# it). concurrency 1 still takes them one at a time.
 #
 # ! §V.50 — THIS PLAN DOES NOT FINISH THE JOB. When k3s restarts on a node it extracts
 # into a new /var/lib/rancher/k3s/data/<hash>/ and repoints data/current, orphaning the
@@ -43,7 +43,7 @@ spec:
   # Pinned, not a channel. A channel resolves to "latest stable" via HTTP redirect,
   # which would silently retarget this Plan when upstream cuts a release — the walk
   # must move one deliberate minor at a time (§V.3).
-  version: v1.34.9+k3s1
+  version: v1.35.6+k3s1
 
   # One node at a time. With two workers, concurrency 2 would take both out together.
   concurrency: 1


### PR DESCRIPTION
Control plane hopped `v1.34.9+k3s1` → `v1.35.6+k3s1`. This points the agent Plan at the
same version so SUC brings both workers up behind it.

## The control-plane hop was clean

§V.50 was applied the moment the API answered rather than discovered after the fact, and
the difference is stark against T17:

| | T17 (1.34, §V.50 unknown) | T19 (1.35, §V.50 applied immediately) |
|---|---|---|
| istio-cni orphaned | ~18 min | ~10 s |
| IPAM reservations leaked | 219 of 254 | **0** (steady at 34) |
| cluster DNS | down | unaffected |
| repo-server restarts | 7, CrashLoop | 0 |
| §V.9 window | 27m27s | within bound |

Both §B.7 and §B.8 were **prevented**, not recovered from.

Prerequisites cleared first: §V.10 removed-API scan passes; `v1.35.6+k3s1` confirmed as the
current 1.35 patch; the T12 component matrix already cleared 1.35 for every component
(ingress-nginx `v1.15.1` supports ≤1.35 — it's 1.36 that it blocks). Fresh cold backup of
the 1.34 datastore taken, verified with the full `state.db`/`-wal`/`-shm` set, three copies
including S3. Unit diff identical, so `--write-kubeconfig-mode=644` survived again.

## Plan change

Both workers now carry the `k3s-upgrade` label. T18 established that a worker hop does not
disturb Vault or CNPG — pods survive a k3s agent restart because the containerd shims
outlive it, and the CNPG primary went straight through its own hop without restarting.
`concurrency: 1` still takes them one at a time, `drain` stays unset, and the §V.50 restart
is still required per node until T46 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hMqm2okNKhHVXoDhX2Cb