### PR TITLE
istio: step 6 of 6 — 1.29.6 → 1.30.3 (§T.10 COMPLETE)

### DIFF
--- a/base-apps/istio-base.yaml
+++ b/base-apps/istio-base.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: base
-    targetRevision: 1.29.6
+    targetRevision: 1.30.3
     helm:
       values: |
         defaultRevision: default

--- a/base-apps/istio-cni.yaml
+++ b/base-apps/istio-cni.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: cni
-    targetRevision: 1.29.6
+    targetRevision: 1.30.3
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-istiod.yaml
+++ b/base-apps/istio-istiod.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: istiod
-    targetRevision: 1.29.6
+    targetRevision: 1.30.3
     helm:
       values: |
         profile: ambient

--- a/base-apps/istio-ztunnel.yaml
+++ b/base-apps/istio-ztunnel.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://istio-release.storage.googleapis.com/charts
     chart: ztunnel
-    targetRevision: 1.29.6
+    targetRevision: 1.30.3
     helm:
       values: |
         global:


### PR DESCRIPTION
Final step. Step 5 passed all four `§V.70` gates.

**1.30 = k8s 1.32–1.36** — the version the whole campaign exists for:

- `§V.60` — landing ingress on 1.29 (k8s 1.31–1.35) would have swapped one 1.35-capped ingress for another and left 1.36 blocked anyway. Only 1.30 reaches 1.36, which is the point of `§T.43`.
- `§R.24` — only 1.29 and 1.30 are supported upstream, and **1.29 goes EOL ~2026-08**. 1.30 is the sole non-EOL target.
- `§T.65` — Gateway API CRDs were raised to v1.5.1 first, because without them TLSRoute and ReferenceGrant become invisible to istiod *silently*, and `§V.63` makes ReferenceGrant load-bearing for the ingress Gateway's cross-namespace `certificateRefs` in `§T.55`.

With this, `§V.59` is satisfied: the Istio upgrade completes **before** any north-south traffic moves onto an Istio Gateway. That was the whole ordering argument — today it disrupts 2 ambient namespaces; after cutover it would have been a 21-hostname production event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ