### PR TITLE
fix(istio-ingress): free staging ports + ClusterIP service

### DIFF
--- a/base-apps/istio-ingress/gateway-options.yaml
+++ b/base-apps/istio-ingress/gateway-options.yaml
@@ -13,6 +13,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  # ClusterIP, not the default LoadBalancer. Under hostNetwork the pod binds
+  # the node directly and the Service is not the data path - but a
+  # LoadBalancer makes k3s klipper spawn svclb DaemonSets that squat the same
+  # hostPorts on EVERY node, which both wastes ports and invites collisions.
+  # Istio still needs the Service to exist to resolve the Gateway address.
   name: gateway-options
   namespace: istio-ingress
 data:
@@ -38,3 +43,6 @@ data:
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               effect: NoSchedule
+  service: |
+    spec:
+      type: ClusterIP

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -1,3 +1,7 @@
+# Staging ports are 18080/18443, NOT 8080/8443: ingress-nginx already binds
+# hostPort 8443 on k3s-control-01 alongside 80 and 443, so the obvious choice
+# collided with the very thing this replaces. Verified free before picking.
+#
 # One HTTPS listener per hostname, each with its own certificateRef, because
 # these are per-host certificates rather than a wildcard.
 #
@@ -21,13 +25,13 @@ spec:
     # Catches every host on plain HTTP; the redirect HTTPRoute attaches here.
     - name: http
       protocol: HTTP
-      port: 8080
+      port: 18080
       allowedRoutes:
         namespaces:
           from: All
     - name: https-coroot
       protocol: HTTPS
-      port: 8443
+      port: 18443
       hostname: coroot.arigsela.com
       tls:
         mode: Terminate


### PR DESCRIPTION
Two scheduling conflicts, both real.

## Ports

The gateway pod would not schedule:
```
0/3 nodes are available: 1 node(s) didn't have free ports for the requested
pod ports, 2 node(s) didn't match Pod's node affinity/selector
```

**ingress-nginx already binds hostPort 8443** on `k3s-control-01`, alongside 80 and 443 — so the obvious staging port collided with the very thing this replaces. Moved to **18080/18443**, verified free on that node before picking (only 80, 443, 8443 bound).

## Service type

Istio defaults the generated Service to `LoadBalancer`, which makes k3s klipper spawn `svclb` DaemonSets squatting the same hostPorts on **every** node. Under hostNetwork the pod binds the node directly and the Service is not the data path — pure waste plus a collision surface. Forced to `ClusterIP`; Istio still needs the Service to exist to resolve the Gateway address.

Only `k3s-control-01` carries `node.kubernetes.io/workload: infrastructure`, which is why the other two nodes were rejected on the selector — intended, since public DNS resolves there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ