### PR TITLE
istio-ingress: default-deny AuthorizationPolicy on the Gateway

### DIFF
--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -1,0 +1,48 @@
+# Access control for the ingress Gateway. THIS IS THE SECURITY BOUNDARY.
+#
+# Istio ALLOW policies are deny-by-default for the workloads they select: any
+# request not matching a rule below is refused. So this single object is both the
+# default-deny and the allow-list, and every host added to the Gateway is denied
+# until it is named here deliberately.
+#
+# Deliberately introduced BEFORE the remaining 18 hosts rather than after. The
+# Gateway currently has no protection but is only reachable on :18443, which the
+# router does not forward. At cutover it moves to :443, which IS forwarded - so
+# the allow-lists have to exist before that moment, not be retrofitted at it.
+#
+# 10.0.0.0/8 is DELIBERATELY NOT CARRIED OVER from the nginx allow-lists (V66).
+# It contains the pod network 10.42.0.0/16 and the node network, so under any
+# SNAT it would make arbitrary internet traffic look allow-listed - failing OPEN
+# and silently (B9). It also turns out to be unnecessary: the router hairpin-NATs
+# LAN traffic to the public address, verified in nginx's own access log, where
+# requests from LAN host 10.0.1.182 arrive as 73.7.190.154. Nothing is lost.
+#
+# ipBlocks, not remoteIpBlocks: the Gateway runs hostNetwork so the packet source
+# IS the client (R35). remoteIpBlocks would need XFF trust, which is V56's hazard
+# and pointless with no proxy in front.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: gateway-allow
+  namespace: istio-ingress
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: main
+  action: ALLOW
+  rules:
+    # coroot - restricted, mirroring its nginx whitelist-source-range minus the
+    # 10.0.0.0/8 entry.
+    - to:
+        - operation:
+            hosts:
+              - coroot.arigsela.com
+              - coroot.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32


### PR DESCRIPTION
Istio ALLOW policies are **deny-by-default** for the workloads they select, so this single object is both the default-deny and the allow-list: any host added to the Gateway is refused until named here deliberately.

## Why now rather than at §T.51

The Gateway had **no access control at all** — safe only because it listens on :18443 and the router does not forward that port (verified: public :18443 refuses connection, :443 answers). At cutover it moves to :443, which **is** forwarded. The allow-lists have to exist before that moment, not be retrofitted at it. `§T.51` becomes incremental: each host gets its rule alongside its route.

## 10.0.0.0/8 is dropped, and it costs nothing

`§V.66` forbids carrying it forward — it contains the pod network `10.42.0.0/16` and the node network, so under any SNAT it would make arbitrary internet traffic look allow-listed, failing **open** and silently (`§B.9`).

It also turns out to be unnecessary. The router hairpin-NATs LAN traffic to the public address — nginx's access log shows requests from LAN host `10.0.1.182` arriving as `73.7.190.154`. LAN clients already match the public /32s. **No reachability is lost.**

## ipBlocks, not remoteIpBlocks

The Gateway runs hostNetwork so the packet source **is** the client (`§R.35`). `remoteIpBlocks` would need XFF trust — `§V.56`'s hazard, and pointless with no proxy in front.

## Verification after merge

The deny direction is testable immediately: a request from a LAN address (`10.0.1.182`, not in the list) direct to `10.0.1.50:18443` must be **refused**. That is a genuine negative test, not an inference.

The allow direction cannot be exercised on :18443 — reaching the Gateway as `73.7.190.154` requires the hairpin path, which needs that port forwarded. It is proven by equivalence today (the same four addresses work through nginx) and gets re-proven per host at cutover, which `§V.53` mandates anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ