### PR TITLE
logging: fix the two block panels, which only broke once blocks existed

### DIFF
--- a/base-apps/logging/grafana-dashboard-coraza.yaml
+++ b/base-apps/logging/grafana-dashboard-coraza.yaml
@@ -135,7 +135,7 @@ data:
         {
           "type": "stat",
           "title": "Requests blocked by the WAF",
-          "description": "waf_filter_tx_interruptions counts actual BLOCKS. 'No data' while every host is in DetectionOnly is correct, not broken. It fills in once a host is flipped to enforcement.",
+          "description": "waf_filter_tx_interruptions counts actual BLOCKS. __name__ MUST stay in the inner aggregation - Envoy bakes rule_id and phase into the metric NAME, so dropping it collapses every rule into one series and undercounts.",
           "id": 4,
           "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
           "datasource": {"type": "prometheus"},
@@ -143,7 +143,7 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus"},
-              "expr": "sum(max by (pod) ({__name__=~\"waf_filter_tx_interruptions.*\"}))",
+              "expr": "sum(max by (pod, __name__) ({__name__=~\"waf_filter_tx_interruptions.*\"}))",
               "legendFormat": "blocked"
             }
           ],
@@ -237,9 +237,9 @@ data:
           }
         },
         {
-          "type": "timeseries",
-          "title": "Blocks by rule — active only after enforcement",
-          "description": "Interruptions by rule_id and phase. Empty during DetectionOnly by design. After a flip, a spike on one rule means a false positive hit real traffic - roll that host back.",
+          "type": "table",
+          "title": "Blocks by rule — cumulative",
+          "description": "Cumulative blocks per rule. Envoy does NOT expose rule_id or phase as labels - they are baked into the metric name - and any range function (rate, increase) strips __name__, leaving identical labelsets that Prometheus rejects. So this is an instant table, not a rate graph. A rule appearing here that matches your own traffic is a false positive: roll that host back.",
           "id": 8,
           "gridPos": {"h": 8, "w": 24, "x": 0, "y": 21},
           "datasource": {"type": "prometheus"},
@@ -247,12 +247,13 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus"},
-              "expr": "sum by (rule_id, phase) (max by (pod, rule_id, phase) (rate({__name__=~\"waf_filter_tx_interruptions.*\"}[5m])))",
-              "legendFormat": "rule {{rule_id}} / {{phase}}"
+              "expr": "sum by (__name__) (max by (pod, __name__) ({__name__=~\"waf_filter_tx_interruptions.*\"}))",
+              "instant": true,
+              "format": "table"
             }
           ],
           "fieldConfig": {
-            "defaults": {"custom": {"drawStyle": "bars", "fillOpacity": 70}, "unit": "reqps", "noValue": "No blocks — every host is in DetectionOnly"},
+            "defaults": {"unit": "short", "noValue": "No blocks recorded"},
             "overrides": []
           }
         },


### PR DESCRIPTION
Both block panels were broken. Neither could have been caught earlier, and that is the interesting part: **they were validated while `waf_filter_tx_interruptions` had zero series**, so the defect had nothing to manifest against. Enforcement produced the first real blocks and both failed immediately.

Validating against empty data is not validating.

## Root cause

Envoy does not expose `rule_id` or `phase` as Prometheus labels. It bakes them into the metric **name**:

```
waf_filter_tx_interruptions_ruleid_949110_phase_http_request_body
```

The only labels available are `__name__`, `container`, `instance`, `job`, `namespace`, `pod`.

## Defect 1 — panel 4 undercounted (silent)

`sum(max by (pod) (...))` drops `__name__`, so every rule collapsed into a single series and `max` returned **1** where the correct total was **2**.

It displayed a plausible wrong number. That is worse than an error — an error gets investigated; a wrong number gets believed. Two requests were blocked (the grafana XSS probe and the n8n path-traversal payload) and the panel said one.

Fixed with `max by (pod, __name__)` — verified returning 2.

## Defect 2 — panel 8 errored (loud)

`rate()` strips `__name__`, leaving two identical labelsets, which Prometheus rejects:

```
vector cannot contain metrics with the same labelset
```

I confirmed **no range function survives a multi-name selector** here — `rate()` and `increase()` both fail, with or without a single-job filter. So the panel is now an **instant table of cumulative blocks per rule** rather than a rate graph. Blocks-over-time is still available from panel 4's sparkline.

Both descriptions now carry the reason, so the next person does not reintroduce a `rate()` here.

## Re-validated with real data present

All 9 Prometheus expressions run against live Prometheus, this time with actual blocks recorded:

```
[1] health          0
[2] transactions    1397
[3] memory %        35.5
[4] blocked         2        ← was reporting 1
[5] throughput      0.24/s
[6] mem vs limit    380809216 / 1073741824
[7] responses       20 series
[8] blocks by rule  2 series ← was erroring
```

pytest 10 passed · agent-docs 21 apps/0 warnings · yamllint clean · dashboard JSON parses, 10 panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ