### PR TITLE
istio-waf: stop Coroot's own UI tripping the WAF content-type rule

### DIFF
--- a/base-apps/istio-waf/docs.md
+++ b/base-apps/istio-waf/docs.md
@@ -132,11 +132,32 @@ first panel watches Wasm load errors rather than only rule hits. An empty
 | Which hosts are inspected | rule `9000` scope regex, `wasmplugin.yaml` |
 | Whether a host blocks or logs | rules `9001`–`9003` (present = log only) |
 | Body inspection | rules `9010` (n8n, path-scoped), `9011` (oncall) |
+| CRS tuning (allow-lists) | rule `9100`, between the two `Include` lines |
 | CRS exclusions | end of the `default` directives list |
 | Log verbosity | `SecDebugLogLevel` |
 
+### Rule 9000 does not stop logging
+
+`ctl:ruleEngine=Off` suppresses *blocking* on unprotected hosts, but CRS rules
+still evaluate and still write to the error log. Observed 2026-08-11..12:
+`POST /stats` on `coroot.arigsela.com` — outside the protected set — returned
+`200` while emitting `920420` and `949111` at Envoy `critical`.
+
+Two consequences worth remembering. Unprotected hosts are a live source of
+`critical` log lines, which Coroot's log alerting reports as "fatal in the
+logs" even though nothing is being enforced. And the anomaly scores those hosts
+accumulate are real: a host sitting at or above 5 is already at the blocking
+threshold, so adding it to rule `9000`'s regex starts returning 403 on its very
+first request. Check what a host currently scores before promoting it.
+
+Rule `9100` exists because of exactly that trap — Coroot's UI would have been
+blocked by its own telemetry the moment the host was promoted.
+
 ## Adding a fourth host
 
+0. Check what it already scores. Unprotected hosts still evaluate CRS (see
+   above), so grep the gateway log for its traffic first — a host already
+   hitting `949111` is at the blocking threshold and will 403 immediately.
 1. Add it to rule `9000`'s regex.
 2. Add a `DetectionOnly` line for it in the `9001`–`9003` block.
 3. Observe ≥7 days, tune (see runbook).

--- a/base-apps/istio-waf/docs/index.md
+++ b/base-apps/istio-waf/docs/index.md
@@ -132,11 +132,32 @@ first panel watches Wasm load errors rather than only rule hits. An empty
 | Which hosts are inspected | rule `9000` scope regex, `wasmplugin.yaml` |
 | Whether a host blocks or logs | rules `9001`–`9003` (present = log only) |
 | Body inspection | rules `9010` (n8n, path-scoped), `9011` (oncall) |
+| CRS tuning (allow-lists) | rule `9100`, between the two `Include` lines |
 | CRS exclusions | end of the `default` directives list |
 | Log verbosity | `SecDebugLogLevel` |
 
+### Rule 9000 does not stop logging
+
+`ctl:ruleEngine=Off` suppresses *blocking* on unprotected hosts, but CRS rules
+still evaluate and still write to the error log. Observed 2026-08-11..12:
+`POST /stats` on `coroot.arigsela.com` — outside the protected set — returned
+`200` while emitting `920420` and `949111` at Envoy `critical`.
+
+Two consequences worth remembering. Unprotected hosts are a live source of
+`critical` log lines, which Coroot's log alerting reports as "fatal in the
+logs" even though nothing is being enforced. And the anomaly scores those hosts
+accumulate are real: a host sitting at or above 5 is already at the blocking
+threshold, so adding it to rule `9000`'s regex starts returning 403 on its very
+first request. Check what a host currently scores before promoting it.
+
+Rule `9100` exists because of exactly that trap — Coroot's UI would have been
+blocked by its own telemetry the moment the host was promoted.
+
 ## Adding a fourth host
 
+0. Check what it already scores. Unprotected hosts still evaluate CRS (see
+   above), so grep the gateway log for its traffic first — a host already
+   hitting `949111` is at the blocking threshold and will 403 immediately.
 1. Add it to rule `9000`'s regex.
 2. Add a `DetectionOnly` line for it in the `9001`–`9003` block.
 3. Observe ≥7 days, tune (see runbook).

--- a/base-apps/istio-waf/wasmplugin.yaml
+++ b/base-apps/istio-waf/wasmplugin.yaml
@@ -122,6 +122,34 @@ spec:
 
         # ── RULES ──────────────────────────────────────────────────────────
         - Include @crs-setup-conf
+
+        # CRS TUNING - must sit BETWEEN the two includes: crs-setup defines the
+        # default, the rules include consumes it. Below the rules include it
+        # would be assigned after 920420 has already read the variable.
+        #
+        # Adds |text/plain| to the CRS 4.14 default allow-list. Coroot's own UI
+        # POSTs telemetry to /stats as text/plain, which 920420 rejects for +5
+        # anomaly - exactly the inbound threshold, so 949111 fires too. Measured
+        # 2026-08-11..12: 21 such requests, 42 of the ~130 daily Envoy `critical`
+        # lines, and both recurring "main-istio fatal in the logs" Coroot alerts.
+        # Every one returned 200, because coroot.arigsela.com is outside rule
+        # 9000's protected set - so this was pure log noise with no enforcement
+        # behind it. It was also a live trap: adding coroot to the protected
+        # regex would have started 403ing Coroot's own UI on day one.
+        #
+        # SCOPE COST, stated plainly: this is global, so text/plain stops being
+        # flagged on grafana/oncall/n8n too. Accepted because bodies are not
+        # inspected there by default (SecRequestBodyAccess Off; only /webhook*
+        # and oncall turn it on, and both senders use JSON), so 920420 was
+        # protocol hygiene rather than a control doing real work.
+        # NOT scoped with `chain` - chains do not bind in this parser, see the
+        # 9010 note above. NOT done with ctl:ruleRemoveById either: rule 9000
+        # already demonstrates that ctl actions misbehave here (ctl:ruleEngine=Off
+        # stops blocking but NOT rule evaluation or logging, which is the very
+        # reason these lines reach the log). A setvar the rule reads itself has
+        # no such ambiguity.
+        - SecAction "id:9100,phase:1,nolog,pass,t:none,setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |text/plain|'"
+
         - Include @owasp_crs/*.conf
 
         # ── EXCLUSIONS ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Chasing the recurring `main-istio` "new fatal in the logs" alerts in Coroot. They are **not** a wasm crash — Coraza maps CRS rule severity onto Envoy log levels, so any rule tagged `[severity "critical"]` or `"emergency"` prints as an Envoy `critical` line, and Coroot's log alerting calls that "fatal".

The trigger is Coroot itself. Its UI `POST`s telemetry to `/stats` with `Content-Type: text/plain`. CRS `920420` rejects that content type for +5 anomaly — exactly the inbound threshold — so `949111` fires alongside it.

Measured 2026-08-11..12:

| | |
|---|---|
| `/stats` requests | 21 (all on `coroot.arigsela.com`) |
| Critical log lines produced | 42 of ~130/day |
| HTTP status returned | **200, every one** |

Zero enforcement behind the noise: `coroot.arigsela.com` is outside rule `9000`'s protected set. The alerts were fed by nothing more than having the dashboard open in a browser.

## The latent trap this also closes

Rule `9000`'s `ctl:ruleEngine=Off` suppresses *blocking* but **not rule evaluation or logging**. Unprotected hosts still accumulate real anomaly scores. Coroot was already sitting at the blocking threshold, so adding it to the protected regex would have started 403ing its own UI on the first request — and the "adding a fourth host" checklist had nothing telling you to check.

Docs now record that behaviour, plus a step 0 to check a host's existing score before promoting it.

## What changed

`SecAction id:9100` adds `|text/plain|` to the CRS 4.14 content-type allow-list, placed **between** the two `Include` lines — `crs-setup` defines the default, the rules include consumes it, so anywhere below would assign the variable after `920420` has already read it.

Deliberately **not** `chain` (does not bind in this parser — see the `9010` note) and **not** `ctl:ruleRemoveById`, since `ctl` actions are precisely what misbehaves here. A `setvar` the rule reads itself has no such ambiguity.

## Scope cost, stated plainly

This is global: `text/plain` stops being flagged on `grafana`/`oncall`/`n8n` too. Accepted because bodies are not inspected on those hosts by default (`SecRequestBodyAccess Off`; only `/webhook*` and `oncall` enable it, and both senders send JSON), so `920420` was protocol hygiene rather than a control doing real work.

## ⚠️ Not verified live

The authz allow-list contains only public IPs and NAT hairpin fails from the LAN, so **no probe path exists from inside the cluster or the LAN**. This file's own `9010` note records a change that silently did not bind and was caught only by live testing, so please probe from an allow-listed source before trusting this:

```bash
# from an allow-listed IP — expect 404 from Coroot, and NO new 920420/949111 lines
curl -sk -o /dev/null -w "%{http_code}\n" -X POST \
  -H "Content-Type: text/plain" --data probe \
  https://coroot.arigsela.com/stats-probe

kubectl logs -n istio-ingress deploy/main-istio --since=2m | grep -cE '920420|949111'
```

`scripts/validate-waf-scope.py` passes. Enforcement on the three protected hosts is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164ycyT3Ea6hLDjnLLt2UeZ