### PR TITLE
eso: stage 4 — chart 0.16.2 → 0.17.0, v1beta1 unserved (§T.32)

### DIFF
--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -10,18 +10,17 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    # STAGE 1 of the ESO walk (T6). 0.16.2 is the LAST version serving
-    # external-secrets.io/v1 alongside v1 (R2) - which is what makes the
-    # manifest migration in T31 possible at all. 0.17.0 unserves v1beta1, and
-    # all three core CRDs currently STORE v1beta1, so going there first would
-    # make existing secrets unreadable (V23/V26).
+    # STAGE 4 of the ESO walk (T32). 0.17.0 UNSERVES external-secrets.io/v1beta1.
     #
-    # Five minors in one hop, against upstream's one-minor-at-a-time advice.
-    # Accepted deliberately: every intervening version serves v1beta1 so nothing
-    # structural changes until T31, and ESO's failure mode is that secret
-    # REFRESH stops while existing Secrets persist (V48) - degradation, not
-    # outage. Rollback is a chart-version revert.
-    targetRevision: 0.16.2
+    # Safe only because stage 3 completed first: all 73 objects (43 ExternalSecret,
+    # 30 SecretStore) were rewritten to force a re-store at v1, then
+    # status.storedVersions was pruned to ["v1"] on all FOUR affected CRDs.
+    # Kubernetes appends to storedVersions but never removes, so that prune is a
+    # manual status patch - it does not happen on its own (V26).
+    #
+    # Had this landed with v1beta1 still in storedVersions, existing secrets would
+    # have become unreadable.
+    targetRevision: 0.17.0
     helm:
       releaseName: external-secrets
       values: |


### PR DESCRIPTION
0.17.0 stops serving `external-secrets.io/v1beta1`. **Safe only because stage 3 completed first.**

## Stage 3, done out-of-band (it cannot be expressed in git)

1. **Snapshotted** 43 ExternalSecrets, 30 SecretStores and all CRDs to disk
2. **Rewrote all 73 objects** (annotate + un-annotate) to force a re-store at the current storage version, `v1`. Health held at 40 Ready / 3 pre-existing throughout; no annotation residue left behind
3. **Confirmed `storedVersions` did not self-prune** — Kubernetes appends but never removes, so the documentation's implication that the API server updates it is wrong in practice
4. **Patched `status.storedVersions` to `[v1]`** on all four affected CRDs

## §V.26 named three CRDs. There are four.

`clusterexternalsecrets` also carried `v1beta1`. Missing it would have left a version in `storedVersions` that 0.17.0 no longer serves.

## Verified after the prune

```
43 objects still readable
write test: OK
Ready = 40/43   (unchanged from baseline)
storedVersions = [v1] on all four CRDs
```

Had this landed with `v1beta1` still in `storedVersions`, existing secrets would have become **unreadable** — the failure `§V.26` exists to prevent.

## Verify after merge

```
kubectl -n external-secrets get deploy -o wide     # v0.17.0
kubectl get externalsecrets -A                      # still 40 Ready / 3 failing
kubectl get crd externalsecrets.external-secrets.io -o jsonpath='{.spec.versions[*].name}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ