### PR TITLE
donetick: close signup again

### DIFF
--- a/base-apps/donetick/configmap.yaml
+++ b/base-apps/donetick/configmap.yaml
@@ -10,11 +10,10 @@ data:
     name: "selfhosted"
     is_done_tick_dot_com: false
 
-    # TEMPORARILY OPEN — reopened 2026-08-03 to add a second full account.
-    # Close this again as soon as that account exists; while it is false, anyone
-    # who can reach the host can register. Procedure and verification query:
-    # runbook.md, "Add a user (signup is closed)".
-    is_user_creation_disabled: false
+    # Closed again 2026-08-03, both adult accounts now exist. Reopening is the
+    # ONLY way to add a user — there is no bootstrap admin and no CLI. Procedure
+    # and verification query: runbook.md, "Add a user (signup is closed)".
+    is_user_creation_disabled: true
 
     database:
       type: "postgres"

--- a/base-apps/donetick/deployments.yaml
+++ b/base-apps/donetick/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # donetick reads its config once, at startup. If you edit configmap.yaml,
         # recompute this or the change syncs and does nothing:
         #   shasum -a 256 base-apps/donetick/configmap.yaml | cut -c1-16
-        checksum/config: "ce2593a286dd7bec"
+        checksum/config: "a5af7bf2a8e93fb4"
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application


### PR DESCRIPTION
Closes registration now that both adult accounts exist. Follow-up to #528, which should not stay merged.

## Verified before closing

This is the step that matters — closing an instance with no account is the one unrecoverable state here, since there's no bootstrap admin and no CLI.

| id | username | user_type | parent | circle |
|---|---|---|---|---|
| 1 | `arigsela` | 0 | null | 1 (admin) |
| 2 | `arigsela_makoto` | 1 | 1 | 1 (member) |
| 3 | `dianuzhka` | 0 | null | **2** (admin) |

Row 3 is the account #528 was opened for, and it's a genuine peer — `user_type=0`, no parent, not a subaccount.

## ⚠️ She's in the wrong circle — separate issue, not fixed here

`dianuzhka` is admin of **circle 2**, not a member of circle 1. donetick creates a personal circle at signup, so registering without redeeming an invite code leaves each account in its own household. **As it stands, neither of you sees the other's chores.**

This does *not* block closing signup — joining a circle is independent of registration. She can redeem the invite code from her account whenever convenient:

- Circle 1 (`asela's circle`) invite code: **`5t6FOJP2W3a1xr0j`**

Once she joins, `dianuzhka's circle` (id 2) can be abandoned.

## Verification

`kubeconform` 2/2, `yamllint` clean. Config checksum bumped so the pod picks the change up — donetick reads config only at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkuzGksz2ZPiVnXRG5ayih