### PR TITLE
argo-cd: re-open the apply window for admin.enabled=false, and document why

### DIFF
--- a/base-apps/argo-cd/docs/runbook.md
+++ b/base-apps/argo-cd/docs/runbook.md
@@ -51,7 +51,16 @@ Added 2026-08-12 with SSO. Work through these in order — they fail at differen
 Add `base-apps/<app>.yaml` (an Argo CD `Application`) plus a `base-apps/<app>/` manifest directory; the `master-app` Application discovers the new file and creates the child Application automatically. There is no manual `argocd app create` step in this repo's workflow.
 
 ### Change Argo CD's own install/config
-Edit `terraform/modules/argocd/helm.tf` (chart/values) or the `module "argocd"` block in `terraform/roots/asela-cluster/argocd.tf` (node placement, resource exclusions), then run the normal `terraform plan`/`terraform apply` from `terraform/roots/asela-cluster/`. This is one of the few things in this repo that is *not* GitOps-synced by Argo CD — it's applied out-of-band via Terraform.
+Edit `terraform/modules/argocd/helm.tf` (chart/values) or the `module "argocd"` block in `terraform/roots/asela-cluster/argocd.tf`. This is one of the few things in this repo that is *not* GitOps-synced by Argo CD — it is applied by the in-cluster Atlantis, which holds the AWS credentials and cluster reachability that GitHub-hosted runners lack.
+
+**Apply before you merge — merging is the last step, not the trigger.** Nothing applies on merge.
+
+1. Open the PR. Atlantis autoplans on any `**/*.tf` change (`atlantis.yaml`).
+2. Wait for `atlantis/plan: asela-cluster` to go green, and read the diff.
+3. Run the **Terraform Apply (gated)** Action with the PR number, or comment `atlantis apply` directly. The Action only posts that comment; the real gate is the `terraform-apply` GitHub Environment's required reviewer.
+4. Confirm `atlantis/apply` is green, **then** merge.
+
+**If you merge first, the change is silently stranded.** Atlantis deletes the saved `plan.tfplan` and the workspace locks within seconds of the PR closing, and `.github/workflows/terraform-apply.yaml` hard-fails on a non-`OPEN` PR (`PR #N is not OPEN (state=MERGED)`). Git then disagrees with the cluster and **no check anywhere reports a failure** — the PR is green and merged, it simply never took effect. Recovery is a fresh PR touching any `.tf` file to re-trigger autoplan, then the sequence above. Verify with `kubectl -n argo-cd get cm argocd-cm -o jsonpath='{.data.admin\.enabled}'` (or whichever key you changed) rather than trusting the merge.
 
 ### Change this app's own GitOps-managed resources (e.g. the ingress)
 Edit `base-apps/argo-cd/ingress.yaml` and push; it is synced like any other app, via the `argo-cd-config` Application (`base-apps/argo-cd.yaml`).

--- a/base-apps/argo-cd/runbook.md
+++ b/base-apps/argo-cd/runbook.md
@@ -51,7 +51,16 @@ Added 2026-08-12 with SSO. Work through these in order — they fail at differen
 Add `base-apps/<app>.yaml` (an Argo CD `Application`) plus a `base-apps/<app>/` manifest directory; the `master-app` Application discovers the new file and creates the child Application automatically. There is no manual `argocd app create` step in this repo's workflow.
 
 ### Change Argo CD's own install/config
-Edit `terraform/modules/argocd/helm.tf` (chart/values) or the `module "argocd"` block in `terraform/roots/asela-cluster/argocd.tf` (node placement, resource exclusions), then run the normal `terraform plan`/`terraform apply` from `terraform/roots/asela-cluster/`. This is one of the few things in this repo that is *not* GitOps-synced by Argo CD — it's applied out-of-band via Terraform.
+Edit `terraform/modules/argocd/helm.tf` (chart/values) or the `module "argocd"` block in `terraform/roots/asela-cluster/argocd.tf`. This is one of the few things in this repo that is *not* GitOps-synced by Argo CD — it is applied by the in-cluster Atlantis, which holds the AWS credentials and cluster reachability that GitHub-hosted runners lack.
+
+**Apply before you merge — merging is the last step, not the trigger.** Nothing applies on merge.
+
+1. Open the PR. Atlantis autoplans on any `**/*.tf` change (`atlantis.yaml`).
+2. Wait for `atlantis/plan: asela-cluster` to go green, and read the diff.
+3. Run the **Terraform Apply (gated)** Action with the PR number, or comment `atlantis apply` directly. The Action only posts that comment; the real gate is the `terraform-apply` GitHub Environment's required reviewer.
+4. Confirm `atlantis/apply` is green, **then** merge.
+
+**If you merge first, the change is silently stranded.** Atlantis deletes the saved `plan.tfplan` and the workspace locks within seconds of the PR closing, and `.github/workflows/terraform-apply.yaml` hard-fails on a non-`OPEN` PR (`PR #N is not OPEN (state=MERGED)`). Git then disagrees with the cluster and **no check anywhere reports a failure** — the PR is green and merged, it simply never took effect. Recovery is a fresh PR touching any `.tf` file to re-trigger autoplan, then the sequence above. Verify with `kubectl -n argo-cd get cm argocd-cm -o jsonpath='{.data.admin\.enabled}'` (or whichever key you changed) rather than trusting the merge.
 
 ### Change this app's own GitOps-managed resources (e.g. the ingress)
 Edit `base-apps/argo-cd/ingress.yaml` and push; it is synced like any other app, via the `argo-cd-config` Application (`base-apps/argo-cd.yaml`).

--- a/terraform/roots/asela-cluster/argocd.tf
+++ b/terraform/roots/asela-cluster/argocd.tf
@@ -1,3 +1,24 @@
+# APPLY BEFORE YOU MERGE. Terraform in this repo is applied by the in-cluster
+# Atlantis while the PR is still OPEN - merging is the LAST step, not the
+# trigger. Nothing applies on merge.
+#
+#   1. open the PR; Atlantis autoplans (atlantis.yaml, when_modified **/*.tf)
+#   2. wait for `atlantis/plan: asela-cluster` to finish
+#   3. run the "Terraform Apply (gated)" Action with the PR number, or comment
+#      `atlantis apply` - the Action just posts that comment behind the
+#      terraform-apply Environment's required-reviewer gate
+#   4. confirm `atlantis/apply` went green, THEN merge
+#
+# Merging first silently strands the change: Atlantis deletes the saved
+# plan.tfplan and the workspace locks within seconds of the PR closing, and
+# .github/workflows/terraform-apply.yaml refuses to run on a non-OPEN PR. Git
+# then says one thing and the cluster another, with no failed check anywhere to
+# tell you - the PR is green and merged, it just never took effect. Recovering
+# means opening a fresh PR that touches a .tf file to re-trigger autoplan.
+#
+# Learned the hard way on PR #547 (admin.enabled=false merged unapplied, so
+# password login stayed live), which is what this very block is fixing.
+
 module "argocd" {
   source    = "../../modules/argocd"
   enabled   = true


### PR DESCRIPTION
## ⚠️ Apply this PR before merging it

#547 merged `admin.enabled = "false"` but **it never reached the cluster** — password login is still live right now:

```
git main:      admin.enabled = "false"
live cluster:  admin.enabled = true
```

## Nothing failed, and that's the problem

Atlantis applies while the PR is **OPEN**. Merging deletes the saved `plan.tfplan` and the workspace locks within seconds — Atlantis posted "Locks and plans deleted..." 3 seconds after the merge. The gated apply Action then refuses to help, correctly:

```
PR #547 state: MERGED
##[error]PR #547 is not OPEN (state=MERGED). Atlantis apply requires an open PR.
```

Every check on #547 was green, the merge succeeded, and git and the cluster quietly disagreed afterwards. **No check anywhere reports this.** That silence is the real hazard, not the ordering rule itself.

## What this PR does

Touching a `.tf` file re-triggers Atlantis autoplan (`when_modified: **/*.tf`), which reopens the apply window. The pending `admin.enabled` diff rides along — expect the plan to show **0 to add, 1 to change, 0 to destroy** on `helm_release.argocd`.

The content is the fix for next time:

- the ordering is stated at the top of `argocd.tf`, where the values actually live
- `runbook.md`'s "Change Argo CD's own install/config" no longer says to run `terraform plan`/`apply` locally. That stopped being how this repo works when Atlantis took over, and following it would bypass the required-reviewer gate on the `terraform-apply` Environment
- added the verification step that would have caught this: check the live ConfigMap key rather than trusting a green merge

## Correct sequence

1. Wait for `atlantis/plan: asela-cluster` (let it finish — don't push again meanwhile)
2. Run **Terraform Apply (gated)** with **this** PR's number, or comment `atlantis apply`
3. Confirm `atlantis/apply` is green
4. **Then** merge

Verify afterwards:

```
kubectl -n argo-cd get cm argocd-cm -o jsonpath='{.data.admin\.enabled}'   # expect: false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz8hTES8Wi8DnKf2CCdVUD