### PR TITLE
fix(istio-ingress): make NET_BIND_SERVICE effective, and Recreate the pod

### DIFF
--- a/base-apps/istio-ingress/gateway-options.yaml
+++ b/base-apps/istio-ingress/gateway-options.yaml
@@ -23,6 +23,13 @@ metadata:
 data:
   deployment: |
     spec:
+      # Recreate, not RollingUpdate. Under hostNetwork on a single pinned node the
+      # new pod cannot start while the old one holds Istio's admin ports (15021,
+      # 15090), so a rolling update deadlocks: new pod Pending on "didn't have
+      # free ports", old pod never removed. Observed at cutover.
+      strategy:
+        type: Recreate
+        rollingUpdate: null
       template:
         spec:
           hostNetwork: true
@@ -48,6 +55,16 @@ data:
             # hand this container every capability.
             - name: istio-proxy
               securityContext:
+                # allowPrivilegeEscalation MUST be true for NET_BIND_SERVICE to
+                # take effect. Envoy runs as uid 1337, and for a non-root process
+                # an added capability only reaches the PERMITTED set - it becomes
+                # EFFECTIVE via ambient capabilities, which the kernel refuses to
+                # raise while no_new_privs is set. allowPrivilegeEscalation: false
+                # sets exactly that bit, so the capability was present and inert:
+                #   cannot bind '0.0.0.0:80': Permission denied
+                # Posture is still tight: every capability dropped except this
+                # one, non-root, read-only root filesystem.
+                allowPrivilegeEscalation: true
                 capabilities:
                   drop:
                     - ALL


### PR DESCRIPTION
Two faults, both exposed by moving to :80/:443.

## Bind permission — the capability was applied and inert

```
cannot bind '0.0.0.0:80': Permission denied
cannot bind '0.0.0.0:443': Permission denied
```

Envoy runs as uid 1337. For a **non-root** process an added capability only reaches the *permitted* set; it becomes *effective* through **ambient** capabilities, which the kernel refuses to raise while `no_new_privs` is set — and `allowPrivilegeEscalation: false` sets exactly that bit.

So `NET_BIND_SERVICE` was present in the container spec and did nothing. Posture stays tight: every capability dropped except this one, still non-root, still read-only root filesystem.

## Rollout deadlock

Under hostNetwork on a single pinned node a RollingUpdate can never converge — the new pod cannot bind Istio's admin ports (15021, 15090) while the old pod holds them, so it sits `Pending` on *"didn't have free ports"* and the old pod is never removed. Switched to `Recreate`.

This would have recurred on **every** future change to this Deployment, not just the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ