### PR TITLE
grafana: restore role_attribute_path — gate 1 PROVEN (§T.62)

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -142,15 +142,13 @@ spec:
           value: "https://github.com/login/oauth/access_token"
         - name: GF_AUTH_GITHUB_API_URL
           value: "https://api.github.com/user"
-        # TEMPORARY -- SPEC.md §T.62. Deliberately matches no one, to prove that
-        # role_attribute_strict=true actually DENIES a login resolving to no role.
-        # Reverted to "login == 'arigsela' && 'Admin' || ''" immediately after.
-        #
-        # arigsela is already linked, so signup is not consulted and
-        # allow_sign_up=false is bypassed -- this isolates gate 1.
-        # Expected: arigsela is REFUSED. Local admin login remains available.
+        # Gate 1 PROVEN 2026-07-30 (SPEC.md §T.62). With this expression inverted
+        # to a login that cannot match, a GitHub login was refused with
+        # [oauth.role_attribute_strict_violation] and zero Successful Login
+        # events -- role_attribute_strict=true genuinely denies a login that
+        # resolves to no role. Do not weaken either of these two lines.
         - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_PATH
-          value: "login == 'zzz-no-such-github-login' && 'Admin' || ''"
+          value: "login == 'arigsela' && 'Admin' || ''"
         - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_STRICT
           value: "true"
         - name: GF_AUTH_GITHUB_CLIENT_ID


### PR DESCRIPTION
Reverts the temporary inversion from #476. **Merge promptly** — GitHub login is
refused for everyone until this lands.

## Result: the gate enforces

With `role_attribute_path` set to a login that cannot match, the GitHub login was
**refused**:

```
oauth.github   "Failed to extract role"
  err=[oauth.role_attribute_strict_violation] idP did not return a role
      attribute, but role_attribute_strict is set
authn.service  "Failed to authenticate request" client=auth.client.github
```

Zero `Successful Login` events on that pod. The `uname=arigsela` entries carry no
`client=auth.client.*` — a pre-existing session cookie, not a fresh
authentication.

The test isolated gate 1 cleanly: `arigsela` is linked, so Grafana resolved the
user by `auth_module`+`auth_id` and never consulted signup — `allow_sign_up=false`
could not mask the outcome.

## Both gates now verified by observation

| Gate | Denies | Evidence |
|---|---|---|
| `role_attribute_strict=true` | a login resolving to no role | this test, 2026-07-30 |
| `allow_sign_up=false` | an unlinked GitHub identity | §B.10, 2026-07-29 |

Neither rests on assumption any more. §T.62 closes.

## Unblocks

The `disable_login_form` / `auth.basic.enabled=false` lockdown, which was
deliberately sequenced after this — verify the gate while a fallback exists,
rather than removing the fallback first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ