### PR TITLE
donetick: temporarily reopen signup to add a second account

### DIFF
--- a/base-apps/donetick/configmap.yaml
+++ b/base-apps/donetick/configmap.yaml
@@ -10,9 +10,11 @@ data:
     name: "selfhosted"
     is_done_tick_dot_com: false
 
-    # Closed 2026-08-03 once the first account existed. Turning this back on is
-    # the ONLY way to add a user — there is no bootstrap admin and no CLI.
-    is_user_creation_disabled: true
+    # TEMPORARILY OPEN — reopened 2026-08-03 to add a second full account.
+    # Close this again as soon as that account exists; while it is false, anyone
+    # who can reach the host can register. Procedure and verification query:
+    # runbook.md, "Add a user (signup is closed)".
+    is_user_creation_disabled: false
 
     database:
       type: "postgres"

--- a/base-apps/donetick/deployments.yaml
+++ b/base-apps/donetick/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # donetick reads its config once, at startup. If you edit configmap.yaml,
         # recompute this or the change syncs and does nothing:
         #   shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16
-        checksum/config: "14560e23412d7bcd"
+        checksum/config: "ce2593a286dd7bec"
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application


### PR DESCRIPTION
Reopens registration so a **second full account** (peer, not a subaccount) can self-register. donetick has no admin-invite flow, and joining a circle requires the account to already exist — so reopening signup is the only path.

## ⚠️ This leaves the instance open to registration

While this is merged, anyone who can reach `chores.arigsela.com` can create an account. That surface is bounded by the Gateway's four-address source allow-list rather than by the app itself, which is the only reason it's acceptable for the few minutes needed. **The follow-up closing it should land the same day.**

## Why not a subaccount

The subaccount path needs no deploy at all — one click in the UI, same as `arigsela_makoto`. But it creates `user_type=1` with `parent_user_id=1`: a managed child account with no independent password reset that can never hold admin. Right for a kid, wrong for a second adult who should be a peer in the circle.

## Sequence

1. Merge this → pod rolls with the new config checksum
2. She registers at https://chores.arigsela.com
3. She joins `asela's circle` with invite code `5t6FOJP2W3a1xr0j`
4. Verify the row exists, then merge the close-signup PR

Step 4's verification is not optional — closing an empty instance is the one unrecoverable state here, since there's no bootstrap admin and no CLI.

```bash
kubectl -n postgresql exec postgresql-cluster-2 -c postgres -- \
  psql -U postgres -d donetick -tAc "select id, username, user_type, parent_user_id from users order by id;"
```

A peer account shows `user_type=0` and a null parent.

## Verification

`kubeconform` 2/2, `yamllint` clean. Config checksum bumped so the pod actually picks up the change — donetick reads its config only at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkuzGksz2ZPiVnXRG5ayih