### PR TITLE
istio: step 4 of 6 — 1.27.9 → 1.28.10 (§T.10)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.27.9
+    targetRevision: 1.28.10
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.27.9
+    targetRevision: 1.28.10
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.27.9
+    targetRevision: 1.28.10
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.27.9
+    targetRevision: 1.28.10
     helm:
       values: |
         global:


### PR DESCRIPTION
Step 4 of 6. Step 3 passed all four `§V.70` gates.

1.28 is k8s 1.30–1.34 — the **last out-of-matrix intermediate** against this 1.35 cluster. From 1.29 onward the walk is back inside the supported matrix (1.29 = 1.31–1.35, 1.30 = 1.32–1.36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ