### PR TITLE
istio-ingress: follow the WAN IP rotation 73.7.190.154 -> 76.97.4.210

### DIFF
--- a/base-apps/istio-ingress/authorizationpolicy.yaml
+++ b/base-apps/istio-ingress/authorizationpolicy.yaml
@@ -15,7 +15,18 @@
 # SNAT it would make arbitrary internet traffic look allow-listed - failing OPEN
 # and silently (B9). It also turns out to be unnecessary: the router hairpin-NATs
 # LAN traffic to the public address, verified in nginx's own access log, where
-# requests from LAN host 10.0.1.182 arrive as 73.7.190.154. Nothing is lost.
+# requests from LAN host 10.0.1.182 arrive as the WAN address. Nothing is lost.
+#
+# THE WAN ADDRESS IS DYNAMIC AND HAS ROTATED ONCE ALREADY:
+# 73.7.190.154 -> 76.97.4.210 (2026-08-12). It is residential Comcast, so expect
+# this again. The symptom is total loss of every host in this file at once: the
+# Route 53 A records (21 of them, NOT Terraform-managed - hand-edited via the
+# AWS API) keep pointing at the dead address, so requests time out; fix only DNS
+# and every host then returns 403 from this policy instead. BOTH have to move
+# together. REPLACE the old /32 here, never append: the old address is returned
+# to the ISP pool and reassigned, and leaving it listed grants a stranger the
+# allow-list. Re-verify the hairpin claim above after any such rotation -
+# confirmed still true on 2026-08-12 (LAN curl arrived as 76.97.4.210).
 #
 # ipBlocks, not remoteIpBlocks: the Gateway runs hostNetwork so the packet source
 # IS the client (R35). remoteIpBlocks would need XFF trust, which is V56's hazard
@@ -42,7 +53,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -54,7 +65,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -66,7 +77,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -78,7 +89,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -91,7 +102,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -109,7 +120,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -121,7 +132,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -133,7 +144,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -145,7 +156,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -157,7 +168,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -200,7 +211,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -213,7 +224,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -227,7 +238,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -242,7 +253,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -270,7 +281,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -284,7 +295,7 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 170.85.56.189/32
               - 170.85.130.202/32
               - 104.28.177.82/32
@@ -302,7 +313,7 @@ spec:
       # Vault API was reachable from the public internet in cleartext (Vault
       # runs tls_disable: 1). No allow-list, no TLS, no auth gate ahead of it.
       #
-      # 73.7.190.154/32 covers the hairpin path: the router hairpin-NATs LAN
+      # 76.97.4.210/32 covers the hairpin path: the router hairpin-NATs LAN
       # traffic to the public address, so this single /32 is how ALL observed
       # traffic arrives, LAN included (see the /8-vs-hairpin note above).
       # 10.0.1.0/24 covers direct LAN access to 10.0.1.110 (not hairpinned),
@@ -329,5 +340,5 @@ spec:
       from:
         - source:
             ipBlocks:
-              - 73.7.190.154/32
+              - 76.97.4.210/32
               - 10.0.1.0/24


### PR DESCRIPTION
## What broke

The ISP rotated the home WAN address from `73.7.190.154` to `76.97.4.210`. Every allow-listed host went unreachable at once — `argocd`, `coroot`, `vault`, `dex`, `backstage` and the rest.

Nothing in the cluster failed. All three nodes Ready, istiod and all three ztunnels running, the Gateway serving normally.

## Two stale pointers, both required

| | Old | Symptom if only this one is fixed |
|---|---|---|
| 21 Route 53 A records | `73.7.190.154` | connections time out |
| 17 restricted rules here | `73.7.190.154/32` | timeouts become `403` |

Fixing either alone leaves you locked out, so they had to move together.

**The Route 53 half is already applied** (change `C09484726GZ47XP12RV3`, INSYNC, all 21 records). Those records are not Terraform-managed and there is no external-dns, so that half cannot travel through this repo. This PR is the remaining half, and access stays broken until it merges and syncs.

## Evidence

The router was forwarding correctly the whole time — Gateway access logs show internet scanners arriving with Host header `76.97.4.210`. Forcing resolution to the new address returned a clean TLS handshake and a policy rejection rather than a hang, isolating the failure to this file:

```
argocd -> 76.97.4.210: HTTP 403   rbac_access_denied_matched_policy[none]
coroot -> 76.97.4.210: HTTP 403   rbac_access_denied_matched_policy[none]
```

## Security note

The old `/32` is **replaced, not appended**. `73.7.190.154` goes back to the ISP pool and gets reassigned; leaving it listed would hand whoever receives it next the allow-list to 17 hosts, including Vault and the Homepage dashboard that enumerates the whole homelab.

## Hairpin premise re-verified

This file deliberately omits `10.0.0.0/8` (V66/B9) because the router hairpin-NATs LAN traffic to the WAN address. A new address invalidates the old observation, so it was re-confirmed: a LAN curl from `10.0.1.182` arrives at the Gateway as `76.97.4.210`. The single `/32` still covers LAN traffic and the `/8` still does not need to return.

## Scope

17 restricted rules updated. `grafana` and the `n8n` webhook paths carry no `from` clause (public by design) and are untouched — verified by parsing the rendered YAML, not by grep:

```
rules with new IP : 17
rules with old IP : 0
rules public      : 2
total rules       : 19
```

## Follow-up worth considering

This address is dynamic residential Comcast and will rotate again, taking every host down with it and with no alerting to say why. Options are a dynamic-DNS updater reconciling both the zone and this policy, or asking the ISP for a static address. Not in scope here; the header comment now documents the runbook in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz8hTES8Wi8DnKf2CCdVUD