### PR TITLE
grafana: 11.3.1 -> 11.3.9 (CVE-2025-3260, -2703, -3454)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: grafana
-        image: grafana/grafana:11.3.1
+        image: grafana/grafana:11.3.9
         ports:
         - containerPort: 3000
           name: http


### PR DESCRIPTION
## What

Bumps Grafana `11.3.1` → `11.3.9`. Image tag only — same minor, so no config,
dashboard, plugin or datasource migration.

## Why

`11.3.1` (Nov 2024) is unpatched against **CVE-2025-3260** (high severity,
authorization bypass) plus CVE-2025-2703 and CVE-2025-3454. Those were fixed in
`11.3.5`; `11.3.6`–`11.3.9` and several `-security-01` rebuilds followed, so
`11.3.9` is the end of that line.

This matters more here than it would elsewhere: `grafana.arigsela.com` is the
**only ingress in the cluster with no `whitelist-source-range`**. Verified from a
non-allow-listed address — `argocd`, `vault` and `dex` all return 403; Grafana
serves its login page. Its patch level *is* the compensating control
(SPEC.md §V.67), on a cluster that sees vulnerability scans hourly (§R.25).

## Verification

- YAML parses; `yamllint` warning count unchanged vs `HEAD` (6 before, 6 after — all
  pre-existing indentation on unrelated lines)
- `11.3.9` confirmed present on Docker Hub (pushed 2025-07-23)
- Grafana restarts once on sync; the `grafana-storage` PVC keeps dashboards and users

## Follow-ups (not in this PR)

- **SPEC.md §T.59** — GitHub OAuth login, gated on Vault credentials
- **SPEC.md §T.60** — `11.3` is EOL upstream (current is `13.1.1`). This is a
  stopgap, not a supported line; the major bump needs its own window per §V.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ