### PR TITLE
certs: batch 2 → letsencrypt-route53 (4 admin UIs) — §T.49

### DIFF
--- a/base-apps/argo-cd/ingress.yaml
+++ b/base-apps/argo-cd/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: argo-cd
   annotations:
     # TLS/SSL Configuration
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 

--- a/base-apps/atlantis/nginx-ingress.yaml
+++ b/base-apps/atlantis/nginx-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: atlantis-nginx
   namespace: atlantis
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/base-apps/kagent/mcp-ingress.yaml
+++ b/base-apps/kagent/mcp-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     # Own TLS cert for the dedicated MCP host — the UI's kagent-tls secret only
     # covers kagent.arigsela.com. cert-manager solves HTTP-01 via this ingress.
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/base-apps/kagent/nginx-ingress.yaml
+++ b/base-apps/kagent/nginx-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kagent-ui-nginx
   namespace: kagent
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"


### PR DESCRIPTION
`argocd` · `atlantis` · `kagent` · `kagent-mcp`

All four carry `whitelist-source-range`, so `ingress-policy` is satisfied.

| Certificate | baseline `notBefore` |
|---|---|
| `argo-cd/argocd-tls` | 2026-06-09 |
| `atlantis/atlantis-tls` | 2026-07-28 |
| `kagent/kagent-tls` | 2026-07-09 |
| `kagent/kagent-mcp-tls` | 2026-07-13 |

Same proven path as #478 and #479 — 8 certificates migrated so far, zero
downtime, every host matching its `§T.50` baseline status code.

## Batch 2 is smaller than planned — four members are blocked

**`n8n`** — both Ingresses share `secretName: n8n-tls`, and only the admin one is
allow-listed. Changing admin alone would leave two Ingresses requesting the same
Certificate with **different issuers**, and `ingress-shim` would flap between
them. They must move together, and the webhook cannot pass `ingress-policy`. That
webhook is also legitimately un-allow-listable — it receives calls from arbitrary
external services. Blocked on `§T.63`.

**`grafana`, `chores-tracker` ×2** — no allow-list, same CI block. `§T.63`.

**`langflow`** — **not in the repo at all.** `langflow.arigsela.com` has served for
131 days with a `letsencrypt-prod` certificate and an Argo tracking-id naming an
application (`langflow-ide-config`) that no longer exists. It is orphaned, cannot
be migrated through GitOps because there is nothing in git to edit, and **will
break at cutover**. Tracked as `§T.64`.

## Verify after merge

```
kubectl get certificate -A -o custom-columns=\
NS:.metadata.namespace,NAME:.metadata.name,ISSUER:.spec.issuerRef.name,\
READY:.status.conditions[0].status,SINCE:.status.notBefore
```

Expect 12 on `letsencrypt-route53`, all Ready. Then check the hosts against
`docs/plans/ingress-migration-baseline-2026-07-29.md` — `argocd` 200,
`atlantis` 200, `kagent` 200, `kagent-mcp` 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ