### PR TITLE
donetick: self-hosted chore tracker on the CNPG cluster

### DIFF
--- a/base-apps/donetick.yaml
+++ b/base-apps/donetick.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: donetick
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/donetick
+    directory:
+      # Backstage entity + TechDocs config, not Kubernetes manifests.
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: donetick
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/donetick/catalog-info.yaml
+++ b/base-apps/donetick/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: donetick
+  namespace: donetick
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=donetick'
+    backstage.io/kubernetes-namespace: donetick
+  tags: [go, postgres, chores, self-hosted]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  system: default/chores-tracker
+  dependsOn:
+    - resource:vault/vault
+    - resource:postgresql/postgresql

--- a/base-apps/donetick/certificate.yaml
+++ b/base-apps/donetick/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: donetick-tls
+  namespace: donetick
+spec:
+  secretName: donetick-tls
+  dnsNames:
+    - donetick.arigsela.com
+  issuerRef:
+    # Not letsencrypt-prod: its only solver is http01.ingress.class=nginx, which
+    # nothing satisfies since the Istio cutover.
+    name: letsencrypt-route53
+    kind: ClusterIssuer

--- a/base-apps/donetick/configmap.yaml
+++ b/base-apps/donetick/configmap.yaml
@@ -1,0 +1,73 @@
+# Mounted over the image's /config. Secrets are deliberately absent and injected
+# as DT_* env vars instead; see deployments.yaml and docs.md.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: donetick-config
+  namespace: donetick
+data:
+  selfhosted.yaml: |
+    name: "selfhosted"
+    is_done_tick_dot_com: false
+
+    # Left false for the FIRST boot so the initial account can be created, then
+    # flipped to true. There is no bootstrap admin and no CLI to make one.
+    is_user_creation_disabled: false
+
+    database:
+      type: "postgres"
+      migration: true
+      host: "postgresql-cluster-rw.postgresql.svc.cluster.local"
+      port: 5432
+      user: "donetick"
+      name: "donetick"
+
+    jwt:
+      session_time: 168h
+      max_refresh: 1440h
+
+    server:
+      port: 2021
+      read_timeout: 10s
+      write_timeout: 10s
+      rate_period: 60s
+      rate_limit: 300
+      cors_allow_origins:
+        - "https://donetick.arigsela.com"
+        # What the Android/iOS Capacitor shell sends as its Origin.
+        - "https://localhost"
+        - "http://localhost"
+        - "capacitor://localhost"
+      serve_frontend: true
+      # Upstream defaults this on; the Swagger UI is unauthenticated.
+      serve_swagger: false
+      public_host: "https://donetick.arigsela.com"
+
+    logging:
+      level: "info"
+      encoding: "json"
+      development: false
+
+    scheduler_jobs:
+      due_job: 30m
+      overdue_job: 3h
+      pre_due_job: 3h
+
+    email:
+      # No SMTP relay in this cluster, so password reset prints its URL to the
+      # pod log instead of mailing it. Recovery path is in runbook.md.
+      log_raw_url: true
+
+    realtime:
+      enabled: true
+      sse_enabled: true
+      heartbeat_interval: 60s
+      connection_timeout: 120s
+      max_connections: 1000
+      max_connections_per_user: 5
+      event_queue_size: 2048
+      cleanup_interval: 2m
+      stale_threshold: 5m
+      enable_compression: true
+      allowed_origins:
+        - "https://donetick.arigsela.com"

--- a/base-apps/donetick/db-external-secret.yaml
+++ b/base-apps/donetick/db-external-secret.yaml
@@ -1,0 +1,21 @@
+---
+# Same Vault property backs the CNPG role in the postgresql namespace. Rotate in
+# Vault, never in either Kubernetes Secret — see runbook.md.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: donetick-db-credentials
+  namespace: donetick
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-donetick-db
+    kind: SecretStore
+  target:
+    name: donetick-db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: donetick-db
+        property: db-password

--- a/base-apps/donetick/db-secret-store.yaml
+++ b/base-apps/donetick/db-secret-store.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-donetick-db
+  namespace: donetick
+spec:
+  provider:
+    vault:
+      server: http://vault.vault.svc.cluster.local:8200
+      path: k8s-secrets
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: donetick-db
+          serviceAccountRef:
+            name: eso-donetick-db

--- a/base-apps/donetick/deployments.yaml
+++ b/base-apps/donetick/deployments.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: donetick
+  namespace: donetick
+  labels:
+    app: donetick
+    app.kubernetes.io/name: donetick
+spec:
+  replicas: 1
+  # Recreate: donetick runs GORM AutoMigrate at startup, so a rolling update
+  # would migrate the schema under the old pod still serving from it.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: donetick
+  template:
+    metadata:
+      labels:
+        app: donetick
+        app.kubernetes.io/name: donetick
+      annotations:
+        # donetick reads its config once, at startup. If you edit configmap.yaml,
+        # recompute this or the change syncs and does nothing:
+        #   shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16
+        checksum/config: "470cc17187a98a27"
+    spec:
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: donetick
+          image: donetick/donetick:v0.1.76
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DT_ENV
+              value: "selfhosted"
+            # Governs every chore due time. CONFIRM THIS IS THE HOUSEHOLD'S ZONE
+            # — unset falls back to UTC.
+            - name: TZ
+              value: "America/New_York"
+            - name: DT_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: donetick-secrets
+                  key: jwt-secret
+            - name: DT_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: donetick-db-credentials
+                  key: password
+          ports:
+            - containerPort: 2021
+              name: http
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          # /api/v1/health is the only health route the binary registers. The
+          # image's own HEALTHCHECK probes /health, which 404s — inert under
+          # Docker, but it would hard-fail a Kubernetes probe.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 2021
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 2021
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 2021
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: donetick-config

--- a/base-apps/donetick/docs.md
+++ b/base-apps/donetick/docs.md
@@ -1,0 +1,107 @@
+---
+type: "Kubernetes App Guide"
+title: "donetick"
+description: "Self-hosted household chore and task tracker (Go + React), backed by the CNPG Postgres cluster."
+app: donetick
+catalog_entity: donetick
+kind: docs
+namespace: donetick
+last_reviewed: 2026-08-03
+status: current
+tags: [go, postgres, chores, self-hosted]
+sources:
+  - base-apps/donetick/deployments.yaml
+  - base-apps/donetick/configmap.yaml
+  - base-apps/donetick/external-secrets.yaml
+  - base-apps/donetick/db-external-secret.yaml
+  - base-apps/donetick/certificate.yaml
+  - base-apps/donetick/httproute.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
+---
+
+# donetick
+
+## What it is
+
+[donetick](https://github.com/donetick/donetick) is a self-hosted chore and task
+tracker for households: recurring chores, assignment across a "circle" of users,
+natural-language due dates, and a mobile-friendly web UI. AGPLv3, upstream
+publishes multi-arch images (`amd64`, `arm64`, `arm/v7`).
+
+It is deployed here as the intended successor to the homegrown
+[chores-tracker](https://github.com/arigsela/chores-tracker) (FastAPI + MySQL).
+Both are in the `chores-tracker` Backstage system. chores-tracker's database and
+`CHORES_TRACKER_INTEGRATION.md` are untouched by this app and are pending
+retirement — see the Gotchas section.
+
+## Architecture & data flow
+
+A single stateless `Deployment`, one replica, one container. The binary serves
+both the JSON API and the compiled React frontend on port 2021; there is no
+separate frontend workload and no sidecar.
+
+Request path: `donetick.arigsela.com` → the shared `main` Gateway in
+`istio-ingress` (listener `https-donetick`) → `HTTPRoute` → `Service/donetick`
+→ pod. TLS terminates at the Gateway using `donetick-tls`, a Secret in this
+namespace reached across namespaces by `reference-grant.yaml`.
+
+All state is in Postgres — the `donetick` database inside the CloudNativePG
+cluster `postgresql-cluster`, not the plain `postgresql` Deployment. That choice
+is the reason there is no PVC here: the CNPG cluster is the only Postgres in this
+cluster with backups (daily 02:00 UTC to S3, 30d retention). The pod itself holds
+nothing that survives a restart.
+
+Schema is applied by GORM `AutoMigrate` at startup (`database.migration: true`),
+so a version bump migrates on the first boot of the new image. This is why the
+Deployment uses `strategy: Recreate` — see Gotchas.
+
+## Where config lives
+
+| What | Where |
+|---|---|
+| Non-secret config (`selfhosted.yaml`) | `configmap.yaml`, mounted over the image's `/config` |
+| JWT signing key | Vault `k8s-secrets/donetick` → `jwt-secret` → `external-secrets.yaml` |
+| DB password | Vault `k8s-secrets/donetick-db` → `db-password` |
+| DB role + database | `base-apps/postgresql/cnpg-cluster.yaml` (`spec.managed.roles`) and `base-apps/postgresql/donetick-database.yaml` |
+| TLS certificate | `certificate.yaml` (ClusterIssuer `letsencrypt-route53`) |
+| Who can reach it | `base-apps/istio-ingress/authorizationpolicy.yaml` |
+
+The DB password is read from **one** Vault key by **two** namespaces, through the
+`donetick-db` Vault role bound to the `eso-donetick-db` ServiceAccount in both
+`donetick` and `postgresql`. The app needs it to authenticate; CloudNativePG
+needs it to provision the role with that same password. Rotating means editing
+Vault once — never either Kubernetes Secret.
+
+## Gotchas & tribal knowledge
+
+- **Not reachable from mobile data.** The Gateway AuthorizationPolicy restricts
+  this host to four source IPs. A phone on LTE is denied at the mesh, which reads
+  as a hang or a TLS-level failure in the app, not a login error. This is the
+  deliberate posture; the alternative considered was public-with-app-auth, as
+  grafana does.
+- **`serve_swagger` is off.** Upstream defaults it on and the Swagger UI is
+  unauthenticated wherever it is served.
+- **First-boot signup window.** `is_user_creation_disabled: false` in
+  `configmap.yaml` exists so the first account can be created. There is no
+  bootstrap admin and no CLI to make one. Flip it to `true` after registering,
+  and understand that flipping it back is the only recovery if you disable signup
+  with no accounts present.
+- **The image's own HEALTHCHECK probes a path that does not exist.** The
+  Dockerfile hits `/health`; the binary only registers `/api/v1/health`. Harmless
+  under Docker, fatal if copied into a Kubernetes probe. The probes here use the
+  real path.
+- **`sslmode=disable` to Postgres, hardcoded.** `internal/database.NewDatabase`
+  builds its DSN with `sslmode=disable TimeZone=Asia/Shanghai` and neither is
+  configurable. The connection is in-cluster only. The timezone in the DSN
+  affects how the driver interprets bare timestamps; donetick stores UTC, and the
+  `TZ` env var on the pod is what governs displayed and scheduled times.
+- **Config is read once, at startup.** Editing `configmap.yaml` without bumping
+  the `checksum/config` annotation syncs a new ConfigMap that nothing reads.
+- **No email.** There is no SMTP relay in this cluster, so password reset cannot
+  send a link. `log_raw_url: true` prints the reset URL to the pod log instead;
+  that is the documented recovery path in the runbook.
+- **chores-tracker is not retired by this app.** Its `chores_tracker` database and
+  `chores_user` role still live inside `postgresql-cluster`, undeclared in Git
+  (see the comment in `cnpg-cluster.yaml`). Nothing here touches them. Retiring
+  them is a separate, deliberate change once data is migrated.

--- a/base-apps/donetick/docs/index.md
+++ b/base-apps/donetick/docs/index.md
@@ -1,0 +1,107 @@
+---
+type: "Kubernetes App Guide"
+title: "donetick"
+description: "Self-hosted household chore and task tracker (Go + React), backed by the CNPG Postgres cluster."
+app: donetick
+catalog_entity: donetick
+kind: docs
+namespace: donetick
+last_reviewed: 2026-08-03
+status: current
+tags: [go, postgres, chores, self-hosted]
+sources:
+  - base-apps/donetick/deployments.yaml
+  - base-apps/donetick/configmap.yaml
+  - base-apps/donetick/external-secrets.yaml
+  - base-apps/donetick/db-external-secret.yaml
+  - base-apps/donetick/certificate.yaml
+  - base-apps/donetick/httproute.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
+---
+
+# donetick
+
+## What it is
+
+[donetick](https://github.com/donetick/donetick) is a self-hosted chore and task
+tracker for households: recurring chores, assignment across a "circle" of users,
+natural-language due dates, and a mobile-friendly web UI. AGPLv3, upstream
+publishes multi-arch images (`amd64`, `arm64`, `arm/v7`).
+
+It is deployed here as the intended successor to the homegrown
+[chores-tracker](https://github.com/arigsela/chores-tracker) (FastAPI + MySQL).
+Both are in the `chores-tracker` Backstage system. chores-tracker's database and
+`CHORES_TRACKER_INTEGRATION.md` are untouched by this app and are pending
+retirement — see the Gotchas section.
+
+## Architecture & data flow
+
+A single stateless `Deployment`, one replica, one container. The binary serves
+both the JSON API and the compiled React frontend on port 2021; there is no
+separate frontend workload and no sidecar.
+
+Request path: `donetick.arigsela.com` → the shared `main` Gateway in
+`istio-ingress` (listener `https-donetick`) → `HTTPRoute` → `Service/donetick`
+→ pod. TLS terminates at the Gateway using `donetick-tls`, a Secret in this
+namespace reached across namespaces by `reference-grant.yaml`.
+
+All state is in Postgres — the `donetick` database inside the CloudNativePG
+cluster `postgresql-cluster`, not the plain `postgresql` Deployment. That choice
+is the reason there is no PVC here: the CNPG cluster is the only Postgres in this
+cluster with backups (daily 02:00 UTC to S3, 30d retention). The pod itself holds
+nothing that survives a restart.
+
+Schema is applied by GORM `AutoMigrate` at startup (`database.migration: true`),
+so a version bump migrates on the first boot of the new image. This is why the
+Deployment uses `strategy: Recreate` — see Gotchas.
+
+## Where config lives
+
+| What | Where |
+|---|---|
+| Non-secret config (`selfhosted.yaml`) | `configmap.yaml`, mounted over the image's `/config` |
+| JWT signing key | Vault `k8s-secrets/donetick` → `jwt-secret` → `external-secrets.yaml` |
+| DB password | Vault `k8s-secrets/donetick-db` → `db-password` |
+| DB role + database | `base-apps/postgresql/cnpg-cluster.yaml` (`spec.managed.roles`) and `base-apps/postgresql/donetick-database.yaml` |
+| TLS certificate | `certificate.yaml` (ClusterIssuer `letsencrypt-route53`) |
+| Who can reach it | `base-apps/istio-ingress/authorizationpolicy.yaml` |
+
+The DB password is read from **one** Vault key by **two** namespaces, through the
+`donetick-db` Vault role bound to the `eso-donetick-db` ServiceAccount in both
+`donetick` and `postgresql`. The app needs it to authenticate; CloudNativePG
+needs it to provision the role with that same password. Rotating means editing
+Vault once — never either Kubernetes Secret.
+
+## Gotchas & tribal knowledge
+
+- **Not reachable from mobile data.** The Gateway AuthorizationPolicy restricts
+  this host to four source IPs. A phone on LTE is denied at the mesh, which reads
+  as a hang or a TLS-level failure in the app, not a login error. This is the
+  deliberate posture; the alternative considered was public-with-app-auth, as
+  grafana does.
+- **`serve_swagger` is off.** Upstream defaults it on and the Swagger UI is
+  unauthenticated wherever it is served.
+- **First-boot signup window.** `is_user_creation_disabled: false` in
+  `configmap.yaml` exists so the first account can be created. There is no
+  bootstrap admin and no CLI to make one. Flip it to `true` after registering,
+  and understand that flipping it back is the only recovery if you disable signup
+  with no accounts present.
+- **The image's own HEALTHCHECK probes a path that does not exist.** The
+  Dockerfile hits `/health`; the binary only registers `/api/v1/health`. Harmless
+  under Docker, fatal if copied into a Kubernetes probe. The probes here use the
+  real path.
+- **`sslmode=disable` to Postgres, hardcoded.** `internal/database.NewDatabase`
+  builds its DSN with `sslmode=disable TimeZone=Asia/Shanghai` and neither is
+  configurable. The connection is in-cluster only. The timezone in the DSN
+  affects how the driver interprets bare timestamps; donetick stores UTC, and the
+  `TZ` env var on the pod is what governs displayed and scheduled times.
+- **Config is read once, at startup.** Editing `configmap.yaml` without bumping
+  the `checksum/config` annotation syncs a new ConfigMap that nothing reads.
+- **No email.** There is no SMTP relay in this cluster, so password reset cannot
+  send a link. `log_raw_url: true` prints the reset URL to the pod log instead;
+  that is the documented recovery path in the runbook.
+- **chores-tracker is not retired by this app.** Its `chores_tracker` database and
+  `chores_user` role still live inside `postgresql-cluster`, undeclared in Git
+  (see the comment in `cnpg-cluster.yaml`). Nothing here touches them. Retiring
+  them is a separate, deliberate change once data is migrated.

--- a/base-apps/donetick/docs/runbook.md
+++ b/base-apps/donetick/docs/runbook.md
@@ -1,0 +1,160 @@
+---
+type: "Kubernetes App Runbook"
+title: "donetick — Runbook"
+description: "Operational runbook for donetick: failure modes, checks, and fixes."
+app: donetick
+catalog_entity: donetick
+kind: runbook
+namespace: donetick
+last_reviewed: 2026-08-03
+status: current
+tags: [go, postgres, chores, self-hosted]
+sources:
+  - base-apps/donetick/deployments.yaml
+  - base-apps/donetick/configmap.yaml
+  - base-apps/donetick/db-external-secret.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
+---
+
+# donetick — Runbook
+
+## First-time provisioning
+
+The manifests do not create Vault material. Before the first sync can succeed:
+
+1. Run `scripts/provision-donetick-vault.sh` inside the `vault-0` pod. It writes
+   both Vault keys, both policies, and both Kubernetes-auth roles, and is
+   idempotent — a re-run preserves existing secrets rather than rotating them:
+
+   ```bash
+   kubectl -n vault cp scripts/provision-donetick-vault.sh vault-0:/tmp/prov.sh
+   kubectl -n vault exec -it vault-0 -- sh
+   export VAULT_TOKEN=<root-or-admin-token>
+   sh /tmp/prov.sh
+   unset VAULT_TOKEN; rm /tmp/prov.sh; exit
+   ```
+
+2. Add `donetick.arigsela.com` to Route 53 pointing at the ingress address, the
+   same record shape as the other hosts.
+
+Order matters only in that the Certificate cannot issue until DNS resolves, and
+the Deployment will crash-loop until both ExternalSecrets have synced. Both
+converge on their own once the prerequisites exist.
+
+## Failure modes
+
+### Symptom: pod crash-loops immediately, log ends at a JWT panic
+
+```
+panic: JWT secret must be at least 32 characters
+```
+
+- **Check:** `kubectl -n donetick get secret donetick-secrets -o jsonpath='{.data.jwt-secret}' | base64 -d | wc -c`
+- **Fix:** the Vault value is short or empty. Rewrite `k8s-secrets/donetick`
+  with 32+ characters and wait for the refresh (1h) or force it with
+  `kubectl -n donetick annotate externalsecret donetick-secrets force-sync=$(date +%s) --overwrite`.
+
+### Symptom: pod starts, then logs repeated `failed to open database`
+
+donetick retries the connection 30 times at 500ms before giving up, so this
+window is about 15 seconds of warnings before the process exits.
+
+- **Check:** does the role exist and does the password match?
+  ```bash
+  kubectl -n postgresql get externalsecret donetick-db-credentials
+  kubectl -n donetick   get externalsecret donetick-db-credentials
+  kubectl -n postgresql get database donetick -o yaml | yq '.status'
+  ```
+- **Fix:** the two ExternalSecrets read the same Vault property; if one is
+  `SecretSyncedError` they have diverged. Resync both. If
+  `Secret/donetick-db-credentials` in `postgresql` is not type
+  `kubernetes.io/basic-auth`, CNPG ignored it and created the role with no
+  password — the operator logs nothing useful here, so check the type directly:
+  `kubectl -n postgresql get secret donetick-db-credentials -o jsonpath='{.type}'`
+
+### Symptom: `Database/donetick` stuck, database never created
+
+- **Check:** `kubectl -n postgresql get database donetick -o jsonpath='{.status}'`
+- **Fix:** almost always the `donetick` role does not exist yet, because its
+  ExternalSecret has not synced and CNPG will not create a role without its
+  password. Fix the secret; the operator retries and converges. Do not create the
+  database by hand — an undeclared database is exactly the state `chores_tracker`
+  is in, and it does not survive a cluster rebuild.
+
+### Symptom: HTTPS fails / browser reports no certificate
+
+- **Check:** `kubectl -n donetick get certificate donetick-tls` then the
+  CertificateRequest and Order beneath it.
+- **Fix:** confirm the issuer is `letsencrypt-route53`. If anything ever points
+  this at `letsencrypt-prod`, it will never complete — that ClusterIssuer solves
+  HTTP-01 through `ingress.class: nginx`, and there is no nginx ingress
+  controller in this cluster since the Istio cutover. Do not delete and recreate
+  the Certificate in a loop while debugging; Let's Encrypt allows 50 issuances
+  per registered domain per week and arigsela.com has approached that ceiling
+  before.
+
+### Symptom: reachable from home, times out from a phone
+
+Working as configured, not a fault. The AuthorizationPolicy allow-lists four
+source IPs and carrier NAT is not among them. See `docs.md`.
+
+### Symptom: config change had no effect
+
+- **Check:** `kubectl -n donetick get pod -o jsonpath='{.items[0].metadata.annotations.checksum/config}'`
+- **Fix:** donetick reads its config once at startup. Bump `checksum/config` in
+  `deployments.yaml` (`shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16`)
+  or `kubectl -n donetick rollout restart deploy/donetick`.
+
+## How-to
+
+### Deploy / update
+
+GitOps only. Bump `image:` in `base-apps/donetick/deployments.yaml` to a pinned
+tag — never `latest` — and merge to `main`. The new pod runs GORM `AutoMigrate`
+on boot; `strategy: Recreate` guarantees the old pod is gone before the migrating
+pod starts, so two schema versions never serve at once.
+
+Before a version bump, confirm the release notes do not require a manual
+migration step, and take a backup (below) — CNPG's scheduled backup runs at
+02:00 UTC, which may be many hours stale.
+
+### Back up / restore
+
+Backups are the CNPG cluster's, not this app's. `base-apps/postgresql/cnpg-scheduled-backup.yaml`
+covers every database in `postgresql-cluster` including this one. For an
+on-demand backup before a risky change, create a `Backup` resource against
+`postgresql-cluster`; see the postgresql runbook.
+
+### Rotate the DB password
+
+```bash
+vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -base64 32 | tr -d '\n' | cut -c1-32)"
+```
+
+Then force-sync both ExternalSecrets (`donetick` and `postgresql` namespaces).
+CNPG applies `ALTER ROLE` from the postgresql-side secret; the app picks up the
+new value on its next pod restart. There is a window where the role has the new
+password and the running pod still holds the old one — restart the Deployment
+after the ExternalSecret shows `SecretSynced`.
+
+### Rotate the JWT secret
+
+Rewrite `k8s-secrets/donetick` `jwt-secret`, force-sync, restart the Deployment.
+Every session and refresh token is invalidated; everyone is logged out. Do it
+deliberately, not as a reflex.
+
+### Close signup after the first account
+
+Set `is_user_creation_disabled: true` in `configmap.yaml`, bump `checksum/config`
+in `deployments.yaml`, merge. Verify at least one account exists first — there is
+no bootstrap admin and no CLI to create one.
+
+### Recover a password with no email configured
+
+There is no SMTP relay. Trigger the reset in the UI, then read the URL from the
+pod log (`log_raw_url: true` in `configmap.yaml`):
+
+```bash
+kubectl -n donetick logs deploy/donetick | grep -i reset
+```

--- a/base-apps/donetick/eso-donetick-db-serviceaccount.yaml
+++ b/base-apps/donetick/eso-donetick-db-serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+# Vault role `donetick-db` is bound to this SA name in both `donetick` and
+# `postgresql`; see base-apps/donetick/docs.md.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-donetick-db
+  namespace: donetick

--- a/base-apps/donetick/external-secrets.yaml
+++ b/base-apps/donetick/external-secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: donetick-secrets
+  namespace: donetick
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: donetick-secrets
+    creationPolicy: Owner
+  data:
+    # Must be >= 32 chars or donetick panics at startup. Rotating logs everyone
+    # out — see runbook.md.
+    - secretKey: jwt-secret
+      remoteRef:
+        key: donetick
+        property: jwt-secret

--- a/base-apps/donetick/httproute.yaml
+++ b/base-apps/donetick/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: donetick
+  namespace: donetick
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-donetick
+  hostnames:
+    - donetick.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: donetick
+          port: 2021

--- a/base-apps/donetick/mkdocs.yml
+++ b/base-apps/donetick/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: donetick
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/base-apps/donetick/reference-grant.yaml
+++ b/base-apps/donetick/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret (V63).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-donetick-tls
+  namespace: donetick
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: donetick-tls

--- a/base-apps/donetick/runbook.md
+++ b/base-apps/donetick/runbook.md
@@ -1,0 +1,160 @@
+---
+type: "Kubernetes App Runbook"
+title: "donetick — Runbook"
+description: "Operational runbook for donetick: failure modes, checks, and fixes."
+app: donetick
+catalog_entity: donetick
+kind: runbook
+namespace: donetick
+last_reviewed: 2026-08-03
+status: current
+tags: [go, postgres, chores, self-hosted]
+sources:
+  - base-apps/donetick/deployments.yaml
+  - base-apps/donetick/configmap.yaml
+  - base-apps/donetick/db-external-secret.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
+---
+
+# donetick — Runbook
+
+## First-time provisioning
+
+The manifests do not create Vault material. Before the first sync can succeed:
+
+1. Run `scripts/provision-donetick-vault.sh` inside the `vault-0` pod. It writes
+   both Vault keys, both policies, and both Kubernetes-auth roles, and is
+   idempotent — a re-run preserves existing secrets rather than rotating them:
+
+   ```bash
+   kubectl -n vault cp scripts/provision-donetick-vault.sh vault-0:/tmp/prov.sh
+   kubectl -n vault exec -it vault-0 -- sh
+   export VAULT_TOKEN=<root-or-admin-token>
+   sh /tmp/prov.sh
+   unset VAULT_TOKEN; rm /tmp/prov.sh; exit
+   ```
+
+2. Add `donetick.arigsela.com` to Route 53 pointing at the ingress address, the
+   same record shape as the other hosts.
+
+Order matters only in that the Certificate cannot issue until DNS resolves, and
+the Deployment will crash-loop until both ExternalSecrets have synced. Both
+converge on their own once the prerequisites exist.
+
+## Failure modes
+
+### Symptom: pod crash-loops immediately, log ends at a JWT panic
+
+```
+panic: JWT secret must be at least 32 characters
+```
+
+- **Check:** `kubectl -n donetick get secret donetick-secrets -o jsonpath='{.data.jwt-secret}' | base64 -d | wc -c`
+- **Fix:** the Vault value is short or empty. Rewrite `k8s-secrets/donetick`
+  with 32+ characters and wait for the refresh (1h) or force it with
+  `kubectl -n donetick annotate externalsecret donetick-secrets force-sync=$(date +%s) --overwrite`.
+
+### Symptom: pod starts, then logs repeated `failed to open database`
+
+donetick retries the connection 30 times at 500ms before giving up, so this
+window is about 15 seconds of warnings before the process exits.
+
+- **Check:** does the role exist and does the password match?
+  ```bash
+  kubectl -n postgresql get externalsecret donetick-db-credentials
+  kubectl -n donetick   get externalsecret donetick-db-credentials
+  kubectl -n postgresql get database donetick -o yaml | yq '.status'
+  ```
+- **Fix:** the two ExternalSecrets read the same Vault property; if one is
+  `SecretSyncedError` they have diverged. Resync both. If
+  `Secret/donetick-db-credentials` in `postgresql` is not type
+  `kubernetes.io/basic-auth`, CNPG ignored it and created the role with no
+  password — the operator logs nothing useful here, so check the type directly:
+  `kubectl -n postgresql get secret donetick-db-credentials -o jsonpath='{.type}'`
+
+### Symptom: `Database/donetick` stuck, database never created
+
+- **Check:** `kubectl -n postgresql get database donetick -o jsonpath='{.status}'`
+- **Fix:** almost always the `donetick` role does not exist yet, because its
+  ExternalSecret has not synced and CNPG will not create a role without its
+  password. Fix the secret; the operator retries and converges. Do not create the
+  database by hand — an undeclared database is exactly the state `chores_tracker`
+  is in, and it does not survive a cluster rebuild.
+
+### Symptom: HTTPS fails / browser reports no certificate
+
+- **Check:** `kubectl -n donetick get certificate donetick-tls` then the
+  CertificateRequest and Order beneath it.
+- **Fix:** confirm the issuer is `letsencrypt-route53`. If anything ever points
+  this at `letsencrypt-prod`, it will never complete — that ClusterIssuer solves
+  HTTP-01 through `ingress.class: nginx`, and there is no nginx ingress
+  controller in this cluster since the Istio cutover. Do not delete and recreate
+  the Certificate in a loop while debugging; Let's Encrypt allows 50 issuances
+  per registered domain per week and arigsela.com has approached that ceiling
+  before.
+
+### Symptom: reachable from home, times out from a phone
+
+Working as configured, not a fault. The AuthorizationPolicy allow-lists four
+source IPs and carrier NAT is not among them. See `docs.md`.
+
+### Symptom: config change had no effect
+
+- **Check:** `kubectl -n donetick get pod -o jsonpath='{.items[0].metadata.annotations.checksum/config}'`
+- **Fix:** donetick reads its config once at startup. Bump `checksum/config` in
+  `deployments.yaml` (`shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16`)
+  or `kubectl -n donetick rollout restart deploy/donetick`.
+
+## How-to
+
+### Deploy / update
+
+GitOps only. Bump `image:` in `base-apps/donetick/deployments.yaml` to a pinned
+tag — never `latest` — and merge to `main`. The new pod runs GORM `AutoMigrate`
+on boot; `strategy: Recreate` guarantees the old pod is gone before the migrating
+pod starts, so two schema versions never serve at once.
+
+Before a version bump, confirm the release notes do not require a manual
+migration step, and take a backup (below) — CNPG's scheduled backup runs at
+02:00 UTC, which may be many hours stale.
+
+### Back up / restore
+
+Backups are the CNPG cluster's, not this app's. `base-apps/postgresql/cnpg-scheduled-backup.yaml`
+covers every database in `postgresql-cluster` including this one. For an
+on-demand backup before a risky change, create a `Backup` resource against
+`postgresql-cluster`; see the postgresql runbook.
+
+### Rotate the DB password
+
+```bash
+vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -base64 32 | tr -d '\n' | cut -c1-32)"
+```
+
+Then force-sync both ExternalSecrets (`donetick` and `postgresql` namespaces).
+CNPG applies `ALTER ROLE` from the postgresql-side secret; the app picks up the
+new value on its next pod restart. There is a window where the role has the new
+password and the running pod still holds the old one — restart the Deployment
+after the ExternalSecret shows `SecretSynced`.
+
+### Rotate the JWT secret
+
+Rewrite `k8s-secrets/donetick` `jwt-secret`, force-sync, restart the Deployment.
+Every session and refresh token is invalidated; everyone is logged out. Do it
+deliberately, not as a reflex.
+
+### Close signup after the first account
+
+Set `is_user_creation_disabled: true` in `configmap.yaml`, bump `checksum/config`
+in `deployments.yaml`, merge. Verify at least one account exists first — there is
+no bootstrap admin and no CLI to create one.
+
+### Recover a password with no email configured
+
+There is no SMTP relay. Trigger the reset in the UI, then read the URL from the
+pod log (`log_raw_url: true` in `configmap.yaml`):
+
+```bash
+kubectl -n donetick logs deploy/donetick | grep -i reset
+```

--- a/base-apps/donetick/secret-store.yaml
+++ b/base-apps/donetick/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: donetick
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "donetick"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/donetick/services.yaml
+++ b/base-apps/donetick/services.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: donetick
+  namespace: donetick
+  labels:
+    app: donetick
+    app.kubernetes.io/name: donetick
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2021
+      targetPort: 2021
+      protocol: TCP
+      name: http
+  selector:
+    app: donetick

--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -31,6 +31,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | crossplane-functions |  |  |  |  |  |
 | crossplane-system |  |  |  |  |  |
 | dex | OIDC provider fronting GitHub — issuer for Vault OIDC (human `vault` login via GitHub SSO) | dex | [docs.md](dex/docs.md) | [runbook.md](dex/runbook.md) | [catalog-info.yaml](dex/catalog-info.yaml) |
+| donetick | Self-hosted household chore and task tracker (Go + React), backed by the CNPG Postgres cluster. | donetick | [docs.md](donetick/docs.md) | [runbook.md](donetick/runbook.md) | [catalog-info.yaml](donetick/catalog-info.yaml) |
 | ecr-auth |  |  |  |  |  |
 | istio-ingress | The cluster's north-south ingress: a Gateway API Gateway on the `istio` GatewayClass, directly internet-facing | istio-ingress | [docs.md](istio-ingress/docs.md) | [runbook.md](istio-ingress/runbook.md) | [catalog-info.yaml](istio-ingress/catalog-info.yaml) |
 | kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | [docs.md](kagent/docs.md) | [runbook.md](kagent/runbook.md) | [catalog-info.yaml](kagent/catalog-info.yaml) |

--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -192,6 +192,20 @@ spec:
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
+    # donetick - restricted. Note this makes a phone-first chore tracker
+      # unreachable from mobile data; carrier NAT is not allow-listable.
+    - to:
+        - operation:
+            hosts:
+              - donetick.arigsela.com
+              - donetick.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
     # n8n WEBHOOK paths - public by design. Webhooks arrive from arbitrary
       # external services and cannot be allow-listed; each workflow authenticates
       # its own. Scoped to the webhook paths ONLY, so the admin UI is untouched.

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -215,6 +215,21 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    # donetick-tls is the one cert here issued from a Certificate tracked in Git
+    # (base-apps/donetick/certificate.yaml), not an ingress-shim leftover.
+    - name: https-donetick
+      protocol: HTTPS
+      port: 443
+      hostname: donetick.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: donetick-tls
+            namespace: donetick
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: https-kagent-mcp
       protocol: HTTPS
       port: 443

--- a/base-apps/postgresql/cnpg-cluster.yaml
+++ b/base-apps/postgresql/cnpg-cluster.yaml
@@ -78,6 +78,14 @@ spec:
         login: true
         passwordSecret:
           name: postgresql-credentials
+      # Owns the `donetick` database (donetick-database.yaml). Its passwordSecret
+      # is kubernetes.io/basic-auth, which CNPG requires and the n8n entry above
+      # does not satisfy — see external-secrets-donetick.yaml.
+      - name: donetick
+        ensure: present
+        login: true
+        passwordSecret:
+          name: donetick-db-credentials
   monitoring:
     enablePodMonitor: false
   postgresql:

--- a/base-apps/postgresql/docs.md
+++ b/base-apps/postgresql/docs.md
@@ -20,6 +20,8 @@ sources:
   - base-apps/postgresql/cnpg-cluster.yaml
   - base-apps/postgresql/cnpg-scheduled-backup.yaml
   - base-apps/postgresql/external-secrets-cnpg-backup.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
 ---
 
 # postgresql
@@ -35,6 +37,7 @@ Two separate PostgreSQL instances share this namespace:
 
 ## Databases it provisions
 - **Primary/root database** — `deployments.yaml` sets `POSTGRES_DB`/`POSTGRES_USER`/`POSTGRES_PASSWORD` from the `postgresql-credentials` Secret's `database-name`/`n8n-user`/`n8n-password` keys. Despite the `n8n-*` key naming (a holdover from this credential's original consumer), this user is the server's effective root/admin login, used by the init Job below to create further roles and databases.
+- **`donetick` database** — the only database here declared through CloudNativePG's `Database` CRD (`donetick-database.yaml`), living in the CNPG cluster rather than the plain Deployment so it inherits the daily S3 backup. Its `donetick` role is declared in `cnpg-cluster.yaml` (`spec.managed.roles`) with its password supplied by `external-secrets-donetick.yaml`. Note that ExternalSecret's `template` block: CNPG requires a role's `passwordSecret` to be type `kubernetes.io/basic-auth` with `username`/`password` keys, and silently creates the role *without* a password if given anything else — the older `n8n` managed role above points at an Opaque `postgresql-credentials` and is an example of what not to copy. The psql-`Job` approach used for `kagent` is not available against this cluster: it has no superuser secret (`enableSuperuserAccess` is unset, defaulting to false), so only the operator can create roles and databases in it. `databaseReclaimPolicy: retain` keeps an Argo prune from dropping the database.
 - **`kagent` database** — provisioned by the `init-kagent-db` `Job` (`init-kagent-db.yaml`), which polls `pg_isready` against `postgresql.postgresql.svc.cluster.local:5432`, then idempotently `CREATE ROLE`/`CREATE DATABASE` for the `kagent` user/db (credentials from the `kagent-db-credentials` Secret) and runs `CREATE EXTENSION IF NOT EXISTS vector` inside it so `kagent` can store vector embeddings. The job is safe to re-run (existence checks before create/alter) and self-cleans after success (`ttlSecondsAfterFinished: 300`).
 
 ## Credential flow (Vault)

--- a/base-apps/postgresql/docs/index.md
+++ b/base-apps/postgresql/docs/index.md
@@ -20,6 +20,8 @@ sources:
   - base-apps/postgresql/cnpg-cluster.yaml
   - base-apps/postgresql/cnpg-scheduled-backup.yaml
   - base-apps/postgresql/external-secrets-cnpg-backup.yaml
+  - base-apps/postgresql/donetick-database.yaml
+  - base-apps/postgresql/external-secrets-donetick.yaml
 ---
 
 # postgresql
@@ -35,6 +37,7 @@ Two separate PostgreSQL instances share this namespace:
 
 ## Databases it provisions
 - **Primary/root database** — `deployments.yaml` sets `POSTGRES_DB`/`POSTGRES_USER`/`POSTGRES_PASSWORD` from the `postgresql-credentials` Secret's `database-name`/`n8n-user`/`n8n-password` keys. Despite the `n8n-*` key naming (a holdover from this credential's original consumer), this user is the server's effective root/admin login, used by the init Job below to create further roles and databases.
+- **`donetick` database** — the only database here declared through CloudNativePG's `Database` CRD (`donetick-database.yaml`), living in the CNPG cluster rather than the plain Deployment so it inherits the daily S3 backup. Its `donetick` role is declared in `cnpg-cluster.yaml` (`spec.managed.roles`) with its password supplied by `external-secrets-donetick.yaml`. Note that ExternalSecret's `template` block: CNPG requires a role's `passwordSecret` to be type `kubernetes.io/basic-auth` with `username`/`password` keys, and silently creates the role *without* a password if given anything else — the older `n8n` managed role above points at an Opaque `postgresql-credentials` and is an example of what not to copy. The psql-`Job` approach used for `kagent` is not available against this cluster: it has no superuser secret (`enableSuperuserAccess` is unset, defaulting to false), so only the operator can create roles and databases in it. `databaseReclaimPolicy: retain` keeps an Argo prune from dropping the database.
 - **`kagent` database** — provisioned by the `init-kagent-db` `Job` (`init-kagent-db.yaml`), which polls `pg_isready` against `postgresql.postgresql.svc.cluster.local:5432`, then idempotently `CREATE ROLE`/`CREATE DATABASE` for the `kagent` user/db (credentials from the `kagent-db-credentials` Secret) and runs `CREATE EXTENSION IF NOT EXISTS vector` inside it so `kagent` can store vector embeddings. The job is safe to re-run (existence checks before create/alter) and self-cleans after success (`ttlSecondsAfterFinished: 300`).
 
 ## Credential flow (Vault)

--- a/base-apps/postgresql/donetick-database.yaml
+++ b/base-apps/postgresql/donetick-database.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: donetick
+  namespace: postgresql
+spec:
+  cluster:
+    name: postgresql-cluster
+  name: donetick
+  owner: donetick
+  ensure: present
+  # CRD default, stated because the alternative drops the database when this
+  # manifest is pruned.
+  databaseReclaimPolicy: retain

--- a/base-apps/postgresql/donetick-db-secret-store.yaml
+++ b/base-apps/postgresql/donetick-db-secret-store.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-donetick-db
+  namespace: postgresql
+spec:
+  provider:
+    vault:
+      server: http://vault.vault.svc.cluster.local:8200
+      path: k8s-secrets
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: donetick-db
+          serviceAccountRef:
+            name: eso-donetick-db

--- a/base-apps/postgresql/eso-donetick-db-serviceaccount.yaml
+++ b/base-apps/postgresql/eso-donetick-db-serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+# Copy of the SA in the `donetick` namespace: CloudNativePG provisions the
+# donetick role from a Secret in THIS namespace, so the same Vault role is bound
+# here too. See base-apps/donetick/docs.md.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-donetick-db
+  namespace: postgresql

--- a/base-apps/postgresql/external-secrets-donetick.yaml
+++ b/base-apps/postgresql/external-secrets-donetick.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: donetick-db-credentials
+  namespace: postgresql
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-donetick-db
+    kind: SecretStore
+  target:
+    name: donetick-db-credentials
+    creationPolicy: Owner
+    # The type is load-bearing. CNPG requires a role's passwordSecret to be
+    # kubernetes.io/basic-auth with username/password keys; given anything else
+    # it creates the role WITHOUT a password and logs nothing. (The older n8n
+    # managed role points at an Opaque secret — do not copy it.)
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "donetick"
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: donetick-db
+        property: db-password

--- a/catalog/platform-entities.yaml
+++ b/catalog/platform-entities.yaml
@@ -120,3 +120,12 @@ metadata:
 spec:
   owner: platform
   domain: products
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: chores-tracker
+  description: Household chore tracking (donetick; supersedes the chores-tracker app).
+spec:
+  owner: platform
+  domain: products

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -16,3 +16,4 @@ dex
 qwen
 openclaw-qwen
 istio-ingress
+donetick

--- a/scripts/provision-donetick-vault.sh
+++ b/scripts/provision-donetick-vault.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# donetick — Vault provisioning (one-time, idempotent, safe to re-run)
+#
+# Creates the scoped Vault secrets, policies, and kubernetes-auth roles that
+# back the ESO manifests in base-apps/donetick/ and base-apps/postgresql/:
+#   - k8s-secrets/donetick-db  (prop: db-password)  -> the app AND the CNPG role
+#   - k8s-secrets/donetick     (prop: jwt-secret)   -> session signing key
+#   - policies donetick / donetick-db (each reads only its one path)
+#   - roles    donetick    (default          @ donetick)
+#              donetick-db (eso-donetick-db  @ donetick,postgresql)
+#
+# The two-role split is the point: the postgresql namespace must read the DB
+# password to provision the CNPG role, and must NOT be able to read the JWT
+# signing key while doing so. This mirrors provision-homelab-agent-vault.sh.
+#
+# SAFE TO RE-RUN: both values are generated ONCE and preserved on every later
+# run. Neither is silently rotated — rotating the DB password without also
+# restarting the app leaves the pod holding a stale credential, and rotating the
+# JWT secret logs every user out. Both are deliberate acts; see
+# base-apps/donetick/runbook.md for the rotation procedures.
+#
+# How to run (inside the vault-0 pod, matching the homelab-agent pattern):
+#
+#   kubectl -n vault cp scripts/provision-donetick-vault.sh vault-0:/tmp/prov.sh
+#   kubectl -n vault exec -it vault-0 -- sh
+#   export VAULT_TOKEN=<root-or-admin-token>
+#   sh /tmp/prov.sh
+#   unset VAULT_TOKEN
+#   rm /tmp/prov.sh
+#   exit
+#
+# Docs: base-apps/donetick/docs.md, base-apps/donetick/runbook.md
+
+set -eu
+
+MOUNT="k8s-secrets"
+APP_PATH="donetick"
+DB_PATH="donetick-db"
+
+# --- pre-checks -------------------------------------------------------------
+if [ -z "${VAULT_TOKEN:-}" ]; then
+  echo "ERROR: VAULT_TOKEN is not set. export VAULT_TOKEN=<root-or-admin-token> and re-run." >&2
+  exit 1
+fi
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+export VAULT_ADDR VAULT_TOKEN
+
+if ! command -v vault >/dev/null 2>&1; then
+  echo "ERROR: vault CLI not found (run this inside the vault-0 pod)." >&2
+  exit 1
+fi
+vault token lookup >/dev/null 2>&1 || {
+  echo "ERROR: VAULT_TOKEN is not valid / cannot authenticate to $VAULT_ADDR." >&2
+  exit 1
+}
+
+# --- helpers ----------------------------------------------------------------
+# 64 hex chars. Hex, not base64: the DB password is interpolated into a
+# libpq DSN by donetick (`password=%s`), where a `'` or a space would need
+# quoting the app does not do. It also clears the 32-character floor that
+# config.validateJWTSecret() enforces, by a wide margin.
+gen_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 64
+    echo
+  fi
+}
+
+# --- 1. DB password: generate once, preserve on re-run ----------------------
+if vault kv get -mount="$MOUNT" -field=db-password "$DB_PATH" >/dev/null 2>&1; then
+  echo "==> $MOUNT/$DB_PATH already has db-password — preserving it (not rotating)"
+else
+  echo "==> generating donetick DB password at $MOUNT/$DB_PATH"
+  vault kv put -mount="$MOUNT" "$DB_PATH" db-password="$(gen_secret)" >/dev/null
+fi
+
+# --- 2. JWT signing key: generate once, preserve on re-run ------------------
+if vault kv get -mount="$MOUNT" -field=jwt-secret "$APP_PATH" >/dev/null 2>&1; then
+  echo "==> $MOUNT/$APP_PATH already has jwt-secret — preserving it (not rotating)"
+else
+  echo "==> generating donetick JWT secret at $MOUNT/$APP_PATH"
+  vault kv put -mount="$MOUNT" "$APP_PATH" jwt-secret="$(gen_secret)" >/dev/null
+fi
+
+# --- 3. Policies (least privilege: one path each) ---------------------------
+echo "==> writing policy donetick"
+vault policy write donetick - <<EOF >/dev/null
+path "$MOUNT/data/$APP_PATH" { capabilities = ["read"] }
+EOF
+
+echo "==> writing policy donetick-db"
+vault policy write donetick-db - <<EOF >/dev/null
+path "$MOUNT/data/$DB_PATH" { capabilities = ["read"] }
+EOF
+
+# --- 4. Kubernetes-auth roles -----------------------------------------------
+# The app role binds the `default` SA, matching every other per-app SecretStore
+# in base-apps/. The db role binds a dedicated SA in BOTH namespaces, because
+# two different consumers need the same one credential.
+echo "==> writing role donetick (default @ donetick)"
+vault write auth/kubernetes/role/donetick \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=donetick \
+  policies=donetick ttl=1h >/dev/null
+
+echo "==> writing role donetick-db (eso-donetick-db @ donetick,postgresql)"
+vault write auth/kubernetes/role/donetick-db \
+  bound_service_account_names=eso-donetick-db \
+  bound_service_account_namespaces=donetick,postgresql \
+  policies=donetick-db ttl=1h >/dev/null
+
+echo
+echo "==> Done. The ExternalSecrets will resolve on the next ESO refresh"
+echo "    (or delete the target Secret to force an immediate resync)."
+echo "    Expect, in order: donetick-db-credentials syncs in both namespaces,"
+echo "    CNPG creates the donetick role, Database/donetick reports ready,"
+echo "    then the Deployment stops crash-looping."


### PR DESCRIPTION
Deploys [donetick](https://github.com/donetick/donetick) v0.1.76 as the intended successor to [chores-tracker](https://github.com/arigsela/chores-tracker). Single Go binary serving the API and React frontend on port 2021 — stateless, no PVC, all state in Postgres.

**This does not deploy anything on merge alone.** `scripts/provision-donetick-vault.sh` must run and the Route 53 record must exist first, or the app syncs and crash-loops on missing secrets. Order and recovery are in `base-apps/donetick/runbook.md`.

## Before merging — two things to confirm

- **`TZ: "America/New_York"`** (`base-apps/donetick/deployments.yaml`). Every chore due time depends on it and there was no way to infer the household's zone.
- **`is_user_creation_disabled: false`** (`base-apps/donetick/configmap.yaml`). Deliberate, so the first account can be created — there is no bootstrap admin and no CLI to make one. Flip it to `true` after signing up.

## Why the CNPG cluster, not the plain `postgresql` Deployment

`base-apps/postgresql/docs.md` says it outright: *"losing the PVC or its node loses all data for every database on this instance"* — no backup CronJob, replica, or standby. `postgresql-cluster` has a daily `ScheduledBackup` to S3 with 30d retention, and already hosts `chores_tracker`, so the app replacing chores-tracker belongs there.

That ruled out the `init-kagent-db.yaml` pattern. That Job works because on the plain Deployment the app user *is* the container superuser (`POSTGRES_USER`). `postgresql-cluster` has no superuser secret (`enableSuperuserAccess` unset, defaults false), so the same Job could not create a role or database there at all. Used CNPG's declarative `Database` CRD instead — the operator holds the superuser connection internally, which is exactly why the CRD can do what a Job in that namespace cannot. CRD confirmed installed (`databases.postgresql.cnpg.io`, chart 0.28.3). First use of it in this repo.

## Found along the way, deliberately not fixed here

The existing **`n8n` managed role** in `cnpg-cluster.yaml` points `passwordSecret` at `postgresql-credentials`, which is Opaque with `n8n-user`/`n8n-password` keys. CNPG requires `kubernetes.io/basic-auth` with `username`/`password` and **silently creates the role without a password** given anything else — no error anywhere near the manifest that caused it. Harmless today because n8n connects to the plain Deployment and that role is vestigial, so it is left alone rather than changed under an unrelated PR. donetick's ExternalSecret templates a proper basic-auth secret; the n8n shape should not be copied.

## First Certificate manifest in the repo

The other ~20 certs came from ingress-shim annotations on the Ingress objects deleted in 95bddef, so they now exist only in the cluster with nothing in Git describing them. New hostnames have to bring their own.

Issuer is **`letsencrypt-route53`**, not `letsencrypt-prod` — that ClusterIssuer's only solver is `http01.ingress.class: nginx`, and there is no nginx ingress controller left to satisfy it. A Certificate pointed at it would sit in a pending challenge forever.

## Access posture

IP-restricted at the Gateway, whole host, same four addresses as n8n's admin UI and weather-kitchen. Worth stating before someone reports it as a bug: **donetick is phone-first and this makes it unreachable from mobile data.** Carrier NAT is not an allow-listable set — that is why grafana went public-with-app-auth instead. donetick has local accounts and TOTP MFA if the trade is ever revisited.

## Secret split

Two Vault keys behind two roles, mirroring `homelab-agent`/`-db`. The `postgresql` namespace must read the DB password to provision the CNPG role and must **not** be able to read the JWT signing key while doing so. One password, one Vault key, read from both namespaces via `eso-donetick-db` — so the app credential and the provisioned role cannot drift apart.

## Upstream quirks encoded in the manifests

- The image's own `HEALTHCHECK` probes `/health`, which the binary does not register — only `/api/v1/health` exists. Inert under Docker, fatal if copied into a Kubernetes probe.
- `internal/database` hardcodes `sslmode=disable` and `TimeZone=Asia/Shanghai` into the DSN; neither is configurable.
- Config is read once at startup, hence the `checksum/config` annotation.
- `serve_swagger` turned off — upstream defaults it on and the Swagger UI is unauthenticated wherever served.

## chores-tracker is not retired here

Its `chores_tracker` database and `chores_user` role still live undeclared inside `postgresql-cluster`. Retiring them is a separate, deliberate change once data is migrated.

## Verification

- `kubeconform` strict: 19/19 valid
- `yamllint`: clean
- `validate-agent-docs.py`, `validate-catalog-refs.py`: pass
- `gen-techdocs.py --check`: in sync
- `kubectl apply --dry-run=server` accepted all six resources touching existing objects — vetted by the CNPG, Istio, Gateway API, and ESO admission webhooks. **Nothing was applied.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkuzGksz2ZPiVnXRG5ayih
