### PR TITLE
istio: step 2 of 6 — 1.25.5 → 1.26.8 (§T.10)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.25.5
+    targetRevision: 1.26.8
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.25.5
+    targetRevision: 1.26.8
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.25.5
+    targetRevision: 1.26.8
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.25.5
+    targetRevision: 1.26.8
     helm:
       values: |
         global:


### PR DESCRIPTION
Step 2 of the `1.24 → 1.30` campaign (`§V.64`, one campaign).

Step 1 passed all four `§V.70` gates: DS 3/3 on both dataplane components, ambient routing 200, both waypoints `Programmed=True`, zero `ContainerCreating`. Waypoint pods followed to `proxyv2:1.25.5` unaided.

**Finding from step 1:** the ztunnel DaemonSet was renamed `ztunnel` → `istio-ztunnel` in chart 1.25.x. A check hardcoding the old name would false-alarm or silently find nothing — same blind-spot family as `§B.7`. Gate checks are matched against live resource names each step rather than a remembered list.

1.26 is k8s 1.29–1.33 against a 1.35 cluster — out of matrix, permitted by `§V.32`'s exception since the end version is in-matrix and the walk completes in one campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ