### PR TITLE
homepage: add the required proxmox.yaml config key (fixes CrashLoopBackOff)

### DIFF
--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -124,3 +124,12 @@ data:
   docker.yaml: ""
   custom.css: ""
   custom.js: ""
+
+  # NINE files, not eight. Homepage copies any missing config file from
+  # /app/src/skeleton at startup — but because these are subPath mounts,
+  # /app/config is not writable, so the copy fails with EACCES and the
+  # container exits 1. proxmox.yaml is unused here and stays empty, but it
+  # MUST exist or the pod CrashLoopBackOffs. Verified against the v1.13.2
+  # skeleton, which contains: bookmarks, custom.css, custom.js, docker,
+  # kubernetes, proxmox, services, settings, widgets.
+  proxmox.yaml: ""

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # you edit configmap.yaml without bumping this, the change deploys and
         # does nothing. Recompute with:
         #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
-        checksum/config: "d094a7e545976433"
+        checksum/config: "910dd3cd79b4a78e"
     spec:
       serviceAccountName: homepage
       nodeSelector:
@@ -124,6 +124,11 @@ spec:
             - name: config
               mountPath: /app/config/custom.js
               subPath: custom.js
+            # Unused, but required: Homepage exits 1 if it cannot find or copy
+            # this file, and subPath mounts make /app/config unwritable.
+            - name: config
+              mountPath: /app/config/proxmox.yaml
+              subPath: proxmox.yaml
             - name: logs
               mountPath: /app/config/logs
       volumes:

--- a/base-apps/homepage/docs.md
+++ b/base-apps/homepage/docs.md
@@ -94,7 +94,7 @@ missing" symptom.
 
 ### Why `checksum/config` exists and is mandatory
 
-`configmap.yaml` is mounted into the container as eight individual `subPath`
+`configmap.yaml` is mounted into the container as nine individual `subPath`
 files (`deployments.yaml`), and **Kubernetes never propagates ConfigMap
 updates into subPath mounts** — this is a documented kubelet limitation, not
 a bug specific to this app. Editing `configmap.yaml` and letting Argo CD sync
@@ -111,7 +111,7 @@ ConfigMap edit. Recompute it after any `configmap.yaml` change:
 shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
 ```
 
-The current value baked into `deployments.yaml` is `d094a7e545976433`.
+The current value baked into `deployments.yaml` is `910dd3cd79b4a78e`.
 Forgetting this step is indistinguishable from a successful, no-op deploy —
 Argo CD reports Synced/Healthy either way.
 

--- a/base-apps/homepage/docs/index.md
+++ b/base-apps/homepage/docs/index.md
@@ -94,7 +94,7 @@ missing" symptom.
 
 ### Why `checksum/config` exists and is mandatory
 
-`configmap.yaml` is mounted into the container as eight individual `subPath`
+`configmap.yaml` is mounted into the container as nine individual `subPath`
 files (`deployments.yaml`), and **Kubernetes never propagates ConfigMap
 updates into subPath mounts** — this is a documented kubelet limitation, not
 a bug specific to this app. Editing `configmap.yaml` and letting Argo CD sync
@@ -111,7 +111,7 @@ ConfigMap edit. Recompute it after any `configmap.yaml` change:
 shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
 ```
 
-The current value baked into `deployments.yaml` is `d094a7e545976433`.
+The current value baked into `deployments.yaml` is `910dd3cd79b4a78e`.
 Forgetting this step is indistinguishable from a successful, no-op deploy —
 Argo CD reports Synced/Healthy either way.
 


### PR DESCRIPTION
The `homepage` pod is in `CrashLoopBackOff`:

```
❌ Failed to initialize required config: /app/config/proxmox.yaml
Reason: EACCES: permission denied, copyfile '/app/src/skeleton/proxmox.yaml' -> '/app/config/proxmox.yaml'
```

## Cause

Homepage v1.13.2's skeleton contains **nine** config files. #530 mounted **eight** — `proxmox.yaml` was missed.

Homepage copies any missing config file from `/app/src/skeleton` at startup. Because the ConfigMap is mounted as individual `subPath` files, `/app/config` isn't writable, so the copy fails with `EACCES` and the process exits 1.

The eight-file list came from the upstream Kubernetes install docs page; `src/skeleton/` is authoritative and has nine. That discrepancy was visible during research and the wrong source was used — then propagated into the plan as a Global Constraint, so every reviewer checked against the wrong number.

## Fix

- `proxmox.yaml: ""` added to the ConfigMap (unused, must exist)
- Matching `subPath` mount
- `checksum/config` bumped `d094a7e5…` → `910dd3cd…`, without which the ConfigMap change would sync and do nothing
- `docs.md` corrected from "eight individual subPath mounts" to nine

## Verification

yamllint clean, kubeconform 6/6, 34 tests, 20 apps in scope, TechDocs in sync, all embedded YAML documents parse, 9 ConfigMap keys ↔ 9 subPath mounts.

Everything else from #530 verified working before the crash: 17 tiles across 6 groups, ExternalSecret `SecretSynced`, cert issued, HTTPS 200, `argocd_app_info` labels confirmed correct, Grafana token confirmed Viewer-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B1TQYVtyN8uXXyXU8owPj