### PR TITLE
gateway: batch 2 — grafana + oncall-agent, public by design

### DIFF
--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -161,3 +161,21 @@ spec:
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
+    # grafana.arigsela.com - PUBLIC BY DESIGN (github-oauth). No `from` clause, so any
+      # source is permitted. Reachable from anywhere by design - dashboards are read from mobile and carrier
+      # IPs cannot be allow-listed. Access control is GitHub OAuth with two
+      # fail-closed gates, both verified by observation (V69/T62).
+    - to:
+        - operation:
+            hosts:
+              - grafana.arigsela.com
+              - grafana.arigsela.com:*
+    # oncall.arigsela.com - PUBLIC BY DESIGN (slack-events-api). No `from` clause, so any
+      # source is permitted. Slack posts Events API callbacks from addresses that are not a stable
+      # allow-listable set. Authenticated at the app layer: SLACK_SIGNING_SECRET
+      # (HMAC) plus API_KEYS. Restricting by IP would break the integration.
+    - to:
+        - operation:
+            hosts:
+              - oncall.arigsela.com
+              - oncall.arigsela.com:*

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -159,3 +159,29 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-grafana
+      protocol: HTTPS
+      port: 18443
+      hostname: grafana.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: grafana-tls
+            namespace: logging
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-oncall
+      protocol: HTTPS
+      port: 18443
+      hostname: oncall.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: oncall-agent-tls
+            namespace: oncall-agent
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/base-apps/logging/httproute.yaml
+++ b/base-apps/logging/httproute.yaml
@@ -1,0 +1,21 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logging
+  namespace: logging
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-grafana
+  hostnames:
+    - grafana.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grafana
+          port: 3000

--- a/base-apps/logging/reference-grant.yaml
+++ b/base-apps/logging/reference-grant.yaml
@@ -1,0 +1,16 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Without an explicit grant the listener comes up SILENTLY certless (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-grafana-tls
+  namespace: logging
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: grafana-tls

--- a/base-apps/oncall-agent/httproute.yaml
+++ b/base-apps/oncall-agent/httproute.yaml
@@ -1,0 +1,21 @@
+# Gateway API replacement for this app's nginx Ingress (T56).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oncall-agent
+  namespace: oncall-agent
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-oncall
+  hostnames:
+    - oncall.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: oncall-agent-api
+          port: 80

--- a/base-apps/oncall-agent/reference-grant.yaml
+++ b/base-apps/oncall-agent/reference-grant.yaml
@@ -1,0 +1,16 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+# Without an explicit grant the listener comes up SILENTLY certless (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-oncall-agent-tls
+  namespace: oncall-agent
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: oncall-agent-tls


### PR DESCRIPTION
Both carry **no `from` clause**, so any source is permitted. Deliberate and recorded — the distinction the `public-by-design` annotation mechanism exists to make (`§T.63`).

| Host | Reason | Why it cannot be IP-restricted |
|---|---|---|
| grafana | `github-oauth` | read from mobile; carrier IPs are not allow-listable. Access control is GitHub OAuth with two fail-closed gates, both verified by observation (`§V.69`/`§T.62`) |
| oncall-agent | `slack-events-api` | Slack posts Events API callbacks from addresses that are not a stable set. Authenticated at the app layer via `SLACK_SIGNING_SECRET` (HMAC) + `API_KEYS` |

Still on :18443; nginx continues serving :443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ