### PR TITLE
homepage: wave 2 — qBittorrent, Sonarr, Radarr, Jellyseerr

### DIFF
--- a/base-apps/homepage/configmap.yaml
+++ b/base-apps/homepage/configmap.yaml
@@ -47,6 +47,10 @@ data:
       Home:
         tab: Home
         style: row
+        columns: 2
+      Media:
+        tab: Home
+        style: row
         columns: 3
 
   kubernetes.yaml: |
@@ -108,11 +112,13 @@ data:
                 - label: Firing
                   format: size
 
-    - Home:
+    # Everything here runs on the Windows/WSL2 box at 10.0.1.200, NOT in the
+    # cluster. It is reachable from pods only because WSL2 mirrored networking
+    # is enabled — see runbook.md. The host needs a DHCP reservation: these IPs
+    # are hardcoded, so a lease change blanks every widget in this group while
+    # the links keep working.
+    - Media:
         - Plex:
-            # Runs on the Windows/WSL2 box, not in the cluster. Reachable only
-            # because of the WSL2 mirrored-networking change documented in
-            # runbook.md. A DHCP lease change here silently blanks the widget.
             href: http://10.0.1.200:32401/web
             description: Media server
             icon: plex.png
@@ -120,6 +126,45 @@ data:
               type: plex
               url: http://10.0.1.200:32401
               key: "{{HOMEPAGE_VAR_PLEX_TOKEN}}"
+        - qBittorrent:
+            href: http://10.0.1.200:8080
+            description: Torrent client
+            icon: qbittorrent.png
+            widget:
+              # qBittorrent has no API key — it authenticates with the WebUI
+              # username and password. "Bypass authentication for clients on
+              # localhost" does not help: the pod is not localhost.
+              type: qbittorrent
+              url: http://10.0.1.200:8080
+              username: "{{HOMEPAGE_VAR_QBIT_USERNAME}}"
+              password: "{{HOMEPAGE_VAR_QBIT_PASSWORD}}"
+        - Sonarr:
+            href: http://10.0.1.200:8989
+            description: TV library manager
+            icon: sonarr.png
+            widget:
+              type: sonarr
+              url: http://10.0.1.200:8989
+              key: "{{HOMEPAGE_VAR_SONARR_KEY}}"
+        - Radarr:
+            href: http://10.0.1.200:7878
+            description: Movie library manager
+            icon: radarr.png
+            widget:
+              type: radarr
+              url: http://10.0.1.200:7878
+              key: "{{HOMEPAGE_VAR_RADARR_KEY}}"
+        - Jellyseerr:
+            href: http://10.0.1.200:5055
+            description: Media requests
+            icon: jellyseerr.png
+            widget:
+              # `seerr`, not `jellyseerr`: Jellyseerr and Overseerr merged into
+              # Seerr upstream. `jellyseerr` still works as an alias today but
+              # is legacy, so prefer the canonical type.
+              type: seerr
+              url: http://10.0.1.200:5055
+              key: "{{HOMEPAGE_VAR_SEERR_KEY}}"
 
   widgets.yaml: |
     - kubernetes:

--- a/base-apps/homepage/deployments.yaml
+++ b/base-apps/homepage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # you edit configmap.yaml without bumping this, the change deploys and
         # does nothing. Recompute with:
         #   shasum -a 256 base-apps/homepage/configmap.yaml | cut -c1-16
-        checksum/config: "be8c91e2c613ec12"
+        checksum/config: "b050dea01b99dbef"
     spec:
       serviceAccountName: homepage
       nodeSelector:
@@ -66,6 +66,31 @@ spec:
                 secretKeyRef:
                   name: homepage-secrets
                   key: grafana-token
+            - name: HOMEPAGE_VAR_QBIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: qbittorrent-username
+            - name: HOMEPAGE_VAR_QBIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: qbittorrent-password
+            - name: HOMEPAGE_VAR_SONARR_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: sonarr-key
+            - name: HOMEPAGE_VAR_RADARR_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: radarr-key
+            - name: HOMEPAGE_VAR_SEERR_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: seerr-key
           ports:
             - containerPort: 3000
               name: http

--- a/base-apps/homepage/external-secrets.yaml
+++ b/base-apps/homepage/external-secrets.yaml
@@ -25,3 +25,26 @@ spec:
       remoteRef:
         key: homepage
         property: grafana-token
+    # Media stack on the WSL2 host (10.0.1.200). Added by
+    # scripts/provision-homepage-media-vault.sh, which PATCHES the same
+    # k8s-secrets/homepage secret rather than replacing it.
+    - secretKey: qbittorrent-username
+      remoteRef:
+        key: homepage
+        property: qbittorrent-username
+    - secretKey: qbittorrent-password
+      remoteRef:
+        key: homepage
+        property: qbittorrent-password
+    - secretKey: sonarr-key
+      remoteRef:
+        key: homepage
+        property: sonarr-key
+    - secretKey: radarr-key
+      remoteRef:
+        key: homepage
+        property: radarr-key
+    - secretKey: seerr-key
+      remoteRef:
+        key: homepage
+        property: seerr-key

--- a/scripts/provision-homepage-media-vault.sh
+++ b/scripts/provision-homepage-media-vault.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# homepage (media widgets) — Vault provisioning (one-time, idempotent)
+#
+# ADDS five properties to the EXISTING k8s-secrets/homepage secret:
+#   qbittorrent-username, qbittorrent-password, sonarr-key, radarr-key, seerr-key
+#
+# Uses `vault kv patch`, NOT `vault kv put`. put REPLACES the whole secret and
+# would silently delete plex-token and grafana-token, breaking the Plex and
+# Grafana tiles. patch merges.
+#
+# No policy or role changes are needed: the `homepage` policy already grants
+# read on k8s-secrets/data/homepage, and these are properties of that same
+# secret.
+#
+# SAFE TO RE-RUN: patch overwrites only the five keys named here. Re-running
+# with the same values is a no-op; re-running with new values rotates them,
+# which requires a pod restart to take effect (env vars are read once at
+# startup) — see base-apps/homepage/runbook.md.
+#
+# How to run — from a laptop, against a port-forward (preferred: uses an
+# OIDC/Dex admin token rather than the break-glass root token):
+#
+#   kubectl port-forward -n vault svc/vault 8200:8200 &
+#   export VAULT_ADDR=http://127.0.0.1:8200
+#   vault login -method=oidc role=admin
+#   QBITTORRENT_USERNAME=... QBITTORRENT_PASSWORD=... \
+#   SONARR_KEY=... RADARR_KEY=... SEERR_KEY=... \
+#     sh scripts/provision-homepage-media-vault.sh
+#
+# Or from inside the vault-0 pod:
+#
+#   kubectl -n vault cp scripts/provision-homepage-media-vault.sh vault-0:/tmp/prov.sh
+#   kubectl -n vault exec -it vault-0 -- sh
+#   export VAULT_TOKEN=<root-or-admin-token>
+#   QBITTORRENT_USERNAME=... ... sh /tmp/prov.sh
+#   unset VAULT_TOKEN; rm /tmp/prov.sh; exit
+set -eu
+
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+export VAULT_ADDR
+
+: "${VAULT_TOKEN:?set VAULT_TOKEN, or run \`vault login\` first — needs write on k8s-secrets/data/homepage}"
+: "${QBITTORRENT_USERNAME:?set QBITTORRENT_USERNAME}"
+: "${QBITTORRENT_PASSWORD:?set QBITTORRENT_PASSWORD}"
+: "${SONARR_KEY:?set SONARR_KEY}"
+: "${RADARR_KEY:?set RADARR_KEY}"
+: "${SEERR_KEY:?set SEERR_KEY}"
+
+# The secret MUST already exist — this only adds to it. If it is missing, the
+# base provisioning never ran; use scripts/provision-homepage-vault.sh first.
+if ! vault kv get k8s-secrets/homepage >/dev/null 2>&1; then
+  echo "ERROR: k8s-secrets/homepage does not exist (or is unreadable)." >&2
+  echo "       Run scripts/provision-homepage-vault.sh first." >&2
+  exit 1
+fi
+
+vault kv patch k8s-secrets/homepage \
+  qbittorrent-username="$QBITTORRENT_USERNAME" \
+  qbittorrent-password="$QBITTORRENT_PASSWORD" \
+  sonarr-key="$SONARR_KEY" \
+  radarr-key="$RADARR_KEY" \
+  seerr-key="$SEERR_KEY"
+
+echo "patched k8s-secrets/homepage with the five media properties"
+echo "existing properties preserved:"
+vault kv get -format=json k8s-secrets/homepage \
+  | grep -oE '"(plex-token|grafana-token)"' | sort -u


### PR DESCRIPTION
⚠️ **Run the Vault script BEFORE merging**, or the ExternalSecret fails and the pod sits in `CreateContainerConfigError` — the `secretKeyRef`s are non-optional.

```bash
kubectl port-forward -n vault svc/vault 8200:8200 &
export VAULT_ADDR=http://127.0.0.1:8200
vault login -method=oidc role=admin

QBITTORRENT_USERNAME=... QBITTORRENT_PASSWORD=... \
SONARR_KEY=... RADARR_KEY=... SEERR_KEY=... \
  sh scripts/provision-homepage-media-vault.sh
```

## What's added

A **Media** group on the Home tab: Plex (moved out of Home), qBittorrent, Sonarr, Radarr, Jellyseerr. `Home` keeps Donetick and Weather Kitchen.

All four verified reachable **from inside a cluster pod** before any config was written — LAN-reachable isn't sufficient, as Plex proved:

```
qbittorrent :8080  200      radarr     :7878  200
sonarr      :8989  200      jellyseerr :5055  307 (login redirect)
```

## Two decisions worth reviewing

**1. `vault kv patch`, not `put`.** The script adds five properties to the *existing* `k8s-secrets/homepage` secret. `vault kv put` replaces the whole secret and would silently delete `plex-token` and `grafana-token`, breaking the two tiles that already work. No policy or role change needed — these are properties of a path the `homepage` policy already reads.

**2. qBittorrent has no API key.** It authenticates with the WebUI username and password, so this adds two properties rather than one. "Bypass authentication for clients on localhost" won't substitute — the pod isn't localhost. Worth a dedicated WebUI account rather than reusing admin.

Jellyseerr uses `type: seerr`: Jellyseerr and Overseerr merged upstream, and `jellyseerr` is now only a legacy alias.

## Verification

The credential chain was checked programmatically, link by link:

```
placeholders   <-> env vars         : match (7)
env secretKeys <-> ExternalSecret   : match (7)
ExternalSecret <-> vault script     : match (7)
```

Plus: every layout group carries a `tab:`, all groups present in layout, yamllint clean, kubeconform 6/6, `sh -n` clean, checksum `be8c91e2…` → `b050dea0…`, all four icons resolve against dashboard-icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B1TQYVtyN8uXXyXU8owPj