### PR TITLE
logging: bound the Prometheus TSDB so it stops eating worker-01's disk

### DIFF
--- a/base-apps/logging/docs.md
+++ b/base-apps/logging/docs.md
@@ -54,7 +54,12 @@ under `base-apps/logging/`.
    `/loki` mount is an `emptyDir`).
 3. **Prometheus** (`prometheus-statefulset.yaml`, single-replica StatefulSet, image
    `prom/prometheus:v3.0.1`) stores metrics on a 50Gi `local-path` PVC with 15-day retention
-   (`--storage.tsdb.retention.time=15d`) and has `--web.enable-remote-write-receiver` on so it
+   (`--storage.tsdb.retention.time=15d`) bounded by a 40GB size cap
+   (`--storage.tsdb.retention.size=40GB`, base-2, so ~43 GB on disk). The size cap matters
+   because `local-path` is a hostPath directory with no quota enforcement — without it the
+   TSDB grew to 59 GB, past its own 50Gi request, consuming worker-01's root filesystem.
+   Whichever limit trips first wins, so sustained ingest growth shortens the retention
+   window rather than filling the node. It has `--web.enable-remote-write-receiver` on so it
    can accept Alloy's remote-write pushes. `prometheus-config.yaml` also has it self-scrape
    the Kubernetes API server, nodes, cAdvisor, and any pod/service annotated for scraping —
    so it collects both from its own service discovery and from Alloy's forwarded metrics.

--- a/base-apps/logging/docs/index.md
+++ b/base-apps/logging/docs/index.md
@@ -54,7 +54,12 @@ under `base-apps/logging/`.
    `/loki` mount is an `emptyDir`).
 3. **Prometheus** (`prometheus-statefulset.yaml`, single-replica StatefulSet, image
    `prom/prometheus:v3.0.1`) stores metrics on a 50Gi `local-path` PVC with 15-day retention
-   (`--storage.tsdb.retention.time=15d`) and has `--web.enable-remote-write-receiver` on so it
+   (`--storage.tsdb.retention.time=15d`) bounded by a 40GB size cap
+   (`--storage.tsdb.retention.size=40GB`, base-2, so ~43 GB on disk). The size cap matters
+   because `local-path` is a hostPath directory with no quota enforcement — without it the
+   TSDB grew to 59 GB, past its own 50Gi request, consuming worker-01's root filesystem.
+   Whichever limit trips first wins, so sustained ingest growth shortens the retention
+   window rather than filling the node. It has `--web.enable-remote-write-receiver` on so it
    can accept Alloy's remote-write pushes. `prometheus-config.yaml` also has it self-scrape
    the Kubernetes API server, nodes, cAdvisor, and any pod/service annotated for scraping —
    so it collects both from its own service discovery and from Alloy's forwarded metrics.

--- a/base-apps/logging/prometheus-statefulset.yaml
+++ b/base-apps/logging/prometheus-statefulset.yaml
@@ -70,6 +70,11 @@ spec:
           - '--config.file=/etc/prometheus/prometheus.yml'
           - '--storage.tsdb.path=/prometheus'
           - '--storage.tsdb.retention.time=15d'
+          # Hard ceiling on the TSDB. The PVC is `local-path`, which is a hostPath
+          # directory with no quota enforcement, so time-based retention alone let the
+          # TSDB grow past its 50Gi request and eat worker-01's root disk. 40GB is
+          # powers-of-2 here (Prometheus size units are base-2), i.e. ~43 GB on disk.
+          - '--storage.tsdb.retention.size=40GB'
           - '--web.console.libraries=/usr/share/prometheus/console_libraries'
           - '--web.console.templates=/usr/share/prometheus/consoles'
           - '--web.enable-lifecycle'


### PR DESCRIPTION
## Why

Investigating a Coroot "disk space > 80%" warning on `coroot-clickhouse-keeper` turned up two things:

1. **The alert was a red herring.** `data-coroot-clickhouse-keeper-1` holds **147 MB** against its 10Gi request. All Coroot PVCs are `local-path` (hostPath), which have no separate filesystem, so Coroot reports the *node's* root disk for every PVC on that node. Nothing is wrong with ClickHouse Keeper.

2. **The real growth driver is Prometheus**, on a different node. Its PVC is at **59.2 GB against a declared 50Gi** — already 9 GB over. `local-path` enforces no quota, so the request is advisory and the TSDB writes straight into worker-01's root filesystem.

Retention itself was working: 24 blocks spanning Jul 28 → Aug 11 (14 days), consistent with `--storage.tsdb.retention.time=15d`. The issue is that 15 days of metrics now *costs* 59 GB at current ingest, and no size limit existed to cap it.

## What changed

Adds `--storage.tsdb.retention.size=40GB` alongside the existing time-based retention. Prometheus size units are powers-of-2, so this is ~43 GB on disk, leaving headroom under the 50Gi request.

Whichever limit trips first now wins — so as ingest grows, the retention *window* shortens instead of the node filling up.

## Trade-off

Reclaims ~16 GB on worker-01 immediately by dropping the oldest blocks, cutting the effective window from ~14 days to roughly **10–11 days** at current ingest. If you'd rather keep the full 15 days, the alternative is growing the PVC and the node's disk instead — raising `retention.size` is a one-line change later.

## Measurements

Taken read-only from the nodes (diagnostic pods deleted afterward):

| Node | Root disk | containerd | journal | Notable PVC |
|---|---|---|---|---|
| k3s-worker-01 | 124 / 193 GB (64%) | 48.7 GB | 3.0 GB | **prometheus 59.2 GB** |
| k3s-worker-02 | 42.1 / 50.9 GB (83%) | 31.9 GB | 2.8 GB | all PVCs <1 GB |

## Not addressed here

- **worker-02 at 83%** is a separate, structural problem: a 51 GB disk carrying the same pod count (37) as worker-01's 193 GB disk, with 31.9 GB of it legitimate container images. Only 0.6 GB is reclaimable by image GC, so GC can't dig it out — k3s's default 85% GC threshold hasn't even fired yet. Being handled by growing that node's disk.
- **No node-level disk alerting exists.** This Prometheus has no node-exporter metrics (`node_filesystem_*` is absent), which is why disk pressure surfaced as a misleading PVC warning in Coroot rather than a node alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ