### PR TITLE
homepage: wave 1 — tabs, status dots, bookmarks, pod-selectors

### DIFF
--- a/base-apps/coroot/httproute.yaml
+++ b/base-apps/coroot/httproute.yaml
@@ -15,6 +15,9 @@ metadata:
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: mdi-radar
     gethomepage.dev/description: eBPF observability
+    # coroot-coroot-0 only; the cluster-agent and node-agent carry
+    # component=coroot-cluster-agent / -node-agent and must not match.
+    gethomepage.dev/pod-selector: app.kubernetes.io/component=coroot
 spec:
   parentRefs:
     - name: main

--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -1,4 +1,5 @@
-# ALL EIGHT FILES MUST EXIST, even empty ones: Homepage expects the full set.
+# ALL NINE FILES MUST EXIST, even empty ones: Homepage expects the full set
+# and cannot create a missing one (see the proxmox.yaml note at the bottom).
 #
 # These are mounted as individual subPath files (see deployments.yaml), and
 # Kubernetes NEVER propagates ConfigMap updates into subPath mounts. Editing
@@ -14,23 +15,37 @@ data:
   settings.yaml: |
     title: Homelab
     headerStyle: boxed
+    # dot = a coloured indicator instead of the default response-time text.
+    statusStyle: dot
+    # EVERY group below must carry a `tab:`. Homepage shows any group WITHOUT
+    # one on ALL tabs — so a single missing `tab:` silently duplicates that
+    # group across every tab rather than erroring.
+    # Tab order follows the order groups appear here.
     layout:
       GitOps & Delivery:
+        tab: Infra
         style: row
         columns: 3
       Automation:
+        tab: Infra
         style: row
         columns: 2
       Observability:
+        tab: Infra
         style: row
         columns: 2
       Platform:
+        tab: Infra
         style: row
         columns: 3
+      Cloud & Code:
+        tab: Infra
       AI & Agents:
+        tab: Home
         style: row
         columns: 4
       Home:
+        tab: Home
         style: row
         columns: 3
 
@@ -120,7 +135,22 @@ data:
           memory: true
           showLabel: true
 
-  bookmarks.yaml: ""
+  # Bookmark groups sit in the same `layout:` block as service groups and need
+  # a `tab:` there too (see settings.yaml above), or they render on every tab.
+  bookmarks.yaml: |
+    - Cloud & Code:
+        - GitHub:
+            - abbr: GH
+              href: https://github.com/arigsela/kubernetes
+        - Actions:
+            - abbr: CI
+              href: https://github.com/arigsela/kubernetes/actions
+        - AWS:
+            - abbr: AW
+              href: https://console.aws.amazon.com/
+        - Route 53:
+            - abbr: 53
+              href: https://console.aws.amazon.com/route53/v2/hostedzones
   docker.yaml: ""
   custom.css: ""
   custom.js: ""

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # you edit configmap.yaml without bumping this, the change deploys and
         # does nothing. Recompute with:
         #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
-        checksum/config: "910dd3cd79b4a78e"
+        checksum/config: "be8c91e2c613ec12"
     spec:
       serviceAccountName: homepage
       nodeSelector:

--- a/base-apps/kagent/httproute-mcp.yaml
+++ b/base-apps/kagent/httproute-mcp.yaml
@@ -16,6 +16,8 @@ metadata:
     gethomepage.dev/group: AI & Agents
     gethomepage.dev/icon: mdi-connection
     gethomepage.dev/description: Kagent MCP endpoint
+    # This route backends kagent-controller, a different pod from the UI above.
+    gethomepage.dev/pod-selector: app.kubernetes.io/component=controller
 spec:
   parentRefs:
     - name: main

--- a/base-apps/kagent/httproute.yaml
+++ b/base-apps/kagent/httproute.yaml
@@ -12,6 +12,11 @@ metadata:
     gethomepage.dev/group: AI & Agents
     gethomepage.dev/icon: mdi-robot
     gethomepage.dev/description: Agent platform UI
+    # This route backends kagent-ui, so select that pod specifically. Omitting
+    # pod-selector does NOT skip the lookup — Homepage guesses
+    # app.kubernetes.io/name=<service> and logs an error every refresh when it
+    # misses. The kagent namespace runs many independently-labelled agents.
+    gethomepage.dev/pod-selector: app.kubernetes.io/component=ui
 spec:
   parentRefs:
     - name: main


### PR DESCRIPTION
Config-only polish. No new credentials, no new infrastructure.

## Changes

- **`statusStyle: dot`** — coloured indicator instead of response-time text
- **Tabs** — `Infra` (GitOps & Delivery, Automation, Observability, Platform, bookmarks) and `Home` (AI & Agents, Home)
- **Bookmarks** — a "Cloud & Code" group: repo, CI, AWS console, Route 53
- **Pod-selectors** for coroot, kagent, kagent-mcp

## Two things worth reviewing carefully

**1. Every group needs a `tab:`.** Homepage renders any group *without* one on **all** tabs, so a single omission silently duplicates that group rather than failing. All seven groups (six service + one bookmark) are assigned; verified by parsing the config and asserting the set difference is empty.

**2. Omitting `pod-selector` was not neutral.** The original reasoning was that a missing selector just means no health dot. Wrong — Homepage guesses `app.kubernetes.io/name=<service>` and logs an error every refresh. From the live pod:

```
<kubernetesStatusService> no pods found with namespace=coroot and labelSelector=app.kubernetes.io/name=coroot
<kubernetesStatusService> no pods found with namespace=kagent and labelSelector=app.kubernetes.io/name=kagent-mcp
```

Each replacement was checked against the running cluster and matches exactly one pod — the one actually backing that hostname:

| Tile | Backend service | Selector | Pods matched |
|---|---|---|---|
| Coroot | `coroot-coroot` | `app.kubernetes.io/component=coroot` | 1 (excludes cluster-agent and node-agent) |
| Kagent | `kagent-ui` | `app.kubernetes.io/component=ui` | 1 |
| Kagent MCP | `kagent-controller` | `app.kubernetes.io/component=controller` | 1 |

Also corrects the stale "ALL EIGHT FILES" comment left over from #531.

## Verification

yamllint clean, kubeconform 6/6 valid, 34 tests, checksum `910dd3cd…` → `be8c91e2…`, all embedded YAML documents parse, every layout group carries a tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B1TQYVtyN8uXXyXU8owPj