### PR TITLE
grafana: GitHub OAuth only — disable local login form and basic auth

### DIFF
--- a/base-apps/logging/grafana-deployment.yaml
+++ b/base-apps/logging/grafana-deployment.yaml
@@ -120,6 +120,27 @@ spec:
         #   ALLOW_SIGN_UP=false         -> only users already in grafana.db may
         #     log in, independent of the JMESPath being correct.
         # Replace both with allowed_organizations once a GitHub org exists (§T.61).
+        # GitHub OAuth is now the ONLY way in. Both of these are required:
+        # disable_login_form alone merely HIDES the UI form, while auth.basic
+        # keeps /api/* accepting username and password - so the credential
+        # surface would remain fully reachable from the internet and the change
+        # would look complete while changing nothing.
+        #
+        # Held back until T62 proved role_attribute_strict actually denies:
+        # inverting role_attribute_path produced a refused login with
+        # [oauth.role_attribute_strict_violation] and zero Successful Login
+        # events. Removing break-glass before that was verified would have risked
+        # locking everyone out of an internet-facing host.
+        #
+        # Recovery if OAuth breaks: revert this commit, Argo re-syncs in ~2min.
+        # kubectl works throughout regardless.
+        #
+        # NB this ends admin API access by username/password. Anything scripted
+        # against Grafana's API needs a service account token instead.
+        - name: GF_AUTH_DISABLE_LOGIN_FORM
+          value: "true"
+        - name: GF_AUTH_BASIC_ENABLED
+          value: "false"
         - name: GF_AUTH_GITHUB_ENABLED
           value: "true"
         # Bootstrap complete -- user arigsela is linked (isExternal=true,


### PR DESCRIPTION
Closes the gap left open at `§T.59`. The local admin login was deliberately **kept** as break-glass while `role_attribute_strict` was unverified — removing it then would have made GitHub OAuth the only way in with no fallback if the filter was wrong. `§T.62` removed that objection and this never followed.

## Both settings are required

`disable_login_form` alone merely **hides the UI form**, while `auth.basic` keeps `/api/*` accepting username and password. The credential surface would stay fully reachable from the internet and the change would look complete while changing nothing.

Verified immediately before this commit:

```
POST /login  (public)      -> 401     credential surface live
GET  /api/org basic (public) -> 401   credential surface live
in-pod /api/org with admin creds -> 200
```

## Why grafana in particular

It is the **only host with no IP allow-list** — public by design, because dashboards are read from mobile and carrier addresses cannot be allow-listed. Its access control is therefore entirely application-layer, which is exactly why it should be one mechanism rather than three.

Remaining gates, both verified by observation (`§V.69`/`§T.62`):

| Gate | Denies |
|---|---|
| `role_attribute_strict=true` | a login resolving to no role |
| `allow_sign_up=false` | identities not already linked in `grafana.db` |

## Cost

**Ends admin API access by username/password** — the `kubectl exec + curl -u` pattern used throughout this migration stops working. Anything scripted against Grafana's API needs a service account token.

**Recovery**: revert, Argo re-syncs in ~2 min. `kubectl` works throughout regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ