### PR TITLE
istio: step 3 of 6 — 1.26.8 → 1.27.9 (§T.10)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.26.8
+    targetRevision: 1.27.9
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.26.8
+    targetRevision: 1.27.9
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.26.8
+    targetRevision: 1.27.9
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.26.8
+    targetRevision: 1.27.9
     helm:
       values: |
         global:


### PR DESCRIPTION
Step 3 of 6. Step 2 passed all four `§V.70` gates.

The ztunnel DaemonSet renamed **back** this step: `ztunnel` (1.24) → `istio-ztunnel` (1.25) → `ztunnel` (1.26). Argo pruned the stale one correctly — verified exactly one ztunnel pod per node, no doubled dataplane.

1.27 is k8s 1.29–1.33 against 1.35 — out of matrix, permitted by `§V.32`'s exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ