### PR TITLE
kagent-secrets: ignore Gateway API defaulted fields on HTTPRoute

### DIFF
--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -27,6 +27,20 @@ spec:
   # for a sync to clobber. Do NOT reach for this pattern to protect
   # hand-applied values; own the resource in Git instead.
   ignoreDifferences:
+    # Gateway API types default group/kind/weight when omitted, and with
+    # ServerSideApply Argo compares the FULL live object - so every defaulted
+    # field reads as drift. Same cause as the external-secrets.io entry below,
+    # and the same fix already applied to the istio-ingress app.
+    # Scoped narrowly: real changes to hostnames, paths, backends or ports
+    # still surface as drift.
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jqPathExpressions:
+        - '.spec.parentRefs[]?.group'
+        - '.spec.parentRefs[]?.kind'
+        - '.spec.rules[]?.backendRefs[]?.group'
+        - '.spec.rules[]?.backendRefs[]?.kind'
+        - '.spec.rules[]?.backendRefs[]?.weight'
     - group: external-secrets.io
       kind: ExternalSecret
       jqPathExpressions:


### PR DESCRIPTION
The two HTTPRoutes show a permanent diff — live carries `group`, `kind` and `weight` that git omits:

```
parentRefs:   - group: gateway.networking.k8s.io / kind: Gateway   (live only)
backendRefs:  - group: '' / kind: Service / weight: 1              (live only)
```

These are **API-server defaults**, not real differences. With `ServerSideApply` Argo compares the full live object, so every defaulted field reads as drift; with client-side apply it compares against `last-applied-configuration` and never sees them.

## The correlation is exact

| App | HTTPRoutes | SSA | Sync |
|---|---|---|---|
| coroot, dex, logging, backstage | yes | no | **Synced** |
| kagent-secrets | yes | **yes** | **OutOfSync** |

## Why ignore rather than remove SSA

This app **already carries the same pattern** for `external-secrets.io` fields (`conversionStrategy`, `decodingStrategy`, `metadataPolicy`) — someone hit this before for a different CRD and solved it the same way. Scoped narrowly, so real changes to hostnames, paths, backends or ports still surface as drift.

## Not addressed

The `ServiceAccount homelab-agent` drift is `§T.42`'s separate issue — the kagent operator copies Argo's tracking-id onto a generated ServiceAccount, which needs an operator fix rather than an ignore rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ