### PR TITLE
grafana: ExternalSecret for GitHub OAuth credentials (merge FIRST)

### DIFF
--- a/base-apps/logging/grafana-github-oauth-external-secret.yaml
+++ b/base-apps/logging/grafana-github-oauth-external-secret.yaml
@@ -1,0 +1,34 @@
+# GitHub OAuth credentials for Grafana's login, from Vault k8s-secrets/grafana:
+#   github-client-id / github-client-secret — the GitHub OAuth App you register
+#     (github.com -> Settings -> Developer settings -> OAuth Apps), callback
+#     https://grafana.arigsela.com/login/github
+#
+# Deliberately a SEPARATE ExternalSecret from grafana-admin rather than two more
+# keys on it: if these properties are missing or wrong, the failure is contained
+# here and cannot disturb the admin credentials the break-glass login depends on.
+#
+# ORDER MATTERS: the Vault properties must exist BEFORE this is committed. The
+# Deployment consumes the target Secret via secretKeyRef, so if it is absent the
+# Grafana pod will not start. Populate Vault first. See SPEC.md §T.59.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-github-oauth
+  namespace: logging
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: grafana-github-oauth
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: grafana
+        property: github-client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: grafana
+        property: github-client-secret


### PR DESCRIPTION
**Merge this before the Deployment PR.** This is the safe half.

## What

Syncs `github-client-id` / `github-client-secret` from Vault `k8s-secrets/grafana`
into a `grafana-github-oauth` Secret in `logging`.

## Why it ships alone

Nothing consumes this Secret yet, so **this commit is inert**. If the Vault
credentials are missing, mistyped, or unreadable by the `logging` role, the
symptom is a `SecretSyncError` on this one object — Grafana keeps running and
serving, completely untouched.

That is the entire point of splitting it. It converts *"did the Vault write
land?"* from something we assume into something the cluster demonstrates, before
anything depends on it.

It is also deliberately a **separate** ExternalSecret rather than two extra keys
on `grafana-admin`. A failure here cannot disturb the admin credentials that the
break-glass login depends on.

## Verify after merge

```
kubectl -n logging get externalsecret grafana-github-oauth
kubectl -n logging get secret grafana-github-oauth -o jsonpath='{.data}' | jq 'keys'
```

Expect `SecretSynced=True` and keys `client-id`, `client-secret`.

If it reports `SecretSyncError`, the likely cause is `vault kv put` having been
used instead of `patch` — which would also have deleted `admin-user` /
`admin-password`. Check that before restarting anything:

```
vault kv get -format=json k8s-secrets/grafana | jq '.data.data | keys'
```

## Next

Only once this is green: the Deployment PR wiring `GF_AUTH_GITHUB_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ