### PR TITLE
certs: final batch → letsencrypt-route53 — §T.49 complete except langflow

### DIFF
--- a/base-apps/chores-tracker-backend/nginx-ingress.yaml
+++ b/base-apps/chores-tracker-backend/nginx-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     # Family-facing application, intended to be reachable without a VPN or an
     # IP allow-list. Authentication is the app's own JWT login.
     arigsela.com/public-by-design: "public-app"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/base-apps/chores-tracker-frontend/nginx-ingress.yaml
+++ b/base-apps/chores-tracker-frontend/nginx-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     # IP allow-list. Authentication is the app's own JWT login.
     arigsela.com/public-by-design: "public-app"
     # TLS/SSL Configuration
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 

--- a/base-apps/logging/grafana-ingress.yaml
+++ b/base-apps/logging/grafana-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     # two fail-closed gates, both verified by observation 2026-07-30:
     # role_attribute_strict=true and allow_sign_up=false. SPEC.md V69 / T62.
     arigsela.com/public-by-design: "github-oauth"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/base-apps/n8n/nginx-ingress-admin.yaml
+++ b/base-apps/n8n/nginx-ingress-admin.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: n8n
   annotations:
     # TLS/SSL Configuration
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 

--- a/base-apps/n8n/nginx-ingress-webhook.yaml
+++ b/base-apps/n8n/nginx-ingress-webhook.yaml
@@ -8,7 +8,7 @@ metadata:
     # IP-restricted. Each workflow authenticates its own webhook.
     arigsela.com/public-by-design: "webhook-receiver"
     # TLS/SSL Configuration
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 

--- a/base-apps/oncall-agent/oncall-agent-external-ingress.yaml
+++ b/base-apps/oncall-agent/oncall-agent-external-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     # absence of SLACK_APP_TOKEN -- this is not Socket Mode, so inbound
     # reachability is required, not optional.
     arigsela.com/public-by-design: "slack-events-api"
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-route53
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"


### PR DESCRIPTION
`grafana` · `chores-tracker` ×2 · `n8n` (admin + webhook) · `oncall-agent`

5 certificates, 6 files. These were blocked not by risk but because
`ingress-policy` could not tell a deliberately-public host from a forgotten
allow-list. #483 gave them a way to declare which, so they can move now.

## n8n's two Ingresses change together

They share `secretName: n8n-tls`. Moving only the admin one would leave two
Ingresses requesting the same Certificate under **different issuers**, with
cert-manager flapping between them indefinitely. That is why n8n could not simply
be included in batch 2.

## Baselines

```
logging/grafana-tls                        2026-07-19T20:18:03Z
chores-tracker/chores-tracker-tls          2026-07-19T23:17:10Z
chores-tracker-frontend/chores-tracker-tls 2026-07-20T18:14:30Z
n8n/n8n-tls                                2026-06-04T18:57:35Z
oncall-agent/oncall-agent-tls              2026-06-06T15:19:56Z
```

## Verify after merge

```
kubectl get certificate -A -o custom-columns=\
NS:.metadata.namespace,NAME:.metadata.name,ISSUER:.spec.issuerRef.name,\
READY:.status.conditions[0].status,SINCE:.status.notBefore
```

Expect **18 on `letsencrypt-route53`**, all Ready. Then check the hosts against
`docs/plans/ingress-migration-baseline-2026-07-29.md` — `grafana` 302,
`chores` 200 (both `/` and `/api/v1/health`), `n8n` 200, `oncall` 200.

`oncall.arigsela.com` is worth a real check rather than just a status code: it
receives Slack Events API callbacks, so if anything about it regressed the
symptom would be a quiet Slack integration rather than a failing curl.

## After this

Every certificate that **can** move has moved. Two remain:

- **`langflow-ide/langflow-ide-tls`** — `§T.64`. Not in the repo at all; there is
  nothing to edit. Needs adopting or deleting.
- **`oncall-crewai/chores-tracker-agent-tls`** — broken since May, challenge
  pending 78 days. Pre-existing (`§R.33`), unrelated to this work.

That completes the goal of `§T.49`: cert-manager is off the ingress critical path,
so retiring ingress-nginx no longer silently breaks renewal ~30 days later — the
trap `§V.52` exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ