### PR TITLE
istio-waf: enforce on all three protected hosts

### DIFF
--- a/base-apps/istio-waf/docs.md
+++ b/base-apps/istio-waf/docs.md
@@ -62,6 +62,34 @@ that.
 Coraza is **defence in depth on top of** the AuthorizationPolicy, not a
 replacement for it.
 
+## Current mode: ENFORCING (since 2026-08-11)
+
+All three hosts block. A request scoring >= 5 on the CRS anomaly scale gets a
+`403` from Coraza and never reaches the app. Rolling one host back means
+re-adding its `DetectionOnly` line in `wasmplugin.yaml`; IDs `9001`-`9003` stay
+reserved for that.
+
+**Known, unfixed false positive.** An n8n webhook whose JSON body carries a
+filesystem path is blocked:
+
+```
+{"file":"../reports/x.csv","dir":"/var/log/app"}
+  930110 Path Traversal   matched ../      in ARGS_POST:json.file
+  930120 OS File Access   matched var/log  in ARGS_POST:json.dir
+  949110 anomaly score 15 vs threshold 5   -> 403
+```
+
+Measured before enforcing and accepted deliberately. A blocked webhook fails
+**silently** from the sender's side, so an automation that stops working with no
+error anywhere is the signature. The fix is a scoped exclusion after the CRS
+include (`SecRuleUpdateTargetById 930110 "!ARGS_POST:json.file"`), never raising
+the anomaly threshold — that would weaken every rule at once.
+
+Enforcement was enabled **without** the 7-day observation window the plan calls
+for. The window's job is to surface false positives from real traffic rather
+than invented payloads, and it has not run — so treat unexplained breakage on
+these three hosts as WAF-related until shown otherwise.
+
 ## Where traffic meets it
 
 ```

--- a/base-apps/istio-waf/docs/index.md
+++ b/base-apps/istio-waf/docs/index.md
@@ -62,6 +62,34 @@ that.
 Coraza is **defence in depth on top of** the AuthorizationPolicy, not a
 replacement for it.
 
+## Current mode: ENFORCING (since 2026-08-11)
+
+All three hosts block. A request scoring >= 5 on the CRS anomaly scale gets a
+`403` from Coraza and never reaches the app. Rolling one host back means
+re-adding its `DetectionOnly` line in `wasmplugin.yaml`; IDs `9001`-`9003` stay
+reserved for that.
+
+**Known, unfixed false positive.** An n8n webhook whose JSON body carries a
+filesystem path is blocked:
+
+```
+{"file":"../reports/x.csv","dir":"/var/log/app"}
+  930110 Path Traversal   matched ../      in ARGS_POST:json.file
+  930120 OS File Access   matched var/log  in ARGS_POST:json.dir
+  949110 anomaly score 15 vs threshold 5   -> 403
+```
+
+Measured before enforcing and accepted deliberately. A blocked webhook fails
+**silently** from the sender's side, so an automation that stops working with no
+error anywhere is the signature. The fix is a scoped exclusion after the CRS
+include (`SecRuleUpdateTargetById 930110 "!ARGS_POST:json.file"`), never raising
+the anomaly threshold — that would weaken every rule at once.
+
+Enforcement was enabled **without** the 7-day observation window the plan calls
+for. The window's job is to surface false positives from real traffic rather
+than invented payloads, and it has not run — so treat unexplained breakage on
+these three hosts as WAF-related until shown otherwise.
+
 ## Where traffic meets it
 
 ```

--- a/base-apps/istio-waf/docs/runbook.md
+++ b/base-apps/istio-waf/docs/runbook.md
@@ -132,6 +132,9 @@ Only when all three hold for that host:
 3. Its primary paths were actually exercised — an empty log means *untested*,
    not *clean*.
 
+(Historical — all three were enforced together on 2026-08-11 without this
+window. Kept because it is the correct procedure for any host added later.)
+
 Then delete that host's `DetectionOnly` line, commit, and soak 48 hours before
 the next host. Order is `grafana` → `oncall` → `n8n`, ascending by
 *silent*-failure risk.
@@ -154,7 +157,7 @@ and block, not wait to be noticed.
 Re-run all three probes after every subsequent flip.
 
 ```bash
-# Detects on a protected host (403 once enforcing, 200/302 while DetectionOnly)
+# Detects on a protected host. ENFORCING since 2026-08-11, so expect 403.
 curl -sS -o /dev/null -w '%{http_code}\n' \
   'https://grafana.arigsela.com/?arg=<script>alert(0)</script>'
 

--- a/base-apps/istio-waf/runbook.md
+++ b/base-apps/istio-waf/runbook.md
@@ -132,6 +132,9 @@ Only when all three hold for that host:
 3. Its primary paths were actually exercised — an empty log means *untested*,
    not *clean*.
 
+(Historical — all three were enforced together on 2026-08-11 without this
+window. Kept because it is the correct procedure for any host added later.)
+
 Then delete that host's `DetectionOnly` line, commit, and soak 48 hours before
 the next host. Order is `grafana` → `oncall` → `n8n`, ascending by
 *silent*-failure risk.
@@ -154,7 +157,7 @@ and block, not wait to be noticed.
 Re-run all three probes after every subsequent flip.
 
 ```bash
-# Detects on a protected host (403 once enforcing, 200/302 while DetectionOnly)
+# Detects on a protected host. ENFORCING since 2026-08-11, so expect 403.
 curl -sS -o /dev/null -w '%{http_code}\n' \
   'https://grafana.arigsela.com/?arg=<script>alert(0)</script>'
 

--- a/base-apps/istio-waf/wasmplugin.yaml
+++ b/base-apps/istio-waf/wasmplugin.yaml
@@ -53,11 +53,32 @@ spec:
         - SecRule REQUEST_HEADERS:Host "!@rx ^(grafana|oncall|n8n)\.arigsela\.com(:\d+)?$" "id:9000,phase:1,pass,nolog,ctl:ruleEngine=Off"
 
         # ── ENFORCEMENT MODE ───────────────────────────────────────────────
-        # A host listed here LOGS BUT DOES NOT BLOCK.
-        # Flipping a host to enforcement = DELETING ITS LINE.
-        - SecRule REQUEST_HEADERS:Host "@rx ^grafana\.arigsela\.com(:\d+)?$" "id:9001,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
-        - SecRule REQUEST_HEADERS:Host "@rx ^oncall\.arigsela\.com(:\d+)?$" "id:9002,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
-        - SecRule REQUEST_HEADERS:Host "@rx ^n8n\.arigsela\.com(:\d+)?$" "id:9003,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
+        # ENFORCING on all three protected hosts since 2026-08-11. A request
+        # scoring >= 5 on the CRS anomaly scale now gets 403 from Coraza and
+        # never reaches the app.
+        #
+        # TO ROLL A HOST BACK, re-add its line here - that is the whole fix:
+        #   - SecRule REQUEST_HEADERS:Host "@rx ^grafana\.arigsela\.com(:\d+)?$" "id:9001,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
+        #   - SecRule REQUEST_HEADERS:Host "@rx ^oncall\.arigsela\.com(:\d+)?$"  "id:9002,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
+        #   - SecRule REQUEST_HEADERS:Host "@rx ^n8n\.arigsela\.com(:\d+)?$"     "id:9003,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
+        # Rule IDs 9001-9003 stay reserved for exactly that purpose.
+        #
+        # KNOWN, UNFIXED FALSE POSITIVE - accepted deliberately, not overlooked.
+        # An n8n webhook whose JSON body carries a filesystem path is blocked:
+        #   {"file":"../reports/x.csv","dir":"/var/log/app"}
+        #     930110 Path Traversal   matched `../`     in ARGS_POST:json.file
+        #     930120 OS File Access   matched `var/log` in ARGS_POST:json.dir
+        #     949110 anomaly score 15, threshold 5  -> 403
+        # Measured 2026-08-11 before enforcing. A blocked webhook fails SILENTLY
+        # from the sender's side, so if an automation stops working with no error
+        # anywhere, look here first. The fix when wanted is a scoped exclusion
+        # after the CRS include, NOT raising the anomaly threshold:
+        #   SecRuleUpdateTargetById 930110 "!ARGS_POST:json.file"
+        #
+        # Enforcement was enabled without the 7-day observation window the plan
+        # calls for. That was a deliberate, informed decision; the window's
+        # purpose is to find false positives like the one above from real traffic
+        # rather than from invented payloads, and it has not run.
 
         # ── BODY INSPECTION ────────────────────────────────────────────────
         # Off by default; on only where an external party controls the payload.


### PR DESCRIPTION
Removes the `DetectionOnly` guards. **grafana, oncall and n8n now block** — a request scoring ≥ 5 on the CRS anomaly scale gets a `403` from Coraza and never reaches the app.

## Measured before flipping

**Clean:**
- Grafana across 5 realistic endpoints, including a PromQL `sum(rate(...))` query → **0 detections**. No body inspection on that host, so only headers and URI are examined.
- 5 of 6 realistic webhook payloads: plain JSON, apostrophes (`O'Brien` — the classic SQLi false positive), URLs, HTML/markdown, SQL-ish prose.

**Admin tooling is not newly at risk.** Rule `9000` sets `ruleEngine=Off` for the 16 internal hosts independently of these guards. argocd fired 5 rules at anomaly score 20 and still returned **200** — that path is unchanged by this PR.

## ⚠️ Known, unfixed false positive — accepted deliberately

```
{"file":"../reports/x.csv","dir":"/var/log/app"}
  930110 Path Traversal   matched ../      in ARGS_POST:json.file
  930120 OS File Access   matched var/log  in ARGS_POST:json.dir
  949110 anomaly score 15 vs threshold 5   → 403
```

An n8n webhook whose JSON body carries a filesystem path **is now blocked**. Score 15 against a threshold of 5 — three times over.

A blocked webhook fails **silently** from the sender's side: it retries and gives up, and nothing in n8n records that the request never arrived. **An automation that quietly stops working is the signature.** This is recorded in the manifest, `docs.md` and `runbook.md` so there's an obvious first place to look.

The fix when wanted is a scoped exclusion after the CRS include:

```
SecRuleUpdateTargetById 930110 "!ARGS_POST:json.file"
```

Never raise the anomaly threshold to fix one rule — that weakens every rule at once.

## Process note

Enforcement was enabled **without** the 7-day observation window the plan calls for. That was a deliberate, informed decision by the repo owner. Worth stating plainly: the window's purpose is to surface false positives from *real* traffic rather than from payloads I invented, and it has not run. The one false positive above was found by guessing what a webhook might contain — there may be others that a week of real traffic would have caught.

Treat unexplained breakage on these three hosts as WAF-related until shown otherwise.

## Rollback

Re-add one line. IDs `9001`–`9003` stay reserved for exactly this:

```yaml
- SecRule REQUEST_HEADERS:Host "@rx ^n8n\.arigsela\.com(:\d+)?$" "id:9003,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly"
```

Or disable everything with one word: `SecRuleEngine Off`.

## After merge

The dashboard's two empty panels — *Requests blocked* and *Blocks by rule* — become live. I'll verify: grafana XSS → 403 (was 302), argocd XSS → still 200, and the path-traversal payload → 403, confirming the known FP is real rather than theoretical.

Verified: 11 directives, no DetectionOnly guards remain, scope guard `9000` intact, body rules and JSON processor unchanged · pytest 10 passed · WAF scope OK · agent-docs, TechDocs, OKF in sync · yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ