### PR TITLE
fix(istio-ingress): explain the drift instead of tolerating it (§V.47)

### DIFF
--- a/base-apps/istio-ingress.yaml
+++ b/base-apps/istio-ingress.yaml
@@ -26,6 +26,27 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: istio-ingress
+  # V47: OutOfSync is only acceptable with a DOCUMENTED benign cause plus an
+  # ignoreDifferences covering it. The cause here is API-server defaulting on
+  # Gateway API types - group/kind/weight fields the schema fills in when
+  # omitted. They are not settable-and-ignored; they simply have defaults.
+  #
+  # Scoped deliberately narrowly: only the defaulted identity fields. Real
+  # changes to hostnames, paths, backends, ports or certificateRefs still show
+  # as drift, which is the point.
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      jqPathExpressions:
+        - '.spec.listeners[]?.tls.certificateRefs[]?.group'
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jqPathExpressions:
+        - '.spec.parentRefs[]?.group'
+        - '.spec.parentRefs[]?.kind'
+        - '.spec.rules[]?.backendRefs[]?.group'
+        - '.spec.rules[]?.backendRefs[]?.kind'
+        - '.spec.rules[]?.backendRefs[]?.weight'
   syncPolicy:
     automated:
       prune: true

--- a/base-apps/istio-ingress/httproute-redirect.yaml
+++ b/base-apps/istio-ingress/httproute-redirect.yaml
@@ -11,7 +11,13 @@ spec:
     - name: main
       sectionName: http
   rules:
-    - filters:
+      # matches is stated explicitly even though "/" is the default: omitting it
+      # lets the API server default it, which then reads as drift against git.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
         - type: RequestRedirect
           requestRedirect:
             scheme: https


### PR DESCRIPTION
`§V.47` permits `OutOfSync` only with a **documented benign cause and an `ignoreDifferences` covering it**. This supplies both.

The cause is API-server defaulting on Gateway API types — `group`, `kind` and `weight` fields the schema fills in when omitted. Removing ServerSideApply (previous PR) was right for its own reasons but did not clear this: the existing objects carry SSA field-manager history and no `last-applied-configuration`, so the comparison still sees the full live object.

## Two fixes, not one blanket ignore

- **`httproute-redirect` states `matches` explicitly.** It was genuinely omitted and then defaulted, so the honest fix is to write it, not ignore it.
- **`ignoreDifferences` covers only the defaulted identity fields.**

Scoped deliberately narrowly. Real changes to hostnames, paths, backends, ports or `certificateRefs` still surface as drift — which is the point of the gate. Ignoring `.spec.rules[].matches` wholesale would have been easier and would have hidden genuine routing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ