### PR TITLE
fix(istio-ingress): clear the sysctl that hostNetwork forbids

### DIFF
--- a/base-apps/istio-ingress/gateway-options.yaml
+++ b/base-apps/istio-ingress/gateway-options.yaml
@@ -22,6 +22,17 @@ data:
         spec:
           hostNetwork: true
           dnsPolicy: ClusterFirstWithHostNet
+          # Istio's generated gateway sets net.ipv4.ip_unprivileged_port_start so
+          # Envoy can bind low ports as non-root. Kubernetes REJECTS that sysctl
+          # when hostNetwork is true:
+          #   spec.template.spec.securityContext.sysctls[0].name: Invalid value:
+          #   "net.ipv4.ip_unprivileged_port_start": may not be specified when
+          #   'hostNetwork' is true
+          # Cleared here. Harmless while staging on :8080/:8443, which are above
+          # 1024 and need no privilege. AT CUTOVER to :80/:443 the container will
+          # need NET_BIND_SERVICE instead - see SPEC.md T53.
+          securityContext:
+            sysctls: []
           nodeSelector:
             node.kubernetes.io/workload: infrastructure
           tolerations:


### PR DESCRIPTION
The Gateway came up `Accepted=True` with **both listeners `Programmed=True` and `ResolvedRefs=True`** — the ReferenceGrant and cross-namespace certificate worked first time — but no Deployment or Service was generated, leaving the Gateway `Programmed=False` with `AddressNotUsable`.

istiod's actual error:

```
Deployment.apps "main-istio" is invalid:
spec.template.spec.securityContext.sysctls[0].name: Invalid value:
"net.ipv4.ip_unprivileged_port_start": may not be specified when 'hostNetwork' is true
```

Istio's generated gateway sets that sysctl so Envoy can bind low ports as non-root. Kubernetes rejects it outright under `hostNetwork`.

Cleared — harmless while staging on :8080/:8443, both above 1024. **At cutover to :80/:443 the container will need `NET_BIND_SERVICE` instead**, recorded for `§T.53` rather than guessed at now.

## The failure shape is worth noting

The Gateway reported `Accepted=True` with every listener green. Only the top-level `Programmed` condition carried the fault, and the real reason lived **exclusively in istiod's log** — not in any resource status. Same family as `§B.7` and `§B.9`: healthy from every angle except the one that mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ