### PR TITLE
gateway: batch 1 — 9 restricted hosts (§T.55/§T.56/§T.51)

### DIFF
--- a/base-apps/argo-cd/httproute.yaml
+++ b/base-apps/argo-cd/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argo-cd
+  namespace: argo-cd
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-argocd
+  hostnames:
+    - argocd.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argo-cd-argocd-server
+          port: 80

--- a/base-apps/argo-cd/reference-grant.yaml
+++ b/base-apps/argo-cd/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-argocd-tls
+  namespace: argo-cd
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: argocd-tls

--- a/base-apps/argo-rollouts/httproute.yaml
+++ b/base-apps/argo-rollouts/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argo-rollouts
+  namespace: argo-rollouts
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-rollouts
+  hostnames:
+    - rollouts.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argo-rollouts-dashboard
+          port: 3100

--- a/base-apps/argo-rollouts/reference-grant.yaml
+++ b/base-apps/argo-rollouts/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-argo-rollouts-tls
+  namespace: argo-rollouts
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: argo-rollouts-tls

--- a/base-apps/argo-workflows/httproute.yaml
+++ b/base-apps/argo-workflows/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argo-workflows
+  namespace: argo-workflows
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-argo-workflows
+  hostnames:
+    - argo-workflows.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argo-workflows-server
+          port: 2746

--- a/base-apps/argo-workflows/reference-grant.yaml
+++ b/base-apps/argo-workflows/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-argo-workflows-tls
+  namespace: argo-workflows
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: argo-workflows-tls

--- a/base-apps/atlantis/httproute.yaml
+++ b/base-apps/atlantis/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: atlantis
+  namespace: atlantis
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-atlantis
+  hostnames:
+    - atlantis.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: atlantis
+          port: 4141

--- a/base-apps/atlantis/reference-grant.yaml
+++ b/base-apps/atlantis/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-atlantis-tls
+  namespace: atlantis
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: atlantis-tls

--- a/base-apps/backstage/httproute.yaml
+++ b/base-apps/backstage/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-backstage
+  hostnames:
+    - backstage.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backstage
+          port: 80

--- a/base-apps/backstage/reference-grant.yaml
+++ b/base-apps/backstage/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-backstage-tls
+  namespace: backstage
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: backstage-tls

--- a/base-apps/dex/httproute.yaml
+++ b/base-apps/dex/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-dex
+  hostnames:
+    - dex.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: dex
+          port: 5556

--- a/base-apps/dex/reference-grant.yaml
+++ b/base-apps/dex/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-dex-tls
+  namespace: dex
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: dex-tls

--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -46,3 +46,118 @@ spec:
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - argocd.arigsela.com
+              - argocd.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - rollouts.arigsela.com
+              - rollouts.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - argo-workflows.arigsela.com
+              - argo-workflows.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+  # atlantis additionally allows GitHub webhook ranges (IPv4 + IPv6).
+    - to:
+        - operation:
+            hosts:
+              - atlantis.arigsela.com
+              - atlantis.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+              - 192.30.252.0/22
+              - 185.199.108.0/22
+              - 140.82.112.0/20
+              - 143.55.64.0/20
+              - 2a0a:a440::/29
+              - 2606:50c0::/32
+    - to:
+        - operation:
+            hosts:
+              - backstage.arigsela.com
+              - backstage.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - dex.arigsela.com
+              - dex.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - kagent.arigsela.com
+              - kagent.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - oncall-crewai.arigsela.com
+              - oncall-crewai.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    - to:
+        - operation:
+            hosts:
+              - vault.arigsela.com
+              - vault.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -42,3 +42,120 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-argocd
+      protocol: HTTPS
+      port: 18443
+      hostname: argocd.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: argocd-tls
+            namespace: argo-cd
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-rollouts
+      protocol: HTTPS
+      port: 18443
+      hostname: rollouts.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: argo-rollouts-tls
+            namespace: argo-rollouts
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-argo-workflows
+      protocol: HTTPS
+      port: 18443
+      hostname: argo-workflows.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: argo-workflows-tls
+            namespace: argo-workflows
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-atlantis
+      protocol: HTTPS
+      port: 18443
+      hostname: atlantis.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: atlantis-tls
+            namespace: atlantis
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-backstage
+      protocol: HTTPS
+      port: 18443
+      hostname: backstage.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: backstage-tls
+            namespace: backstage
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-dex
+      protocol: HTTPS
+      port: 18443
+      hostname: dex.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: dex-tls
+            namespace: dex
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-kagent
+      protocol: HTTPS
+      port: 18443
+      hostname: kagent.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: kagent-tls
+            namespace: kagent
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-oncall-crewai
+      protocol: HTTPS
+      port: 18443
+      hostname: oncall-crewai.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: oncall-crewai-frontend-tls
+            namespace: oncall-crewai
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-vault
+      protocol: HTTPS
+      port: 18443
+      hostname: vault.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: vault-arigsela-tls
+            namespace: vault
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/base-apps/kagent/httproute.yaml
+++ b/base-apps/kagent/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kagent
+  namespace: kagent
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-kagent
+  hostnames:
+    - kagent.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kagent-ui
+          port: 8080

--- a/base-apps/kagent/reference-grant.yaml
+++ b/base-apps/kagent/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-kagent-tls
+  namespace: kagent
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: kagent-tls

--- a/base-apps/oncall-crewai/httproute.yaml
+++ b/base-apps/oncall-crewai/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oncall-crewai
+  namespace: oncall-crewai
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-oncall-crewai
+  hostnames:
+    - oncall-crewai.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: crewai-frontend
+          port: 80

--- a/base-apps/oncall-crewai/reference-grant.yaml
+++ b/base-apps/oncall-crewai/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-oncall-crewai-frontend-tls
+  namespace: oncall-crewai
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: oncall-crewai-frontend-tls

--- a/base-apps/vault/httproute.yaml
+++ b/base-apps/vault/httproute.yaml
@@ -1,0 +1,23 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+# Lives in the app namespace so the backendRef is same-namespace and needs no
+# second ReferenceGrant. Backend read from the LIVE Ingress, not inferred.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-vault
+  hostnames:
+    - vault.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: vault
+          port: 8200

--- a/base-apps/vault/reference-grant.yaml
+++ b/base-apps/vault/reference-grant.yaml
@@ -1,0 +1,17 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Gateway API requires an explicit grant for any cross-namespace certificateRef;
+# without it the listener comes up SILENTLY certless rather than erroring (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-vault-arigsela-tls
+  namespace: vault
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: vault-arigsela-tls


### PR DESCRIPTION
`argocd` · `rollouts` · `argo-workflows` · `atlantis` · `backstage` · `dex` · `kagent` · `oncall-crewai` · `vault`

Each host gets **four things together** — that is the point of resequencing `§T.51`: an HTTPS listener with its own `certificateRef`, a ReferenceGrant so that ref resolves, an HTTPRoute in the app namespace, and an allow rule. **A host is never present on the Gateway without a rule governing it.**

Still staged on :18443. nginx continues serving all 21 hosts on :443 — nothing about live traffic changes here.

## Backends read from the live Ingress

Not inferred. coroot proved that matters (`coroot` → `coroot-coroot:8080`). Same for ports: rollouts `:3100`, argo-workflows `:2746`, dex `:5556`, kagent-ui `:8080`, vault `:8200`.

## Allow-lists are not uniform

Carried over verbatim minus `10.0.0.0/8` (`§V.66`):

- **atlantis keeps the GitHub webhook ranges, IPv4 and IPv6** — 10 entries. It receives webhooks from GitHub, so normalising it to the base four would silently break terraform PR runs.
- The other eight use the base four addresses.

## Deliberately not in this batch

| Host | Why |
|---|---|
| grafana, oncall-agent | public-by-design → batch 2 |
| chores, weather-kitchen | split hosts, need `§V.62` exclusion-set handling |
| n8n | admin and webhook paths have different postures |
| kagent-mcp | HTTP basic auth has no Istio equivalent (`§T.52`) |
| chores-agent | cert broken since May — **and its allow-list is `0.0.0.0/0,::/0`, so it is decorative**; that host is public today despite appearing restricted |
| langflow | not in the repo at all (`§T.64`) |
| vault.local | internal, no TLS, needs an HTTP listener |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ