### PR TITLE
certs: vault + dex → letsencrypt-route53 — last of the unblocked (§T.49)

### DIFF
--- a/base-apps/dex/ingress.yaml
+++ b/base-apps/dex/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   name: dex
   namespace: dex
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/base-apps/vault/ingress-public.yaml
+++ b/base-apps/vault/ingress-public.yaml
@@ -14,7 +14,7 @@ metadata:
   name: vault-ui
   namespace: vault
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"


### PR DESCRIPTION
Deliberately **last, and together**: everything else authenticates through these
two. Vault's UI login is OIDC via `dex`, so if `dex`'s certificate broke, the tool
you would normally reach for is the one that stopped working.

## Why the risk is still low

cert-manager serves the **existing** Secret until the replacement is `Ready`, and
both certificates run to **2026-10-13** — about 2.5 months of runway. A failed
issuance therefore degrades to "nothing happened", not an outage. Both carry
`whitelist-source-range`, so `ingress-policy` is satisfied.

## Baselines

```
vault/vault-arigsela-tls  letsencrypt-prod  notBefore 2026-07-15T21:41:26Z
dex/dex-tls               letsencrypt-prod  notBefore 2026-07-15T21:12:21Z
dex OIDC discovery        issuer https://dex.arigsela.com   authz .../auth
```

Vault's trust of `dex` is configured **inside Vault**, not in any manifest, and is
validated against public roots. Old and new certificates are both Let's Encrypt,
so the OIDC path is unaffected by the issuer change.

## Verify after merge

```
kubectl -n vault get certificate vault-arigsela-tls -o jsonpath='{.spec.issuerRef.name} {.status.notBefore}{"\n"}'
kubectl -n dex   get certificate dex-tls            -o jsonpath='{.spec.issuerRef.name} {.status.notBefore}{"\n"}'

curl -s -o /dev/null -w 'vault %{http_code}\n' https://vault.arigsela.com/   # baseline 307
curl -s https://dex.arigsela.com/.well-known/openid-configuration | jq .issuer
```

The dex discovery check is the one that matters — it proves the OIDC path Vault
depends on still works over the new certificate.

## After this

14 of 21 migrated. The remaining 6 are blocked, not pending:

- **`§T.63`** — grafana, chores ×2, n8n ×2, oncall-agent. Seven ingresses have no
  allow-list and the intent behind each is undecided. n8n additionally shares one
  secret across an allow-listed admin ingress and an un-allow-listable webhook.
- **`§T.64`** — langflow, which is not in the repo at all.
- `chores-tracker-agent-tls` was already broken before this work began (`§R.33`),
  with a challenge pending for 78 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ