### PR TITLE
security: restrict oncall.arigsela.com to the IP allow-list (pauses Slack integration)

### DIFF
--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -170,15 +170,40 @@ spec:
             hosts:
               - grafana.arigsela.com
               - grafana.arigsela.com:*
-    # oncall.arigsela.com - PUBLIC BY DESIGN (slack-events-api). No `from` clause, so any
-      # source is permitted. Slack posts Events API callbacks from addresses that are not a stable
-      # allow-listable set. Authenticated at the app layer: SLACK_SIGNING_SECRET
-      # (HMAC) plus API_KEYS. Restricting by IP would break the integration.
+    # oncall.arigsela.com - RESTRICTED 2026-08-11. Was PUBLIC BY DESIGN
+    # (slack-events-api) with no `from` clause.
+    #
+    # THIS PAUSES THE SLACK EVENTS API INTEGRATION. Slack posts callbacks from
+    # AWS addresses it does not publish as a stable set, so there is no allow-list
+    # that keeps Slack working - the choice is public or paused, and paused was
+    # chosen deliberately. If Slack event handling is wanted back, DELETE THIS
+    # `from` BLOCK; nothing else needs to change. The failure mode meanwhile is
+    # silent from Slack's side (it just retries and gives up), so do not expect an
+    # alert to tell you the integration is off.
+    #
+    # Why: with no allow-list this host took 373 requests in a ~1h window, ALL of
+    # them GET scanner traffic hunting web shells (/wp-content/plugins/hellopress/
+    # wp_filemanager.php, /coffee.php, /mgrr.php ...) and ZERO POSTs, i.e. no Slack
+    # traffic at all. The app held up - 193x404, 177x301, and the only three 200s
+    # were `GET /` - so this is not incident response, it is removing an
+    # internet-facing surface that was earning nothing.
+    #
+    # It stays inside the Coraza WAF's scope regex (rule 9000) deliberately: it is
+    # the most-probed host on this Gateway, the allow-list and the WAF are
+    # independent controls, and leaving it covered means protection is already in
+    # place if the `from` block above is ever removed to bring Slack back.
     - to:
         - operation:
             hosts:
               - oncall.arigsela.com
               - oncall.arigsela.com:*
+      from:
+        - source:
+            ipBlocks:
+              - 73.7.190.154/32
+              - 170.85.56.189/32
+              - 170.85.130.202/32
+              - 104.28.177.82/32
     # weather-kitchen - restricted.
     - to:
         - operation:

--- a/base-apps/istio-waf/docs.md
+++ b/base-apps/istio-waf/docs.md
@@ -37,16 +37,30 @@ all, hence reachable from the public internet) until they were given an IP
 allow-list as part of this work (2026-08-11) — see
 `authorizationpolicy.yaml`'s comment on that rule for what that exposure was.
 
-Three hosts are public by design and cannot be IP-restricted:
+Two hosts are public by design and cannot be IP-restricted:
 
 | Host | Why open | App-layer control |
 |---|---|---|
 | `grafana.arigsela.com` | Read from mobile; carrier IPs unlistable | GitHub OAuth |
-| `oncall.arigsela.com` | Slack Events API callbacks | HMAC signing secret |
 | `n8n.arigsela.com` `/webhook*` | Arbitrary external senders | Per-workflow auth |
 
-Coraza covers exactly those three. It is **defence in depth on top of** the
-AuthorizationPolicy, not a replacement for it.
+`oncall.arigsela.com` was a third until **2026-08-11**, when it was given an IP
+allow-list. Slack does not publish stable egress addresses, so there is no
+allow-list that keeps the Events API working — the choice was public or paused,
+and paused was chosen. Deleting the `from` block on that rule in
+`authorizationpolicy.yaml` restores it, and nothing else needs to change.
+
+Coraza's scope regex still covers all **three**, which is a deliberate superset
+of the public set. `oncall` is the most-probed hostname on this Gateway, the
+allow-list and the WAF are independent controls, and keeping it in scope means
+protection is already in place if that `from` block is ever removed.
+
+`scripts/validate-waf-scope.py` enforces the direction that matters — every
+public host must be covered — and does not object to the WAF covering more than
+that.
+
+Coraza is **defence in depth on top of** the AuthorizationPolicy, not a
+replacement for it.
 
 ## Where traffic meets it
 

--- a/base-apps/istio-waf/docs/index.md
+++ b/base-apps/istio-waf/docs/index.md
@@ -37,16 +37,30 @@ all, hence reachable from the public internet) until they were given an IP
 allow-list as part of this work (2026-08-11) — see
 `authorizationpolicy.yaml`'s comment on that rule for what that exposure was.
 
-Three hosts are public by design and cannot be IP-restricted:
+Two hosts are public by design and cannot be IP-restricted:
 
 | Host | Why open | App-layer control |
 |---|---|---|
 | `grafana.arigsela.com` | Read from mobile; carrier IPs unlistable | GitHub OAuth |
-| `oncall.arigsela.com` | Slack Events API callbacks | HMAC signing secret |
 | `n8n.arigsela.com` `/webhook*` | Arbitrary external senders | Per-workflow auth |
 
-Coraza covers exactly those three. It is **defence in depth on top of** the
-AuthorizationPolicy, not a replacement for it.
+`oncall.arigsela.com` was a third until **2026-08-11**, when it was given an IP
+allow-list. Slack does not publish stable egress addresses, so there is no
+allow-list that keeps the Events API working — the choice was public or paused,
+and paused was chosen. Deleting the `from` block on that rule in
+`authorizationpolicy.yaml` restores it, and nothing else needs to change.
+
+Coraza's scope regex still covers all **three**, which is a deliberate superset
+of the public set. `oncall` is the most-probed hostname on this Gateway, the
+allow-list and the WAF are independent controls, and keeping it in scope means
+protection is already in place if that `from` block is ever removed.
+
+`scripts/validate-waf-scope.py` enforces the direction that matters — every
+public host must be covered — and does not object to the WAF covering more than
+that.
+
+Coraza is **defence in depth on top of** the AuthorizationPolicy, not a
+replacement for it.
 
 ## Where traffic meets it
 


### PR DESCRIPTION
Gives `oncall.arigsela.com` the same four `/32` allow-list every other restricted host uses. **This deliberately pauses the Slack Events API integration** — see below.

## Why

Measured over a ~1h window before the change, oncall took **373 requests with no IP filtering**:

- **0 POSTs.** Slack Events callbacks are POSTs, so there was no Slack traffic in the window at all.
- Top paths were web-shell reconnaissance:
  ```
  5  /wp-content/plugins/hellopress/wp_filemanager.php   ← known WP RCE
  4  /this_is_a_new_hello_world.php
  4  /coffee.php
  4  /mgrr.php
  4  /inso.php
  ```
- App responses: **193 × 404, 177 × 301, and exactly three 200s — all `GET /`.**

Nothing reached anything and the app's HMAC held. This is not incident response; it removes an internet-facing surface that was serving only scanners.

## The tradeoff, stated plainly

Slack publishes **no stable egress range** — their senders are AWS addresses that rotate, which is why the original comment on this rule said they are "not a stable allow-listable set". There is no allow-list that keeps the Events API working. The choice was public or paused, and paused was chosen.

**To restore it:** delete the `from` block on this rule. Nothing else needs to change. The comment records that the failure mode is silent from Slack's side — it retries and gives up — so don't expect an alert to reveal the integration is off.

## oncall stays in the WAF's scope, on purpose

The Coraza scope regex (rule `9000`) still covers all three of grafana / oncall / n8n, which is now a deliberate **superset** of the public set:

- oncall is the most-probed hostname on this Gateway.
- The allow-list and the WAF are independent controls; having both is the point.
- If the `from` block is ever removed to bring Slack back, protection is already in place rather than needing to be remembered.

`scripts/validate-waf-scope.py` enforces the direction that matters — every *public* host must be covered — and correctly does not object to the WAF covering more than that.

## Not changed

`grafana.arigsela.com` (GitHub OAuth, needed from mobile where carrier IPs can't be listed) and `n8n.arigsela.com` `/webhook*` (load-bearing for automations) remain public by design.

## Verification

19 rules before and after, with only oncall gaining a `from` — checked structurally, not by eye. pytest 10 passed · WAF scope OK, public set is now `grafana` + `n8n` while scope still covers all three · agent-docs 21 apps/0 warnings · TechDocs and OKF in sync · one **fewer** yamllint warning than main.

## After merge

```
curl -sS -o /dev/null -w '%{http_code}\n' https://oncall.arigsela.com/   # from an off-network IP: expect 403
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ