### PR TITLE
eso: final stage — chart 0.20.4 → 2.8.0 (§T.33 complete)

### DIFF
--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -10,13 +10,17 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    # STAGE 5 of the ESO walk (T33). Ordinary chart upgrades from here - v1beta1
-    # is gone from both the served set and storage, so no schema migration remains.
+    # FINAL stage of the ESO walk (T33). 0.20.4 -> 2.8.0, crossing two majors.
     #
-    # 0.20.x is the last 0.x line; 1.0.0 follows. R4 notes >=0.20 requires k8s
-    # >=1.34 and this cluster is on 1.35, so the matrix constraint that forced
-    # V13's interleaving no longer binds.
-    targetRevision: 0.20.4
+    # Checked rather than assumed: 1.0.0 documents no breaking changes, and 2.0.0's
+    # only breaking change is the removal of the Alibaba and Device42 providers.
+    # All 30 SecretStores here use the vault provider, so neither applies.
+    #
+    # 2.7 is the newest version with a documented k8s matrix, and it caps at 1.35 -
+    # this cluster's version. NO ESO release supports 1.36 yet, so ESO remains a
+    # 1.36 blocker (R18) even fully current. That is now a waiting game on upstream
+    # rather than 23 minors of technical debt.
+    targetRevision: 2.8.0
     helm:
       releaseName: external-secrets
       values: |


### PR DESCRIPTION
Crosses two majors. **Checked rather than assumed:**

| Version | Breaking change |
|---|---|
| 1.0.0 | none documented |
| 2.0.0 | removes the **Alibaba** and **Device42** providers |

All 30 SecretStores here use the `vault` provider, so neither removal applies.

## Stage 5 verified before this

0.20.4 healthy, 40/43 Ready unchanged.

Worth noting the 0.20.4 chart **reintroduces a `v1beta1` entry** in the CRD spec, which looks alarming after stage 3's work. It is benign: `served=false`, `deprecated=true`, and a server-side dry-run confirms objects **cannot** be created at that version. `storedVersions` stays `[v1]`, so nothing can re-pollute it — the documented *unserved but not yet removed from spec* state.

## ESO is still a 1.36 blocker

2.7 is the newest release with a documented k8s matrix and it caps at **1.35** — this cluster's version. No ESO release supports 1.36 yet.

The difference is that this is now a **waiting game on upstream** rather than 23 minors of accumulated debt, and `§V.48`'s *"runs ~4 minors out of matrix"* deferral is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ