### PR TITLE
kagent-secrets: ignore the operator-copied tracking-id on generated ServiceAccounts

### DIFF
--- a/base-apps/kagent-secrets.yaml
+++ b/base-apps/kagent-secrets.yaml
@@ -33,6 +33,20 @@ spec:
     # and the same fix already applied to the istio-ingress app.
     # Scoped narrowly: real changes to hostnames, paths, backends or ports
     # still surface as drift.
+    # The kagent operator GENERATES a ServiceAccount per Agent (ownerReferences
+    # point at the Agent, so it is garbage-collected with it) and copies the
+    # Agent's annotations onto it - including Argo's tracking-id. That makes Argo
+    # adopt a resource git never declared: the repo contains only the Agent.
+    #
+    # T42 concluded this needed an upstream kagent fix rather than an ignore rule.
+    # That was based on the SA being a git resource whose annotation was being
+    # overwritten. It is not - it is operator-owned and owner-referenced, so the
+    # annotation is the ONLY thing making Argo look at it. Ignoring it is
+    # therefore correct rather than a workaround.
+    - group: ''
+      kind: ServiceAccount
+      jsonPointers:
+        - /metadata/annotations/argocd.argoproj.io~1tracking-id
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       jqPathExpressions:


### PR DESCRIPTION
The last drifting resource in the cluster. The live ServiceAccount carries the **Agent's** tracking-id rather than its own:

```
live:    kagent-secrets:kagent.dev/Agent:kagent/homelab-agent
desired: kagent-secrets:/ServiceAccount:kagent/homelab-agent
```

## This corrects §T.42's conclusion

That task recorded *"needs a kagent fix, not an ignore rule"* — assuming the ServiceAccount was a git resource whose annotation the operator was overwriting. **It is not.** Checked:

- `base-apps/kagent/agents/homelab-agent.yaml` declares **only an `Agent`**
- the live SA has `ownerReferences: [Agent/homelab-agent]`

So the operator **generates** the ServiceAccount and garbage-collects it with the Agent. Git never declared it. The copied annotation is the *only* reason Argo looks at it — Argo adopts any resource carrying its tracking-id.

Ignoring the annotation is therefore **correct rather than a workaround**: it stops Argo claiming a resource that was never its to manage. An upstream kagent fix would still be welcome — copying annotations wholesale onto generated resources is the actual bug — but nothing here waits on it.

Scoped to the tracking-id annotation on ServiceAccount only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQqKoCNk9BuG2eUA3dC4NJ