### PR TITLE
eso: stage 1 — chart 0.11.0 → 0.16.2 (§T.6)

### DIFF
--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -10,7 +10,18 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.11.0
+    # STAGE 1 of the ESO walk (T6). 0.16.2 is the LAST version serving
+    # external-secrets.io/v1beta1 alongside v1 (R2) - which is what makes the
+    # manifest migration in T31 possible at all. 0.17.0 unserves v1beta1, and
+    # all three core CRDs currently STORE v1beta1, so going there first would
+    # make existing secrets unreadable (V23/V26).
+    #
+    # Five minors in one hop, against upstream's one-minor-at-a-time advice.
+    # Accepted deliberately: every intervening version serves v1beta1 so nothing
+    # structural changes until T31, and ESO's failure mode is that secret
+    # REFRESH stops while existing Secrets persist (V48) - degradation, not
+    # outage. Rollback is a chart-version revert.
+    targetRevision: 0.16.2
     helm:
       releaseName: external-secrets
       values: |


### PR DESCRIPTION
**0.16.2 is the last version serving `v1beta1` alongside `v1`** (`§R.2`) — which is what makes the manifest migration in `§T.31` possible at all.

All three core CRDs currently **store** `v1beta1`, and `v1` is not served at all today:

```
externalsecrets      served=[v1alpha1 v1beta1]  storage=v1beta1  stored=[v1beta1]
secretstores         served=[v1alpha1 v1beta1]  storage=v1beta1  stored=[v1beta1]
clustersecretstores  served=[v1alpha1 v1beta1]  storage=v1beta1  stored=[v1beta1]
```

Going straight to 0.17.0 would make existing secrets **unreadable** (`§V.23`/`§V.26`).

## Five minors in one hop

Against upstream's one-minor-at-a-time advice, taken deliberately: every intervening version serves `v1beta1` so nothing structural changes before `§T.31`; ESO's failure mode is that secret **refresh** stops while existing Secrets persist (`§V.48` — degradation, not outage); and rollback is a chart-version revert. 22 sequential upgrades is a poor trade here.

## Baseline (§V.11)

**43 ExternalSecrets, 40 Ready, 3 failing.** The three are pre-existing `SecretSyncedError` — missing Vault paths in `langflow-ide`, `oncall-crewai` and `whoami-test`. **They must not be read as regressions.**

## Expect drift after this lands

The 0.16.x webhook rewrites stored objects `v1beta1 → v1` while git still says `v1beta1`, so `selfHeal` fights the webhook until `§T.31` migrates the 61 manifests (`§V.24`, `§R.7`). That window is kept short — `§T.31` follows immediately.

## Verify after merge

```
kubectl -n external-secrets get deploy -o wide          # v0.16.2
kubectl get crd externalsecrets.external-secrets.io -o jsonpath='{.spec.versions[*].name}'   # expect v1 present
kubectl get externalsecrets -A                          # still 40 Ready / 3 failing
```

`v1` appearing in the served versions is the gate for `§T.31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ