### PR TITLE
fix(istio-ingress): drop ServerSideApply — it was causing the drift

### DIFF
--- a/base-apps/istio-ingress.yaml
+++ b/base-apps/istio-ingress.yaml
@@ -32,4 +32,13 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true
+      # ServerSideApply deliberately NOT set. With SSA, Argo compares the full
+      # live object, so every field the API server defaults on Gateway API types
+      # shows as drift and the app sits permanently OutOfSync:
+      #   HTTPRoute  parentRefs[].group/kind, rules[].matches,
+      #              backendRefs[].group/kind/weight
+      #   Gateway    listeners[].tls.certificateRefs[].group
+      # With client-side apply Argo compares against last-applied-configuration
+      # and never sees them. The correlation was exact - every route-hosting app
+      # without SSA was Synced, both apps with it were OutOfSync. See V47: the
+      # remedy for defaulted-field drift is not blanket SSA (R19).


### PR DESCRIPTION
The app sat `OutOfSync` with Gateway and HTTPRoute permanently differing from git, while every listener was resolved and the ingress served correctly.

## Cause: API-server defaulting, not istiod

```
HTTPRoute  parentRefs[].group/kind, rules[].matches,
           backendRefs[].group/kind/weight
Gateway    listeners[].tls.certificateRefs[].group
```

With `ServerSideApply`, Argo compares the **full live object**, so every defaulted field reads as drift. With client-side apply it compares against `last-applied-configuration` and never sees them.

## The correlation was exact

| App | SSA | Sync |
|---|---|---|
| coroot, argo-cd-config, backstage, dex, logging | no | **Synced** |
| istio-ingress, kagent-secrets | **yes** | **OutOfSync** |

All of them host HTTPRoutes. The only two OutOfSync apps are the only two with SSA.

SSA was copied from a template rather than chosen. Nothing here needs it — these are small objects, well inside the annotation size limit SSA exists to escape.

`§V.47` already warned against blanket ServerSideApply as a drift remedy, and `§R.19` recorded that 5 of 8 drifting apps *already had it and drifted regardless*. This is the same lesson from the other direction: **SSA did not fail to fix drift here, it created it.**

`kagent-secrets` has the same problem for the same reason — left for its own change, since it also carries the pre-existing `§T.42` ServiceAccount drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ