### PR TITLE
istio-waf: fix body-inspection scoping and JSON parsing (Gate B4 failure)

### DIFF
--- a/base-apps/istio-waf/docs/runbook.md
+++ b/base-apps/istio-waf/docs/runbook.md
@@ -53,9 +53,18 @@ kubectl -n argo-cd patch application istio-waf --type merge \
 This is the dangerous one — it looks identical to "no attacks."
 - **Check:** is the filter actually attached?
   ```bash
-  istioctl -n istio-ingress proxy-config listener deploy/main-istio -o json | grep -c coraza
+  POD=$(kubectl -n istio-ingress get pods \
+    -l gateway.networking.k8s.io/gateway-name=main -o jsonpath='{.items[0].metadata.name}')
+  kubectl -n istio-ingress exec $POD -c istio-proxy -- \
+    pilot-agent request GET config_dump | grep -c -i coraza
   ```
-  Expect > 0. If 0, the plugin is attached to nothing — check `targetRefs`.
+  Expect > 0 (was 20 when verified 2026-08-11). If 0, the plugin is attached to
+  nothing — check `targetRefs`.
+
+  Use `pilot-agent`, NOT `istioctl` (not installed) and NOT `curl` inside the
+  container (not present in the istio-proxy image). A failed exec produces empty
+  output and `grep -c` then returns 0, which reads exactly like "filter not
+  attached" — that false negative happened during the real Gate A run.
 - **Check:** did the module load?
   ```logql
   {namespace="istio-ingress", container="istio-proxy"} |~ "(?i)(wasm.*(fail|error|unable)|(fail|error|unable).*wasm)"

--- a/base-apps/istio-waf/runbook.md
+++ b/base-apps/istio-waf/runbook.md
@@ -53,9 +53,18 @@ kubectl -n argo-cd patch application istio-waf --type merge \
 This is the dangerous one — it looks identical to "no attacks."
 - **Check:** is the filter actually attached?
   ```bash
-  istioctl -n istio-ingress proxy-config listener deploy/main-istio -o json | grep -c coraza
+  POD=$(kubectl -n istio-ingress get pods \
+    -l gateway.networking.k8s.io/gateway-name=main -o jsonpath='{.items[0].metadata.name}')
+  kubectl -n istio-ingress exec $POD -c istio-proxy -- \
+    pilot-agent request GET config_dump | grep -c -i coraza
   ```
-  Expect > 0. If 0, the plugin is attached to nothing — check `targetRefs`.
+  Expect > 0 (was 20 when verified 2026-08-11). If 0, the plugin is attached to
+  nothing — check `targetRefs`.
+
+  Use `pilot-agent`, NOT `istioctl` (not installed) and NOT `curl` inside the
+  container (not present in the istio-proxy image). A failed exec produces empty
+  output and `grep -c` then returns 0, which reads exactly like "filter not
+  attached" — that false negative happened during the real Gate A run.
 - **Check:** did the module load?
   ```logql
   {namespace="istio-ingress", container="istio-proxy"} |~ "(?i)(wasm.*(fail|error|unable)|(fail|error|unable).*wasm)"

--- a/base-apps/istio-waf/wasmplugin.yaml
+++ b/base-apps/istio-waf/wasmplugin.yaml
@@ -61,16 +61,37 @@ spec:
 
         # ── BODY INSPECTION ────────────────────────────────────────────────
         # Off by default; on only where an external party controls the payload.
-        # n8n's admin UI shares the hostname with its webhooks, so the path guard
-        # is required - running CRS body inspection over the workflow editor's
-        # JSON is a near-certain false positive.
+        #
+        # 9010 IS DELIBERATELY NOT A CHAINED RULE. It was, and the chain did not
+        # bind: Gate B4 (2026-08-11, live) showed a SQL-injection POST body to
+        # n8n's /rest/login firing 942100 via ARGS_POST_NAMES, i.e. body
+        # inspection was active on the WHOLE n8n host including the admin UI -
+        # exactly what the path guard existed to prevent. The chain starter fired
+        # standalone; Coraza's parser appears to treat each directives_map entry
+        # as its own directive, so `chain` never bound to the following SecRule.
+        # Control case that isolates it: the same body sent to grafana (which has
+        # no body rule) fired NOTHING, proving SecRequestBodyAccess Off works and
+        # the chain specifically was the broken part.
+        #
+        # The replacement matches on REQUEST_URI alone, with no host predicate,
+        # which is safe because rule 9000 has already turned the engine OFF for
+        # every host outside the protected set. Within that set: n8n's webhook
+        # paths get bodies and its admin UI does not; grafana has no /webhook*
+        # path; and oncall turns bodies on wholesale via 9011 regardless.
+        # DO NOT reintroduce `chain` here without re-running Gate B4.
         - SecRequestBodyAccess Off
         - SecRequestBodyLimit 1048576
         - SecRequestBodyLimitAction ProcessPartial
-        - |-
-          SecRule REQUEST_HEADERS:Host "@rx ^n8n\.arigsela\.com(:\d+)?$" "id:9010,phase:1,pass,nolog,chain,ctl:requestBodyAccess=On"
-            SecRule REQUEST_URI "@rx ^/(webhook|webhook-test|mcp-server)" "t:lowercase"
+        - SecRule REQUEST_URI "@rx ^/(webhook|webhook-test|mcp-server)" "id:9010,phase:1,pass,nolog,t:lowercase,ctl:requestBodyAccess=On"
         - SecRule REQUEST_HEADERS:Host "@rx ^oncall\.arigsela\.com(:\d+)?$" "id:9011,phase:1,pass,nolog,ctl:requestBodyAccess=On"
+        # JSON bodies must be parsed AS JSON. Without this, Coraza processes them
+        # as URL-encoded form data: Gate B4 observed the entire JSON document
+        # arriving as a single form parameter NAME
+        # (`ARGS_POST_NAMES:{"q":"' OR 1`). That is wrong in both directions - it
+        # can miss a real JSON-borne injection, and it manufactures nonsense
+        # matches out of ordinary payloads. Both of the hosts that get body
+        # inspection here (n8n webhooks, oncall/Slack) send JSON.
+        - SecRule REQUEST_HEADERS:Content-Type "@rx ^application/json" "id:9012,phase:1,pass,nolog,t:lowercase,ctl:requestBodyProcessor=JSON"
 
         # ── LOGGING ────────────────────────────────────────────────────────
         # 3 logs rule matches. Upstream's example uses 9 = every internal

--- a/docs/superpowers/plans/2026-08-11-coraza-waf.md
+++ b/docs/superpowers/plans/2026-08-11-coraza-waf.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- **GitOps only.** Every change is a git commit that Argo CD syncs. No `kubectl apply`, ever (CLAUDE.md, SPEC §C). `kubectl`/`istioctl` are for **reading and verifying** only.
+- **GitOps only.** Every change is a git commit that Argo CD syncs. No `kubectl apply`, ever (CLAUDE.md, SPEC §C). `kubectl` is for **reading and verifying** only (`istioctl` is not installed on this machine; use `pilot-agent request GET config_dump` inside the gateway pod for Envoy config).
 - **Own commit, own sync, own rollback point per component.** Do not batch unrelated changes (SPEC §V.8).
 - **Image pinned:** `oci://ghcr.io/corazawaf/coraza-proxy-wasm:0.6.0`. Never `latest` — an untagged URL flips `imagePullPolicy` to `Always` and lets gateway behaviour change with no commit.
 - **`failStrategy: FAIL_OPEN`** on the WasmPlugin. Istio's default is `FAIL_CLOSE`, which would 5xx all 19 hostnames on a fetch failure or plugin panic.
@@ -293,11 +293,19 @@ Expected: evidence the module fetched and initialised. **A `failed to load` or S
 - [ ] **Step 1: Gate A — prove the filter is in the listener chain**
 
 ```bash
-istioctl -n istio-ingress proxy-config listener \
-  deploy/main-istio -o json | grep -c "coraza"
+POD=$(kubectl -n istio-ingress get pods \
+  -l gateway.networking.k8s.io/gateway-name=main -o jsonpath='{.items[0].metadata.name}')
+kubectl -n istio-ingress exec $POD -c istio-proxy -- \
+  pilot-agent request GET config_dump | grep -c -i coraza
 ```
 
-Expected: a count **greater than 0**.
+Expected: a count **greater than 0** (it was 20 when this ran for real on 2026-08-11).
+
+Use `pilot-agent`, NOT `istioctl` — it is not installed — and NOT `curl` inside
+the container, which the istio-proxy image does not ship. Either mistake makes
+the exec fail, producing empty output that `grep -c` reports as `0`, which is
+indistinguishable from "the filter is not attached". That false negative
+actually occurred on the first Gate A attempt.
 
 If this is `0`, the plugin attached to nothing. Check `targetRefs.name` matches the Gateway (`main`) and that the `WasmPlugin` is in namespace `istio-ingress`. **Do not interpret an absence of detections as success until this passes** — that is precisely the failure this gate exists to catch.
 
@@ -647,9 +655,18 @@ kubectl -n argo-cd patch application istio-waf --type merge \
 This is the dangerous one — it looks identical to "no attacks."
 - **Check:** is the filter actually attached?
   ```bash
-  istioctl -n istio-ingress proxy-config listener deploy/main-istio -o json | grep -c coraza
+  POD=$(kubectl -n istio-ingress get pods \
+    -l gateway.networking.k8s.io/gateway-name=main -o jsonpath='{.items[0].metadata.name}')
+  kubectl -n istio-ingress exec $POD -c istio-proxy -- \
+    pilot-agent request GET config_dump | grep -c -i coraza
   ```
-  Expect > 0. If 0, the plugin is attached to nothing — check `targetRefs`.
+  Expect > 0 (was 20 when verified 2026-08-11). If 0, the plugin is attached to
+  nothing — check `targetRefs`.
+
+  Use `pilot-agent`, NOT `istioctl` (not installed) and NOT `curl` inside the
+  container (not present in the istio-proxy image). A failed exec produces empty
+  output and `grep -c` then returns 0, which reads exactly like "filter not
+  attached" — that false negative happened during the real Gate A run.
 - **Check:** did the module load?
   ```logql
   {namespace="istio-ingress", container="istio-proxy"} |~ "(?i)(wasm.*(fail|error|unable)|(fail|error|unable).*wasm)"

--- a/docs/superpowers/specs/2026-08-11-coraza-waf-design.md
+++ b/docs/superpowers/specs/2026-08-11-coraza-waf-design.md
@@ -45,7 +45,7 @@ For these three, requests reach the application uninspected. That is the gap thi
 - Istio **1.30.3**, `ambient` profile (istiod + `ztunnel` DS + `istio-cni` DS).
 - Gateway `main` in namespace `istio-ingress`, `gatewayClassName: istio`, Gateway API — **not** `IstioOperator`.
 - Gateway runs as a **single pod** pinned to `k3s-control-01` via `nodeSelector`, no `hostNetwork`, `externalTrafficPolicy: Local`.
-- `gateway-options.yaml` sets **no resource requests or limits** — the pod runs on Istio defaults.
+- `gateway-options.yaml` sets no resource block, so the pod runs on Istio's defaults: **2 CPU / 1Gi memory limits**, 100m/128Mi requests (measured 2026-08-11).
 - Observability: Alloy → Loki → Grafana, plus Prometheus. Grafana dashboards mount as **explicit volumes**, not via a sidecar.
 
 ## 3. Why Coraza
@@ -344,7 +344,7 @@ The LogQL behind each panel goes in `runbook.md` as copy-pasteable queries. The 
 
 ### 9.1 The OOM risk deserves emphasis
 
-The Gateway is a **single pod** pinned to `k3s-control-01`, and `gateway-options.yaml` sets **no resources** — it runs on Istio defaults. Adding a compiled CRS plus body-inspection buffers means the WAF's memory failure mode is not "the WAF degrades," it is "all ingress stops."
+The Gateway is a **single pod** pinned to `k3s-control-01`. `gateway-options.yaml` sets no resource block, so Istio's defaults apply: 2 CPU / 1Gi limits. Measured with the WAF loaded (2026-08-11): 43m CPU, 293Mi memory — 29% of the memory limit, under the 50% gate, so no explicit resources block is needed. Adding a compiled CRS plus body-inspection buffers means the WAF's memory failure mode is not "the WAF degrades," it is "all ingress stops."
 
 Gate C establishes the actual limit and observed headroom **before** Phase 2 enables body inspection, and sets an explicit limit on the gateway if the default proves tight.
 


### PR DESCRIPTION
Gate B4 was run live against the deployed plugin (#536) and **failed**. Two defects, both found by probing rather than by reading config. Neither blocks traffic — the WAF is detection-only — but both would corrupt the 7-day observation window that the n8n enforcement decision rests on.

## Defect 1 — rule 9010's chain never bound

A SQL-injection POST body sent to n8n's **`/rest/login`** (not a webhook path) fired `942100`:

```
[data "Matched Data: s&1 found within ARGS_POST_NAMES:{\"q\":\"' OR 1..."]
[uri "/rest/login?wafprobe=b4a"]
```

`ARGS_POST_NAMES` means the **body** was inspected — so body inspection was active across the entire n8n host, including the admin UI. That is exactly what the path guard existed to prevent, and the admin UI is the single most false-positive-prone surface in scope.

**The control case is what makes this conclusive:** the identical body sent to `grafana` (which has no body rule) fired **nothing**. So `SecRequestBodyAccess Off` works correctly and the chain specifically was broken. Coraza appears to treat each `directives_map` entry as its own directive, so `chain` never bound to the `SecRule` that followed it.

**Fix:** drop the chain, match on `REQUEST_URI` alone. Removing the host predicate is safe because rule `9000` has already turned the engine off for every host outside the protected set. Within that set: n8n's webhook paths get bodies and its admin UI does not; grafana has no `/webhook*` path; oncall enables bodies wholesale via `9011` regardless.

## Defect 2 — JSON parsed as URL-encoded form data

Visible in the same evidence: the entire JSON document arrived as a single form parameter **name**. That is wrong in both directions — it can miss a real JSON-borne injection, and it manufactures nonsense matches from ordinary payloads. Both body-inspected hosts (n8n webhooks, oncall/Slack) send JSON.

**Fix:** new rule `9012` setting `ctl:requestBodyProcessor=JSON` on `Content-Type: application/json`.

## Plan corrections the gates exposed

- **Gate A specified `istioctl`, which is not installed.** The working command is `pilot-agent request GET config_dump` inside the gateway pod. Also documented: `curl` is absent from the istio-proxy image, so a failed exec produces empty output that `grep -c` reports as `0` — indistinguishable from "filter not attached". **That false negative actually happened on the first Gate A run** and nearly produced a wrong conclusion.
- **The design doc claimed the gateway has no resource limits.** Istio sets 2 CPU / 1Gi by default. Measured with the WAF loaded: 43m CPU, 293Mi memory — 29% of the limit, under the 50% gate, so no resources block is needed.

## Gate results for the record (from #536)

| Gate | Result |
|---|---|
| A — filter attached | ✅ 20 coraza refs in config_dump |
| B1 — detection fires | ✅ CRS 4.14.0, anomaly score 20, **302 not 403** → `DetectionOnly` honoured (resolves §12.1) |
| B2 — internal hosts excluded | ✅ argocd 200 with XSS payload, no rules; all 9 admin hosts reachable |
| B3 — `:443` no bypass | ✅ same 6 rules fired → `(:\d+)?` guard confirmed |
| B4 — body scoping | ❌ this PR |
| C — memory | ✅ 293Mi/1Gi = 29%, 0 restarts, no wasm errors |

## After merge

Re-run Gate B4 both ways: SQLi body to `/rest/login` must fire **no** `942xxx`; the same body to `/webhook/...` must fire it. Then the 7-day observation window starts.

Verified locally: 14 single-line directives, no `chain` remaining, pytest 10 passed, WAF scope OK, agent-docs 21 apps/0 warnings, TechDocs and OKF in sync, yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ