### PR TITLE
eso: stage 5 — chart 0.17.0 → 0.20.4 (§T.33)

### DIFF
--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -10,17 +10,13 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    # STAGE 4 of the ESO walk (T32). 0.17.0 UNSERVES external-secrets.io/v1beta1.
+    # STAGE 5 of the ESO walk (T33). Ordinary chart upgrades from here - v1beta1
+    # is gone from both the served set and storage, so no schema migration remains.
     #
-    # Safe only because stage 3 completed first: all 73 objects (43 ExternalSecret,
-    # 30 SecretStore) were rewritten to force a re-store at v1, then
-    # status.storedVersions was pruned to ["v1"] on all FOUR affected CRDs.
-    # Kubernetes appends to storedVersions but never removes, so that prune is a
-    # manual status patch - it does not happen on its own (V26).
-    #
-    # Had this landed with v1beta1 still in storedVersions, existing secrets would
-    # have become unreadable.
-    targetRevision: 0.17.0
+    # 0.20.x is the last 0.x line; 1.0.0 follows. R4 notes >=0.20 requires k8s
+    # >=1.34 and this cluster is on 1.35, so the matrix constraint that forced
+    # V13's interleaving no longer binds.
+    targetRevision: 0.20.4
     helm:
       releaseName: external-secrets
       values: |


### PR DESCRIPTION
Ordinary chart upgrade. `v1beta1` is gone from both the served set and storage on all four CRDs, so **no schema migration remains** and the rest of the walk carries no data risk.

0.20.x is the last 0.x line. `§R.4` notes ≥0.20 requires k8s ≥1.34; this cluster is on 1.35, so the matrix constraint that originally forced `§V.13`'s interleaving no longer binds.

## Stage 4 verified before this

```
served=[v1] stored=[v1]  on all four CRDs
43 ExternalSecrets, 40 Ready, same 3 pre-existing Vault-path failures
live refresh confirmed 2026-08-03T13:35:56Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ