### PR TITLE
eso: ServerSideApply — the SecretStore CRDs exceed the annotation limit

### DIFF
--- a/base-apps/external-secrets.yaml
+++ b/base-apps/external-secrets.yaml
@@ -50,3 +50,20 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # ServerSideApply is REQUIRED here, not a preference. The SecretStore and
+      # ClusterSecretStore CRDs are ~1.1MB each - their schema covers every
+      # provider - and client-side apply stores the whole previous object in the
+      # kubectl.kubernetes.io/last-applied-configuration annotation. That
+      # annotation had reached 255KB against Kubernetes' 262144-byte limit, so
+      # the next sync was rejected outright:
+      #
+      #   CustomResourceDefinition "secretstores.external-secrets.io" is invalid:
+      #   metadata.annotations: Too long: may not be more than 262144 bytes
+      #
+      # SSA does not use that annotation, so the limit does not apply.
+      #
+      # NB this is the OPPOSITE conclusion to istio-ingress, where SSA was
+      # REMOVED because it surfaced API-server-defaulted fields as permanent
+      # drift. Neither is a general rule: SSA is right for objects too large for
+      # the annotation, wrong for small objects with heavy schema defaulting.
+      - ServerSideApply=true


### PR DESCRIPTION
The app has been `OutOfSync` since the walk completed, with sync failing on **two of sixteen** CRDs:

```
CustomResourceDefinition "secretstores.external-secrets.io" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

## Measured, not guessed

| CRD | object size | `last-applied` annotation |
|---|---|---|
| `secretstores` | 1,155,304 B | **255,418 B** |
| `clustersecretstores` | 1,155,293 B | **255,465 B** |
| `externalsecrets` | 176,155 B | 38,461 B |

The limit is 262,144. The two big ones are ~2.5 KB under it, so the next sync writes a slightly larger annotation and is rejected. `externalsecrets` is nowhere near, which is why only two fail.

**ServerSideApply does not use that annotation**, so the limit does not apply.

## This is the opposite conclusion to istio-ingress

SSA was **removed** there yesterday because it surfaced API-server-defaulted fields as permanent drift. Neither is a general rule:

- SSA is **right** for objects too large for the annotation
- SSA is **wrong** for small objects with heavy schema defaulting

Which is the same point `§R.19` made from another angle when it found 5 of 8 drifting apps already had SSA and drifted regardless.

## Not caused by the version walk

The annotation grows with CRD size, and these CRDs have been large for several releases. The walk is simply what made a sync attempt happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ