### PR TITLE
istio: step 1 of 6 — 1.24.0 → 1.25.5 (§T.10)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.24.0
+    targetRevision: 1.25.5
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.24.0
+    targetRevision: 1.25.5
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.24.0
+    targetRevision: 1.25.5
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.24.0
+    targetRevision: 1.25.5
     helm:
       values: |
         global:


### PR DESCRIPTION
First step of the `1.24 → 1.30` campaign. Six sequential minors, **one campaign**
(`§V.64`): `1.25.5 → 1.26.8 → 1.27.9 → 1.28.10 → 1.29.6 → 1.30.3`.

Not skippable — `§R.23`: `istio-cni` and `ztunnel` are compatible with a control
plane only at `1.x..1.x+1`, so maximum skew is one minor.

## Why all four components in one PR

The existing sync-waves already encode `§R.23`'s required order:

| App | wave | role |
|---|---|---|
| `istio-base` | −2 | CRDs |
| `istio-istiod` | −1 | control plane |
| `istio-cni` | 0 | dataplane, in-place |
| `istio-ztunnel` | 1 | dataplane, in-place — **disrupts ambient traffic per node** |

Splitting across PRs would leave the mesh version-skewed between merges for no
benefit. Control-plane-ahead-of-dataplane *during* the step is the documented
order and sits within the one-minor skew `§R.23` allows.

In-place rather than revisioned, per `§V.12`'s exception and `§T.66`'s decision.
Governed by `§V.70`.

`1.25.5` is the latest patch of that minor — for a transient intermediate, fewer
known bugs matters more than matching `.0`.

`§V.32`'s exception covers the matrix gap: 1.25 is k8s 1.29–1.32 and this cluster
is on 1.35, so this intermediate is **out of matrix**. Permitted because the end
version (1.30, k8s 1.32–1.36) is in matrix and the walk completes in one campaign.

## Pre-step baseline

```
istiod   pilot:1.24.0-distroless
cni      install-cni:1.24.0-distroless  3/3
ztunnel  ztunnel:1.24.0                 3/3
both waypoints Programmed=True
chores.arigsela.com 200, /api/v1/health 200
0 pods stuck ContainerCreating
```

## `§V.70` gate — all four required before step 2

1. `istio-cni-node` + `ztunnel` DS Ready on **all 3 nodes**
2. both ambient namespaces still routing
3. both waypoint Gateways `Programmed=True`
4. **no pod stuck `ContainerCreating`** — `§B.7`'s signature, where the DS read
   3/3 Ready throughout a cluster-wide DNS outage

Then rollback is proven on this step before step 2 is attempted.

## Expect disruption

The ztunnel step briefly disrupts ambient traffic **per node** (`§R.23`). That is
expected behaviour, not a fault — `§V.70` says expect it, don't diagnose it. Only
2 of 45 namespaces are enrolled, which is precisely why this campaign is cheap
now and expensive after the ingress cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ