### PR TITLE
grafana: log in with GitHub OAuth (merge AFTER #472)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: grafana
-        image: grafana/grafana:11.3.1
+        image: grafana/grafana:11.3.9
         ports:
         - containerPort: 3000
           name: http

--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -100,10 +100,52 @@ spec:
               key: admin-password
         - name: GF_USERS_ALLOW_SIGN_UP
           value: "false"
+        # Must be the public URL: Grafana derives the OAuth redirect_uri from
+        # this. Left at localhost:3000 the GitHub round-trip breaks before it
+        # starts. See SPEC.md §T.59.
         - name: GF_SERVER_ROOT_URL
-          value: "http://localhost:3000"
+          value: "https://grafana.arigsela.com"
         - name: GF_INSTALL_PLUGINS
           value: ""
+        # GitHub OAuth. Direct to github.com rather than via dex: dex's
+        # staticClients do not filter identities, so that route needs this same
+        # role_attribute_path anyway AND would require making dex.arigsela.com
+        # publicly reachable. See SPEC.md §V.68.
+        #
+        # TWO fail-closed gates, both required — SPEC.md §V.69:
+        #   ROLE_ATTRIBUTE_STRICT=true  -> a login matching no role is DENIED.
+        #     Without it the default is false and non-matching users are let in
+        #     with the default org role. This host has no IP allow-list, so that
+        #     would expose dashboards to every GitHub account in existence.
+        #   ALLOW_SIGN_UP=false         -> only users already in grafana.db may
+        #     log in, independent of the JMESPath being correct.
+        # Replace both with allowed_organizations once a GitHub org exists (§T.61).
+        - name: GF_AUTH_GITHUB_ENABLED
+          value: "true"
+        - name: GF_AUTH_GITHUB_ALLOW_SIGN_UP
+          value: "false"
+        - name: GF_AUTH_GITHUB_SCOPES
+          value: "user:email,read:org"
+        - name: GF_AUTH_GITHUB_AUTH_URL
+          value: "https://github.com/login/oauth/authorize"
+        - name: GF_AUTH_GITHUB_TOKEN_URL
+          value: "https://github.com/login/oauth/access_token"
+        - name: GF_AUTH_GITHUB_API_URL
+          value: "https://api.github.com/user"
+        - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_PATH
+          value: "login == 'arigsela' && 'Admin' || ''"
+        - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_STRICT
+          value: "true"
+        - name: GF_AUTH_GITHUB_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: grafana-github-oauth
+              key: client-id
+        - name: GF_AUTH_GITHUB_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: grafana-github-oauth
+              key: client-secret
         volumeMounts:
         - name: storage
           mountPath: /var/lib/grafana


### PR DESCRIPTION
**Do not merge until #472 reports `SecretSynced=True`.** The Deployment consumes
`grafana-github-oauth` via `secretKeyRef`; if that Secret is absent, the pod will
not start.

> Commit list shows the `11.3.9` bump from #471 because this branched before that
> squash-merged. The **diff against `main` is OAuth-only** — the image line is
> already identical. A squash merge collapses it cleanly.

## What

- `GF_AUTH_GITHUB_*` — GitHub as a login provider
- `GF_SERVER_ROOT_URL` — was `http://localhost:3000`. Grafana derives the OAuth
  `redirect_uri` from this, so the round-trip could never have completed. Wrong
  independently of OAuth.

## Why GitHub directly, not dex

Dex's `staticClients` do not filter identities — they issue tokens to whoever the
connector authenticates. Routing through dex needs this **same**
`role_attribute_path` filter anyway, *and* additionally requires making
`dex.arigsela.com` publicly reachable, since it is IP-allow-listed today and a
phone off wifi would 403 mid-flow. More work, more exposure, no benefit.
SPEC.md §V.68.

## The security-relevant part

The GitHub account is **personal, no org**, so `allowed_organizations` and
`team_ids` are unavailable, and `allowed_emails` does not exist for Grafana's
GitHub provider. That leaves `role_attribute_path` — which **fails open**:
`role_attribute_strict` defaults to `false`, and with it off a login matching no
role is admitted with the default org role.

On `grafana.arigsela.com` — the only ingress with no `whitelist-source-range`, on
a cluster scanned hourly — that means every GitHub account in existence would get
Viewer access, silently.

So there are **two** gates, both fail-closed (SPEC.md §V.69):

| Gate | Effect |
|---|---|
| `ROLE_ATTRIBUTE_STRICT=true` | a login matching no role is denied |
| `ALLOW_SIGN_UP=false` | only users already in `grafana.db` may log in — independent of the JMESPath being right |

Local admin login retained as break-glass.

## Required before this counts as done

**Log in from a second GitHub account and confirm it is refused.** Testing with
`arigsela` only proves the door opens, not that it is locked. The failure mode is
silent, so this test is the verification.

## Follow-up

SPEC.md §T.61 — a GitHub org unlocks `allowed_organizations`, a membership check
that fails closed, retiring this JMESPath. It would also let dex's connector set
`orgs:`, hardening **Vault's** login too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ