### PR TITLE
donetick: close signup, and record what the deploy actually hit

### DIFF
--- a/base-apps/donetick/configmap.yaml
+++ b/base-apps/donetick/configmap.yaml
@@ -10,9 +10,9 @@ data:
     name: "selfhosted"
     is_done_tick_dot_com: false
 
-    # Left false for the FIRST boot so the initial account can be created, then
-    # flipped to true. There is no bootstrap admin and no CLI to make one.
-    is_user_creation_disabled: false
+    # Closed 2026-08-03 once the first account existed. Turning this back on is
+    # the ONLY way to add a user — there is no bootstrap admin and no CLI.
+    is_user_creation_disabled: true
 
     database:
       type: "postgres"

--- a/base-apps/donetick/deployments.yaml
+++ b/base-apps/donetick/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # donetick reads its config once, at startup. If you edit configmap.yaml,
         # recompute this or the change syncs and does nothing:
         #   shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16
-        checksum/config: "470cc17187a98a27"
+        checksum/config: "3089ee379b814412"
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application

--- a/base-apps/donetick/docs/runbook.md
+++ b/base-apps/donetick/docs/runbook.md
@@ -132,11 +132,33 @@ on-demand backup before a risky change, create a `Backup` resource against
 vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -base64 32 | tr -d '\n' | cut -c1-32)"
 ```
 
-Then force-sync both ExternalSecrets (`donetick` and `postgresql` namespaces).
-CNPG applies `ALTER ROLE` from the postgresql-side secret; the app picks up the
-new value on its next pod restart. There is a window where the role has the new
-password and the running pod still holds the old one — restart the Deployment
-after the ExternalSecret shows `SecretSynced`.
+**This does not work as written today.** CNPG is supposed to apply `ALTER ROLE`
+from the postgresql-side secret, but its managed-role reconciler is inert on this
+cluster — the `donetick` role was created by hand on 2026-08-03 and the operator
+does not manage it. Rotating in Vault alone therefore changes the app's password
+and NOT the database's, and donetick fails authentication on its next restart.
+
+Until `docs/troubleshooting/cnpg-managed-roles-inert.md` is resolved, rotation is
+a two-step manual operation:
+
+```bash
+# 1. new value into Vault
+vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -hex 32)"
+
+# 2. force-sync both ExternalSecrets, then apply it to Postgres YOURSELF
+kubectl -n postgresql annotate externalsecret donetick-db-credentials force-sync=$(date +%s) --overwrite
+kubectl -n donetick   annotate externalsecret donetick-db-credentials force-sync=$(date +%s) --overwrite
+
+P=$(kubectl -n postgresql get secret donetick-db-credentials -o jsonpath='{.data.password}' | base64 -d)
+kubectl -n postgresql exec -i postgresql-cluster-2 -c postgres -- \
+  psql -U postgres -c "ALTER ROLE donetick WITH PASSWORD '$P'"
+
+# 3. restart the app so it picks up the new secret
+kubectl -n donetick rollout restart deploy/donetick
+```
+
+Order matters: change Postgres before restarting the app, or the pod comes up
+holding a password the database has not accepted yet.
 
 ### Rotate the JWT secret
 
@@ -144,11 +166,18 @@ Rewrite `k8s-secrets/donetick` `jwt-secret`, force-sync, restart the Deployment.
 Every session and refresh token is invalidated; everyone is logged out. Do it
 deliberately, not as a reflex.
 
-### Close signup after the first account
+### Add a user (signup is closed)
 
-Set `is_user_creation_disabled: true` in `configmap.yaml`, bump `checksum/config`
-in `deployments.yaml`, merge. Verify at least one account exists first — there is
-no bootstrap admin and no CLI to create one.
+`is_user_creation_disabled: true` since 2026-08-03. donetick has no admin-invite
+flow, so adding someone means reopening signup, having them register, then
+closing it again: set the flag to `false` in `configmap.yaml`, bump
+`checksum/config` in `deployments.yaml`, merge, wait for the rollout, register,
+then revert both. Confirm the new row before closing:
+
+```bash
+kubectl -n postgresql exec postgresql-cluster-2 -c postgres -- \
+  psql -U postgres -d donetick -tAc "select id, username from users order by id;"
+```
 
 ### Recover a password with no email configured
 

--- a/base-apps/donetick/runbook.md
+++ b/base-apps/donetick/runbook.md
@@ -132,11 +132,33 @@ on-demand backup before a risky change, create a `Backup` resource against
 vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -base64 32 | tr -d '\n' | cut -c1-32)"
 ```
 
-Then force-sync both ExternalSecrets (`donetick` and `postgresql` namespaces).
-CNPG applies `ALTER ROLE` from the postgresql-side secret; the app picks up the
-new value on its next pod restart. There is a window where the role has the new
-password and the running pod still holds the old one — restart the Deployment
-after the ExternalSecret shows `SecretSynced`.
+**This does not work as written today.** CNPG is supposed to apply `ALTER ROLE`
+from the postgresql-side secret, but its managed-role reconciler is inert on this
+cluster — the `donetick` role was created by hand on 2026-08-03 and the operator
+does not manage it. Rotating in Vault alone therefore changes the app's password
+and NOT the database's, and donetick fails authentication on its next restart.
+
+Until `docs/troubleshooting/cnpg-managed-roles-inert.md` is resolved, rotation is
+a two-step manual operation:
+
+```bash
+# 1. new value into Vault
+vault kv put k8s-secrets/donetick-db db-password="$(openssl rand -hex 32)"
+
+# 2. force-sync both ExternalSecrets, then apply it to Postgres YOURSELF
+kubectl -n postgresql annotate externalsecret donetick-db-credentials force-sync=$(date +%s) --overwrite
+kubectl -n donetick   annotate externalsecret donetick-db-credentials force-sync=$(date +%s) --overwrite
+
+P=$(kubectl -n postgresql get secret donetick-db-credentials -o jsonpath='{.data.password}' | base64 -d)
+kubectl -n postgresql exec -i postgresql-cluster-2 -c postgres -- \
+  psql -U postgres -c "ALTER ROLE donetick WITH PASSWORD '$P'"
+
+# 3. restart the app so it picks up the new secret
+kubectl -n donetick rollout restart deploy/donetick
+```
+
+Order matters: change Postgres before restarting the app, or the pod comes up
+holding a password the database has not accepted yet.
 
 ### Rotate the JWT secret
 
@@ -144,11 +166,18 @@ Rewrite `k8s-secrets/donetick` `jwt-secret`, force-sync, restart the Deployment.
 Every session and refresh token is invalidated; everyone is logged out. Do it
 deliberately, not as a reflex.
 
-### Close signup after the first account
+### Add a user (signup is closed)
 
-Set `is_user_creation_disabled: true` in `configmap.yaml`, bump `checksum/config`
-in `deployments.yaml`, merge. Verify at least one account exists first — there is
-no bootstrap admin and no CLI to create one.
+`is_user_creation_disabled: true` since 2026-08-03. donetick has no admin-invite
+flow, so adding someone means reopening signup, having them register, then
+closing it again: set the flag to `false` in `configmap.yaml`, bump
+`checksum/config` in `deployments.yaml`, merge, wait for the rollout, register,
+then revert both. Confirm the new row before closing:
+
+```bash
+kubectl -n postgresql exec postgresql-cluster-2 -c postgres -- \
+  psql -U postgres -d donetick -tAc "select id, username from users order by id;"
+```
 
 ### Recover a password with no email configured
 

--- a/base-apps/postgresql/cnpg-cluster.yaml
+++ b/base-apps/postgresql/cnpg-cluster.yaml
@@ -81,6 +81,12 @@ spec:
       # Owns the `donetick` database (donetick-database.yaml). Its passwordSecret
       # is kubernetes.io/basic-auth, which CNPG requires and the n8n entry above
       # does not satisfy — see external-secrets-donetick.yaml.
+      #
+      # DECLARED BUT NOT ENFORCED. The operator never reconciled this entry, so
+      # the role was created by hand on 2026-08-03 to unblock the deploy. The
+      # declaration is kept so a working reconciler adopts the role instead of
+      # conflicting with it. Until then a Vault rotation does NOT reach Postgres:
+      # docs/troubleshooting/cnpg-managed-roles-inert.md
       - name: donetick
         ensure: present
         login: true

--- a/base-apps/postgresql/external-secrets-donetick.yaml
+++ b/base-apps/postgresql/external-secrets-donetick.yaml
@@ -18,6 +18,13 @@ spec:
     # managed role points at an Opaque secret — do not copy it.)
     template:
       type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          # Upstream's managed-role example carries this. It did NOT make the
+          # role reconcile here (see docs/troubleshooting/cnpg-managed-roles-inert.md),
+          # but the secret is meant to be watched, so it belongs in Git rather
+          # than as a label someone added live and ESO later stripped.
+          cnpg.io/reload: "true"
       data:
         username: "donetick"
         password: "{{ .password }}"

--- a/docs/troubleshooting/cnpg-managed-roles-inert.md
+++ b/docs/troubleshooting/cnpg-managed-roles-inert.md
@@ -1,0 +1,86 @@
+# CNPG managed-role reconciliation is inert on postgresql-cluster
+
+**Status:** open
+**Found:** 2026-08-03, deploying donetick (PR #525)
+**Affects:** every role added to `spec.managed.roles` on `postgresql-cluster`
+**Operator:** CloudNativePG 1.29.1 (chart `cloudnative-pg` 0.28.3)
+
+## Symptom
+
+A role added to `postgresql-cluster`'s `spec.managed.roles` is never created in
+PostgreSQL. It appears in **no** `status.managedRolesStatus` bucket at all —
+not `reconciled`, not `pending-reconciliation`, and critically not
+`cannotReconcile`, which is where the operator records roles it has evaluated and
+rejected. Nothing is logged by either the operator or the instance manager.
+
+Downstream, anything depending on the role stalls with an accurate but misleading
+error. For donetick that was a `Database` resource retrying every 30s:
+
+```
+while creating database "donetick": ERROR: role "donetick" does not exist (SQLSTATE 42704)
+```
+
+which reads like a `Database` problem and is not one.
+
+## What is NOT the cause
+
+Each of these was checked and ruled out, so nobody has to check them again:
+
+| Hypothesis | Finding |
+|---|---|
+| Role missing from the applied spec | Present in the live object and in Argo's `last-applied-configuration` |
+| Wrong Secret type | `kubernetes.io/basic-auth`, as CNPG requires |
+| Wrong Secret keys | `username` (= role name) and `password`, both correct |
+| Operator lacks RBAC on the Secret | The generated `Role/postgresql-cluster` lists `donetick-db-credentials` by name — the operator raised an `UpdatingRole` event to add it |
+| Missing `cnpg.io/reload` label | Added; no effect. Note `postgresql-credentials`, whose `n8n` role DID reconcile, does not carry it either |
+| Instance manager holding a stale spec | Instance restarted; role synchronizer re-initialized and still did nothing |
+| Operator controller wedged | Operator restarted; no effect |
+| No Cluster update event to drive the loop | Forced one by annotating the Cluster; no effect |
+| Cluster unhealthy | All conditions `True`; `Ready`, archiving and backups working |
+
+## Corroborating evidence
+
+The one role that ever reconciled, `n8n`, carries a frozen status:
+
+```
+"passwordStatus":{"n8n":{"resourceVersion":"2789594","transactionID":2502}}
+```
+
+That `resourceVersion` is orders of magnitude below current. The synchronizer
+logs `setting up RoleSynchronizer loop` at instance start and then never speaks
+again, on either the old pod (up 6 days) or a freshly started one.
+
+`chores_user` sits in `not-managed`, which is correct and expected — it was
+created by hand and is not in the spec.
+
+## Workaround in effect
+
+The `donetick` role was created manually on 2026-08-03 from the password already
+in `donetick-db-credentials`, so it matches Vault exactly:
+
+```bash
+P=$(kubectl -n postgresql get secret donetick-db-credentials -o jsonpath='{.data.password}' | base64 -d)
+kubectl -n postgresql exec -i postgresql-cluster-2 -c postgres -- \
+  psql -U postgres -c "ALTER ROLE donetick WITH PASSWORD '$P'"   # or CREATE ROLE ... LOGIN
+```
+
+The `spec.managed.roles` entry is deliberately **kept** in Git. If the reconciler
+is ever fixed it will adopt the existing role rather than conflict with it, and
+the declaration stays the source of truth in the meantime.
+
+**The cost, which is the part that bites:** a Vault rotation no longer reaches
+PostgreSQL on its own. `base-apps/donetick/runbook.md` documents the two-step
+manual rotation this forces. Anyone adding another role to this cluster will hit
+the same wall.
+
+## Where to pick it up
+
+- Compare against a scratch CNPG cluster on the same operator — if managed roles
+  work there, the fault is specific to `postgresql-cluster`, which was adopted
+  into GitOps on 2026-07-15 after running unmanaged since 2025-12-03 and may
+  carry state the operator does not expect.
+- Read the 1.29.1 role synchronizer source for the conditions under which it
+  returns without recording status; a role landing in no bucket is the specific
+  behaviour to explain.
+- Check upstream issues for managed roles silently skipped in 1.28/1.29.
+- A version bump is plausible but unverified — do not assume it fixes this.


### PR DESCRIPTION
Follow-up to #525, now that donetick is live and serving at https://donetick.arigsela.com.

## Close signup

The first account exists (`arigsela`, id 1, plus its circle — confirmed in the database), so `is_user_creation_disabled` goes to `true`.

donetick has no admin-invite flow, so the runbook's "close signup" section is replaced with the procedure for actually adding someone later: reopen, register, close again — including the SQL to confirm the new row **before** closing, because closing an empty instance locks you out with no CLI recovery.

## The role is declared but not enforced

CNPG never reconciled the `donetick` entry in `spec.managed.roles`, so the role was created by hand to unblock the deploy. The declaration is deliberately **kept** — a working reconciler adopts an existing role rather than conflicting with it, and Git stays the source of truth. Both the manifest and the docs now say this out loud instead of implying the operator owns the role.

## The runbook's rotation procedure was wrong

It said to rotate in Vault and let CNPG apply `ALTER ROLE`. With the reconciler inert, that changes the app's password and *not* the database's, so the next pod restart fails authentication — a documented procedure that breaks the thing it claims to maintain. Replaced with the two-step manual rotation, ordered so Postgres changes before the app restarts.

## `cnpg.io/reload` label

Added to the ExternalSecret template. **It did not fix the reconciler.** It's here because upstream's managed-role example carries it, and because I set it on the live secret while testing — leaving that as drift would have had ESO strip it on the next refresh, quietly reverting something a reader might later assume was in effect.

## New: `docs/troubleshooting/cnpg-managed-roles-inert.md`

The finding is bigger than donetick — it affects any role added to `postgresql-cluster`.

The doc leads with what was **ruled out** (spec contents, secret type, secret keys, RBAC, the reload label, stale instance spec, wedged operator, missing update event, cluster health) so the next person doesn't repeat the elimination. The signature is a role landing in **no** `managedRolesStatus` bucket — not even `cannotReconcile`, where a rejected role would go — with nothing logged by either the operator or the instance manager.

Corroborating: `n8n`, the only role that ever reconciled, has a frozen `passwordStatus` at `resourceVersion: 2789594`. The synchronizer logs `setting up RoleSynchronizer loop` at instance start and never speaks again — on a 6-day-old pod and a freshly started one alike.

## Verification

- `kubeconform` strict 4/4, `yamllint` clean
- `validate-agent-docs.py`, `validate-catalog-refs.py` pass
- `kubectl apply --dry-run=server` accepted the ExternalSecret change
- Live state confirmed before writing: `users` table has exactly one row, donetick returns 200 through the gateway, Argo `Synced/Healthy`

Merging restarts the donetick pod (config checksum bump). Expect a few seconds of downtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkuzGksz2ZPiVnXRG5ayih
