### PR TITLE
eso: stage 2 — migrate 55 manifests v1beta1 → v1 (§T.31)

### DIFF
--- a/base-apps/atlantis/external-secrets.yaml
+++ b/base-apps/atlantis/external-secrets.yaml
@@ -1,7 +1,7 @@
 ---
 # atlantis-vcs: GitHub token + webhook secret
 # Referenced by Helm chart via vcsSecretName: atlantis-vcs
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: atlantis-vcs
@@ -26,7 +26,7 @@ spec:
 ---
 # atlantis-env: AWS creds + Infracost API key as env var names
 # Referenced by Helm chart via environmentSecrets: [{name: atlantis-env}]
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: atlantis-env

--- a/base-apps/atlantis/secret-store.yaml
+++ b/base-apps/atlantis/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/backstage/external-secrets.yaml
+++ b/base-apps/backstage/external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: backstage-secrets

--- a/base-apps/backstage/secret-store.yaml
+++ b/base-apps/backstage/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/cert-manager/external-secret.yaml
+++ b/base-apps/cert-manager/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: route53-credentials

--- a/base-apps/cert-manager/secret-store.yaml
+++ b/base-apps/cert-manager/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/crossplane-compositions/composition-application.yaml
+++ b/base-apps/crossplane-compositions/composition-application.yaml
@@ -61,7 +61,7 @@ spec:
 
           def make_secret_store(name, namespace, annotations):
               return {
-                  "apiVersion": "external-secrets.io/v1beta1",
+                  "apiVersion": "external-secrets.io/v1",
                   "kind": "SecretStore",
                   "metadata": {
                       "name": "vault-backend",
@@ -123,7 +123,7 @@ spec:
 
           def make_external_secret(name, namespace, annotations):
               return {
-                  "apiVersion": "external-secrets.io/v1beta1",
+                  "apiVersion": "external-secrets.io/v1",
                   "kind": "ExternalSecret",
                   "metadata": {
                       "name": f"{name}-db",
@@ -202,7 +202,7 @@ spec:
           def make_aws_external_secret(name, namespace, annotations):
               """Reads from Vault → projects to K8s Secret <name>-aws with AWS SDK-named keys."""
               return {
-                  "apiVersion": "external-secrets.io/v1beta1",
+                  "apiVersion": "external-secrets.io/v1",
                   "kind": "ExternalSecret",
                   "metadata": {
                       "name": f"{name}-aws",

--- a/base-apps/crossplane-system/secret-store.yaml
+++ b/base-apps/crossplane-system/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/dex/external-secret.yaml
+++ b/base-apps/dex/external-secret.yaml
@@ -6,7 +6,7 @@
 #     and Vault's oidc auth config (generated during setup).
 # Consumed by the Dex Deployment via envFrom; the config.yaml references them
 # as $GITHUB_CLIENT_ID / $GITHUB_CLIENT_SECRET / $VAULT_CLIENT_SECRET.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: dex-secrets

--- a/base-apps/dex/secret-store.yaml
+++ b/base-apps/dex/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/ecr-auth/external-secret.yaml
+++ b/base-apps/ecr-auth/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ecr-auth-secrets

--- a/base-apps/ecr-auth/secret-store.yaml
+++ b/base-apps/ecr-auth/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -11,7 +11,7 @@ spec:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
     # STAGE 1 of the ESO walk (T6). 0.16.2 is the LAST version serving
-    # external-secrets.io/v1beta1 alongside v1 (R2) - which is what makes the
+    # external-secrets.io/v1 alongside v1 (R2) - which is what makes the
     # manifest migration in T31 possible at all. 0.17.0 unserves v1beta1, and
     # all three core CRDs currently STORE v1beta1, so going there first would
     # make existing secrets unreadable (V23/V26).

--- a/base-apps/kagent/agent-docs-mcp-external-secret.yaml
+++ b/base-apps/kagent/agent-docs-mcp-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: agent-docs-github-mcp-token

--- a/base-apps/kagent/agent-docs-mcp-secret-store.yaml
+++ b/base-apps/kagent/agent-docs-mcp-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-agent-docs-mcp

--- a/base-apps/kagent/backstage-mcp-external-secret.yaml
+++ b/base-apps/kagent/backstage-mcp-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: backstage-mcp-token

--- a/base-apps/kagent/backstage-mcp-secret-store.yaml
+++ b/base-apps/kagent/backstage-mcp-secret-store.yaml
@@ -2,7 +2,7 @@
 # Authenticates as eso-backstage-mcp against the Vault kubernetes-auth role "backstage-mcp",
 # whose policy reads only k8s-secrets/data/kagent-backstage-mcp.
 # Replaces use of the broad `vault-backend` store + monolithic `kagent` Vault key.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backstage-mcp

--- a/base-apps/kagent/external-secrets.yaml
+++ b/base-apps/kagent/external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kagent-db-credentials

--- a/base-apps/kagent/homelab-agent-db-external-secret.yaml
+++ b/base-apps/kagent/homelab-agent-db-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: homelab-agent-db

--- a/base-apps/kagent/homelab-agent-db-secret-store.yaml
+++ b/base-apps/kagent/homelab-agent-db-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-homelab-agent-db

--- a/base-apps/kagent/homelab-agent-external-secret.yaml
+++ b/base-apps/kagent/homelab-agent-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: homelab-agent-secrets

--- a/base-apps/kagent/homelab-agent-secret-store.yaml
+++ b/base-apps/kagent/homelab-agent-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-homelab-agent

--- a/base-apps/kagent/kagent-anthropic-external-secret.yaml
+++ b/base-apps/kagent/kagent-anthropic-external-secret.yaml
@@ -14,7 +14,7 @@
 # The target Secret name (kagent-anthropic) and key (ANTHROPIC_API_KEY) are
 # unchanged, so the controller keeps resolving it; deletionPolicy Retain is
 # carried over from the live object.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kagent-anthropic-secrets

--- a/base-apps/kagent/kagent-anthropic-secret-store.yaml
+++ b/base-apps/kagent/kagent-anthropic-secret-store.yaml
@@ -5,7 +5,7 @@
 # This is the last credential to be scoped. With it, the broad `vault-backend`
 # store (Vault role `kagent`, bound to the namespace's `default` ServiceAccount,
 # able to read the monolithic `kagent` key) has no consumers left and is deleted.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-kagent-anthropic

--- a/base-apps/kagent/kagent-db-secret-store.yaml
+++ b/base-apps/kagent/kagent-db-secret-store.yaml
@@ -2,7 +2,7 @@
 # Authenticates as eso-kagent-db against the Vault kubernetes-auth role "kagent-db",
 # whose policy reads only k8s-secrets/data/kagent-db.
 # Replaces use of the broad `vault-backend` store + monolithic `kagent` Vault key.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-kagent-db

--- a/base-apps/kagent/kagent-mcp-basic-auth-secret-store.yaml
+++ b/base-apps/kagent/kagent-mcp-basic-auth-secret-store.yaml
@@ -2,7 +2,7 @@
 # Authenticates as eso-kagent-mcp-basic-auth against the Vault kubernetes-auth role "kagent-mcp-basic-auth",
 # whose policy reads only k8s-secrets/data/kagent-mcp-basic-auth.
 # Replaces use of the broad `vault-backend` store + monolithic `kagent` Vault key.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-kagent-mcp-basic-auth

--- a/base-apps/kagent/mcp-basic-auth-external-secret.yaml
+++ b/base-apps/kagent/mcp-basic-auth-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kagent-mcp-basic-auth

--- a/base-apps/kyverno-policies/agent-identity.yaml
+++ b/base-apps/kyverno-policies/agent-identity.yaml
@@ -33,7 +33,7 @@ spec:
         any:
           - resources:
               kinds:
-                - external-secrets.io/v1beta1/ExternalSecret
+                - external-secrets.io/v1/ExternalSecret
               namespaces:
                 - kagent
       validate:
@@ -67,7 +67,7 @@ spec:
         any:
           - resources:
               kinds:
-                - external-secrets.io/v1beta1/ExternalSecret
+                - external-secrets.io/v1/ExternalSecret
       validate:
         message: >-
           ExternalSecret '{{ request.object.metadata.name }}' must not read the monolithic

--- a/base-apps/logging/grafana-admin-external-secret.yaml
+++ b/base-apps/logging/grafana-admin-external-secret.yaml
@@ -8,7 +8,7 @@
 # GF_SECURITY_ADMIN_PASSWORD only seeds the password on first boot (Grafana then
 # owns it in grafana.db), but sourcing it from Vault means a fresh boot / PVC
 # wipe uses the strong password rather than resetting to "admin".
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana-admin

--- a/base-apps/logging/grafana-github-oauth-external-secret.yaml
+++ b/base-apps/logging/grafana-github-oauth-external-secret.yaml
@@ -10,7 +10,7 @@
 # ORDER MATTERS: the Vault properties must exist BEFORE this is committed. The
 # Deployment consumes the target Secret via secretKeyRef, so if it is absent the
 # Grafana pod will not start. Populate Vault first. See SPEC.md §T.59.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana-github-oauth

--- a/base-apps/logging/loki-s3-external-secret.yaml
+++ b/base-apps/logging/loki-s3-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: loki-s3-credentials

--- a/base-apps/logging/secret-store.yaml
+++ b/base-apps/logging/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/n8n/external-secrets.yaml
+++ b/base-apps/n8n/external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: n8n-secrets

--- a/base-apps/n8n/secret-store.yaml
+++ b/base-apps/n8n/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/oncall-agent/external-secret.yaml
+++ b/base-apps/oncall-agent/external-secret.yaml
@@ -1,7 +1,7 @@
 # ExternalSecret for OnCall Agent API (k3s homelab)
 # Syncs secrets from Vault to Kubernetes
 # Target secret name matches deployment.yaml secretKeyRef: oncall-agent-secrets
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: oncall-agent-secrets

--- a/base-apps/oncall-agent/secret-store.yaml
+++ b/base-apps/oncall-agent/secret-store.yaml
@@ -1,6 +1,6 @@
 # SecretStore for OnCall Agent (k3s homelab)
 # Connects to Vault using Kubernetes authentication
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/oncall-crewai/dungeons-dragons-agent/external-secret.yaml
+++ b/base-apps/oncall-crewai/dungeons-dragons-agent/external-secret.yaml
@@ -23,7 +23,7 @@
 # ------------------------------------------------------------------------------
 # The orchestrator needs the Anthropic API key (for routing LLM calls) and
 # API keys (for authenticating requests from the ingress/frontend).
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: dungeons-dragons-agent-orchestrator-secrets
@@ -70,7 +70,7 @@ spec:
 # The sub-agent needs the same core secrets as the orchestrator:
 # - anthropic-api-key for its own CrewAI agent LLM calls
 # - api-keys for A2A protocol authentication (orchestrator -> sub-agent)
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: character-creation-agent-secrets

--- a/base-apps/oncall-crewai/dungeons-dragons-agent/secret-store.yaml
+++ b/base-apps/oncall-crewai/dungeons-dragons-agent/secret-store.yaml
@@ -14,7 +14,7 @@
 # The scaffolder creates the Vault policy, K8s auth role, and placeholder secrets
 # automatically during project creation — no manual Vault commands needed.
 # ==============================================================================
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: dungeons-dragons-agent-vault

--- a/base-apps/oncall-crewai/external-secret.yaml
+++ b/base-apps/oncall-crewai/external-secret.yaml
@@ -3,7 +3,7 @@
 # Vault path: k8s-secrets/oncall-crewai
 
 # K8s Agent secrets
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: k8s-agent-secrets
@@ -32,7 +32,7 @@ spec:
 
 ---
 # GitHub Agent secrets
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: github-agent-secrets
@@ -66,7 +66,7 @@ spec:
 
 ---
 # Orchestrator secrets
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: orchestrator-secrets

--- a/base-apps/oncall-crewai/secret-store.yaml
+++ b/base-apps/oncall-crewai/secret-store.yaml
@@ -1,6 +1,6 @@
 # SecretStore for OnCall CrewAI (k3s homelab)
 # Connects to Vault using Kubernetes authentication
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/openshell/external-secret.yaml
+++ b/base-apps/openshell/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: openshell-jwt-keys

--- a/base-apps/openshell/secret-store.yaml
+++ b/base-apps/openshell/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/postgresql/external-secrets-cnpg-backup.yaml
+++ b/base-apps/postgresql/external-secrets-cnpg-backup.yaml
@@ -8,7 +8,7 @@
 # Fixed same day: the credentials now live in the dedicated Vault key
 # `postgresql-backup` (same IAM user, copied verbatim), and the `postgresql`
 # Vault policy grants read on that path.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: postgresql-backup-credentials

--- a/base-apps/postgresql/external-secrets-kagent-audit.yaml
+++ b/base-apps/postgresql/external-secrets-kagent-audit.yaml
@@ -2,7 +2,7 @@
 # The read-only credential the agent-audit tool uses to read kagent's event stream.
 # Scoped per the agent-identity contract: dedicated ESO SA + SecretStore + Vault
 # role + per-consumer Vault key. See templates/agent-identity/README.md.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kagent-audit-credentials

--- a/base-apps/postgresql/external-secrets-kagent.yaml
+++ b/base-apps/postgresql/external-secrets-kagent.yaml
@@ -32,7 +32,7 @@
 # The secretKey names differ from the kagent-namespace copy because the init Job's
 # env vars expect kagent-user / kagent-password / kagent-database. Same Vault
 # properties underneath.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kagent-db-credentials

--- a/base-apps/postgresql/external-secrets.yaml
+++ b/base-apps/postgresql/external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: postgresql-credentials

--- a/base-apps/postgresql/homelab-agent-db-external-secret.yaml
+++ b/base-apps/postgresql/homelab-agent-db-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: homelab-agent-db-credentials

--- a/base-apps/postgresql/homelab-agent-db-secret-store.yaml
+++ b/base-apps/postgresql/homelab-agent-db-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-homelab-agent-db

--- a/base-apps/postgresql/kagent-audit-secret-store.yaml
+++ b/base-apps/postgresql/kagent-audit-secret-store.yaml
@@ -7,7 +7,7 @@
 #
 # So it gets its own Vault key, its own ESO ServiceAccount, its own Vault role,
 # and — see init-kagent-audit-role.yaml — its own SELECT-only Postgres role.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-kagent-audit-ro

--- a/base-apps/postgresql/kagent-db-secret-store.yaml
+++ b/base-apps/postgresql/kagent-db-secret-store.yaml
@@ -8,7 +8,7 @@
 # scoped to the `kagent` namespace: the validator globs base-apps/kagent/, and the
 # Kyverno rule matched namespaces: [kagent]. A kagent credential living in ANOTHER
 # namespace fell straight through. Both gates are widened in the same change.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-kagent-db

--- a/base-apps/postgresql/secret-store.yaml
+++ b/base-apps/postgresql/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/weather-kitchen-backend/external_secrets.yaml
+++ b/base-apps/weather-kitchen-backend/external_secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: weather-kitchen-backend-secrets

--- a/base-apps/weather-kitchen-backend/secret-store.yaml
+++ b/base-apps/weather-kitchen-backend/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend

--- a/base-apps/whoami-test/external-secret.yaml
+++ b/base-apps/whoami-test/external-secret.yaml
@@ -1,6 +1,6 @@
 # Seed the Vault key k8s-secrets/whoami-test with your app's secrets;
 # every property under it is synced into the whoami-test-secrets Secret.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: whoami-test-secrets

--- a/base-apps/whoami-test/secret-store.yaml
+++ b/base-apps/whoami-test/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend


### PR DESCRIPTION
31 `ExternalSecret` and 25 `SecretStore` across 55 files. Pure apiVersion rename — the schemas are compatible, which is why the conversion webhook handles it transparently.

## Why immediately after stage 1

The 0.16.x webhook converts stored objects to `v1` on read — **all 43 live ExternalSecrets already report `external-secrets.io/v1`** — while git still said `v1beta1`. `§V.24` anticipated `selfHeal` fighting the webhook through that window, so the window is kept short.

**The drift did not actually materialise.** Zero apps are OutOfSync on ESO resources, because Argo normalises apiVersion when comparing. `§R.7` recorded upstream #5478 as *"resolution = migrate manifests, not a code fix"*, and that is what this is — but the urgency `§V.24` implied was lower than feared. Recording that rather than claiming the pause worked.

## Not migrated, deliberately

The two `external-secrets.io/v1alpha1` references in `crossplane-compositions/composition-application.yaml` are `PushSecret` inside a Crossplane Python template — a **different CRD**, still storing `v1alpha1`, with no `v1`. Renaming them would break scaffolding for new apps.

## Still gated

`storedVersions` now reads `[v1beta1,v1]` on all three core CRDs — **both**, not just `v1`. `§V.26` forbids 0.17.0 until it reads `[v1]` alone, which requires every stored object rewritten and the list pruned.

That is stage 3, and it is the step where getting it wrong makes secrets unreadable.

## Verify after merge

```
kubectl get externalsecrets -A          # still 40 Ready / 3 pre-existing failures
kubectl -n argo-cd get app | grep -c OutOfSync
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ