### PR TITLE
gateway: batch 3 — split hosts and n8n's two postures

### DIFF
--- a/base-apps/chores-tracker-backend/httproute.yaml
+++ b/base-apps/chores-tracker-backend/httproute.yaml
@@ -1,0 +1,26 @@
+# Backend half of a SPLIT HOST (SPEC.md V62). See the frontend route for how the
+# /api/docs and /api/openapi.json exclusions are expressed.
+#
+# The nginx rewrite-target: /api/$1 is deliberately NOT ported. It was an
+# IDENTITY rewrite - the file's own comment said "Pass /api requests through
+# without rewriting" - so there is nothing to reproduce.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: chores-tracker-backend
+  namespace: chores-tracker
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-chores
+  hostnames:
+    - chores.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: chores-tracker-backend
+          port: 80

--- a/base-apps/chores-tracker-backend/reference-grant.yaml
+++ b/base-apps/chores-tracker-backend/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-chores-tracker-tls
+  namespace: chores-tracker
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: chores-tracker-tls

--- a/base-apps/chores-tracker-frontend/httproute.yaml
+++ b/base-apps/chores-tracker-frontend/httproute.yaml
@@ -1,0 +1,42 @@
+# Frontend half of a SPLIT HOST (SPEC.md V62).
+#
+# The nginx Ingress expressed this as one regex on the BACKEND:
+#   /api/(?!docs|openapi\.json)(.*)
+# i.e. everything under /api goes to the backend EXCEPT /api/docs and
+# /api/openapi.json, which belong to the frontend. Gateway API has no negative
+# lookahead, so the exclusion is expressed the other way round: the two excluded
+# paths are EXACT matches here, and exact outranks prefix in Gateway API
+# precedence, so they win over the backend's /api prefix.
+#
+# Translating the regex naively as "/api prefix -> backend" would silently send
+# /api/docs to the backend. That is the subtle break V62 exists to prevent.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: chores-tracker-frontend
+  namespace: chores-tracker-frontend
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-chores
+  hostnames:
+    - chores.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /api/docs
+        - path:
+            type: Exact
+            value: /api/openapi.json
+      backendRefs:
+        - name: chores-tracker-frontend
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: chores-tracker-frontend
+          port: 80

--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -179,3 +179,50 @@ spec:
             hosts:
               - oncall.arigsela.com
               - oncall.arigsela.com:*
+    # chores - public-by-design (family app, app-level JWT auth).
+    - to:
+        - operation:
+            hosts:
+              - chores.arigsela.com
+              - chores.arigsela.com:*
+    # weather-kitchen - restricted.
+    - to:
+        - operation:
+            hosts:
+              - weather-kitchen.arigsela.com
+              - weather-kitchen.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    # n8n WEBHOOK paths - public by design. Webhooks arrive from arbitrary
+      # external services and cannot be allow-listed; each workflow authenticates
+      # its own. Scoped to the webhook paths ONLY, so the admin UI is untouched.
+    - to:
+        - operation:
+            hosts:
+              - n8n.arigsela.com
+              - n8n.arigsela.com:*
+            paths:
+              - /webhook
+              - /webhook/*
+              - /webhook-test
+              - /webhook-test/*
+              - /mcp-server
+              - /mcp-server/*
+    # n8n everything else (the admin UI) - restricted.
+    - to:
+        - operation:
+            hosts:
+              - n8n.arigsela.com
+              - n8n.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -185,3 +185,42 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-chores
+      protocol: HTTPS
+      port: 18443
+      hostname: chores.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: chores-tracker-tls
+            namespace: chores-tracker
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-weather-kitchen
+      protocol: HTTPS
+      port: 18443
+      hostname: weather-kitchen.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: weather-kitchen-tls
+            namespace: weather-kitchen
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-n8n
+      protocol: HTTPS
+      port: 18443
+      hostname: n8n.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: n8n-tls
+            namespace: n8n
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/base-apps/n8n/httproute.yaml
+++ b/base-apps/n8n/httproute.yaml
@@ -1,0 +1,23 @@
+# n8n serves two postures on one hostname from one backend: an allow-listed admin
+# UI at / and publicly-reachable webhook endpoints. Routing is identical for
+# both; the distinction is enforced in the AuthorizationPolicy by path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-n8n
+  hostnames:
+    - n8n.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: n8n
+          port: 5678

--- a/base-apps/n8n/reference-grant.yaml
+++ b/base-apps/n8n/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-n8n-tls
+  namespace: n8n
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: n8n-tls

--- a/base-apps/weather-kitchen-backend/httproute.yaml
+++ b/base-apps/weather-kitchen-backend/httproute.yaml
@@ -1,0 +1,26 @@
+# Backend half of a SPLIT HOST (SPEC.md V62). See the frontend route for how the
+# /api/docs and /api/openapi.json exclusions are expressed.
+#
+# The nginx rewrite-target: /api/$1 is deliberately NOT ported. It was an
+# IDENTITY rewrite - the file's own comment said "Pass /api requests through
+# without rewriting" - so there is nothing to reproduce.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: weather-kitchen-backend
+  namespace: weather-kitchen
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-weather-kitchen
+  hostnames:
+    - weather-kitchen.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: weather-kitchen-backend
+          port: 80

--- a/base-apps/weather-kitchen-backend/reference-grant.yaml
+++ b/base-apps/weather-kitchen-backend/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-weather-kitchen-tls
+  namespace: weather-kitchen
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: weather-kitchen-tls

--- a/base-apps/weather-kitchen-frontend/httproute.yaml
+++ b/base-apps/weather-kitchen-frontend/httproute.yaml
@@ -1,0 +1,42 @@
+# Frontend half of a SPLIT HOST (SPEC.md V62).
+#
+# The nginx Ingress expressed this as one regex on the BACKEND:
+#   /api/(?!docs|openapi\.json)(.*)
+# i.e. everything under /api goes to the backend EXCEPT /api/docs and
+# /api/openapi.json, which belong to the frontend. Gateway API has no negative
+# lookahead, so the exclusion is expressed the other way round: the two excluded
+# paths are EXACT matches here, and exact outranks prefix in Gateway API
+# precedence, so they win over the backend's /api prefix.
+#
+# Translating the regex naively as "/api prefix -> backend" would silently send
+# /api/docs to the backend. That is the subtle break V62 exists to prevent.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: weather-kitchen-frontend
+  namespace: weather-kitchen-frontend
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-weather-kitchen
+  hostnames:
+    - weather-kitchen.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /api/docs
+        - path:
+            type: Exact
+            value: /api/openapi.json
+      backendRefs:
+        - name: weather-kitchen-frontend
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: weather-kitchen-frontend
+          port: 80


### PR DESCRIPTION
`chores` · `weather-kitchen` · `n8n` — the ones that break **subtly** rather than loudly.

## Split hosts (§V.62)

nginx expressed the split as one regex on the **backend**:

```
/api/(?!docs|openapi\.json)(.*)
```

Everything under `/api` to the backend **except** `/api/docs` and `/api/openapi.json`, which belong to the frontend. Gateway API has no negative lookahead, so the exclusion is **inverted**: those two become `Exact` matches on the *frontend* route, and exact outranks prefix in Gateway API precedence — so they win over the backend's `/api` prefix.

Translating that regex naively as "`/api` prefix → backend" would silently send `/api/docs` to the backend. That is exactly the failure `§V.62` exists to prevent, and **it would have looked like a working migration**.

The nginx `rewrite-target: /api/$1` is deliberately **not** ported — it was an *identity* rewrite (the manifest's own comment: *"Pass /api requests through without rewriting"*). `§R.30` counted it as hard work; it was free.

## n8n — two postures, one hostname, one backend

Routing is identical for both; the distinction is enforced in the AuthorizationPolicy **by path**:

| Paths | Posture |
|---|---|
| `/webhook`, `/webhook-test`, `/mcp-server` (+ subpaths) | public, no `from` |
| everything else (admin UI) | restricted to the base 4 |

Istio ALLOW rules are OR'd, so the union is: anyone reaches the webhooks, only allow-listed sources reach the admin UI.

`chores` is public-by-design (family app, app-level JWT); `weather-kitchen` is restricted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ