### PR TITLE
grafana: allow_sign_up=true to bootstrap the GitHub link (TEMPORARY)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -122,8 +122,14 @@ spec:
         # Replace both with allowed_organizations once a GitHub org exists (§T.61).
         - name: GF_AUTH_GITHUB_ENABLED
           value: "true"
+        # TEMPORARILY true to bootstrap the account link, then back to false.
+        # Grafana 11 links an OAuth identity to a user only by auth_module+auth_id,
+        # and that link is created BY signup. oauth_allow_insecure_email_lookup is
+        # false by default, so pre-creating a user by email cannot link either --
+        # which makes allow_sign_up=false unreachable from a cold start. See
+        # SPEC.md §B.10. role_attribute_strict below remains the active gate.
         - name: GF_AUTH_GITHUB_ALLOW_SIGN_UP
-          value: "false"
+          value: "true"
         - name: GF_AUTH_GITHUB_SCOPES
           value: "user:email,read:org"
         - name: GF_AUTH_GITHUB_AUTH_URL


### PR DESCRIPTION
**Temporary — reverted to `false` immediately after the account link exists.**

## The problem

`allow_sign_up=false` is unreachable from a cold start, so it locked out the
legitimate user on first login:

```
user.sync  "Failed to create user, signup is not allowed for module"
           auth_module=oauth_github auth_id=2475907   -> github.com/arigsela
```

Grafana 11 links an OAuth identity to a user **only** by `auth_module` +
`auth_id`, and that link is created *by* signup. Confirmed against the running
instance:

```
[auth] oauth_allow_insecure_email_lookup : false
```

With email lookup off, pre-creating a Grafana user with a matching email cannot
link either. There is no path to a linked account that does not pass through a
signup — so the gate can only be applied *after* the account exists, never
before. That is a flaw in how it was introduced in #473, not in the gate itself.

## What stays protected

`role_attribute_strict=true` is **unchanged** and remains the active gate for the
whole window:

```
role_attribute_path   : login == 'arigsela' && 'Admin' || ''
role_attribute_strict : true
```

A login that does not match resolves to no role and is denied. That is the
primary identity filter; `allow_sign_up` was only ever the backstop.

## Sequence

1. Merge this → sync → log in as `arigsela` → account and auth link created
2. **Immediately test a second GitHub account → must be refused**
3. Follow-up PR sets `allow_sign_up=false` again, permanently

Step 2 is the real verification and this is the ideal moment for it: if the
JMESPath were wrong, this is the window where it shows, while we are watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ