### PR TITLE
gateway: batch 4 — kagent-mcp and vault's internal hosts

### DIFF
--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -226,3 +226,27 @@ spec:
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
+    # kagent-mcp - restricted. Basic auth dropped (T52); the allow-list is now the
+      # only control, which is why it must be right.
+    - to:
+        - operation:
+            hosts:
+              - kagent-mcp.arigsela.com
+              - kagent-mcp.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
+    # vault.local / vault.10.0.1.110 - LAN-only names, no public DNS, no TLS.
+      # Not reachable from outside the network, so an IP rule here would be
+      # theatre rather than control.
+    - to:
+        - operation:
+            hosts:
+              - vault.local
+              - vault.local:*
+              - vault.10.0.1.110
+              - vault.10.0.1.110:*

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -26,6 +26,10 @@ spec:
     - name: http
       protocol: HTTP
       port: 18080
+      # Scoped to *.arigsela.com so the internal vault hostnames can have their
+      # own HTTP listeners. Those are plaintext by design and must NOT be caught
+      # by the https-redirect route attached to this listener.
+      hostname: "*.arigsela.com"
       allowedRoutes:
         namespaces:
           from: All
@@ -221,6 +225,36 @@ spec:
           - kind: Secret
             name: n8n-tls
             namespace: n8n
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-kagent-mcp
+      protocol: HTTPS
+      port: 18443
+      hostname: kagent-mcp.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: kagent-mcp-tls
+            namespace: kagent
+      allowedRoutes:
+        namespaces:
+          from: All
+    # vault.local / vault.10.0.1.110 are LAN-only names with no public DNS and no
+    # TLS - the Vault listener itself runs plaintext (tls_disable: 1). Separate
+    # HTTP listeners so the https-redirect route does not apply to them.
+    - name: http-vault-local
+      protocol: HTTP
+      port: 18080
+      hostname: vault.local
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http-vault-ip
+      protocol: HTTP
+      port: 18080
+      hostname: vault.10.0.1.110
       allowedRoutes:
         namespaces:
           from: All

--- a/base-apps/kagent/httproute-mcp.yaml
+++ b/base-apps/kagent/httproute-mcp.yaml
@@ -1,0 +1,27 @@
+# kagent MCP endpoint (T56).
+#
+# HTTP basic auth is NOT carried over - Istio has no equivalent and T52's options
+# were ext_authz, dex OIDC, or dropping it. Decision 2026-07-31: keep the host,
+# drop the credential, retain the IP allow-list. Weaker than today, but this
+# endpoint backs a live MCP client (~/.claude.json points at
+# https://kagent-mcp.arigsela.com/mcp) so removing the host would have broken it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kagent-mcp
+  namespace: kagent
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-kagent-mcp
+  hostnames:
+    - kagent-mcp.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      backendRefs:
+        - name: kagent-controller
+          port: 8083

--- a/base-apps/kagent/reference-grant-mcp.yaml
+++ b/base-apps/kagent/reference-grant-mcp.yaml
@@ -1,0 +1,15 @@
+# Grant for the kagent-mcp TLS secret (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-kagent-mcp-tls
+  namespace: kagent
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: kagent-mcp-tls

--- a/base-apps/vault/httproute-internal.yaml
+++ b/base-apps/vault/httproute-internal.yaml
@@ -1,0 +1,30 @@
+# Vault's LAN-only hostnames. Plaintext by design: the Vault listener runs with
+# tls_disable: 1, there is no public DNS for these names, and no certificate.
+# Annotated internal-hostname-not-routable in the ingress-policy contract (T63).
+#
+# The nginx rewrite-target: / is not ported - with a single "/" prefix rule it
+# was an identity rewrite.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vault-internal
+  namespace: vault
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: http-vault-local
+    - name: main
+      namespace: istio-ingress
+      sectionName: http-vault-ip
+  hostnames:
+    - vault.local
+    - vault.10.0.1.110
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: vault
+          port: 8200


### PR DESCRIPTION
## kagent-mcp kept, not dropped

HTTP basic auth has no Istio equivalent, and `§T.52`'s options were ext_authz, dex OIDC, or removing the host. Dropping it looked fine until the endpoint turned out to back a **live MCP client** — `~/.claude.json` points at `https://kagent-mcp.arigsela.com/mcp`. Removal would have broken working tooling rather than retiring dead config.

Decision: keep the host, drop the credential, retain the IP allow-list. That is genuinely **weaker than today** — the allow-list is now the only control on it, which is why it is carried over exactly.

## Vault internal hosts

`vault.local` and `vault.10.0.1.110` are LAN-only names with no public DNS and no certificate; the Vault listener runs `tls_disable: 1`, so plaintext is the design rather than an oversight.

They need their own HTTP listeners, which meant **scoping the catch-all HTTP listener to `*.arigsela.com`**. Otherwise the `https-redirect` route attached to it would bounce these hosts to a TLS endpoint that does not exist — turning a working plaintext service into a redirect loop.

The nginx `rewrite-target: /` is not ported; with a single `/` prefix rule it was an identity rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ