### PR TITLE
homepage: self-hosted dashboard for cluster apps and Plex

### DIFF
--- a/base-apps/argo-rollouts/httproute.yaml
+++ b/base-apps/argo-rollouts/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: argo-rollouts
   namespace: argo-rollouts
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Argo Rollouts
+    gethomepage.dev/group: GitOps & Delivery
+    gethomepage.dev/icon: mdi-rocket-launch
+    gethomepage.dev/description: Progressive delivery
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=argo-rollouts
 spec:
   parentRefs:
     - name: main

--- a/base-apps/argo-workflows/httproute.yaml
+++ b/base-apps/argo-workflows/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: argo-workflows
   namespace: argo-workflows
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Argo Workflows
+    gethomepage.dev/group: Automation
+    gethomepage.dev/icon: mdi-sitemap
+    gethomepage.dev/description: Workflow orchestration
+    gethomepage.dev/pod-selector: app=server
 spec:
   parentRefs:
     - name: main

--- a/base-apps/atlantis/httproute.yaml
+++ b/base-apps/atlantis/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: atlantis
   namespace: atlantis
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Atlantis
+    gethomepage.dev/group: GitOps & Delivery
+    gethomepage.dev/icon: mdi-terraform
+    gethomepage.dev/description: Terraform PR automation
+    gethomepage.dev/pod-selector: app=atlantis
 spec:
   parentRefs:
     - name: main

--- a/base-apps/backstage/httproute.yaml
+++ b/base-apps/backstage/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: backstage
   namespace: backstage
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Backstage
+    gethomepage.dev/group: Platform
+    gethomepage.dev/icon: backstage.png
+    gethomepage.dev/description: Developer portal
+    gethomepage.dev/pod-selector: app=backstage
 spec:
   parentRefs:
     - name: main

--- a/base-apps/coroot/httproute.yaml
+++ b/base-apps/coroot/httproute.yaml
@@ -9,6 +9,12 @@ kind: HTTPRoute
 metadata:
   name: coroot
   namespace: coroot
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Coroot
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: mdi-radar
+    gethomepage.dev/description: eBPF observability
 spec:
   parentRefs:
     - name: main

--- a/base-apps/dex/httproute.yaml
+++ b/base-apps/dex/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: dex
   namespace: dex
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Dex
+    gethomepage.dev/group: Platform
+    gethomepage.dev/icon: mdi-account-key
+    gethomepage.dev/description: OIDC identity provider
+    gethomepage.dev/pod-selector: app=dex
 spec:
   parentRefs:
     - name: main

--- a/base-apps/donetick/httproute.yaml
+++ b/base-apps/donetick/httproute.yaml
@@ -3,6 +3,18 @@ kind: HTTPRoute
 metadata:
   name: donetick
   namespace: donetick
+  annotations:
+    # Dashboard tile, discovered by homepage via gateway-api. href is derived
+    # from the hostnames below, so the tile follows the host automatically.
+    # NEVER add a credential here — annotations are plaintext and get no
+    # {{HOMEPAGE_VAR_*}} substitution. Widget tiles live in
+    # base-apps/homepage/configmap.yaml instead.
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Donetick
+    gethomepage.dev/group: Home
+    gethomepage.dev/icon: mdi-checkbox-marked-circle-outline
+    gethomepage.dev/description: Household chore tracker
+    gethomepage.dev/pod-selector: app=donetick
 spec:
   parentRefs:
     - name: main

--- a/base-apps/homepage.yaml
+++ b/base-apps/homepage.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: homepage
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arigsela/kubernetes
+    targetRevision: main
+    path: base-apps/homepage
+    directory:
+      # Backstage entity + TechDocs config, not Kubernetes manifests.
+      exclude: '{catalog-info.yaml,mkdocs.yml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: homepage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-apps/homepage/catalog-info.yaml
+++ b/base-apps/homepage/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: homepage
+  namespace: homepage
+  annotations:
+    agent-docs/path: docs.md
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-label-selector: 'app=homepage'
+    backstage.io/kubernetes-namespace: homepage
+  tags: [dashboard, gitops, self-hosted]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/platform
+  # default/platform is a Domain + Group, not a System — there is no System
+  # named bare "platform" (see catalog/platform-entities.yaml). Falling back to
+  # backstage's system, per templates/agent-docs/README.md: both are internal,
+  # unauthenticated-by-network-policy dashboards onto the rest of the cluster.
+  system: default/platform-tooling
+  dependsOn:
+    - resource:vault/vault

--- a/base-apps/homepage/certificate.yaml
+++ b/base-apps/homepage/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: homepage-tls
+  namespace: homepage
+spec:
+  secretName: homepage-tls
+  dnsNames:
+    - home.arigsela.com
+  issuerRef:
+    # Not letsencrypt-prod: its only solver is http01.ingress.class=nginx, which
+    # nothing satisfies since the Istio cutover.
+    name: letsencrypt-route53
+    kind: ClusterIssuer

--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -1,0 +1,64 @@
+# ALL EIGHT FILES MUST EXIST, even empty ones: Homepage expects the full set.
+#
+# These are mounted as individual subPath files (see deployments.yaml), and
+# Kubernetes NEVER propagates ConfigMap updates into subPath mounts. Editing
+# this file therefore syncs cleanly and changes NOTHING until the pod restarts.
+# After any edit here, recompute the checksum in deployments.yaml:
+#   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage
+  namespace: homepage
+data:
+  settings.yaml: |
+    title: Homelab
+    headerStyle: boxed
+    layout:
+      GitOps & Delivery:
+        style: row
+        columns: 3
+      Automation:
+        style: row
+        columns: 2
+      Observability:
+        style: row
+        columns: 2
+      Platform:
+        style: row
+        columns: 3
+      AI & Agents:
+        style: row
+        columns: 4
+      Home:
+        style: row
+        columns: 3
+
+  kubernetes.yaml: |
+    # cluster: use the in-cluster ServiceAccount.
+    # gateway: discover tiles from Gateway API HTTPRoute annotations.
+    # ingress/traefik stay off — this cluster uses neither.
+    mode: cluster
+    gateway: true
+    ingress: false
+
+  services.yaml: ""
+
+  widgets.yaml: |
+    - kubernetes:
+        cluster:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+          label: cluster
+        nodes:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+
+  bookmarks.yaml: ""
+  docker.yaml: ""
+  custom.css: ""
+  custom.js: ""

--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -42,7 +42,63 @@ data:
     gateway: true
     ingress: false
 
-  services.yaml: ""
+  # Only widget-bearing tiles live here. Link-only tiles are discovered from
+  # gethomepage.dev/* annotations on each app's own httproute.yaml. The split
+  # exists because Homepage substitutes {{HOMEPAGE_VAR_*}} in config files but
+  # not in annotations — a credential must never appear in an annotation.
+  services.yaml: |
+    - GitOps & Delivery:
+        - Argo CD:
+            href: https://argocd.arigsela.com
+            description: GitOps continuous delivery
+            icon: argo-cd.png
+            widget:
+              # Driven by Prometheus rather than an Argo CD API token: creating
+              # an apiKey account means editing argocd-cm, and this repo's
+              # Terraform module writes to the deprecated server.config.* path
+              # the chart ignores. See templates/agent-docs/README.md.
+              type: prometheusmetric
+              url: http://prometheus.logging.svc.cluster.local:9090
+              metrics:
+                - label: Apps
+                  query: count(argocd_app_info)
+                - label: Synced
+                  query: count(argocd_app_info{sync_status="Synced"})
+                - label: OutOfSync
+                  query: count(argocd_app_info{sync_status="OutOfSync"})
+                - label: Degraded
+                  query: count(argocd_app_info{health_status="Degraded"})
+
+    - Observability:
+        - Grafana:
+            href: https://grafana.arigsela.com
+            description: Dashboards and alerting
+            icon: grafana.png
+            widget:
+              # customapi + Bearer, NOT the built-in `grafana` widget: that one
+              # speaks only basic auth, and this Grafana runs with
+              # GF_AUTH_BASIC_ENABLED=false (GitHub OAuth is the only way in).
+              # `format: size` returns the length of the root JSON array.
+              type: customapi
+              url: http://grafana.logging.svc.cluster.local:3000/api/alertmanager/grafana/api/v2/alerts
+              headers:
+                Authorization: "Bearer {{HOMEPAGE_VAR_GRAFANA_TOKEN}}"
+              mappings:
+                - label: Firing
+                  format: size
+
+    - Home:
+        - Plex:
+            # Runs on the Windows/WSL2 box, not in the cluster. Reachable only
+            # because of the WSL2 mirrored-networking change documented in
+            # runbook.md. A DHCP lease change here silently blanks the widget.
+            href: http://10.0.1.200:32401/web
+            description: Media server
+            icon: plex.png
+            widget:
+              type: plex
+              url: http://10.0.1.200:32401
+              key: "{{HOMEPAGE_VAR_PLEX_TOKEN}}"
 
   widgets.yaml: |
     - kubernetes:

--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -59,15 +59,21 @@ data:
               # the chart ignores. See templates/agent-docs/README.md.
               type: prometheusmetric
               url: http://prometheus.logging.svc.cluster.local:9090
+              # count() over a selector that matches NO series returns an empty
+              # vector, not 0 — and Homepage's prometheusmetric widget renders an
+              # empty result as "-", identically to a broken/misspelled label.
+              # `or vector(0)` forces the filtered queries to resolve to a real
+              # 0 in the healthy state, so "-" stays reserved for "the query
+              # itself is broken." Do not simplify this away.
               metrics:
                 - label: Apps
                   query: count(argocd_app_info)
                 - label: Synced
-                  query: count(argocd_app_info{sync_status="Synced"})
+                  query: count(argocd_app_info{sync_status="Synced"}) or vector(0)
                 - label: OutOfSync
-                  query: count(argocd_app_info{sync_status="OutOfSync"})
+                  query: count(argocd_app_info{sync_status="OutOfSync"}) or vector(0)
                 - label: Degraded
-                  query: count(argocd_app_info{health_status="Degraded"})
+                  query: count(argocd_app_info{health_status="Degraded"}) or vector(0)
 
     - Observability:
         - Grafana:

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -33,6 +33,12 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        # The logs volume below is an emptyDir mounted at /app/config/logs.
+        # Without fsGroup, emptyDir mounts root-owned and UID 1000 can't write
+        # to it. UID 1000 is correct — upstream's v1.13.2 Dockerfile does
+        # `COPY --chown=1000:1000` for all app files — so only the volume's
+        # ownership needed fixing, not the UID.
+        fsGroup: 1000
       containers:
         - name: homepage
           image: ghcr.io/gethomepage/homepage:v1.13.2
@@ -67,6 +73,10 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
+              # cpu is required alongside memory: the repo's Kyverno
+              # ClusterPolicy require-resource-limits (Audit mode) flags any
+              # container missing either limit as a PolicyReport violation.
+              cpu: 500m
               memory: 512Mi
           volumeMounts:
             - name: config

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app: homepage
+    app.kubernetes.io/name: homepage
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: homepage
+  template:
+    metadata:
+      labels:
+        app: homepage
+        app.kubernetes.io/name: homepage
+      annotations:
+        # REQUIRED, not cosmetic. The config below is mounted via subPath, and
+        # Kubernetes never propagates ConfigMap updates into subPath mounts. If
+        # you edit configmap.yaml without bumping this, the change deploys and
+        # does nothing. Recompute with:
+        #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
+        checksum/config: "9b6da78ba4ae760c"
+    spec:
+      serviceAccountName: homepage
+      nodeSelector:
+        node.kubernetes.io/workload: application
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: homepage
+          image: ghcr.io/gethomepage/homepage:v1.13.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Mandatory since v1.0 — Homepage rejects requests for any Host not
+            # listed here. The pod IP entry is what lets the kubelet probe pass;
+            # dropping it makes the pod fail readiness with no obvious cause.
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: "$(MY_POD_IP):3000,home.arigsela.com"
+          ports:
+            - containerPort: 3000
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /app/config/settings.yaml
+              subPath: settings.yaml
+            - name: config
+              mountPath: /app/config/services.yaml
+              subPath: services.yaml
+            - name: config
+              mountPath: /app/config/widgets.yaml
+              subPath: widgets.yaml
+            - name: config
+              mountPath: /app/config/kubernetes.yaml
+              subPath: kubernetes.yaml
+            - name: config
+              mountPath: /app/config/bookmarks.yaml
+              subPath: bookmarks.yaml
+            - name: config
+              mountPath: /app/config/docker.yaml
+              subPath: docker.yaml
+            - name: config
+              mountPath: /app/config/custom.css
+              subPath: custom.css
+            - name: config
+              mountPath: /app/config/custom.js
+              subPath: custom.js
+            - name: logs
+              mountPath: /app/config/logs
+      volumes:
+        - name: config
+          configMap:
+            name: homepage
+        - name: logs
+          emptyDir: {}

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # you edit configmap.yaml without bumping this, the change deploys and
         # does nothing. Recompute with:
         #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
-        checksum/config: "243d51a75a0b41e9"
+        checksum/config: "d094a7e545976433"
     spec:
       serviceAccountName: homepage
       nodeSelector:
@@ -71,13 +71,13 @@ spec:
               name: http
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/healthcheck
               port: 3000
             initialDelaySeconds: 15
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/healthcheck
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -91,6 +91,14 @@ spec:
               # container missing either limit as a PolicyReport violation.
               cpu: 500m
               memory: 512Mi
+          # This pod is the cluster's only unauthenticated web surface, and it
+          # holds a Grafana API token plus cluster-wide read RBAC — it drops
+          # every capability it does not need. No NET_BIND_SERVICE: Homepage
+          # binds port 3000, not a privileged (<1024) port.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           volumeMounts:
             - name: config
               mountPath: /app/config/settings.yaml

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # you edit configmap.yaml without bumping this, the change deploys and
         # does nothing. Recompute with:
         #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
-        checksum/config: "9b6da78ba4ae760c"
+        checksum/config: "243d51a75a0b41e9"
     spec:
       serviceAccountName: homepage
       nodeSelector:
@@ -53,6 +53,19 @@ spec:
             # dropping it makes the pod fail readiness with no obvious cause.
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: "$(MY_POD_IP):3000,home.arigsela.com"
+            # Referenced as {{HOMEPAGE_VAR_*}} in configmap.yaml. Homepage
+            # substitutes these in config files ONLY — never in annotations,
+            # which is why every widget-bearing tile is static.
+            - name: HOMEPAGE_VAR_PLEX_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: plex-token
+            - name: HOMEPAGE_VAR_GRAFANA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: grafana-token
           ports:
             - containerPort: 3000
               name: http

--- a/base-apps/homepage/docs.md
+++ b/base-apps/homepage/docs.md
@@ -1,0 +1,232 @@
+---
+type: "Kubernetes App Guide"
+title: "homepage"
+description: "Homelab dashboard listing every cluster app plus the WSL2-hosted Plex server, with live widgets for Plex, Grafana, Argo CD, and cluster resources."
+app: homepage
+catalog_entity: homepage
+kind: docs
+namespace: homepage
+last_reviewed: 2026-08-04
+status: current
+tags: [dashboard, gitops, self-hosted]
+sources:
+  - base-apps/homepage/configmap.yaml
+  - base-apps/homepage/deployments.yaml
+  - base-apps/homepage/serviceaccount.yaml
+  - base-apps/homepage/external-secrets.yaml
+  - base-apps/homepage/secret-store.yaml
+  - base-apps/homepage/httproute.yaml
+  - base-apps/homepage/certificate.yaml
+  - base-apps/homepage.yaml
+  - terraform/roots/asela-cluster/argocd.tf
+  - base-apps/logging/grafana-deployment.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+---
+
+# homepage
+
+## What it is
+
+[gethomepage/homepage](https://github.com/gethomepage/homepage) is a static,
+server-rendered dashboard: one page, tiles grouped into rows, each tile a link
+plus an optional live-data widget. It is the landing page for the homelab —
+`home.arigsela.com` — and the one place that enumerates essentially every app
+this repo deploys, in-cluster or not.
+
+It is deployed as a single stateless `Deployment`, one replica, one container,
+image `ghcr.io/gethomepage/homepage:v1.13.2`. There is no database and no
+persistent volume; all state is either baked into the ConfigMap or discovered
+live from the Kubernetes API on each page load.
+
+## Architecture & data flow
+
+Request path: `home.arigsela.com` → the shared `main` Gateway in
+`istio-ingress` (listener `https-homepage`) → `HTTPRoute` → `Service/homepage`
+→ pod, port 3000. TLS terminates at the Gateway using `homepage-tls`, a
+Secret in this namespace reached across namespaces by `reference-grant.yaml`.
+
+Homepage builds its page from two independent sources, and this split is the
+single most important thing to understand about this app:
+
+**The tile-sourcing rule, verbatim:** *Tiles with a widget are defined in
+`configmap.yaml`. Link-only tiles are defined by annotations on their own
+`httproute.yaml`. Never put a credential in an annotation — annotations are
+plaintext in Git, and Homepage performs `{{HOMEPAGE_VAR_*}}` substitution only
+in config files, never in annotations.*
+
+Concretely: `configmap.yaml`'s `services.yaml` hand-lists exactly three tiles
+that need a widget (Argo CD, Grafana, Plex — see below), because only widgets
+need credentials or a non-default query. Every other app on the dashboard is
+discovered by Homepage's Kubernetes provider (`kubernetes.yaml`: `mode:
+cluster`, `gateway: true`) reading `gethomepage.dev/*` annotations off
+`HTTPRoute` objects cluster-wide — which is why the ClusterRole below grants
+read on `gateway.networking.k8s.io` resources.
+
+### Adding a new app to the dashboard
+
+Add six annotations to the app's own `httproute.yaml` (see
+`base-apps/argo-rollouts/httproute.yaml` or
+`base-apps/weather-kitchen-frontend/httproute.yaml` for worked examples):
+
+```yaml
+metadata:
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: My App
+    gethomepage.dev/group: Home        # must match a key under settings.yaml's `layout:`
+    gethomepage.dev/icon: mdi-something  # or an upstream dashboard-icons filename, e.g. grafana.png
+    gethomepage.dev/description: One line
+    gethomepage.dev/pod-selector: app=my-app   # optional; drives the tile's health dot
+```
+
+The tile appears with **no pod restart and no change to this app whatsoever**
+— annotations are read from the Kubernetes API per request, not baked into a
+config that needs reloading. This is the single most useful asymmetry to
+know about this app: `configmap.yaml` changes need a rollout (see the
+`checksum/config` note below); `httproute.yaml` annotation changes do not,
+because they never go through the ConfigMap/subPath path at all.
+
+If `group` does not match one of the keys under `layout:` in `settings.yaml`
+(`GitOps & Delivery`, `Automation`, `Observability`, `Platform`, `AI &
+Agents`, `Home`), Homepage silently renders the tile into its own
+unconfigured row rather than erroring — see the runbook for the "tile
+missing" symptom.
+
+### Why `checksum/config` exists and is mandatory
+
+`configmap.yaml` is mounted into the container as eight individual `subPath`
+files (`deployments.yaml`), and **Kubernetes never propagates ConfigMap
+updates into subPath mounts** — this is a documented kubelet limitation, not
+a bug specific to this app. Editing `configmap.yaml` and letting Argo CD sync
+it deploys the new ConfigMap object cleanly and changes **nothing** in the
+running pod, because the subPath mount was resolved once at pod creation and
+is never re-synced.
+
+The fix is the `checksum/config` pod-template annotation in
+`deployments.yaml`: because it's part of the pod template, changing its value
+forces a new pod (and therefore a fresh subPath resolution) on every
+ConfigMap edit. Recompute it after any `configmap.yaml` change:
+
+```bash
+shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
+```
+
+The current value baked into `deployments.yaml` is `243d51a75a0b41e9`.
+Forgetting this step is indistinguishable from a successful, no-op deploy —
+Argo CD reports Synced/Healthy either way.
+
+### Why the Argo CD tile reads Prometheus, not the Argo CD API
+
+The natural design would be an Argo CD `apiKey` account and the built-in
+`argocd` widget. That requires editing `argocd-cm`, and in this repo the
+Argo CD Terraform module (`terraform/modules/argocd`) writes Helm values
+under the deprecated `server.config.*` path, which the chart no longer reads
+(it reads `configs.cm.*`) — see `templates/agent-docs/README.md` for the full
+account of why that path is dead. So instead the tile uses a `prometheusmetric`
+widget against `argocd_app_info`, counting apps by `sync_status` and
+`health_status`.
+
+**This has a dependency that lives entirely outside the `homepage`
+namespace, and outside Argo CD sync entirely:** `argocd_app_info` only
+exists because `controller.metrics.enabled` is set in
+`terraform/roots/asela-cluster/argocd.tf`, which creates the
+`argocd-application-controller-metrics` Service and its Prometheus scrape
+annotations. That Terraform is applied by **Atlantis on a pull request behind
+a required-reviewer gate** — not by Argo CD's automated sync, and not by
+anything in this app's own manifests. A blank or all-zero Argo CD tile is
+therefore very often a Terraform/Atlantis problem, not a homepage problem;
+see the runbook.
+
+### Why the Grafana tile uses `customapi` + a Bearer header, not the built-in `grafana` widget
+
+That Grafana (`base-apps/logging/grafana-deployment.yaml`) runs
+`GF_AUTH_BASIC_ENABLED=false` and `GF_AUTH_DISABLE_LOGIN_FORM=true`, so
+GitHub OAuth is the *only* interactive way to log in — there is no
+username/password to authenticate against. Homepage's built-in `grafana`
+widget speaks only HTTP basic auth and cannot authenticate against this
+instance at all.
+
+The tile instead uses the generic `customapi` widget with an explicit
+`Authorization: Bearer {{HOMEPAGE_VAR_GRAFANA_TOKEN}}` header against a
+Grafana service-account token. This was verified directly: a `glsa_`-prefixed
+service-account token returns `401` when sent as basic auth, and `200` when
+sent as a Bearer header. **If someone "fixes" this back to the built-in
+`grafana` widget expecting it to be simpler, it will break** — the widget
+issue is not the token, it's the auth scheme.
+
+### The external Plex dependency (lives outside Git)
+
+The Plex tile points at `10.0.1.200:32401` — **not** Plex's default port
+32400. Plex itself runs on a Windows/WSL2 host, not in the cluster; it is
+reachable from cluster pods only because WSL2 mirrored networking is enabled
+on that host (`networkingMode=mirrored` in `%UserProfile%\.wslconfig`,
+requires WSL 2.0+ and Windows 11 22H2+). Without mirrored networking, WSL2's
+default NAT mode puts Plex behind a private address the cluster cannot route
+to.
+
+The Windows host needs a static DHCP reservation: `10.0.1.200` is hardcoded
+into `configmap.yaml`'s Plex tile (both `href` and the widget `url`), and
+there is nothing in this app that would notice or recover from the lease
+moving. If the widget goes blank while the link still works, this dependency
+— entirely outside this repo, outside the cluster, and outside Kubernetes —
+is almost always why. See the runbook for the probe command.
+
+## Where config lives
+
+| What | Where |
+|---|---|
+| Layout, groups, kubernetes-provider mode | `configmap.yaml` (`settings.yaml`, `kubernetes.yaml`) |
+| The three widget-bearing tiles (Argo CD, Grafana, Plex) | `configmap.yaml` (`services.yaml`) |
+| Cluster-resources widget (CPU/memory on the tile row) | `configmap.yaml` (`widgets.yaml`) |
+| Link-only tiles for every other app | `gethomepage.dev/*` annotations on that app's own `httproute.yaml` |
+| Plex token, Grafana service-account token | Vault `k8s-secrets/homepage` → `external-secrets.yaml` |
+| Allowed request hostnames | `HOMEPAGE_ALLOWED_HOSTS` env var in `deployments.yaml` |
+| TLS certificate | `certificate.yaml` (ClusterIssuer `letsencrypt-route53`) |
+| Who can reach it at all | `base-apps/istio-ingress/authorizationpolicy.yaml` |
+| RBAC for cluster/gateway discovery | `serviceaccount.yaml` |
+
+## RBAC
+
+The app holds a **cluster-wide READ** `ClusterRole`: `namespaces`, `pods`,
+`nodes` (core API), `httproutes` and `gateways`
+(`gateway.networking.k8s.io`), and `nodes`/`pods` under `metrics.k8s.io`.
+This is the one new privilege this app introduces to the cluster — every
+other app in this repo is namespace-scoped.
+
+It is deliberately **narrower** than upstream's example RBAC manifest:
+upstream also grants `ingresses` (`networking.k8s.io`/`extensions`) and
+`traefik.io` `ingressroutes`. Both are dropped here because this cluster is
+**Gateway-API only** — there is no nginx Ingress controller and no Traefik
+since the Istio cutover, so those rules would be dead grants that only widen
+the blast radius of a compromised pod for no functional benefit.
+
+## No authentication of its own
+
+Upstream is explicit that Homepage has **no built-in authentication and none
+is planned**. This app is reachable, unauthenticated, by anyone whose source
+IP is on the allow-list — and the page it serves enumerates essentially every
+service in the homelab (name, description, group, and for three apps, live
+operational data). The Istio `AuthorizationPolicy` IP allow-list in
+`base-apps/istio-ingress/authorizationpolicy.yaml` is therefore not *a*
+control, it is the **only** control standing in front of a full service
+inventory of this cluster.
+
+This is also why the Grafana credential baked into this app is a
+**Viewer-scoped service-account token**, not the admin credentials used
+elsewhere in this cluster (see
+`base-apps/logging/grafana-admin-external-secret.yaml`) — a leak of this
+app's environment should not hand out Grafana admin. There is no equivalent
+scoped credential for Argo CD (the tile reads Prometheus, which has no
+authentication of its own inside the cluster network) or Plex (the token is
+Plex's own least-privileged "server" access token, not an account password).
+
+## Known follow-ups (deliberately out of scope)
+
+- **Tautulli** would give real now-playing detail on the Plex tile; the core
+  Plex API this widget uses only reports library counts and a stream count.
+- **Coroot, Backstage, Vault, n8n, Atlantis, and Kagent have no Homepage
+  widget** and are permanently link-only tiles unless someone hand-builds a
+  `customapi` widget for each, the same way the Grafana tile was built.
+- **The WSL2 `portproxy` fallback**, if the Windows host ever needs it instead
+  of mirrored networking, requires a Scheduled Task to survive reboots —
+  `netsh interface portproxy` rules do not persist on their own.

--- a/base-apps/homepage/docs.md
+++ b/base-apps/homepage/docs.md
@@ -111,7 +111,7 @@ ConfigMap edit. Recompute it after any `configmap.yaml` change:
 shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
 ```
 
-The current value baked into `deployments.yaml` is `243d51a75a0b41e9`.
+The current value baked into `deployments.yaml` is `d094a7e545976433`.
 Forgetting this step is indistinguishable from a successful, no-op deploy —
 Argo CD reports Synced/Healthy either way.
 

--- a/base-apps/homepage/docs/index.md
+++ b/base-apps/homepage/docs/index.md
@@ -1,0 +1,232 @@
+---
+type: "Kubernetes App Guide"
+title: "homepage"
+description: "Homelab dashboard listing every cluster app plus the WSL2-hosted Plex server, with live widgets for Plex, Grafana, Argo CD, and cluster resources."
+app: homepage
+catalog_entity: homepage
+kind: docs
+namespace: homepage
+last_reviewed: 2026-08-04
+status: current
+tags: [dashboard, gitops, self-hosted]
+sources:
+  - base-apps/homepage/configmap.yaml
+  - base-apps/homepage/deployments.yaml
+  - base-apps/homepage/serviceaccount.yaml
+  - base-apps/homepage/external-secrets.yaml
+  - base-apps/homepage/secret-store.yaml
+  - base-apps/homepage/httproute.yaml
+  - base-apps/homepage/certificate.yaml
+  - base-apps/homepage.yaml
+  - terraform/roots/asela-cluster/argocd.tf
+  - base-apps/logging/grafana-deployment.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+---
+
+# homepage
+
+## What it is
+
+[gethomepage/homepage](https://github.com/gethomepage/homepage) is a static,
+server-rendered dashboard: one page, tiles grouped into rows, each tile a link
+plus an optional live-data widget. It is the landing page for the homelab —
+`home.arigsela.com` — and the one place that enumerates essentially every app
+this repo deploys, in-cluster or not.
+
+It is deployed as a single stateless `Deployment`, one replica, one container,
+image `ghcr.io/gethomepage/homepage:v1.13.2`. There is no database and no
+persistent volume; all state is either baked into the ConfigMap or discovered
+live from the Kubernetes API on each page load.
+
+## Architecture & data flow
+
+Request path: `home.arigsela.com` → the shared `main` Gateway in
+`istio-ingress` (listener `https-homepage`) → `HTTPRoute` → `Service/homepage`
+→ pod, port 3000. TLS terminates at the Gateway using `homepage-tls`, a
+Secret in this namespace reached across namespaces by `reference-grant.yaml`.
+
+Homepage builds its page from two independent sources, and this split is the
+single most important thing to understand about this app:
+
+**The tile-sourcing rule, verbatim:** *Tiles with a widget are defined in
+`configmap.yaml`. Link-only tiles are defined by annotations on their own
+`httproute.yaml`. Never put a credential in an annotation — annotations are
+plaintext in Git, and Homepage performs `{{HOMEPAGE_VAR_*}}` substitution only
+in config files, never in annotations.*
+
+Concretely: `configmap.yaml`'s `services.yaml` hand-lists exactly three tiles
+that need a widget (Argo CD, Grafana, Plex — see below), because only widgets
+need credentials or a non-default query. Every other app on the dashboard is
+discovered by Homepage's Kubernetes provider (`kubernetes.yaml`: `mode:
+cluster`, `gateway: true`) reading `gethomepage.dev/*` annotations off
+`HTTPRoute` objects cluster-wide — which is why the ClusterRole below grants
+read on `gateway.networking.k8s.io` resources.
+
+### Adding a new app to the dashboard
+
+Add six annotations to the app's own `httproute.yaml` (see
+`base-apps/argo-rollouts/httproute.yaml` or
+`base-apps/weather-kitchen-frontend/httproute.yaml` for worked examples):
+
+```yaml
+metadata:
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: My App
+    gethomepage.dev/group: Home        # must match a key under settings.yaml's `layout:`
+    gethomepage.dev/icon: mdi-something  # or an upstream dashboard-icons filename, e.g. grafana.png
+    gethomepage.dev/description: One line
+    gethomepage.dev/pod-selector: app=my-app   # optional; drives the tile's health dot
+```
+
+The tile appears with **no pod restart and no change to this app whatsoever**
+— annotations are read from the Kubernetes API per request, not baked into a
+config that needs reloading. This is the single most useful asymmetry to
+know about this app: `configmap.yaml` changes need a rollout (see the
+`checksum/config` note below); `httproute.yaml` annotation changes do not,
+because they never go through the ConfigMap/subPath path at all.
+
+If `group` does not match one of the keys under `layout:` in `settings.yaml`
+(`GitOps & Delivery`, `Automation`, `Observability`, `Platform`, `AI &
+Agents`, `Home`), Homepage silently renders the tile into its own
+unconfigured row rather than erroring — see the runbook for the "tile
+missing" symptom.
+
+### Why `checksum/config` exists and is mandatory
+
+`configmap.yaml` is mounted into the container as eight individual `subPath`
+files (`deployments.yaml`), and **Kubernetes never propagates ConfigMap
+updates into subPath mounts** — this is a documented kubelet limitation, not
+a bug specific to this app. Editing `configmap.yaml` and letting Argo CD sync
+it deploys the new ConfigMap object cleanly and changes **nothing** in the
+running pod, because the subPath mount was resolved once at pod creation and
+is never re-synced.
+
+The fix is the `checksum/config` pod-template annotation in
+`deployments.yaml`: because it's part of the pod template, changing its value
+forces a new pod (and therefore a fresh subPath resolution) on every
+ConfigMap edit. Recompute it after any `configmap.yaml` change:
+
+```bash
+shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
+```
+
+The current value baked into `deployments.yaml` is `243d51a75a0b41e9`.
+Forgetting this step is indistinguishable from a successful, no-op deploy —
+Argo CD reports Synced/Healthy either way.
+
+### Why the Argo CD tile reads Prometheus, not the Argo CD API
+
+The natural design would be an Argo CD `apiKey` account and the built-in
+`argocd` widget. That requires editing `argocd-cm`, and in this repo the
+Argo CD Terraform module (`terraform/modules/argocd`) writes Helm values
+under the deprecated `server.config.*` path, which the chart no longer reads
+(it reads `configs.cm.*`) — see `templates/agent-docs/README.md` for the full
+account of why that path is dead. So instead the tile uses a `prometheusmetric`
+widget against `argocd_app_info`, counting apps by `sync_status` and
+`health_status`.
+
+**This has a dependency that lives entirely outside the `homepage`
+namespace, and outside Argo CD sync entirely:** `argocd_app_info` only
+exists because `controller.metrics.enabled` is set in
+`terraform/roots/asela-cluster/argocd.tf`, which creates the
+`argocd-application-controller-metrics` Service and its Prometheus scrape
+annotations. That Terraform is applied by **Atlantis on a pull request behind
+a required-reviewer gate** — not by Argo CD's automated sync, and not by
+anything in this app's own manifests. A blank or all-zero Argo CD tile is
+therefore very often a Terraform/Atlantis problem, not a homepage problem;
+see the runbook.
+
+### Why the Grafana tile uses `customapi` + a Bearer header, not the built-in `grafana` widget
+
+That Grafana (`base-apps/logging/grafana-deployment.yaml`) runs
+`GF_AUTH_BASIC_ENABLED=false` and `GF_AUTH_DISABLE_LOGIN_FORM=true`, so
+GitHub OAuth is the *only* interactive way to log in — there is no
+username/password to authenticate against. Homepage's built-in `grafana`
+widget speaks only HTTP basic auth and cannot authenticate against this
+instance at all.
+
+The tile instead uses the generic `customapi` widget with an explicit
+`Authorization: Bearer {{HOMEPAGE_VAR_GRAFANA_TOKEN}}` header against a
+Grafana service-account token. This was verified directly: a `glsa_`-prefixed
+service-account token returns `401` when sent as basic auth, and `200` when
+sent as a Bearer header. **If someone "fixes" this back to the built-in
+`grafana` widget expecting it to be simpler, it will break** — the widget
+issue is not the token, it's the auth scheme.
+
+### The external Plex dependency (lives outside Git)
+
+The Plex tile points at `10.0.1.200:32401` — **not** Plex's default port
+32400. Plex itself runs on a Windows/WSL2 host, not in the cluster; it is
+reachable from cluster pods only because WSL2 mirrored networking is enabled
+on that host (`networkingMode=mirrored` in `%UserProfile%\.wslconfig`,
+requires WSL 2.0+ and Windows 11 22H2+). Without mirrored networking, WSL2's
+default NAT mode puts Plex behind a private address the cluster cannot route
+to.
+
+The Windows host needs a static DHCP reservation: `10.0.1.200` is hardcoded
+into `configmap.yaml`'s Plex tile (both `href` and the widget `url`), and
+there is nothing in this app that would notice or recover from the lease
+moving. If the widget goes blank while the link still works, this dependency
+— entirely outside this repo, outside the cluster, and outside Kubernetes —
+is almost always why. See the runbook for the probe command.
+
+## Where config lives
+
+| What | Where |
+|---|---|
+| Layout, groups, kubernetes-provider mode | `configmap.yaml` (`settings.yaml`, `kubernetes.yaml`) |
+| The three widget-bearing tiles (Argo CD, Grafana, Plex) | `configmap.yaml` (`services.yaml`) |
+| Cluster-resources widget (CPU/memory on the tile row) | `configmap.yaml` (`widgets.yaml`) |
+| Link-only tiles for every other app | `gethomepage.dev/*` annotations on that app's own `httproute.yaml` |
+| Plex token, Grafana service-account token | Vault `k8s-secrets/homepage` → `external-secrets.yaml` |
+| Allowed request hostnames | `HOMEPAGE_ALLOWED_HOSTS` env var in `deployments.yaml` |
+| TLS certificate | `certificate.yaml` (ClusterIssuer `letsencrypt-route53`) |
+| Who can reach it at all | `base-apps/istio-ingress/authorizationpolicy.yaml` |
+| RBAC for cluster/gateway discovery | `serviceaccount.yaml` |
+
+## RBAC
+
+The app holds a **cluster-wide READ** `ClusterRole`: `namespaces`, `pods`,
+`nodes` (core API), `httproutes` and `gateways`
+(`gateway.networking.k8s.io`), and `nodes`/`pods` under `metrics.k8s.io`.
+This is the one new privilege this app introduces to the cluster — every
+other app in this repo is namespace-scoped.
+
+It is deliberately **narrower** than upstream's example RBAC manifest:
+upstream also grants `ingresses` (`networking.k8s.io`/`extensions`) and
+`traefik.io` `ingressroutes`. Both are dropped here because this cluster is
+**Gateway-API only** — there is no nginx Ingress controller and no Traefik
+since the Istio cutover, so those rules would be dead grants that only widen
+the blast radius of a compromised pod for no functional benefit.
+
+## No authentication of its own
+
+Upstream is explicit that Homepage has **no built-in authentication and none
+is planned**. This app is reachable, unauthenticated, by anyone whose source
+IP is on the allow-list — and the page it serves enumerates essentially every
+service in the homelab (name, description, group, and for three apps, live
+operational data). The Istio `AuthorizationPolicy` IP allow-list in
+`base-apps/istio-ingress/authorizationpolicy.yaml` is therefore not *a*
+control, it is the **only** control standing in front of a full service
+inventory of this cluster.
+
+This is also why the Grafana credential baked into this app is a
+**Viewer-scoped service-account token**, not the admin credentials used
+elsewhere in this cluster (see
+`base-apps/logging/grafana-admin-external-secret.yaml`) — a leak of this
+app's environment should not hand out Grafana admin. There is no equivalent
+scoped credential for Argo CD (the tile reads Prometheus, which has no
+authentication of its own inside the cluster network) or Plex (the token is
+Plex's own least-privileged "server" access token, not an account password).
+
+## Known follow-ups (deliberately out of scope)
+
+- **Tautulli** would give real now-playing detail on the Plex tile; the core
+  Plex API this widget uses only reports library counts and a stream count.
+- **Coroot, Backstage, Vault, n8n, Atlantis, and Kagent have no Homepage
+  widget** and are permanently link-only tiles unless someone hand-builds a
+  `customapi` widget for each, the same way the Grafana tile was built.
+- **The WSL2 `portproxy` fallback**, if the Windows host ever needs it instead
+  of mirrored networking, requires a Scheduled Task to survive reboots —
+  `netsh interface portproxy` rules do not persist on their own.

--- a/base-apps/homepage/docs/index.md
+++ b/base-apps/homepage/docs/index.md
@@ -111,7 +111,7 @@ ConfigMap edit. Recompute it after any `configmap.yaml` change:
 shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
 ```
 
-The current value baked into `deployments.yaml` is `243d51a75a0b41e9`.
+The current value baked into `deployments.yaml` is `d094a7e545976433`.
 Forgetting this step is indistinguishable from a successful, no-op deploy —
 Argo CD reports Synced/Healthy either way.
 

--- a/base-apps/homepage/docs/runbook.md
+++ b/base-apps/homepage/docs/runbook.md
@@ -1,0 +1,93 @@
+---
+type: "Kubernetes App Runbook"
+title: "homepage runbook"
+description: "Operational runbook for homepage: failure modes, checks, and fixes."
+app: homepage
+catalog_entity: homepage
+kind: runbook
+namespace: homepage
+last_reviewed: 2026-08-04
+status: current
+tags: [dashboard, gitops, self-hosted]
+sources:
+  - base-apps/homepage/configmap.yaml
+  - base-apps/homepage/deployments.yaml
+  - base-apps/homepage/external-secrets.yaml
+  - base-apps/homepage/secret-store.yaml
+  - base-apps/homepage/httproute.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - terraform/roots/asela-cluster/argocd.tf
+  - scripts/provision-homepage-vault.sh
+---
+
+# homepage runbook
+
+## First-time provisioning
+
+The manifests do not create Vault material. Before the first sync can
+succeed, run `scripts/provision-homepage-vault.sh` inside the `vault-0` pod —
+idempotent, writes `plex-token` and `grafana-token` under `k8s-secrets/homepage`
+plus the matching policy and Kubernetes-auth role, and leaves existing values
+untouched on a re-run:
+
+```bash
+kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
+kubectl -n vault exec -it vault-0 -- sh
+export VAULT_TOKEN=<root-or-admin-token>
+PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh /tmp/prov.sh
+unset VAULT_TOKEN; rm /tmp/prov.sh; exit
+```
+
+`GRAFANA_TOKEN` must be a Grafana **service-account token with the Viewer
+role**, not an admin credential — see the "No authentication of its own"
+section in `docs.md` for why. `PLEX_TOKEN` is Plex's own server access token
+(`X-Plex-Token`), obtainable from an authenticated Plex Web session.
+
+## Failure modes
+
+| Symptom | Check | Fix |
+|---|---|---|
+| Blank page, or requests rejected outright | `kubectl -n homepage exec deploy/homepage -- printenv HOMEPAGE_ALLOWED_HOSTS` | Must contain `home.arigsela.com` and `$(MY_POD_IP):3000`. Homepage rejects any request whose `Host` header isn't listed here; this is the most likely first-boot failure and reads as a generic blank/error page, not an auth error. |
+| Edited `configmap.yaml`, Argo synced Healthy, nothing changed | Pod `AGE` (`kubectl -n homepage get pods`) versus the commit time | `configmap.yaml` is mounted via `subPath`, and Kubernetes never propagates ConfigMap updates into subPath mounts. Bump `checksum/config` in `deployments.yaml` (`shasum -a 256 base-apps/homepage/configmap.yaml \| cut -c1-16`) and re-sync, or `kubectl -n homepage rollout restart deploy/homepage`. |
+| A new app's tile is missing from the dashboard | The six `gethomepage.dev/*` annotations on that app's own `httproute.yaml` | Typo in a key, or `enabled` missing/not `"true"`. Also confirm `gethomepage.dev/group` exactly matches a key under `layout:` in `configmap.yaml`'s `settings.yaml` (`GitOps & Delivery`, `Automation`, `Observability`, `Platform`, `AI & Agents`, `Home`) — a mismatch doesn't error, it just renders into an unconfigured row that's easy to miss. No pod restart is needed either way; annotations are read live. |
+| Two tiles show up for one app | Whether two `HTTPRoute`s in that app's namespace(s) share the same hostname | Annotate only the tile-facing route. This is exactly why `base-apps/weather-kitchen-backend/httproute.yaml` is deliberately **unannotated** — it shares `weather-kitchen.arigsela.com` with `weather-kitchen-frontend`, which carries the annotations. |
+| Plex tile stats blank, but the `href` link still works from a browser | `kubectl run plex-probe --rm -it --restart=Never --image=curlimages/curl:8.10.1 -- curl -m5 http://10.0.1.200:32401/identity` | If this times out from inside the cluster but Plex is reachable from your own LAN device, WSL2 mirrored networking is off (check `%UserProfile%\.wslconfig` on the Windows host after any Windows/WSL update) or the DHCP lease for the WSL2 host moved off `10.0.1.200`. Neither is fixable from Git — see docs.md. |
+| Argo CD tile blank, or all counters read `0` | `count(argocd_app_info)` against Prometheus (`kubectl -n logging port-forward svc/prometheus 9090:9090`, then query) | Zero results means `controller.metrics.enabled` in `terraform/roots/asela-cluster/argocd.tf` was never applied (Atlantis PR not merged/applied) or was reverted, **or** the `argocd-application-controller-metrics` Service lost its `prometheus.io/scrape` annotation and Prometheus stopped scraping it. This is a Terraform/Atlantis problem, not a homepage or Argo CD sync problem — `kubectl -n argo-cd get app homepage` can show Healthy while this tile is empty. |
+| Grafana tile errors (not just blank) | `curl -H "Authorization: Bearer <token>" https://grafana.arigsela.com/api/alertmanager/grafana/api/v2/alerts` | `401`/`403` means the service-account token was revoked or the service account deleted in Grafana's UI — Grafana tokens don't auto-expire unless one was set. Mint a new Viewer-role token and follow "Rotate a credential" below. |
+| `403` on every host, not just `home.arigsela.com` | Your current public source IP against the `ipBlocks` list in `base-apps/istio-ingress/authorizationpolicy.yaml` | Your ISP reassigned your address. This affects every hostname behind the Gateway — homepage is just the one you happen to be looking at when you notice, because it's the landing page. Fix is a PR adding the new address to the shared allow-list, not anything in this app. |
+
+## Rotate a credential (Plex or Grafana token)
+
+1. Write the new value to Vault:
+   ```bash
+   vault kv patch k8s-secrets/homepage plex-token="<new-token>"
+   # or
+   vault kv patch k8s-secrets/homepage grafana-token="<new-token>"
+   ```
+2. The `ExternalSecret` refreshes on its own within an hour (`refreshInterval:
+   1h` in `external-secrets.yaml`), or force it immediately:
+   ```bash
+   kubectl -n homepage annotate externalsecret homepage-secrets force-sync=$(date +%s) --overwrite
+   ```
+3. **Restart the Deployment.** Homepage reads its `HOMEPAGE_VAR_*` env vars
+   once at process start — updating the underlying Kubernetes `Secret` does
+   not make the running container pick up the new value:
+   ```bash
+   kubectl -n homepage rollout restart deploy/homepage
+   ```
+
+Order matters: force-sync before restarting, or the new pod starts holding
+the stale value and you repeat the restart for nothing.
+
+## Deploy / update
+
+GitOps only. Bump `image:` in `base-apps/homepage/deployments.yaml` to a
+pinned tag — never `latest` — and merge to `main`. Because `strategy:
+Recreate`, there is a brief full outage of the dashboard during the swap;
+nothing else in the cluster depends on homepage being up, so this is
+low-risk to do at any time.
+
+Before a version bump, skim the upstream release notes for widget or config
+schema changes — `services.yaml`/`widgets.yaml`/`settings.yaml` shape has
+changed across major versions before, and a schema-incompatible ConfigMap
+after a bump can render as a blank page with no obvious pod-log error.

--- a/base-apps/homepage/external-secrets.yaml
+++ b/base-apps/homepage/external-secrets.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-secrets
+  namespace: homepage
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: homepage-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: plex-token
+      remoteRef:
+        key: homepage
+        property: plex-token
+    # A dedicated Grafana SERVICE ACCOUNT token (Viewer), NOT the admin
+    # credentials in base-apps/logging/grafana-admin-external-secret.yaml.
+    # Homepage is unauthenticated; admin creds must not sit in its environment.
+    # A token rather than a username/password because that Grafana runs with
+    # GF_AUTH_BASIC_ENABLED=false — see grafana-deployment.yaml.
+    - secretKey: grafana-token
+      remoteRef:
+        key: homepage
+        property: grafana-token

--- a/base-apps/homepage/httproute.yaml
+++ b/base-apps/homepage/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  parentRefs:
+    - name: main
+      namespace: istio-ingress
+      sectionName: https-homepage
+  hostnames:
+    - home.arigsela.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: homepage
+          port: 3000

--- a/base-apps/homepage/mkdocs.yml
+++ b/base-apps/homepage/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: homepage
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Runbook: runbook.md
+plugins:
+  - techdocs-core

--- a/base-apps/homepage/reference-grant.yaml
+++ b/base-apps/homepage/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the ingress Gateway in istio-ingress read this namespace's TLS secret.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-homepage-tls
+  namespace: homepage
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: istio-ingress
+  to:
+    - group: ""
+      kind: Secret
+      name: homepage-tls

--- a/base-apps/homepage/runbook.md
+++ b/base-apps/homepage/runbook.md
@@ -1,0 +1,93 @@
+---
+type: "Kubernetes App Runbook"
+title: "homepage runbook"
+description: "Operational runbook for homepage: failure modes, checks, and fixes."
+app: homepage
+catalog_entity: homepage
+kind: runbook
+namespace: homepage
+last_reviewed: 2026-08-04
+status: current
+tags: [dashboard, gitops, self-hosted]
+sources:
+  - base-apps/homepage/configmap.yaml
+  - base-apps/homepage/deployments.yaml
+  - base-apps/homepage/external-secrets.yaml
+  - base-apps/homepage/secret-store.yaml
+  - base-apps/homepage/httproute.yaml
+  - base-apps/istio-ingress/authorizationpolicy.yaml
+  - terraform/roots/asela-cluster/argocd.tf
+  - scripts/provision-homepage-vault.sh
+---
+
+# homepage runbook
+
+## First-time provisioning
+
+The manifests do not create Vault material. Before the first sync can
+succeed, run `scripts/provision-homepage-vault.sh` inside the `vault-0` pod —
+idempotent, writes `plex-token` and `grafana-token` under `k8s-secrets/homepage`
+plus the matching policy and Kubernetes-auth role, and leaves existing values
+untouched on a re-run:
+
+```bash
+kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
+kubectl -n vault exec -it vault-0 -- sh
+export VAULT_TOKEN=<root-or-admin-token>
+PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh /tmp/prov.sh
+unset VAULT_TOKEN; rm /tmp/prov.sh; exit
+```
+
+`GRAFANA_TOKEN` must be a Grafana **service-account token with the Viewer
+role**, not an admin credential — see the "No authentication of its own"
+section in `docs.md` for why. `PLEX_TOKEN` is Plex's own server access token
+(`X-Plex-Token`), obtainable from an authenticated Plex Web session.
+
+## Failure modes
+
+| Symptom | Check | Fix |
+|---|---|---|
+| Blank page, or requests rejected outright | `kubectl -n homepage exec deploy/homepage -- printenv HOMEPAGE_ALLOWED_HOSTS` | Must contain `home.arigsela.com` and `$(MY_POD_IP):3000`. Homepage rejects any request whose `Host` header isn't listed here; this is the most likely first-boot failure and reads as a generic blank/error page, not an auth error. |
+| Edited `configmap.yaml`, Argo synced Healthy, nothing changed | Pod `AGE` (`kubectl -n homepage get pods`) versus the commit time | `configmap.yaml` is mounted via `subPath`, and Kubernetes never propagates ConfigMap updates into subPath mounts. Bump `checksum/config` in `deployments.yaml` (`shasum -a 256 base-apps/homepage/configmap.yaml \| cut -c1-16`) and re-sync, or `kubectl -n homepage rollout restart deploy/homepage`. |
+| A new app's tile is missing from the dashboard | The six `gethomepage.dev/*` annotations on that app's own `httproute.yaml` | Typo in a key, or `enabled` missing/not `"true"`. Also confirm `gethomepage.dev/group` exactly matches a key under `layout:` in `configmap.yaml`'s `settings.yaml` (`GitOps & Delivery`, `Automation`, `Observability`, `Platform`, `AI & Agents`, `Home`) — a mismatch doesn't error, it just renders into an unconfigured row that's easy to miss. No pod restart is needed either way; annotations are read live. |
+| Two tiles show up for one app | Whether two `HTTPRoute`s in that app's namespace(s) share the same hostname | Annotate only the tile-facing route. This is exactly why `base-apps/weather-kitchen-backend/httproute.yaml` is deliberately **unannotated** — it shares `weather-kitchen.arigsela.com` with `weather-kitchen-frontend`, which carries the annotations. |
+| Plex tile stats blank, but the `href` link still works from a browser | `kubectl run plex-probe --rm -it --restart=Never --image=curlimages/curl:8.10.1 -- curl -m5 http://10.0.1.200:32401/identity` | If this times out from inside the cluster but Plex is reachable from your own LAN device, WSL2 mirrored networking is off (check `%UserProfile%\.wslconfig` on the Windows host after any Windows/WSL update) or the DHCP lease for the WSL2 host moved off `10.0.1.200`. Neither is fixable from Git — see docs.md. |
+| Argo CD tile blank, or all counters read `0` | `count(argocd_app_info)` against Prometheus (`kubectl -n logging port-forward svc/prometheus 9090:9090`, then query) | Zero results means `controller.metrics.enabled` in `terraform/roots/asela-cluster/argocd.tf` was never applied (Atlantis PR not merged/applied) or was reverted, **or** the `argocd-application-controller-metrics` Service lost its `prometheus.io/scrape` annotation and Prometheus stopped scraping it. This is a Terraform/Atlantis problem, not a homepage or Argo CD sync problem — `kubectl -n argo-cd get app homepage` can show Healthy while this tile is empty. |
+| Grafana tile errors (not just blank) | `curl -H "Authorization: Bearer <token>" https://grafana.arigsela.com/api/alertmanager/grafana/api/v2/alerts` | `401`/`403` means the service-account token was revoked or the service account deleted in Grafana's UI — Grafana tokens don't auto-expire unless one was set. Mint a new Viewer-role token and follow "Rotate a credential" below. |
+| `403` on every host, not just `home.arigsela.com` | Your current public source IP against the `ipBlocks` list in `base-apps/istio-ingress/authorizationpolicy.yaml` | Your ISP reassigned your address. This affects every hostname behind the Gateway — homepage is just the one you happen to be looking at when you notice, because it's the landing page. Fix is a PR adding the new address to the shared allow-list, not anything in this app. |
+
+## Rotate a credential (Plex or Grafana token)
+
+1. Write the new value to Vault:
+   ```bash
+   vault kv patch k8s-secrets/homepage plex-token="<new-token>"
+   # or
+   vault kv patch k8s-secrets/homepage grafana-token="<new-token>"
+   ```
+2. The `ExternalSecret` refreshes on its own within an hour (`refreshInterval:
+   1h` in `external-secrets.yaml`), or force it immediately:
+   ```bash
+   kubectl -n homepage annotate externalsecret homepage-secrets force-sync=$(date +%s) --overwrite
+   ```
+3. **Restart the Deployment.** Homepage reads its `HOMEPAGE_VAR_*` env vars
+   once at process start — updating the underlying Kubernetes `Secret` does
+   not make the running container pick up the new value:
+   ```bash
+   kubectl -n homepage rollout restart deploy/homepage
+   ```
+
+Order matters: force-sync before restarting, or the new pod starts holding
+the stale value and you repeat the restart for nothing.
+
+## Deploy / update
+
+GitOps only. Bump `image:` in `base-apps/homepage/deployments.yaml` to a
+pinned tag — never `latest` — and merge to `main`. Because `strategy:
+Recreate`, there is a brief full outage of the dashboard during the swap;
+nothing else in the cluster depends on homepage being up, so this is
+low-risk to do at any time.
+
+Before a version bump, skim the upstream release notes for widget or config
+schema changes — `services.yaml`/`widgets.yaml`/`settings.yaml` shape has
+changed across major versions before, and a schema-incompatible ConfigMap
+after a bump can render as a blank page with no obvious pod-log error.

--- a/base-apps/homepage/secret-store.yaml
+++ b/base-apps/homepage/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: homepage
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "k8s-secrets"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "homepage"
+          serviceAccountRef:
+            name: "default"

--- a/base-apps/homepage/serviceaccount.yaml
+++ b/base-apps/homepage/serviceaccount.yaml
@@ -1,0 +1,40 @@
+# Homepage discovers tiles by reading HTTPRoutes cluster-wide, and reads pods
+# and nodes for health dots and the cluster-resources widget. This is the one
+# new privilege this app introduces: cluster-wide READ on pods and namespaces.
+#
+# Narrower than upstream's example manifest, which also grants ingresses
+# (networking.k8s.io/extensions) and traefik.io ingressroutes. This cluster runs
+# neither — all routing is Gateway API — so those rules are omitted.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: homepage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homepage
+rules:
+  - apiGroups: [""]
+    resources: [namespaces, pods, nodes]
+    verbs: [get, list]
+  - apiGroups: [gateway.networking.k8s.io]
+    resources: [httproutes, gateways]
+    verbs: [get, list]
+  - apiGroups: [metrics.k8s.io]
+    resources: [nodes, pods]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homepage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homepage
+subjects:
+  - kind: ServiceAccount
+    name: homepage
+    namespace: homepage

--- a/base-apps/homepage/services.yaml
+++ b/base-apps/homepage/services.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app: homepage
+    app.kubernetes.io/name: homepage
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: homepage

--- a/base-apps/index.md
+++ b/base-apps/index.md
@@ -33,6 +33,7 @@ stubs pending backfill (see `scripts/agent-docs-scope.txt`).
 | dex | OIDC provider fronting GitHub — issuer for Vault OIDC (human `vault` login via GitHub SSO) | dex | [docs.md](dex/docs.md) | [runbook.md](dex/runbook.md) | [catalog-info.yaml](dex/catalog-info.yaml) |
 | donetick | Self-hosted household chore and task tracker (Go + React), backed by the CNPG Postgres cluster. | donetick | [docs.md](donetick/docs.md) | [runbook.md](donetick/runbook.md) | [catalog-info.yaml](donetick/catalog-info.yaml) |
 | ecr-auth |  |  |  |  |  |
+| homepage | Homelab dashboard listing every cluster app plus the WSL2-hosted Plex server, with live widgets for Plex, Grafana, Argo CD, and cluster resources. | homepage | [docs.md](homepage/docs.md) | [runbook.md](homepage/runbook.md) | [catalog-info.yaml](homepage/catalog-info.yaml) |
 | istio-ingress | The cluster's north-south ingress: a Gateway API Gateway on the `istio` GatewayClass, directly internet-facing | istio-ingress | [docs.md](istio-ingress/docs.md) | [runbook.md](istio-ingress/runbook.md) | [catalog-info.yaml](istio-ingress/catalog-info.yaml) |
 | kagent | Kubernetes-native AI agent platform (kagent Helm controller, declarative agents, MCP tool servers) | kagent | [docs.md](kagent/docs.md) | [runbook.md](kagent/runbook.md) | [catalog-info.yaml](kagent/catalog-info.yaml) |
 | kyverno-policies |  |  |  |  |  |

--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -206,6 +206,21 @@ spec:
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
+    # homepage — restricted. The dashboard enumerates every service in the
+    # homelab and Homepage itself ships no authentication (upstream states none
+    # is planned), so the allow-list is the ONLY control here.
+    - to:
+        - operation:
+            hosts:
+              - home.arigsela.com
+              - home.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
     # n8n WEBHOOK paths - public by design. Webhooks arrive from arbitrary
       # external services and cannot be allow-listed; each workflow authenticates
       # its own. Scoped to the webhook paths ONLY, so the admin UI is untouched.

--- a/base-apps/istio-ingress/gateway.yaml
+++ b/base-apps/istio-ingress/gateway.yaml
@@ -232,6 +232,19 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-homepage
+      protocol: HTTPS
+      port: 443
+      hostname: home.arigsela.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: homepage-tls
+            namespace: homepage
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: https-kagent-mcp
       protocol: HTTPS
       port: 443

--- a/base-apps/kagent/httproute-mcp.yaml
+++ b/base-apps/kagent/httproute-mcp.yaml
@@ -10,6 +10,12 @@ kind: HTTPRoute
 metadata:
   name: kagent-mcp
   namespace: kagent
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Kagent MCP
+    gethomepage.dev/group: AI & Agents
+    gethomepage.dev/icon: mdi-connection
+    gethomepage.dev/description: Kagent MCP endpoint
 spec:
   parentRefs:
     - name: main

--- a/base-apps/kagent/httproute.yaml
+++ b/base-apps/kagent/httproute.yaml
@@ -6,6 +6,12 @@ kind: HTTPRoute
 metadata:
   name: kagent
   namespace: kagent
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Kagent
+    gethomepage.dev/group: AI & Agents
+    gethomepage.dev/icon: mdi-robot
+    gethomepage.dev/description: Agent platform UI
 spec:
   parentRefs:
     - name: main

--- a/base-apps/n8n/httproute.yaml
+++ b/base-apps/n8n/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: n8n
   namespace: n8n
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: n8n
+    gethomepage.dev/group: Automation
+    gethomepage.dev/icon: n8n.png
+    gethomepage.dev/description: Workflow automation
+    gethomepage.dev/pod-selector: app=n8n
 spec:
   parentRefs:
     - name: main

--- a/base-apps/oncall-agent/httproute.yaml
+++ b/base-apps/oncall-agent/httproute.yaml
@@ -4,6 +4,13 @@ kind: HTTPRoute
 metadata:
   name: oncall-agent
   namespace: oncall-agent
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Oncall Agent
+    gethomepage.dev/group: AI & Agents
+    gethomepage.dev/icon: mdi-bell-alert
+    gethomepage.dev/description: AI on-call incident agent
+    gethomepage.dev/pod-selector: app=oncall-agent-api
 spec:
   parentRefs:
     - name: main

--- a/base-apps/oncall-crewai/httproute.yaml
+++ b/base-apps/oncall-crewai/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: oncall-crewai
   namespace: oncall-crewai
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Oncall CrewAI
+    gethomepage.dev/group: AI & Agents
+    gethomepage.dev/icon: mdi-account-group
+    gethomepage.dev/description: Multi-agent incident response
+    gethomepage.dev/pod-selector: app=crewai-frontend
 spec:
   parentRefs:
     - name: main

--- a/base-apps/vault/httproute.yaml
+++ b/base-apps/vault/httproute.yaml
@@ -6,6 +6,13 @@ kind: HTTPRoute
 metadata:
   name: vault
   namespace: vault
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Vault
+    gethomepage.dev/group: Platform
+    gethomepage.dev/icon: vault.png
+    gethomepage.dev/description: Secrets management
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=vault
 spec:
   parentRefs:
     - name: main

--- a/base-apps/weather-kitchen-frontend/httproute.yaml
+++ b/base-apps/weather-kitchen-frontend/httproute.yaml
@@ -15,6 +15,13 @@ kind: HTTPRoute
 metadata:
   name: weather-kitchen-frontend
   namespace: weather-kitchen-frontend
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Weather Kitchen
+    gethomepage.dev/group: Home
+    gethomepage.dev/icon: mdi-weather-partly-cloudy
+    gethomepage.dev/description: Kitchen weather display
+    gethomepage.dev/pod-selector: app=weather-kitchen-frontend
 spec:
   parentRefs:
     - name: main

--- a/scripts/agent-docs-scope.txt
+++ b/scripts/agent-docs-scope.txt
@@ -17,3 +17,4 @@ qwen
 openclaw-qwen
 istio-ingress
 donetick
+homepage

--- a/scripts/provision-homepage-vault.sh
+++ b/scripts/provision-homepage-vault.sh
@@ -3,7 +3,7 @@
 #
 # Creates the scoped Vault secret, policy, and kubernetes-auth role backing the
 # ESO manifests in base-apps/homepage/:
-#   - k8s-secrets/homepage  (props: plex-token, grafana-user, grafana-password)
+#   - k8s-secrets/homepage  (props: plex-token, grafana-token)
 #   - policy homepage       (reads only that one path)
 #   - role   homepage       (default SA @ homepage namespace)
 #
@@ -15,20 +15,21 @@
 #
 #   kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
 #   kubectl -n vault exec -it vault-0 -- sh
-#   PLEX_TOKEN=... GRAFANA_USER=homepage GRAFANA_PASSWORD=... sh /tmp/prov.sh
+#   export VAULT_TOKEN=<root token>
+#   PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh /tmp/prov.sh
 set -eu
 
 : "${PLEX_TOKEN:?set PLEX_TOKEN}"
-: "${GRAFANA_USER:?set GRAFANA_USER}"
-: "${GRAFANA_PASSWORD:?set GRAFANA_PASSWORD}"
+: "${GRAFANA_TOKEN:?set GRAFANA_TOKEN}"
+# Fail loudly here rather than 403-ing on the first vault call.
+: "${VAULT_TOKEN:?set VAULT_TOKEN — run this inside vault-0 with a token that can write policies and auth roles}"
 
 if vault kv get k8s-secrets/homepage >/dev/null 2>&1; then
   echo "k8s-secrets/homepage already exists — leaving values untouched."
 else
   vault kv put k8s-secrets/homepage \
     plex-token="$PLEX_TOKEN" \
-    grafana-user="$GRAFANA_USER" \
-    grafana-password="$GRAFANA_PASSWORD"
+    grafana-token="$GRAFANA_TOKEN"
   echo "wrote k8s-secrets/homepage"
 fi
 

--- a/scripts/provision-homepage-vault.sh
+++ b/scripts/provision-homepage-vault.sh
@@ -7,30 +7,61 @@
 #   - policy homepage       (reads only that one path)
 #   - role   homepage       (default SA @ homepage namespace)
 #
-# SAFE TO RE-RUN: values are written only if absent. Nothing is silently
-# rotated — rotating a value without restarting the pod leaves it holding a
-# stale credential. See base-apps/homepage/runbook.md for rotation.
+# SAFE TO RE-RUN, WITH ONE CAVEAT: the k8s-secrets/homepage write is
+# conditional — it's skipped when the secret is confirmed to already exist,
+# so a plex-token/grafana-token pair already in place is never silently
+# rotated (rotating without restarting the pod would leave it holding a
+# stale credential; see base-apps/homepage/runbook.md). The policy and role
+# writes below are NOT conditional — `vault policy write` and
+# `vault write auth/kubernetes/role/homepage` always run and always
+# overwrite. That's intentional: they write exactly the documented policy/
+# role, so re-running just re-asserts the intended state.
 #
-# How to run (inside the vault-0 pod, matching the donetick pattern):
+# How to run — two routes:
 #
-#   kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
-#   kubectl -n vault exec -it vault-0 -- sh
-#   export VAULT_TOKEN=<root token>
-#   PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh /tmp/prov.sh
+#   1. From your laptop (preferred — lets you use an OIDC/Dex admin token
+#      instead of the break-glass root token):
+#        kubectl -n vault port-forward svc/vault 8200:8200
+#        export VAULT_ADDR=http://127.0.0.1:8200
+#        export VAULT_TOKEN=<OIDC/Dex admin token, or root token>
+#        PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh scripts/provision-homepage-vault.sh
+#
+#   2. Inside the vault-0 pod (matching the donetick pattern):
+#        kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
+#        kubectl -n vault exec -it vault-0 -- sh
+#        export VAULT_TOKEN=<root token>
+#        PLEX_TOKEN=... GRAFANA_TOKEN=glsa_... sh /tmp/prov.sh
 set -eu
 
 : "${PLEX_TOKEN:?set PLEX_TOKEN}"
 : "${GRAFANA_TOKEN:?set GRAFANA_TOKEN}"
 # Fail loudly here rather than 403-ing on the first vault call.
-: "${VAULT_TOKEN:?set VAULT_TOKEN — run this inside vault-0 with a token that can write policies and auth roles}"
+: "${VAULT_TOKEN:?set VAULT_TOKEN to a token that can write policies and auth roles (see header for how to run)}"
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+export VAULT_ADDR VAULT_TOKEN
 
-if vault kv get k8s-secrets/homepage >/dev/null 2>&1; then
+# --- 1. Secret: write once, preserve on re-run -------------------------------
+# `vault kv get` fails for every reason a path can't be read, not just
+# "the secret is absent" — unset/wrong VAULT_ADDR, a sealed Vault, or a token
+# with write-but-not-read on this path would all land here too. Treating any
+# of those as "absent" would silently overwrite live credentials, exactly
+# what the header above promises doesn't happen. So capture the output and
+# only treat it as "go ahead and write" when it's actually a missing-secret
+# response; anything else aborts loudly instead of guessing.
+get_out="$(vault kv get k8s-secrets/homepage 2>&1)" && get_status=0 || get_status=$?
+
+if [ "$get_status" -eq 0 ]; then
   echo "k8s-secrets/homepage already exists — leaving values untouched."
-else
+elif printf '%s\n' "$get_out" | grep -qi 'no value found'; then
   vault kv put k8s-secrets/homepage \
     plex-token="$PLEX_TOKEN" \
     grafana-token="$GRAFANA_TOKEN"
   echo "wrote k8s-secrets/homepage"
+else
+  echo "ERROR: could not determine whether k8s-secrets/homepage exists (not proceeding, to avoid a silent overwrite)." >&2
+  echo "  VAULT_ADDR=$VAULT_ADDR" >&2
+  echo "$get_out" >&2
+  exit 1
 fi
 
 vault policy write homepage - <<'EOF'

--- a/scripts/provision-homepage-vault.sh
+++ b/scripts/provision-homepage-vault.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# homepage — Vault provisioning (one-time, idempotent, safe to re-run)
+#
+# Creates the scoped Vault secret, policy, and kubernetes-auth role backing the
+# ESO manifests in base-apps/homepage/:
+#   - k8s-secrets/homepage  (props: plex-token, grafana-user, grafana-password)
+#   - policy homepage       (reads only that one path)
+#   - role   homepage       (default SA @ homepage namespace)
+#
+# SAFE TO RE-RUN: values are written only if absent. Nothing is silently
+# rotated — rotating a value without restarting the pod leaves it holding a
+# stale credential. See base-apps/homepage/runbook.md for rotation.
+#
+# How to run (inside the vault-0 pod, matching the donetick pattern):
+#
+#   kubectl -n vault cp scripts/provision-homepage-vault.sh vault-0:/tmp/prov.sh
+#   kubectl -n vault exec -it vault-0 -- sh
+#   PLEX_TOKEN=... GRAFANA_USER=homepage GRAFANA_PASSWORD=... sh /tmp/prov.sh
+set -eu
+
+: "${PLEX_TOKEN:?set PLEX_TOKEN}"
+: "${GRAFANA_USER:?set GRAFANA_USER}"
+: "${GRAFANA_PASSWORD:?set GRAFANA_PASSWORD}"
+
+if vault kv get k8s-secrets/homepage >/dev/null 2>&1; then
+  echo "k8s-secrets/homepage already exists — leaving values untouched."
+else
+  vault kv put k8s-secrets/homepage \
+    plex-token="$PLEX_TOKEN" \
+    grafana-user="$GRAFANA_USER" \
+    grafana-password="$GRAFANA_PASSWORD"
+  echo "wrote k8s-secrets/homepage"
+fi
+
+vault policy write homepage - <<'EOF'
+path "k8s-secrets/data/homepage" {
+  capabilities = ["read"]
+}
+path "k8s-secrets/metadata/homepage" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "wrote policy homepage"
+
+vault write auth/kubernetes/role/homepage \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=homepage \
+  policies=homepage \
+  ttl=24h
+echo "wrote role homepage"

--- a/terraform/roots/asela-cluster/argocd.tf
+++ b/terraform/roots/asela-cluster/argocd.tf
@@ -47,6 +47,30 @@ module "argocd" {
           effect = "NoSchedule"
         }
       ]
+      # Creates the argocd-application-controller-metrics Service, which exposes
+      # argocd_app_info on :8082. Without this the metric does not exist at all —
+      # the chart only renders that Service when controller.metrics.enabled.
+      #
+      # The scrape annotations are picked up by the EXISTING Prometheus
+      # `kubernetes-service-endpoints` job (base-apps/logging/prometheus-config.yaml),
+      # which keeps any Service annotated prometheus.io/scrape=true and honors
+      # prometheus.io/port. So no Prometheus config change is needed here.
+      #
+      # Set in this `settings` map rather than as a `set` block in
+      # modules/argocd/helm.tf: helm's set syntax requires escaping the dots in
+      # annotation keys (cf. the `server.config.exec\\.enabled` line there).
+      #
+      # Consumed by the Argo CD tile on home.arigsela.com, which reads Prometheus
+      # instead of the Argo CD API to avoid needing an apiKey account in argocd-cm.
+      metrics = {
+        enabled = true
+        service = {
+          annotations = {
+            "prometheus.io/scrape" = "true"
+            "prometheus.io/port"   = "8082"
+          }
+        }
+      }
     }
 
     # Dex server node placement


### PR DESCRIPTION
Deploys [gethomepage/homepage](https://github.com/gethomepage/homepage) at `home.arigsela.com` — one page listing every app in the cluster plus the Plex server on the Windows/WSL2 box.

## How tiles get defined

Two sources, split by one rule:

> Tiles with a widget live in `configmap.yaml`. Link-only tiles live as annotations on their own `httproute.yaml`. **Never put a credential in an annotation** — annotations are plaintext in Git and Homepage does `{{HOMEPAGE_VAR_*}}` substitution only in config files.

That gives **14 annotated HTTPRoutes + 3 static tiles = 17**. The annotation approach means a tile follows its hostname automatically — the concrete case this avoids is `chores.arigsela.com` changing hands from chores-tracker to donetick, where a static tile would still read "Chores Tracker".

## Widgets

| Tile | Source | Why |
|---|---|---|
| Argo CD | `prometheusmetric` → `argocd_app_info` | An apiKey account needs `argocd-cm`, and this repo's TF module writes to the deprecated `server.config.*` path the chart ignores |
| Grafana | `customapi` + Bearer → firing alert count | That Grafana runs `GF_AUTH_BASIC_ENABLED=false`, so Homepage's built-in `grafana` widget (basic auth only) **cannot** authenticate. Verified: 401 basic, 200 Bearer |
| Plex | `plex` widget → `10.0.1.200:32401` | Port 32401, not the default 32400 |
| Cluster resources | built-in `kubernetes` widget | metrics-server, no credential |

## Terraform

Enables Argo CD controller metrics so `argocd_app_info` exists at all. **Atlantis will autoplan this** — expect an in-place update to `helm_release.argocd` touching only `controller.metrics`. Anything proposing a replacement or an image-tag change means chart drift; stop and investigate.

The Argo CD tile reads `-` until that apply lands. Expected, not broken.

## Security

- Restricted to the existing 4-IP allow-list. Homepage ships **no authentication** and upstream says none is planned, so the `AuthorizationPolicy` is the only control on a page that enumerates every service here.
- Gateway listener and allow rule are in the **same commit and same Argo app** — no window where the host is exposed without a rule, and the policy is deny-by-default so it fails closed.
- Grafana credential is a **Viewer-scoped service-account token**, not admin.
- ClusterRole is read-only and narrower than upstream's (Ingress and Traefik rules dropped — this cluster is Gateway API only).

## Verification status

Built in an isolated worktree, so **nothing here has run against the cluster**. Offline gates all pass: yamllint, kubeconform, 218 tests, 20 apps in agent-docs scope, TechDocs in sync.

Verified against live systems during development: Plex reachable from an in-cluster pod, Grafana's Bearer endpoint, DNS resolving to `73.7.190.154`.

**The post-merge checklist is in `docs/superpowers/plans/2026-08-04-homelab-dashboard.md`** — five ordered phases, starting with a regression check on the other 17 hosts, since this PR edits two files every hostname depends on.

## Known guess

The Argo CD PromQL hardcodes `sync_status="Synced"` / `health_status="Degraded"`. The metric doesn't exist until Atlantis applies, so this couldn't be verified. Queries use `or vector(0)` so a healthy cluster shows `0` — a `-` on OutOfSync/Degraded therefore means the labels are wrong. Fix is one line plus a `checksum/config` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B1TQYVtyN8uXXyXU8owPj