### PR TITLE
gateway-api: CRDs v1.2.0 → v1.5.1 (preflight for §T.10)

### DIFF
--- a/base-apps/istio-gateway-api.yaml
+++ b/base-apps/istio-gateway-api.yaml
@@ -11,7 +11,13 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kubernetes-sigs/gateway-api
-    targetRevision: v1.2.0
+    # Istio 1.30 REQUIRES Gateway API v1.5.x. Without it, TLSRoute and
+    # ReferenceGrant become INVISIBLE to istiod - silently. V63 makes
+    # ReferenceGrant load-bearing for the Gateway's cross-namespace
+    # certificateRefs in T55, so this must land before T10 reaches 1.30.
+    # v1.5.1, not v1.6.1: v1.5.x is what Istio 1.30 requires and is tested
+    # against. v1.6 additionally GAs TCPRoute/UDPRoute, which nothing needs.
+    targetRevision: v1.5.1
     path: config/crd/standard
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
**Istio 1.30 requires Gateway API v1.5.x.** From the 1.30 upgrade notes: without
it, *TLSRoute and ReferenceGrant resources become invisible to istiod* — silently.

That matters here beyond TLSRoute. `§V.63` makes ReferenceGrant load-bearing for
the Gateway's cross-namespace `certificateRefs` in `§T.55`: 18 TLS secrets live
across 20 namespaces, so the ingress Gateway cannot read any of them without
ReferenceGrants istiod can actually see. Listeners would come up certless, with
no error.

## Why v1.5.1 and not v1.6.1

v1.5.x is what Istio 1.30 requires and is tested against. v1.6 additionally GAs
TCPRoute/UDPRoute, which nothing here needs. Taking the newest for its own sake
adds API surface and moves off the tested combination.

## Verified safe — no storage migration required

| CRD | stored now | at v1.5.1 |
|---|---|---|
| `backendtlspolicies` | `v1` | `v1` (storage) |
| `gatewayclasses` | `v1` | `v1` (storage) |
| `gateways` | `v1` | `v1` (storage) |
| `grpcroutes` | `v1` | `v1` (storage) |
| `httproutes` | `v1` | `v1` (storage) |
| **`referencegrants`** | **`v1beta1`** | **`v1beta1` still STORAGE**, `v1` added as served |

That last row is the one that had to be checked. It is why this is **not** the
ESO situation from `§R.3`/`§V.26`, where git said `v1`, etcd said `v1beta1`, and
Kubernetes refused to drop a version listed in `storedVersions`.

## Also adopts an orphan

`backendtlspolicies` is at bundle **v1.4.0 and managed by nothing** — it only
entered the standard channel at v1.4, so an app pinned to v1.2.0 never covered it.

## Side effect

Installs `listenersets`, `tlsroutes`, and the `vap_safeupgrades`
ValidatingAdmissionPolicy. Nothing uses them — API surface, not behaviour.

## Verify after merge

```
kubectl get crd -o json | jq -r '.items[]
  | select(.metadata.name|endswith("gateway.networking.k8s.io"))
  | "\(.metadata.name)  \(.metadata.annotations["gateway.networking.k8s.io/bundle-version"])"'

kubectl get gateway -A          # both istio-waypoint Gateways must stay Programmed=True
kubectl -n chores-tracker get pods
```

The waypoint check is the real one — they are the only live consumers of these
CRDs, and a CRD change that broke them would otherwise surface later as an
ambient-mesh fault with no obvious cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ