### PR TITLE
docs(istio-ingress): agent-docs for the new ingress (§T.67)

### DIFF
--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -35,7 +35,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | dex | OIDC provider fronting GitHub — issuer for Vault OIDC (human `vault` login via GitHub SSO) | dex | [docs.md](dex/docs.md) | [runbook.md](dex/runbook.md) | [catalog-info.yaml](dex/catalog-info.yaml) |
 | ecr-auth |  |  |  |  |  |
 | istio-ambient-config |  |  |  |  |  |
-| istio-ingress |  |  |  |  |  |
+| istio-ingress | The cluster's north-south ingress: a Gateway API Gateway on the `istio` GatewayClass, directly internet-facing | istio-ingress | [docs.md](istio-ingress/docs.md) | [runbook.md](istio-ingress/runbook.md) | [catalog-info.yaml](istio-ingress/catalog-info.yaml) |
 | kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | [docs.md](kagent/docs.md) | [runbook.md](kagent/runbook.md) | [catalog-info.yaml](kagent/catalog-info.yaml) |
 | kyverno-policies |  |  |  |  |  |
 | logging | Observability stack (Alloy collector, Loki logs on S3, Prometheus metrics, Grafana) | logging | [docs.md](logging/docs.md) | [runbook.md](logging/runbook.md) | [catalog-info.yaml](logging/catalog-info.yaml) |

--- a/base-apps/istio-ingress.yaml
+++ b/base-apps/istio-ingress.yaml
@@ -19,6 +19,10 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/istio-ingress
+    directory:
+      # catalog-info.yaml is a Backstage entity, not a Kubernetes manifest.
+      # Exclude it so Argo CD does not try to apply it and fail sync.
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
   destination:
     server: https://kubernetes.default.svc
     namespace: istio-ingress

--- a/base-apps/istio-ingress/catalog-info.yaml
+++ b/base-apps/istio-ingress/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'gateway.networking.k8s.io/gateway-name=main'
+    backstage.io/kubernetes-namespace: istio-ingress
+  tags: [ingress, gateway-api, istio]
+spec:
+  type: infrastructure
+  lifecycle: production
+  owner: group:default/platform
+  system: default/platform-networking
+  dependsOn:
+    - resource:cert-manager/cert-manager

--- a/base-apps/istio-ingress/docs.md
+++ b/base-apps/istio-ingress/docs.md
@@ -1,0 +1,118 @@
+---
+type: "Kubernetes App Guide"
+title: "istio-ingress"
+description: "The cluster's north-south ingress: a Gateway API Gateway on the `istio` GatewayClass, directly internet-facing"
+app: istio-ingress
+catalog_entity: istio-ingress
+kind: docs
+namespace: istio-ingress
+last_reviewed: 2026-07-31
+status: current
+tags: [ingress, gateway-api, istio]
+sources:
+  - base-apps/istio-ingress.yaml
+  - base-apps/istio-ingress/gateway.yaml
+  - base-apps/istio-ingress/gateway-options.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - base-apps/istio-ingress/telemetry.yaml
+---
+
+# istio-ingress
+
+## What it is
+
+The cluster's single north-south entry point, replacing `ingress-nginx` on
+2026-07-31. A Gateway API `Gateway` named `main` on the `istio` GatewayClass
+(controller `istio.io/gateway-controller`), serving 18 hostnames on `:80`/`:443`.
+
+`ingress-nginx` was retired because its upstream repository is archived — the
+final release `controller-v1.15.1` supports Kubernetes 1.31–1.35 and there will
+never be 1.36 support. It was the single component blocking the cluster's
+Kubernetes upgrade path.
+
+Do not confuse this Gateway with the two `istio-waypoint` Gateways in
+`chores-tracker` and `chores-tracker-frontend`. Those are **ambient mesh
+waypoints** doing east-west policy enforcement inside the mesh; they serve no
+external traffic. This is the only Gateway that does.
+
+## How traffic arrives
+
+```
+internet → 73.7.190.154 → router → k3s-control-01
+         → klipper svclb (hostPort :80/:443)
+         → Service main-istio (externalTrafficPolicy: Local)
+         → Envoy (main-istio pod)
+         → HTTPRoute → app Service
+```
+
+There is no reverse proxy, tunnel, or WAF in front. The Gateway is directly
+internet-facing and the cluster is scanned continuously — assume anything
+exposed is found the same day.
+
+## Why it does NOT use hostNetwork
+
+`ingress-nginx` ran `hostNetwork: true` and got the real client IP for free. The
+obvious move was to copy that. It does not work, and the reason is worth knowing
+before anyone tries again:
+
+Envoy runs as uid 1337. Istio permits it to bind privileged ports using the
+`net.ipv4.ip_unprivileged_port_start` sysctl — and **Kubernetes forbids that
+sysctl when `hostNetwork` is true**. nginx got away with it because *its image*
+carries `cap_net_bind_service` as a file capability, so a non-root process can
+raise it. Istio's Envoy image has no such file capability, so `NET_BIND_SERVICE`
+in the container spec is present and inert:
+
+```
+cannot bind '0.0.0.0:443': Permission denied
+```
+
+Adding `allowPrivilegeEscalation: true` does not help either. hostNetwork and an
+Istio gateway are mutually exclusive on privileged ports, whatever securityContext
+is applied.
+
+Instead: no hostNetwork. Envoy binds inside the pod network namespace where
+Istio's own sysctl applies, klipper performs the privileged bind on the host, and
+`externalTrafficPolicy: Local` carries the client address through. That last part
+is not assumed — the access log records the real client address (see
+`telemetry.yaml`).
+
+## Access control
+
+`authorizationpolicy.yaml` is **the security boundary**. Istio ALLOW policies are
+deny-by-default for the workloads they select, so that one object is both the
+default-deny and the allow-list: a host added to the Gateway is refused until it
+is named there deliberately.
+
+`10.0.0.0/8` from the old nginx allow-lists is **deliberately not carried over**.
+It contains the pod network `10.42.0.0/16` and the node network, so under any
+SNAT it would make arbitrary internet traffic look allow-listed — failing open,
+silently. It also costs nothing to drop: the router hairpin-NATs LAN traffic to
+the public address, so LAN clients already match the public `/32`s.
+
+`ipBlocks` is correct here rather than `remoteIpBlocks`, because
+`externalTrafficPolicy: Local` means the packet source *is* the client.
+`remoteIpBlocks` would require trusting `X-Forwarded-For`, which is meaningless
+with no proxy in front and dangerous if mis-scoped.
+
+Hosts that are public by design carry no `from` clause and are annotated
+`arigsela.com/public-by-design` on their manifests, which the `ingress-policy` CI
+check honors: `n8n`'s webhook paths, `oncall-agent` (Slack Events API, HMAC-signed),
+`grafana` (GitHub OAuth), `chores` (family app, app-level JWT).
+
+## Certificates
+
+All certificates use `letsencrypt-route53` (DNS-01). Nothing here depends on the
+ingress for issuance — deliberately, since HTTP-01 solves *through* the ingress
+and would have made ingress replacement break certificate renewal silently, about
+30 days later.
+
+Certificates stay in their app namespaces and are reached by `ReferenceGrant`.
+Every app with a listener has one; without it the listener comes up **silently
+certless** rather than erroring.
+
+## Routes
+
+`HTTPRoute`s live in the **app** namespaces, not here. That keeps each
+`backendRef` same-namespace (so no second ReferenceGrant is needed) and keeps the
+route beside what it routes to. Cross-namespace attachment is permitted by the
+Gateway's `allowedRoutes.namespaces.from: All`.

--- a/base-apps/istio-ingress/docs/index.md
+++ b/base-apps/istio-ingress/docs/index.md
@@ -1,0 +1,118 @@
+---
+type: "Kubernetes App Guide"
+title: "istio-ingress"
+description: "The cluster's north-south ingress: a Gateway API Gateway on the `istio` GatewayClass, directly internet-facing"
+app: istio-ingress
+catalog_entity: istio-ingress
+kind: docs
+namespace: istio-ingress
+last_reviewed: 2026-07-31
+status: current
+tags: [ingress, gateway-api, istio]
+sources:
+  - base-apps/istio-ingress.yaml
+  - base-apps/istio-ingress/gateway.yaml
+  - base-apps/istio-ingress/gateway-options.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - base-apps/istio-ingress/telemetry.yaml
+---
+
+# istio-ingress
+
+## What it is
+
+The cluster's single north-south entry point, replacing `ingress-nginx` on
+2026-07-31. A Gateway API `Gateway` named `main` on the `istio` GatewayClass
+(controller `istio.io/gateway-controller`), serving 18 hostnames on `:80`/`:443`.
+
+`ingress-nginx` was retired because its upstream repository is archived — the
+final release `controller-v1.15.1` supports Kubernetes 1.31–1.35 and there will
+never be 1.36 support. It was the single component blocking the cluster's
+Kubernetes upgrade path.
+
+Do not confuse this Gateway with the two `istio-waypoint` Gateways in
+`chores-tracker` and `chores-tracker-frontend`. Those are **ambient mesh
+waypoints** doing east-west policy enforcement inside the mesh; they serve no
+external traffic. This is the only Gateway that does.
+
+## How traffic arrives
+
+```
+internet → 73.7.190.154 → router → k3s-control-01
+         → klipper svclb (hostPort :80/:443)
+         → Service main-istio (externalTrafficPolicy: Local)
+         → Envoy (main-istio pod)
+         → HTTPRoute → app Service
+```
+
+There is no reverse proxy, tunnel, or WAF in front. The Gateway is directly
+internet-facing and the cluster is scanned continuously — assume anything
+exposed is found the same day.
+
+## Why it does NOT use hostNetwork
+
+`ingress-nginx` ran `hostNetwork: true` and got the real client IP for free. The
+obvious move was to copy that. It does not work, and the reason is worth knowing
+before anyone tries again:
+
+Envoy runs as uid 1337. Istio permits it to bind privileged ports using the
+`net.ipv4.ip_unprivileged_port_start` sysctl — and **Kubernetes forbids that
+sysctl when `hostNetwork` is true**. nginx got away with it because *its image*
+carries `cap_net_bind_service` as a file capability, so a non-root process can
+raise it. Istio's Envoy image has no such file capability, so `NET_BIND_SERVICE`
+in the container spec is present and inert:
+
+```
+cannot bind '0.0.0.0:443': Permission denied
+```
+
+Adding `allowPrivilegeEscalation: true` does not help either. hostNetwork and an
+Istio gateway are mutually exclusive on privileged ports, whatever securityContext
+is applied.
+
+Instead: no hostNetwork. Envoy binds inside the pod network namespace where
+Istio's own sysctl applies, klipper performs the privileged bind on the host, and
+`externalTrafficPolicy: Local` carries the client address through. That last part
+is not assumed — the access log records the real client address (see
+`telemetry.yaml`).
+
+## Access control
+
+`authorizationpolicy.yaml` is **the security boundary**. Istio ALLOW policies are
+deny-by-default for the workloads they select, so that one object is both the
+default-deny and the allow-list: a host added to the Gateway is refused until it
+is named there deliberately.
+
+`10.0.0.0/8` from the old nginx allow-lists is **deliberately not carried over**.
+It contains the pod network `10.42.0.0/16` and the node network, so under any
+SNAT it would make arbitrary internet traffic look allow-listed — failing open,
+silently. It also costs nothing to drop: the router hairpin-NATs LAN traffic to
+the public address, so LAN clients already match the public `/32`s.
+
+`ipBlocks` is correct here rather than `remoteIpBlocks`, because
+`externalTrafficPolicy: Local` means the packet source *is* the client.
+`remoteIpBlocks` would require trusting `X-Forwarded-For`, which is meaningless
+with no proxy in front and dangerous if mis-scoped.
+
+Hosts that are public by design carry no `from` clause and are annotated
+`arigsela.com/public-by-design` on their manifests, which the `ingress-policy` CI
+check honors: `n8n`'s webhook paths, `oncall-agent` (Slack Events API, HMAC-signed),
+`grafana` (GitHub OAuth), `chores` (family app, app-level JWT).
+
+## Certificates
+
+All certificates use `letsencrypt-route53` (DNS-01). Nothing here depends on the
+ingress for issuance — deliberately, since HTTP-01 solves *through* the ingress
+and would have made ingress replacement break certificate renewal silently, about
+30 days later.
+
+Certificates stay in their app namespaces and are reached by `ReferenceGrant`.
+Every app with a listener has one; without it the listener comes up **silently
+certless** rather than erroring.
+
+## Routes
+
+`HTTPRoute`s live in the **app** namespaces, not here. That keeps each
+`backendRef` same-namespace (so no second ReferenceGrant is needed) and keeps the
+route beside what it routes to. Cross-namespace attachment is permitted by the
+Gateway's `allowedRoutes.namespaces.from: All`.

--- a/base-apps/istio-ingress/docs/runbook.md
+++ b/base-apps/istio-ingress/docs/runbook.md
@@ -1,0 +1,165 @@
+---
+type: "Kubernetes App Runbook"
+title: "istio-ingress Runbook"
+description: "Failure modes for the north-south Gateway: certless listeners, unreachable hosts, and the traps found replacing ingress-nginx"
+app: istio-ingress
+catalog_entity: istio-ingress
+kind: runbook
+namespace: istio-ingress
+last_reviewed: 2026-07-31
+status: current
+tags: [ingress, gateway-api, istio]
+sources:
+  - base-apps/istio-ingress/gateway.yaml
+  - base-apps/istio-ingress/gateway-options.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - scripts/hop-verify.sh
+---
+
+# istio-ingress Runbook
+
+## First: what to check, in order
+
+```bash
+kubectl -n istio-ingress get gateway main                 # Programmed=True?
+kubectl -n istio-ingress get pods                          # 1/1 Running?
+kubectl -n istio-ingress logs deploy/main-istio --tail=50  # Envoy's own view
+scripts/hop-verify.sh gate                                 # the four gate checks
+```
+
+`hop-verify`'s `check_ingress` asserts the Gateway is Programmed, its data plane
+has ready pods, **every** listener resolved its `certificateRef`, and the
+AuthorizationPolicy exists. That last one matters: an ingress that serves but
+enforces nothing is worse than one that is down.
+
+## A host returns 404 through the Gateway
+
+The request reached Envoy but matched no route. **403 means the opposite** — it
+routed fine and the AuthorizationPolicy refused it. That distinction is the
+fastest triage available here; do not confuse them.
+
+```bash
+kubectl -n istio-ingress get gateway main -o json | jq '.status.listeners[]
+  | {name, attachedRoutes, conditions: [.conditions[] | {type, status}]}'
+kubectl -n <app-ns> get httproute -o yaml    # Accepted? ResolvedRefs?
+```
+
+Usual causes: the `sectionName` in the HTTPRoute does not match a listener name;
+the hostname on the route does not match the listener's; or the backend Service
+name is wrong. **Backend names are not app names** — `coroot`'s Service is
+`coroot-coroot`, not `coroot`. Read the Service, do not infer it.
+
+## A listener serves the wrong certificate, or none
+
+Almost always a missing or mis-scoped `ReferenceGrant`. Gateway API requires an
+explicit grant for any cross-namespace `certificateRef`, and **without it the
+listener comes up silently certless rather than erroring**.
+
+```bash
+kubectl -n istio-ingress get gateway main -o json \
+  | jq '.status.listeners[] | select(.conditions[]
+        | select(.type=="ResolvedRefs" and .status!="True")) | .name'
+kubectl -n <app-ns> get referencegrant
+```
+
+The grant lives in the namespace that **owns the secret**, and its `from` must
+name `Gateway` in `istio-ingress`.
+
+## Everything is 403, including from an allow-listed address
+
+Check what source address Envoy actually saw — do not assume:
+
+```bash
+kubectl -n istio-ingress logs deploy/main-istio --tail=20 | grep rbac_access_denied
+```
+
+The access log records the downstream address. If it shows a node or pod address
+rather than the real client, `externalTrafficPolicy` has reverted to `Cluster`
+and every client now looks like the node.
+
+**Do not "fix" that by adding `10.0.0.0/8` to the allow-list.** That is the
+failure this design exists to avoid: the node address is inside that range, so
+the rule would then admit the entire internet while every host still returned
+200. Fix `externalTrafficPolicy` instead.
+
+## Changing gateway-options.yaml appears to do nothing
+
+**istiod does not re-reconcile the generated Deployment when the
+`parametersRef` ConfigMap changes.** The ConfigMap will hold the new values while
+the Deployment keeps the old ones, indefinitely.
+
+```bash
+kubectl -n istio-ingress get cm gateway-options -o yaml      # new values
+kubectl -n istio-ingress get deploy main-istio -o yaml       # old values
+kubectl -n istio-ingress delete deploy main-istio            # istiod rebuilds it
+```
+
+Deleting the Deployment is the supported way to force it. istiod recreates it
+within seconds, applying the current ConfigMap.
+
+## The gateway pod is Pending on "didn't have free ports"
+
+Something else holds the hostPorts klipper wants. Check what:
+
+```bash
+kubectl get pods -A -o json | jq -r '.items[]
+  | select(.spec.nodeName=="k3s-control-01")
+  | .metadata.name as $n | .spec.containers[].ports[]?
+  | select(.hostPort) | "\($n) \(.hostPort)"'
+```
+
+Only `k3s-control-01` carries `node.kubernetes.io/workload: infrastructure`, so
+the other two nodes will always be rejected on the selector — that is intended,
+since public DNS resolves to that node.
+
+## Do not give this Gateway hostNetwork
+
+It cannot bind `:80`/`:443` if you do, and the failure is confusing: the Gateway
+reports `Accepted=True` with **every listener green** while no Deployment exists
+at all, and the real reason appears only in istiod's log.
+
+```
+Deployment.apps "main-istio" is invalid: spec.template.spec.securityContext
+.sysctls[0].name: Invalid value: "net.ipv4.ip_unprivileged_port_start":
+may not be specified when 'hostNetwork' is true
+```
+
+Istio permits low-port binding via that sysctl; Kubernetes forbids the sysctl
+under hostNetwork; and Istio's image has no file capability to fall back on, so
+`NET_BIND_SERVICE` is inert. See `docs.md`. This was tried, twice, and cost an
+outage.
+
+## Adding a host
+
+Four things, together — never a listener without a rule:
+
+1. listener in `gateway.yaml` (hostname + `certificateRefs`)
+2. `ReferenceGrant` in the app namespace
+3. `HTTPRoute` in the app namespace (`sectionName` = listener name)
+4. rule in `authorizationpolicy.yaml`, **or** the host is refused
+
+Then verify by observation, not by reading YAML:
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' https://<host>/     # from an allow-listed address
+# and from one that is NOT allow-listed — must be 403
+```
+
+## Gotchas that cost time
+
+- **Argo app names are not directory names.** `base-apps/kagent/` is owned by the
+  app `kagent-secrets`; `base-apps/chores-tracker-backend/` by
+  `chores-tracker-backend`, not `chores-tracker`. Refreshing the wrong name does
+  nothing and looks like the change failed.
+- **The child Application's own spec is owned by `master-app`.** Changing
+  `targetRevision` in git and refreshing the child re-syncs it from its *old*
+  spec. Refresh `master-app`.
+- **Strategic merge patches replace list fields.** Restate `drop: [ALL]` when
+  adding a capability, or the container silently gets every capability.
+- **`RequestRedirect` preserves the request port** unless `port` is set
+  explicitly.
+- **Istio defaults the generated Service to `LoadBalancer`**, which makes klipper
+  spawn `svclb` DaemonSets squatting hostPorts on every node.
+- **Resource names change between Istio versions.** The ztunnel DaemonSet was
+  `ztunnel` at 1.24, `istio-ztunnel` at 1.25, and `ztunnel` again at 1.26. Read
+  live names; do not hardcode.

--- a/base-apps/istio-ingress/mkdocs.yml
+++ b/base-apps/istio-ingress/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: istio-ingress
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/base-apps/istio-ingress/runbook.md
+++ b/base-apps/istio-ingress/runbook.md
@@ -1,0 +1,165 @@
+---
+type: "Kubernetes App Runbook"
+title: "istio-ingress Runbook"
+description: "Failure modes for the north-south Gateway: certless listeners, unreachable hosts, and the traps found replacing ingress-nginx"
+app: istio-ingress
+catalog_entity: istio-ingress
+kind: runbook
+namespace: istio-ingress
+last_reviewed: 2026-07-31
+status: current
+tags: [ingress, gateway-api, istio]
+sources:
+  - base-apps/istio-ingress/gateway.yaml
+  - base-apps/istio-ingress/gateway-options.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - scripts/hop-verify.sh
+---
+
+# istio-ingress Runbook
+
+## First: what to check, in order
+
+```bash
+kubectl -n istio-ingress get gateway main                 # Programmed=True?
+kubectl -n istio-ingress get pods                          # 1/1 Running?
+kubectl -n istio-ingress logs deploy/main-istio --tail=50  # Envoy's own view
+scripts/hop-verify.sh gate                                 # the four gate checks
+```
+
+`hop-verify`'s `check_ingress` asserts the Gateway is Programmed, its data plane
+has ready pods, **every** listener resolved its `certificateRef`, and the
+AuthorizationPolicy exists. That last one matters: an ingress that serves but
+enforces nothing is worse than one that is down.
+
+## A host returns 404 through the Gateway
+
+The request reached Envoy but matched no route. **403 means the opposite** — it
+routed fine and the AuthorizationPolicy refused it. That distinction is the
+fastest triage available here; do not confuse them.
+
+```bash
+kubectl -n istio-ingress get gateway main -o json | jq '.status.listeners[]
+  | {name, attachedRoutes, conditions: [.conditions[] | {type, status}]}'
+kubectl -n <app-ns> get httproute -o yaml    # Accepted? ResolvedRefs?
+```
+
+Usual causes: the `sectionName` in the HTTPRoute does not match a listener name;
+the hostname on the route does not match the listener's; or the backend Service
+name is wrong. **Backend names are not app names** — `coroot`'s Service is
+`coroot-coroot`, not `coroot`. Read the Service, do not infer it.
+
+## A listener serves the wrong certificate, or none
+
+Almost always a missing or mis-scoped `ReferenceGrant`. Gateway API requires an
+explicit grant for any cross-namespace `certificateRef`, and **without it the
+listener comes up silently certless rather than erroring**.
+
+```bash
+kubectl -n istio-ingress get gateway main -o json \
+  | jq '.status.listeners[] | select(.conditions[]
+        | select(.type=="ResolvedRefs" and .status!="True")) | .name'
+kubectl -n <app-ns> get referencegrant
+```
+
+The grant lives in the namespace that **owns the secret**, and its `from` must
+name `Gateway` in `istio-ingress`.
+
+## Everything is 403, including from an allow-listed address
+
+Check what source address Envoy actually saw — do not assume:
+
+```bash
+kubectl -n istio-ingress logs deploy/main-istio --tail=20 | grep rbac_access_denied
+```
+
+The access log records the downstream address. If it shows a node or pod address
+rather than the real client, `externalTrafficPolicy` has reverted to `Cluster`
+and every client now looks like the node.
+
+**Do not "fix" that by adding `10.0.0.0/8` to the allow-list.** That is the
+failure this design exists to avoid: the node address is inside that range, so
+the rule would then admit the entire internet while every host still returned
+200. Fix `externalTrafficPolicy` instead.
+
+## Changing gateway-options.yaml appears to do nothing
+
+**istiod does not re-reconcile the generated Deployment when the
+`parametersRef` ConfigMap changes.** The ConfigMap will hold the new values while
+the Deployment keeps the old ones, indefinitely.
+
+```bash
+kubectl -n istio-ingress get cm gateway-options -o yaml      # new values
+kubectl -n istio-ingress get deploy main-istio -o yaml       # old values
+kubectl -n istio-ingress delete deploy main-istio            # istiod rebuilds it
+```
+
+Deleting the Deployment is the supported way to force it. istiod recreates it
+within seconds, applying the current ConfigMap.
+
+## The gateway pod is Pending on "didn't have free ports"
+
+Something else holds the hostPorts klipper wants. Check what:
+
+```bash
+kubectl get pods -A -o json | jq -r '.items[]
+  | select(.spec.nodeName=="k3s-control-01")
+  | .metadata.name as $n | .spec.containers[].ports[]?
+  | select(.hostPort) | "\($n) \(.hostPort)"'
+```
+
+Only `k3s-control-01` carries `node.kubernetes.io/workload: infrastructure`, so
+the other two nodes will always be rejected on the selector — that is intended,
+since public DNS resolves to that node.
+
+## Do not give this Gateway hostNetwork
+
+It cannot bind `:80`/`:443` if you do, and the failure is confusing: the Gateway
+reports `Accepted=True` with **every listener green** while no Deployment exists
+at all, and the real reason appears only in istiod's log.
+
+```
+Deployment.apps "main-istio" is invalid: spec.template.spec.securityContext
+.sysctls[0].name: Invalid value: "net.ipv4.ip_unprivileged_port_start":
+may not be specified when 'hostNetwork' is true
+```
+
+Istio permits low-port binding via that sysctl; Kubernetes forbids the sysctl
+under hostNetwork; and Istio's image has no file capability to fall back on, so
+`NET_BIND_SERVICE` is inert. See `docs.md`. This was tried, twice, and cost an
+outage.
+
+## Adding a host
+
+Four things, together — never a listener without a rule:
+
+1. listener in `gateway.yaml` (hostname + `certificateRefs`)
+2. `ReferenceGrant` in the app namespace
+3. `HTTPRoute` in the app namespace (`sectionName` = listener name)
+4. rule in `authorizationpolicy.yaml`, **or** the host is refused
+
+Then verify by observation, not by reading YAML:
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' https://<host>/     # from an allow-listed address
+# and from one that is NOT allow-listed — must be 403
+```
+
+## Gotchas that cost time
+
+- **Argo app names are not directory names.** `base-apps/kagent/` is owned by the
+  app `kagent-secrets`; `base-apps/chores-tracker-backend/` by
+  `chores-tracker-backend`, not `chores-tracker`. Refreshing the wrong name does
+  nothing and looks like the change failed.
+- **The child Application's own spec is owned by `master-app`.** Changing
+  `targetRevision` in git and refreshing the child re-syncs it from its *old*
+  spec. Refresh `master-app`.
+- **Strategic merge patches replace list fields.** Restate `drop: [ALL]` when
+  adding a capability, or the container silently gets every capability.
+- **`RequestRedirect` preserves the request port** unless `port` is set
+  explicitly.
+- **Istio defaults the generated Service to `LoadBalancer`**, which makes klipper
+  spawn `svclb` DaemonSets squatting hostPorts on every node.
+- **Resource names change between Istio versions.** The ztunnel DaemonSet was
+  `ztunnel` at 1.24, `istio-ztunnel` at 1.25, and `ztunnel` again at 1.26. Read
+  live names; do not hardcode.

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -18,3 +18,4 @@ dex
 whoami-test
 qwen
 openclaw-qwen
+istio-ingress


### PR DESCRIPTION
The nginx runbook documented ingress architecture and failure modes, and it was deleted with nginx at `§T.53` — at exactly the moment the architecture changed. This replaces it.

Three contract files plus `mkdocs.yml`, the app added to `agent-docs-scope.txt`, and `directory.exclude` added to the Argo Application (the validator requires it — `catalog-info.yaml` is a Backstage entity Argo would otherwise try to apply and fail on). Generated indexes refreshed.

## The runbook captures what this cost to learn

None of it is guessable from the manifests:

- **hostNetwork cannot work here.** Istio permits low-port binding via the `net.ipv4.ip_unprivileged_port_start` sysctl; Kubernetes forbids that sysctl under hostNetwork; Istio's image has no file capability to fall back on, so `NET_BIND_SERVICE` is inert. nginx got away with it because *its* image carries `cap_net_bind_service`. Tried twice, cost an outage.
- **The failure looked healthy** — Gateway `Accepted=True` with every listener green while no Deployment existed; reason only in istiod's log.
- **istiod does not re-reconcile** the Deployment when the `parametersRef` ConfigMap changes. Delete the Deployment.
- **403 vs 404 is the fastest triage**: 403 = routed then refused, 404 = no route matched.
- **A missing ReferenceGrant produces a silently certless listener.**
- **Do not "fix" a blanket 403 with `10.0.0.0/8`** — the node address is inside it, so that admits the entire internet while every host still returns 200.
- Argo app names are not directory names; the child's spec is owned by `master-app`.
- Strategic merge patches **replace** list fields — restate `drop: [ALL]`.
- Resource names move between Istio versions (`ztunnel` → `istio-ztunnel` → `ztunnel` across 1.24/1.25/1.26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ