### PR TITLE
grafana: close the signup window (allow_sign_up=false)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -122,14 +122,18 @@ spec:
         # Replace both with allowed_organizations once a GitHub org exists (§T.61).
         - name: GF_AUTH_GITHUB_ENABLED
           value: "true"
-        # TEMPORARILY true to bootstrap the account link, then back to false.
-        # Grafana 11 links an OAuth identity to a user only by auth_module+auth_id,
-        # and that link is created BY signup. oauth_allow_insecure_email_lookup is
-        # false by default, so pre-creating a user by email cannot link either --
-        # which makes allow_sign_up=false unreachable from a cold start. See
-        # SPEC.md §B.10. role_attribute_strict below remains the active gate.
+        # Bootstrap complete -- user arigsela is linked (isExternal=true,
+        # authLabels=[GitHub]), so closing this no longer locks anyone out.
+        #
+        # This gate can only ever be closed AFTER a link exists, never before:
+        # Grafana 11 links an OAuth identity by auth_module+auth_id, created BY
+        # signup, and oauth_allow_insecure_email_lookup is false by default so
+        # pre-creating a user by email cannot link either. SPEC.md §B.10.
+        #
+        # Adding a future user therefore means flipping this true, letting them
+        # log in once, and flipping it back.
         - name: GF_AUTH_GITHUB_ALLOW_SIGN_UP
-          value: "true"
+          value: "false"
         - name: GF_AUTH_GITHUB_SCOPES
           value: "user:email,read:org"
         - name: GF_AUTH_GITHUB_AUTH_URL


### PR DESCRIPTION
Restores the second fail-closed gate. Safe to merge now — `arigsela` is linked
(`isExternal=true`, `authLabels=[GitHub]`, verified via `/api/users/2`), so this
no longer locks anyone out.

## Known gap, accepted deliberately

**`role_attribute_strict=true` has never been observed denying anything.**

The verification attempt re-authenticated as `arigsela` both times — GitHub's own
session selects the identity, and logging out of Grafana does not change it:

```
13:51:04  Successful Logout   id=user:2
13:51:09  userId=2 uname=arigsela
13:51:44  userId=2 uname=arigsela
```

Corroborated server-side: still 2 users, zero `signup is not allowed` events, and
no `auth_id` other than `2475907` has ever reached Grafana.

Merging this **forecloses that test** — a second account will now be refused by
*this* gate, telling us nothing about gate 1. That trade was made knowingly:
the system ends up safe, but standing on one verified gate and one assumed one.

The residual risk is narrow but real: if `role_attribute_path` is wrong, the only
thing preventing arbitrary GitHub access is `allow_sign_up=false` — so a future
edit flipping it true for provisioning would open the door with no warning.

Tracked as **SPEC.md §T.62**. Two ways to close it later:

- invert `role_attribute_path` to a login that cannot match, confirm you are
  denied, revert — needs no second account
- a genuine second GitHub identity, signed in at github.com first

## Operational note

Adding a future user now requires: flip `allow_sign_up` true → they log in once →
flip back to false. That is inherent to the mechanism, not incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ