### PR TITLE
istio-ingress: Gateway + coroot route (§T.55/§T.56 canary)

### DIFF
--- a/base-apps/coroot/httproute.yaml
+++ b/base-apps/coroot/httproute.yaml
@@ -1,0 +1,26 @@
+# Gateway API replacement for this app's nginx Ingress (SPEC.md T56).
+#
+# Deliberately lives in the app namespace rather than beside the Gateway: the
+# backendRef is then same-namespace and needs no ReferenceGrant, and the route
+# stays with the thing it routes to. Attaching across namespaces is allowed by
+# the Gateway's allowedRoutes.namespaces.from: All.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coroot
+  namespace: coroot
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-coroot
+  hostnames:
+    - coroot.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: coroot-coroot
+          port: 8080

--- a/base-apps/coroot/reference-grant.yaml
+++ b/base-apps/coroot/reference-grant.yaml
@@ -1,0 +1,21 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+#
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring
+# (SPEC.md V63). The grant lives here, in the namespace that owns the secret, so
+# the app grants access to its own material rather than the Gateway helping
+# itself.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-coroot-tls
+  namespace: coroot
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: coroot-tls

--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -35,6 +35,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | dex | OIDC provider fronting GitHub — issuer for Vault OIDC (human `vault` login via GitHub SSO) | dex | [docs.md](dex/docs.md) | [runbook.md](dex/runbook.md) | [catalog-info.yaml](dex/catalog-info.yaml) |
 | ecr-auth |  |  |  |  |  |
 | istio-ambient-config |  |  |  |  |  |
+| istio-ingress |  |  |  |  |  |
 | kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | [docs.md](kagent/docs.md) | [runbook.md](kagent/runbook.md) | [catalog-info.yaml](kagent/catalog-info.yaml) |
 | kyverno-policies |  |  |  |  |  |
 | logging | Observability stack (Alloy collector, Loki logs on S3, Prometheus metrics, Grafana) | logging | [docs.md](logging/docs.md) | [runbook.md](logging/runbook.md) | [catalog-info.yaml](logging/catalog-info.yaml) |

--- a/base-apps/istio-ingress.yaml
+++ b/base-apps/istio-ingress.yaml
@@ -1,0 +1,31 @@
+# The north-south ingress Gateway that replaces ingress-nginx (SPEC.md T43/T55).
+#
+# Staged on :8080/:8443 deliberately. ingress-nginx holds :80/:443 on
+# k3s-control-01 via hostNetwork and the two cannot share those ports (V55), so
+# every host is validated on the alternate ports first and the swap to :80/:443
+# happens inside the maintenance window T54 authorised.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: istio-ingress
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/istio-ingress
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: istio-ingress
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/base-apps/istio-ingress/gateway-options.yaml
+++ b/base-apps/istio-ingress/gateway-options.yaml
@@ -1,0 +1,29 @@
+# Customisation for the Deployment/Service Istio generates for the Gateway.
+# Referenced from the Gateway via spec.infrastructure.parametersRef.
+#
+# hostNetwork is the point of this file. ingress-nginx gets the real client IP
+# for free because it runs hostNetwork, and V61 makes that a precondition of
+# every AuthorizationPolicy ipBlocks rule in T51: behind a SNAT'ing Service every
+# client would appear as the node address, and because 10.0.0.0/8 is already in
+# all 15 allow-lists (B9) the result would be silently OPEN rather than a loud
+# lockout. hostNetwork avoids the question entirely.
+#
+# Pinned to k3s-control-01 for the same reason nginx is: public DNS resolves to
+# this node, so the Gateway has to answer there.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-options
+  namespace: istio-ingress
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
+          nodeSelector:
+            node.kubernetes.io/workload: infrastructure
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -1,0 +1,40 @@
+# One HTTPS listener per hostname, each with its own certificateRef, because
+# these are per-host certificates rather than a wildcard.
+#
+# The certificates stay in their app namespaces and are reached by
+# ReferenceGrant (V63). The alternative - reissuing all 20 into this namespace -
+# would mean another ~20 ACME issuances in the same week T49 already spent ~20,
+# against a 50/week limit per registered domain.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main
+  namespace: istio-ingress
+spec:
+  gatewayClassName: istio
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gateway-options
+  listeners:
+    # Catches every host on plain HTTP; the redirect HTTPRoute attaches here.
+    - name: http
+      protocol: HTTP
+      port: 8080
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-coroot
+      protocol: HTTPS
+      port: 8443
+      hostname: coroot.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: coroot-tls
+            namespace: coroot
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/base-apps/istio-ingress/httproute-redirect.yaml
+++ b/base-apps/istio-ingress/httproute-redirect.yaml
@@ -1,0 +1,18 @@
+# Every plain-HTTP request redirects to HTTPS, replacing the
+# force-ssl-redirect annotation carried by 21 Ingress manifests (R30).
+# Attaches only to the :8080 listener; HTTPS traffic is untouched.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-redirect
+  namespace: istio-ingress
+spec:
+  parentRefs:
+    - name: main
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301


### PR DESCRIPTION
First north-south Gateway in this cluster. `§R.26` corrected the earlier belief that ingress infrastructure already existed — the two live Gateways are ambient **waypoints** doing east-west policy, there are zero HTTPRoutes, and nothing serves north-south.

Deliberately **one host end to end** so the hard parts are proven before nineteen more depend on them. `coroot` for the same reason it was the `§T.49` canary.

## Nothing about live traffic changes

Staged on **:8080/:8443**. ingress-nginx holds :80/:443 on `k3s-control-01` via hostNetwork and the two cannot share them (`§V.55`), so hosts are validated on alternate ports and the swap happens inside the window `§T.54` authorised.

## hostNetwork is a precondition, not a preference

Set via `spec.infrastructure.parametersRef` → ConfigMap strategic merge patch.

Behind a SNAT'ing Service every client appears as the node address — and since `10.0.0.0/8` is already in all 15 allow-lists (`§B.9`), translating them to `AuthorizationPolicy` `ipBlocks` would fail **open** rather than loudly. hostNetwork sidesteps it; nginx gets the real client IP the same way today. `§V.61`.

## Certs stay put

Reached by ReferenceGrant (`§V.63`). Reissuing ~20 into `istio-ingress` would mean another ~20 ACME issuances in the week `§T.49` already spent ~20, against 50/week per registered domain.

## Routes live in app namespaces

Not beside the Gateway — the backendRef is then same-namespace and needs no second ReferenceGrant, and the route stays with what it routes to.

Verified against the **live** Ingress: the backend is `coroot-coroot:8080`, not `coroot:8080`.

## Verify after merge

```
kubectl -n istio-ingress get gateway main
kubectl -n istio-ingress get pods -o wide          # hostNetwork, on k3s-control-01
kubectl -n coroot get httproute coroot -o yaml     # Accepted + ResolvedRefs
curl -k --resolve coroot.arigsela.com:8443:10.0.1.50 https://coroot.arigsela.com:8443/
```

The listener must report `ResolvedRefs=True` — that is the ReferenceGrant working. A certless listener is the silent failure `§V.63` exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ