### PR TITLE
certs: coroot → letsencrypt-route53 (DNS-01) — §T.49 canary

### DIFF
--- a/base-apps/coroot/ingress.yaml
+++ b/base-apps/coroot/ingress.yaml
@@ -5,7 +5,10 @@ metadata:
   namespace: coroot
   annotations:
     # TLS/SSL Configuration
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # DNS-01 via Route 53, not HTTP-01 via nginx. HTTP-01 solves through
+    # ingress.class: nginx, so it breaks the moment ingress-nginx is retired --
+    # and it breaks silently, ~30 days later at renewal. SPEC.md §V.52 / §T.49.
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"


### PR DESCRIPTION
**First of 19.** Deliberately one app, to prove the path before the rest follow.

## Why this matters more than it looks

20 of 24 certificates use `letsencrypt-prod`, which solves **HTTP-01 through
`ingress.class: nginx`**. Retiring ingress-nginx breaks renewal for all of them —
and it breaks *silently*. Existing certificates keep serving; the failure appears
~30 days later at renewal, long after the migration looks complete. `§V.52`
exists specifically to stop that.

`letsencrypt-route53` is already there, `Ready=True`, has **no `dnsZones`
restriction**, and is proven in this cluster by `vcluster-sandbox-1`. Moving
issuance to DNS-01 takes cert-manager off the ingress critical path completely.

It is also independent of both blockers — `§T.10` (the Istio upgrade) and `§T.54`
(the cutover) — so it can land today.

## Chosen as canary because

Single Ingress, single host, no split routing, no rate-limit annotations, and not
something you need at 2am. `dex` would be the worst possible first move — every
OIDC consumer depends on it.

## Baseline

```
coroot-tls  Ready=True  issuer=letsencrypt-prod
            notBefore=2026-07-27T11:30:43Z  notAfter=2026-10-25T11:30:42Z
```

## Verify after merge

```
kubectl -n coroot get certificate coroot-tls \
  -o jsonpath='{.spec.issuerRef.name} {.status.notBefore}{"\n"}'
curl -s -o /dev/null -w '%{http_code}\n' https://coroot.arigsela.com/   # 200
```

Expect `letsencrypt-route53` and a **new** `notBefore`. No downtime — the existing
Secret keeps serving until the replacement is Ready.

DNS-01 takes a little longer than HTTP-01 (Route 53 propagation), so allow a few
minutes.

## Note on rate limits

19 more certificates against one registered domain sits well inside Let's
Encrypt's 50/week. There is **no staging issuer on the DNS-01 path**, so these hit
production ACME directly — which is the reason for going app by app rather than
changing 19 files at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ