### PR TITLE
grafana: TEMP — invert role_attribute_path to prove the gate denies (§T.62)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -142,8 +142,15 @@ spec:
           value: "https://github.com/login/oauth/access_token"
         - name: GF_AUTH_GITHUB_API_URL
           value: "https://api.github.com/user"
+        # TEMPORARY -- SPEC.md §T.62. Deliberately matches no one, to prove that
+        # role_attribute_strict=true actually DENIES a login resolving to no role.
+        # Reverted to "login == 'arigsela' && 'Admin' || ''" immediately after.
+        #
+        # arigsela is already linked, so signup is not consulted and
+        # allow_sign_up=false is bypassed -- this isolates gate 1.
+        # Expected: arigsela is REFUSED. Local admin login remains available.
         - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_PATH
-          value: "login == 'arigsela' && 'Admin' || ''"
+          value: "login == 'zzz-no-such-github-login' && 'Admin' || ''"
         - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_STRICT
           value: "true"
         - name: GF_AUTH_GITHUB_CLIENT_ID


### PR DESCRIPTION
**Temporary. Reverted as soon as the result is observed.** Do not leave merged.

## Why

`role_attribute_strict=true` has never been observed denying anything. The earlier
test re-authenticated as `arigsela` twice, because GitHub's session picks the
identity and logging out of Grafana does not change it.

This tests the **mechanism** rather than the identity, so it needs no second
GitHub account.

## What it does

Sets `role_attribute_path` to a login that cannot match, so `arigsela` resolves
to no role. With `role_attribute_strict=true`, that must be refused.

**This isolates gate 1.** `arigsela` is already linked (`isExternal=true`,
`authLabels=[GitHub]`), so Grafana resolves the user by `auth_module`+`auth_id`
and never consults signup — `allow_sign_up=false` is bypassed and cannot mask
the result.

## Expected

| Result | Meaning |
|---|---|
| **Refused** | `role_attribute_strict` enforces. Gate 1 proven. I revert immediately. |
| **Admitted, any role** | The flag is not enforcing. Grafana is open to every GitHub account whenever `allow_sign_up` is true. I disable `auth.github` outright rather than patch it. |

I will confirm from the server side either way — a denial leaves a distinctive
`user.sync` / role-mapping line, so we are not relying on what the browser shows.

## Safety

Local admin login remains available throughout. That is exactly why this runs
**before** any `disable_login_form` change and not after: verify the gate while a
fallback still exists, rather than removing the fallback and then discovering the
gate never worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ