### PR TITLE
istio: step 5 of 6 — 1.28.10 → 1.29.6 (§T.10)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.28.10
+    targetRevision: 1.29.6
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.28.10
+    targetRevision: 1.29.6
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.28.10
+    targetRevision: 1.29.6
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.28.10
+    targetRevision: 1.29.6
     helm:
       values: |
         global:


### PR DESCRIPTION
Step 5 of 6. Step 4 passed all four `§V.70` gates (the cni DS read 2/3 for ~45s mid-rollout, then settled at 3/3 — rolling update, not a stall).

**1.29 = k8s 1.31–1.35**, so from this step the mesh is back inside the supported matrix for the first time since 1.24. `§V.32`'s exception no longer needs to carry it — 1.29 and 1.30 both stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ