### PR TITLE
fix: drop the now-empty repo source from vcluster-sandbox-1

### DIFF
--- a/base-apps/vcluster-sandbox-1.yaml
+++ b/base-apps/vcluster-sandbox-1.yaml
@@ -46,9 +46,6 @@ spec:
             fromHost:
               storageClasses:
                 enabled: true
-    - repoURL: https://github.com/arigsela/kubernetes
-      targetRevision: main
-      path: base-apps/vcluster-sandbox-1
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Completes #482, which I left incomplete.

## What went wrong

Removing both files under `base-apps/vcluster-sandbox-1/` left the directory
untracked — git does not store empty directories — so Argo could not generate
manifests for the second source:

```
ComparisonError: Failed to load target state: failed to generate manifest for
source 2 of 2: base-apps/vcluster-sandbox-1: app path does not exist
```

With the comparison failing, the app sat at `sync=Unknown` and **never pruned**.
The dead Ingress and Certificate stayed in the cluster — the opposite of what
#482 intended. The source should have been removed in the same change.

## The fix

Drop the repo source, leaving only the loft.sh chart. That source uses an inline
`valuesObject` and does not reference the repo source, so this is safe. Once the
comparison succeeds, `prune: true` removes the two orphaned resources.

**The vcluster itself is untouched and stays running.**

## Verify after merge

```
kubectl -n argo-cd get application vcluster-sandbox-1   # Synced/Healthy, not Unknown
kubectl -n vcluster-sandbox-1 get ingress,certificate   # expect none
kubectl -n vcluster-sandbox-1 get pods                  # vcluster STILL RUNNING
```

## Note

The chart still sets `proxy.extraSANs: sandbox-1.vcluster.arigsela.com` on the
vcluster's own serving certificate. Harmless — an internal cert nothing reaches
externally — and removing it would restart the vcluster for no gain.

## Worth remembering

Emptying a directory that an Argo source points at does not remove the source; it
**breaks** it, and a broken comparison silently disables pruning. The failure mode
is quiet — `health` stays `Healthy`, so a health-only check sees nothing wrong.
That is the same blind spot `§V.47` describes for drift and `§B.7` for the CNI
outage: liveness is not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ