### PR TITLE
Remove Cloudflare: it is no longer in front of this cluster

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -40,7 +40,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | logging | Observability stack (Alloy collector, Loki logs on S3, Prometheus metrics, Grafana) | logging | [docs.md](logging/docs.md) | [runbook.md](logging/runbook.md) | [catalog-info.yaml](logging/catalog-info.yaml) |
 | loki-aws-infrastructure |  |  |  |  |  |
 | n8n | Workflow automation platform (shared PostgreSQL, Vault, admin UI + public webhooks) | n8n | [docs.md](n8n/docs.md) | [runbook.md](n8n/runbook.md) | [catalog-info.yaml](n8n/catalog-info.yaml) |
-| nginx-ingress | Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware) | ingress-nginx | [docs.md](nginx-ingress/docs.md) | [runbook.md](nginx-ingress/runbook.md) | [catalog-info.yaml](nginx-ingress/catalog-info.yaml) |
+| nginx-ingress | Shared `nginx` IngressClass controller (Rancher HelmChart, hostNetwork DaemonSet, directly internet-facing) | ingress-nginx | [docs.md](nginx-ingress/docs.md) | [runbook.md](nginx-ingress/runbook.md) | [catalog-info.yaml](nginx-ingress/catalog-info.yaml) |
 | ollama | Local LLM/embedding model server (Ollama, CPU-only, PVC-backed) | ollama | [docs.md](ollama/docs.md) | [runbook.md](ollama/runbook.md) | [catalog-info.yaml](ollama/catalog-info.yaml) |
 | oncall-agent | AI on-call/incident-response agent (Anthropic Claude, Slack, GitOps PRs) | oncall-agent | [docs.md](oncall-agent/docs.md) | [runbook.md](oncall-agent/runbook.md) | [catalog-info.yaml](oncall-agent/catalog-info.yaml) |
 | oncall-crewai |  |  |  |  |  |

--- a/base-apps/nginx-ingress/catalog-info.yaml
+++ b/base-apps/nginx-ingress/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
     backstage.io/kubernetes-label-selector: 'app.kubernetes.io/instance=ingress-nginx'
     backstage.io/kubernetes-namespace: ingress-nginx
-  tags: [ingress, daemonset, cloudflare]
+  tags: [ingress, daemonset]
 spec:
   type: infrastructure
   lifecycle: production

--- a/base-apps/nginx-ingress/docs.md
+++ b/base-apps/nginx-ingress/docs.md
@@ -1,14 +1,14 @@
 ---
 type: "Kubernetes App Guide"
 title: "nginx-ingress"
-description: "Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware)"
+description: "Shared `nginx` IngressClass controller (Rancher HelmChart, hostNetwork DaemonSet, directly internet-facing)"
 app: nginx-ingress
 catalog_entity: nginx-ingress
 kind: docs
 namespace: ingress-nginx
 last_reviewed: 2026-07-10
 status: current
-tags: [ingress, daemonset, cloudflare]
+tags: [ingress, daemonset]
 sources:
   - base-apps/nginx-ingress.yaml
   - base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -28,7 +28,7 @@ This is **not** deployed as a plain Argo CD-managed Deployment/Helm chart the wa
 - Scheduling: `nodeSelector: node.kubernetes.io/workload: infrastructure` plus a toleration for the control-plane taint (`node-role.kubernetes.io/control-plane:NoSchedule`), so it runs on infrastructure/control-plane nodes.
 - Timeouts/keepalive tuned explicitly: `proxy-read-timeout`/`proxy-connect-timeout`/`proxy-send-timeout` all `30`, plus `keep-alive-requests`/`upstream-keepalive-*` settings — the values comment notes these replace prior `ServersTransport`-based timeout fixes.
 - TLS/HTTP: `ssl-protocols: "TLSv1.2 TLSv1.3"`, `use-http2: "true"`.
-- Cloudflare integration: `use-forwarded-headers`/`compute-full-forwarded-for` are enabled, `forwarded-for-header`/`real-ip-header` are set to `X-Forwarded-For`, and `trusted-proxies` is populated with Cloudflare's published IP ranges plus the cluster's private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) — this cluster sits behind a Cloudflare tunnel, so the controller must trust Cloudflare's edge to read real client IPs.
+- **No `X-Forwarded-For` handling, deliberately.** Nothing proxies this cluster: the controller is `hostNetwork` and binds `:80`/`:443` directly, so the socket source address is the client address, and the access log shows real public IPs arriving. An earlier config enabled `use-forwarded-headers` with `real-ip-header: X-Forwarded-For` and a `trusted-proxies` list that included `10.0.0.0/8` — which contains the pod network `10.42.0.0/16`, so any pod that could reach the ingress was able to set its own `X-Forwarded-For` and be believed, bypassing the `whitelist-source-range` allow-lists that guard most Ingresses here. Do not reintroduce those keys unless a real proxy is placed in front, and then scope `trusted-proxies` to that proxy's addresses only.
 
 ## How other apps use it
 Any app that wants external HTTP(S) routing creates an `Ingress` with `ingressClassName: nginx` (e.g. `vault`, `argo-cd`, `coroot`, `logging` (`grafana-ingress.yaml`), `kagent`, `oncall-agent`, `oncall-crewai`, `vcluster-sandbox-1`). cert-manager's HTTP-01 issuers (`letsencrypt-prod`, `letsencrypt-staging`) also depend on this controller being reachable to complete ACME challenges.

--- a/base-apps/nginx-ingress/docs/index.md
+++ b/base-apps/nginx-ingress/docs/index.md
@@ -1,14 +1,14 @@
 ---
 type: "Kubernetes App Guide"
 title: "nginx-ingress"
-description: "Shared `nginx` IngressClass controller (Rancher HelmChart, DaemonSet, Cloudflare-aware)"
+description: "Shared `nginx` IngressClass controller (Rancher HelmChart, hostNetwork DaemonSet, directly internet-facing)"
 app: nginx-ingress
 catalog_entity: nginx-ingress
 kind: docs
 namespace: ingress-nginx
 last_reviewed: 2026-07-10
 status: current
-tags: [ingress, daemonset, cloudflare]
+tags: [ingress, daemonset]
 sources:
   - base-apps/nginx-ingress.yaml
   - base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -28,7 +28,7 @@ This is **not** deployed as a plain Argo CD-managed Deployment/Helm chart the wa
 - Scheduling: `nodeSelector: node.kubernetes.io/workload: infrastructure` plus a toleration for the control-plane taint (`node-role.kubernetes.io/control-plane:NoSchedule`), so it runs on infrastructure/control-plane nodes.
 - Timeouts/keepalive tuned explicitly: `proxy-read-timeout`/`proxy-connect-timeout`/`proxy-send-timeout` all `30`, plus `keep-alive-requests`/`upstream-keepalive-*` settings — the values comment notes these replace prior `ServersTransport`-based timeout fixes.
 - TLS/HTTP: `ssl-protocols: "TLSv1.2 TLSv1.3"`, `use-http2: "true"`.
-- Cloudflare integration: `use-forwarded-headers`/`compute-full-forwarded-for` are enabled, `forwarded-for-header`/`real-ip-header` are set to `X-Forwarded-For`, and `trusted-proxies` is populated with Cloudflare's published IP ranges plus the cluster's private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) — this cluster sits behind a Cloudflare tunnel, so the controller must trust Cloudflare's edge to read real client IPs.
+- **No `X-Forwarded-For` handling, deliberately.** Nothing proxies this cluster: the controller is `hostNetwork` and binds `:80`/`:443` directly, so the socket source address is the client address, and the access log shows real public IPs arriving. An earlier config enabled `use-forwarded-headers` with `real-ip-header: X-Forwarded-For` and a `trusted-proxies` list that included `10.0.0.0/8` — which contains the pod network `10.42.0.0/16`, so any pod that could reach the ingress was able to set its own `X-Forwarded-For` and be believed, bypassing the `whitelist-source-range` allow-lists that guard most Ingresses here. Do not reintroduce those keys unless a real proxy is placed in front, and then scope `trusted-proxies` to that proxy's addresses only.
 
 ## How other apps use it
 Any app that wants external HTTP(S) routing creates an `Ingress` with `ingressClassName: nginx` (e.g. `vault`, `argo-cd`, `coroot`, `logging` (`grafana-ingress.yaml`), `kagent`, `oncall-agent`, `oncall-crewai`, `vcluster-sandbox-1`). cert-manager's HTTP-01 issuers (`letsencrypt-prod`, `letsencrypt-staging`) also depend on this controller being reachable to complete ACME challenges.

--- a/base-apps/nginx-ingress/docs/runbook.md
+++ b/base-apps/nginx-ingress/docs/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ingress-nginx
 last_reviewed: 2026-07-10
 status: current
-tags: [ingress, daemonset, cloudflare]
+tags: [ingress, daemonset]
 sources:
   - base-apps/nginx-ingress.yaml
   - base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -27,13 +27,13 @@ sources:
 - **Fix:** if no nodes carry the `infrastructure` workload label, that's a cluster/node-labeling issue outside this app's manifests, not something to fix by editing `nginx-ingress-controller.yaml`'s scheduling constraints without confirming intent first — raise a PR only if the `nodeSelector`/toleration itself needs to change.
 
 ### Symptom: apps behind the ingress see wrong client IPs, or IP-based rate limiting/allow-lists misbehave
-- **Check:** `kubectl -n ingress-nginx get configmap ingress-nginx-controller -o yaml` and confirm the `trusted-proxies` entries still match Cloudflare's current published IP ranges (the values in `nginx-ingress-controller.yaml` are a point-in-time list of Cloudflare CIDRs plus the cluster's private ranges). Traffic arrives via a Cloudflare tunnel, so `use-forwarded-headers`/`real-ip-header: X-Forwarded-For` only produce correct client IPs when `trusted-proxies` covers Cloudflare's current edge ranges.
-- **Fix:** recommend a PR updating the `trusted-proxies` value in `base-apps/nginx-ingress/nginx-ingress-controller.yaml` to Cloudflare's current IP list (https://www.cloudflare.com/ips/); do not edit the live ConfigMap, since Argo CD/helm-controller will revert it.
+- **Check:** the controller does **no** `X-Forwarded-For` processing by design. It is `hostNetwork`, so the client address is the socket source address — `kubectl -n ingress-nginx logs -l app.kubernetes.io/component=controller | tail` should show real public IPs in the first field. If apps see `10.42.x.x` or a single repeated address instead, something is proxying that should not be, or the header keys were reintroduced.
+- **Fix:** do not "fix" this by enabling `use-forwarded-headers`/`real-ip-header`. Those were removed because the old `trusted-proxies` list included `10.0.0.0/8`, which contains the pod network, letting any pod spoof its source IP past the `whitelist-source-range` allow-lists. If a real reverse proxy is introduced, add the keys back with `trusted-proxies` scoped to that proxy's addresses only, via a PR to `nginx-ingress-controller.yaml` — never edit the live ConfigMap, since Argo CD/helm-controller reverts it.
 
 ## How-to
 
 ### Route a new app through this ingress
 Set `ingressClassName: nginx` on the app's `Ingress` (see `base-apps/vault/ingress.yaml` or `base-apps/argo-cd/ingress.yaml` for the pattern). For TLS, pair it with cert-manager's `letsencrypt-prod`/`letsencrypt-staging` `ClusterIssuer` (HTTP-01, routes through this same controller) as documented in `base-apps/cert-manager/docs.md`.
 
-### Change controller config (timeouts, TLS, Cloudflare ranges, scheduling)
+### Change controller config (timeouts, TLS, scheduling)
 Edit `valuesContent` in `base-apps/nginx-ingress/nginx-ingress-controller.yaml` and open a PR; Argo CD syncs the `HelmChart` object, and k3s's helm-controller re-runs the Helm upgrade job in `kube-system` against the release in `ingress-nginx`.

--- a/base-apps/nginx-ingress/nginx-ingress-controller.yaml
+++ b/base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -35,11 +35,19 @@ spec:
         # SSL and connection optimizations
         ssl-protocols: "TLSv1.2 TLSv1.3"
         use-http2: "true"
-        # Cloudflare tunnel optimization
-        use-forwarded-headers: "true"
-        compute-full-forwarded-for: "true"
-        forwarded-for-header: "X-Forwarded-For"
-        real-ip-header: "X-Forwarded-For"
-        trusted-proxies: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+        # NO X-Forwarded-For handling on purpose.
+        #
+        # Nothing proxies this cluster any more — the controller is hostNetwork and binds
+        # :80/:443 directly, so the socket's source address IS the client address. Access
+        # logs confirm it: real public IPs arrive, not an edge network's.
+        #
+        # The previous config set use-forwarded-headers + real-ip-header: X-Forwarded-For
+        # with a trusted-proxies list. That list included 10.0.0.0/8, and the pod network
+        # (10.42.0.0/16) sits inside it — so any pod able to reach the ingress could send
+        # its own X-Forwarded-For and have nginx believe it, defeating the
+        # whitelist-source-range allow-lists that guard most of the Ingresses here.
+        #
+        # Do not reintroduce these keys unless a real proxy is put in front, and if one is,
+        # set trusted-proxies to that proxy's addresses ONLY — never a broad private range.
     tcp: {}
     udp: {}

--- a/base-apps/nginx-ingress/runbook.md
+++ b/base-apps/nginx-ingress/runbook.md
@@ -8,7 +8,7 @@ kind: runbook
 namespace: ingress-nginx
 last_reviewed: 2026-07-10
 status: current
-tags: [ingress, daemonset, cloudflare]
+tags: [ingress, daemonset]
 sources:
   - base-apps/nginx-ingress.yaml
   - base-apps/nginx-ingress/nginx-ingress-controller.yaml
@@ -27,13 +27,13 @@ sources:
 - **Fix:** if no nodes carry the `infrastructure` workload label, that's a cluster/node-labeling issue outside this app's manifests, not something to fix by editing `nginx-ingress-controller.yaml`'s scheduling constraints without confirming intent first — raise a PR only if the `nodeSelector`/toleration itself needs to change.
 
 ### Symptom: apps behind the ingress see wrong client IPs, or IP-based rate limiting/allow-lists misbehave
-- **Check:** `kubectl -n ingress-nginx get configmap ingress-nginx-controller -o yaml` and confirm the `trusted-proxies` entries still match Cloudflare's current published IP ranges (the values in `nginx-ingress-controller.yaml` are a point-in-time list of Cloudflare CIDRs plus the cluster's private ranges). Traffic arrives via a Cloudflare tunnel, so `use-forwarded-headers`/`real-ip-header: X-Forwarded-For` only produce correct client IPs when `trusted-proxies` covers Cloudflare's current edge ranges.
-- **Fix:** recommend a PR updating the `trusted-proxies` value in `base-apps/nginx-ingress/nginx-ingress-controller.yaml` to Cloudflare's current IP list (https://www.cloudflare.com/ips/); do not edit the live ConfigMap, since Argo CD/helm-controller will revert it.
+- **Check:** the controller does **no** `X-Forwarded-For` processing by design. It is `hostNetwork`, so the client address is the socket source address — `kubectl -n ingress-nginx logs -l app.kubernetes.io/component=controller | tail` should show real public IPs in the first field. If apps see `10.42.x.x` or a single repeated address instead, something is proxying that should not be, or the header keys were reintroduced.
+- **Fix:** do not "fix" this by enabling `use-forwarded-headers`/`real-ip-header`. Those were removed because the old `trusted-proxies` list included `10.0.0.0/8`, which contains the pod network, letting any pod spoof its source IP past the `whitelist-source-range` allow-lists. If a real reverse proxy is introduced, add the keys back with `trusted-proxies` scoped to that proxy's addresses only, via a PR to `nginx-ingress-controller.yaml` — never edit the live ConfigMap, since Argo CD/helm-controller reverts it.
 
 ## How-to
 
 ### Route a new app through this ingress
 Set `ingressClassName: nginx` on the app's `Ingress` (see `base-apps/vault/ingress.yaml` or `base-apps/argo-cd/ingress.yaml` for the pattern). For TLS, pair it with cert-manager's `letsencrypt-prod`/`letsencrypt-staging` `ClusterIssuer` (HTTP-01, routes through this same controller) as documented in `base-apps/cert-manager/docs.md`.
 
-### Change controller config (timeouts, TLS, Cloudflare ranges, scheduling)
+### Change controller config (timeouts, TLS, scheduling)
 Edit `valuesContent` in `base-apps/nginx-ingress/nginx-ingress-controller.yaml` and open a PR; Argo CD syncs the `HelmChart` object, and k3s's helm-controller re-runs the Helm upgrade job in `kube-system` against the release in `ingress-nginx`.

--- a/docs/plans/newsletter-digest-n8n-prd.md
+++ b/docs/plans/newsletter-digest-n8n-prd.md
@@ -217,7 +217,7 @@ Every run logs to stdout (visible in Cowork transcript): `POST status`, `http_co
 
 ## 10. Open Questions / Decisions Needed
 
-1. **n8n network reachability.** Is the n8n instance already internet-accessible over HTTPS, or behind VPN only? If internal-only, we need a public URL (Cloudflare Tunnel / existing reverse proxy) before the skill sandbox can reach it.
+1. **n8n network reachability.** Is the n8n instance already internet-accessible over HTTPS, or behind VPN only? If internal-only, we need a public URL (the existing nginx ingress) before the skill sandbox can reach it.
 2. **Gmail node vs. SMTP node in n8n.** Gmail node is simpler but requires OAuth; SMTP is provider-agnostic. Preference?
 3. **Where to store the bearer token on the skill side?** Options: session env var set at Cowork startup, a file in the skill's directory that the skill reads at run time, or passed as a skill argument. Recommendation: session env var — no secret on disk, and the skill already runs in the session context.
 4. **Retry policy on transient failures.** v1 proposal: no retry in the skill itself (single POST; fall back to draft on any failure). Acceptable, or do you want one retry with backoff before falling back?

--- a/docs/plans/vcluster-implementation-plan.md
+++ b/docs/plans/vcluster-implementation-plan.md
@@ -35,7 +35,7 @@ vcluster runs as a Helm chart in its own namespace per virtual cluster (k3s cont
 ## Risks & Open Questions (must resolve during implementation)
 
 1. **ArgoCD multi-source support** — verified in Phase 0 (Task 0.3). If < 2.6, fall back to two-Application pattern (see Task 2.1 fallback).
-2. **LAN DNS for `*.vcluster.arigsela.com`** — must resolve to a node IP, not Cloudflare Tunnel. Verified in Phase 0 (Task 0.4).
+2. **LAN DNS for `*.vcluster.arigsela.com`** — must resolve to a node IP. Verified in Phase 0 (Task 0.4).
 3. **nginx-ingress restart blip** — Phase 1 includes a ~30s ingress unavailability when the controller restarts.
 4. **vcluster cert SAN propagation** — `controlPlane.proxy.extraSANs` must end up in the vcluster's internal cert. Verified in Task 2.5; rollout restart is the documented fix if it doesn't propagate on first deploy.
 

--- a/docs/reference/vcluster/getting-started.md
+++ b/docs/reference/vcluster/getting-started.md
@@ -44,7 +44,7 @@ getent hosts sandbox-1.vcluster.arigsela.com  # Linux
 grep vcluster.arigsela.com /etc/hosts          # macOS
 ```
 
-> **Why `/etc/hosts` and not real DNS?** External `*.arigsela.com` traffic goes through Cloudflare Tunnel which terminates TLS. We need direct LAN access to the cluster's nginx-ingress for these test workloads. Long-term, add a wildcard A record at your LAN DNS resolver (Pi-hole, AdGuard, router) for `*.vcluster.arigsela.com → 10.0.1.50`.
+> **Why `/etc/hosts` and not real DNS?** There is no LAN DNS record for `*.vcluster.arigsela.com`, so it will not resolve on your machine. These test workloads need to reach the cluster's nginx-ingress directly by node IP. Long-term, add a wildcard A record at your LAN DNS resolver (Pi-hole, AdGuard, router) for `*.vcluster.arigsela.com → 10.0.1.50`.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-03-golden-poc-phase-2-adapters.md
+++ b/docs/superpowers/plans/2026-05-03-golden-poc-phase-2-adapters.md
@@ -1237,7 +1237,7 @@ curl -fsS -X POST https://github-webhook.<base-domain>/webhook \
 # Expected: HTTP 401 (signature missing) — proves the endpoint is reachable.
 ```
 
-If the URL isn't reachable from the public internet (homelab NAT issues), set up a Cloudflare Tunnel or smee.io proxy now. The GitHub App's webhook URL must be publicly reachable.
+If the URL isn't reachable from the public internet (homelab NAT issues), set up an smee.io proxy now. The GitHub App's webhook URL must be publicly reachable.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md
+++ b/docs/superpowers/specs/2026-05-02-golden-ai-platform-poc-design.md
@@ -433,7 +433,7 @@ Not cuttable: the XAgent + Composition + "Try it" button. Without those three, t
 |---|---|
 | agentregistry pre-1.0 instability | Pin a specific version; fallback path is hand-written kagent ToolServer CRs that inline MCP server image refs (skipping the registry for that agent). |
 | kagent OTLP → Langfuse format mismatch | Verify during Phase 0; if mismatch, drop a small OTel collector in between. |
-| GitHub webhook delivery to homelab cluster | Cloudflare Tunnel or smee.io for the demo. Test in Phase 2. |
+| GitHub webhook delivery to homelab cluster | smee.io for the demo, or the existing public ingress. Test in Phase 2. |
 | Slack Events API setup | Standard pattern but requires public-facing endpoint; reuse existing nginx-ingress + cert-manager. |
 | Composition function-python protobuf edge cases (the float-vs-int issue your existing XApplication script flagged) | Copy the casting pattern from your existing compose function. |
 | Demo flakiness | Cluster Health pre-baked for >=1 week; curl fallback for every surface; backup recorded video. |

--- a/docs/superpowers/specs/2026-05-12-vcluster-design.md
+++ b/docs/superpowers/specs/2026-05-12-vcluster-design.md
@@ -70,7 +70,7 @@ Ephemeral dev/test sandboxes. Optimized for fast create/destroy, not long-lived 
 | One namespace per vcluster | Yes | vcluster convention; gives Kyverno + cert-manager natural scoping |
 | API access | nginx-ingress with `ssl-passthrough` | Stable hostnames; kubectl talks to real K8s API with proper TLS |
 | TLS | Per-vcluster cert-manager Certificate | Cleanest GitOps story; no secret replication across namespaces |
-| DNS | LAN-resolved `*.vcluster.arigsela.com` → node IP | Cloudflare Tunnel terminates TLS — cannot be used for passthrough |
+| DNS | LAN-resolved `*.vcluster.arigsela.com` → node IP | needs TLS passthrough to the vcluster, so it must hit a node directly |
 | Istio ambient | Vcluster namespaces NOT enrolled | Keeps API server traffic out of ztunnel for simpler debugging |
 | Kyverno | Existing policies apply unchanged | Synced pods are real pods on the host; ECR pull-secret injection works for free |
 | ArgoCD Application shape | Multi-source (Helm + git path) | One Application per vcluster; requires ArgoCD ≥ 2.6 |
@@ -80,7 +80,7 @@ Ephemeral dev/test sandboxes. Optimized for fast create/destroy, not long-lived 
 
 1. **Enable SSL passthrough in nginx-ingress.** Edit `base-apps/nginx-ingress/nginx-ingress-controller.yaml` to add `enable-ssl-passthrough: "true"` under `controller.extraArgs` in the Helm `valuesContent`. Cluster-wide change; nominal CPU cost.
 
-2. **Confirm LAN DNS for `*.vcluster.arigsela.com`.** Must resolve to a host-cluster node IP, bypassing Cloudflare Tunnel (which would terminate TLS and break passthrough). Pi-hole/router/`/etc/hosts` — outside the repo. Implementation plan will include a verification step.
+2. **Confirm LAN DNS for `*.vcluster.arigsela.com`.** Must resolve to a host-cluster node IP — anything that terminates TLS in front would break passthrough. Pi-hole/router/`/etc/hosts` — outside the repo. Implementation plan will include a verification step.
 
 3. **Confirm ArgoCD ≥ 2.6** for multi-source Application support. If not, fall back to two Applications per vcluster (chart Application + extras Application).
 

--- a/docs/superpowers/specs/2026-05-13-smoke-test-app-design.md
+++ b/docs/superpowers/specs/2026-05-13-smoke-test-app-design.md
@@ -25,7 +25,7 @@ The following are deliberately out of scope. Each is a credible v1.1 follow-up.
 - **Vault/ESO inside the smoke-test vcluster.** No secret injection.
 - **Backstage catalog entries for smoke tests.** Smoke tests don't get a `catalog-info.yaml`.
 - **Status-reflected-in-Backstage UI.** The XR `status.phase` is set, but Backstage doesn't surface it without further plugin work.
-- **Public access via Cloudflare Tunnel.** LAN-only via `/etc/hosts` (or LAN DNS) pattern, same as `*.vcluster.arigsela.com`.
+- **Public access.** LAN-only via `/etc/hosts` (or LAN DNS) pattern, same as `*.vcluster.arigsela.com`.
 
 ## Design decisions (locked during brainstorming)
 

--- a/scripts/503-error-monitor.sh
+++ b/scripts/503-error-monitor.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # 503-error-monitor.sh
+#
+# Tails the request path end to end while reproducing a 503, so you can see which hop
+# actually broke rather than guessing from the browser.
+#
+# The path is: client -> ingress-nginx (hostNetwork, binds :80/:443 on the infrastructure
+# node) -> the app's Service -> pods. There is no proxy in front of the cluster, so a 503
+# is produced by ingress-nginx itself and the reason is almost always visible in the
+# controller log alongside the upstream it tried.
 
 set -euo pipefail
 
-echo "Starting comprehensive log monitoring for 503 errors..."
+echo "Starting log monitoring for 503 errors..."
 echo "Press Ctrl+C to stop monitoring"
 
 LOG_DIR="/tmp/503-troubleshooting-$(date +%Y%m%d-%H%M%S)"
@@ -11,24 +19,27 @@ mkdir -p "$LOG_DIR"
 
 echo "Logs will be written to: $LOG_DIR"
 
-# Start log streams in background, prefixing pod names when possible
-kubectl logs -f -n cloudflare -l app=cloudflared --prefix=true > "$LOG_DIR/cloudflare.log" 2>&1 &
-CLOUDFLARE_PID=$!
+PIDS=()
 
-kubectl logs -f -n kube-system deployment/traefik --prefix=true > "$LOG_DIR/traefik.log" 2>&1 &
-TRAEFIK_PID=$!
+# The ingress controller is the component that emits the 503, so this is the log that
+# matters most: it names the upstream and the reason.
+kubectl logs -f -n ingress-nginx -l app.kubernetes.io/component=controller --prefix=true \
+  > "$LOG_DIR/ingress-nginx.log" 2>&1 &
+PIDS+=($!)
 
-kubectl logs -f -n chores-tracker -l app=chores-tracker --prefix=true > "$LOG_DIR/backend.log" 2>&1 &
-BACKEND_PID=$!
+kubectl logs -f -n chores-tracker -l app=chores-tracker --prefix=true \
+  > "$LOG_DIR/backend.log" 2>&1 &
+PIDS+=($!)
 
-kubectl logs -f -n chores-tracker-frontend -l app=chores-tracker-frontend --prefix=true > "$LOG_DIR/frontend.log" 2>&1 &
-FRONTEND_PID=$!
+kubectl logs -f -n chores-tracker-frontend -l app=chores-tracker-frontend --prefix=true \
+  > "$LOG_DIR/frontend.log" 2>&1 &
+PIDS+=($!)
 
 echo "Monitoring for 503 errors... (Ctrl+C to stop)"
 
 cleanup() {
   echo "Stopping log monitoring..."
-  kill "$CLOUDFLARE_PID" "$TRAEFIK_PID" "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  kill "${PIDS[@]}" 2>/dev/null || true
   wait || true
   echo "Logs saved in: $LOG_DIR"
 }
@@ -40,4 +51,3 @@ grep -iE "(^|\W)(503|timeout|timed out|connection reset|unavailable|upstream)\b"
 
 # Wait for background log streams
 wait
-


### PR DESCRIPTION
Nothing proxies this cluster any more, so the Cloudflare-shaped configuration is not just
stale — one piece of it is a live bypass of the ingress allow-lists.

## The security part

The controller was configured with:

```yaml
use-forwarded-headers: "true"
real-ip-header: "X-Forwarded-For"
trusted-proxies: "<10 Cloudflare CIDRs>,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
```

`trusted-proxies` includes `10.0.0.0/8`, and **the pod network `10.42.0.0/16` is inside
it**. Any pod that could reach the ingress could therefore send its own `X-Forwarded-For`
and have nginx take it as the client IP — defeating the `whitelist-source-range`
allow-lists that guard 14 of the 25 Ingresses here.

The controller is `hostNetwork`, so the socket source address *is* the client address and
no forwarded-header handling is wanted at all. The keys are removed and replaced with a
comment explaining why, so they don't get helpfully re-added. If a real proxy is ever put
in front, `trusted-proxies` should be scoped to that proxy's addresses only — never a broad
private range.

### Evidence it is genuinely gone

Access logs show real public client addresses arriving directly, and the allow-lists doing
their job:

```
74.248.24.145  "GET /0PJcpMFsD8B.php"  403     <- scanner, blocked
164.92.144.52  "GET /"                 403     <- not allow-listed
73.7.190.154   "GET /api/v1/stream/..." 200    <- allow-listed
```

No edge-network addresses at all.

## Everything else

- Stale runbook procedure removed — it instructed an operator to go fetch Cloudflare's
  current published IP list and update `trusted-proxies`.
- `cloudflare` doc/catalog tags dropped; `docs.md` description corrected.
- vcluster and golden-poc design docs stated as fact that `*.arigsela.com` terminates TLS
  at a tunnel. That would actively mislead anyone reading them now, so the reasoning is
  rewritten rather than the word deleted.
- `503-error-monitor.sh` was tailing a `cloudflare` namespace and a `traefik` deployment —
  two of its four streams pointed at things that do not exist (traefik is disabled via
  `disable: traefik`). It now tails ingress-nginx, which is what actually emits the 503.
- `base-apps/index.md` and the techdocs copies are **regenerated**, not hand-edited.

Repo-wide sweep for `cloudflare|cloudflared|cf-connecting|cf-ray` returns nothing.
`gen-okf.py --check`, `gen-techdocs.py --check` and `validate-agent-docs.py` all pass.

## Operational note

Merging this changes `valuesContent`, so k3s's helm-controller re-runs the Helm upgrade and
the controller reloads its config. Expect a brief blip on the 20 public hostnames. Nothing
about routing, TLS, or the allow-lists themselves changes — only the forwarded-header
handling, which is currently inert for direct traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hMqm2okNKhHVXoDhX2Cb