### PR TITLE
wan-ip-monitor: arm it, and drop the schedule to twice daily

### DIFF
--- a/base-apps/wan-ip-monitor/configmap-reconcile.yaml
+++ b/base-apps/wan-ip-monitor/configmap-reconcile.yaml
@@ -331,7 +331,7 @@ data:
 
         Returns (url, created). `created` is False when this rotation already
         had a PR, which is what keeps a rotation that sits unmerged for a day
-        from opening 288 of them - and what keeps the notification quiet.
+        from opening one per run - and what keeps the notification quiet.
 
         This never merges or approves the PR it opens - a human always merges.
         """
@@ -558,7 +558,7 @@ data:
         print("allow-list PR: %s (new=%s)" % (pr_url, pr_created))
 
         # Only speak up when something actually happened. Between the rotation
-        # and the merge this runs every 5 minutes with the PR already open and
+        # and the merge this runs on every tick with the PR already open and
         # DNS already fixed; alerting on each of those would train the operator
         # to ignore the notification.
         if updated or pr_created:

--- a/base-apps/wan-ip-monitor/cronjob.yaml
+++ b/base-apps/wan-ip-monitor/cronjob.yaml
@@ -1,6 +1,23 @@
-# Runs every 5 minutes. Steady state is two read-only API calls, so the cost of
-# checking often is negligible and the reward is that a rotation is caught
-# before it is noticed.
+# Runs twice a day, at 00:00 and 12:00.
+#
+# BE CLEAR ABOUT WHAT THIS CADENCE COSTS: detection latency is now up to 12
+# hours, so a rotation at 00:05 is not noticed until noon. For that whole window
+# every host in authorizationpolicy.yaml is unreachable - DNS points at an
+# address the house no longer holds - which is precisely the outage this app was
+# built after. The tool shortens such an outage from "however long until someone
+# investigates" to "at most 12 hours, then automatic", but it no longer catches a
+# rotation before a human would.
+#
+# That is a deliberate trade, not an oversight. A steady-state run is two
+# read-only API calls, so the API cost of running often is negligible; what is
+# not negligible is `pip install boto3` on every single run (see the image note
+# below), which at */5 meant 288 PyPI fetches a day and made a PyPI outage a
+# recurring failure mode. Twice a day makes that noise instead of a nuisance.
+#
+# If detection latency starts mattering more than that, the ordering is: bake an
+# image so pip drops out of the hot path, THEN raise the frequency - not the
+# other way round. Hourly (`0 * * * *`) is the obvious middle ground and costs 24
+# runs a day.
 #
 # The allow-list is read from GitHub `main` via the API
 # (reconcile.py's read_policy_from_main), NOT from a mounted copy of the live
@@ -15,7 +32,7 @@
 # binary but no `python3` on PATH to run reconcile.py under - the CLI bundles
 # its own internal interpreter without exposing it for scripting. boto3 and
 # PyYAML are installed at container start instead of baked into a custom image,
-# trading a few seconds of startup (negligible on a 5-minute schedule) for not
+# trading a few seconds of startup (immaterial twice a day) for not
 # maintaining a bespoke image. See docs.md ("Container image choice").
 apiVersion: batch/v1
 kind: CronJob
@@ -23,7 +40,7 @@ metadata:
   name: wan-ip-monitor
   namespace: wan-ip-monitor
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "0 */12 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
@@ -52,8 +69,30 @@ spec:
               env:
                 - name: AWS_DEFAULT_REGION
                   value: us-east-1
+                # ARMED 2026-08-12. Was "true" from first deploy until a dry run
+                # proved both credentials live, which is what this flag is for:
+                # every write in this job - the Route 53 change batch and the
+                # allow-list PR - is gated on it, so a disarmed deploy exercises
+                # detection, the zone read and the GitHub read while touching
+                # nothing.
+                #
+                # The dry run that justified flipping it (job manual-check):
+                #   detected=76.97.4.210 dry_run=True
+                #   route53: 21 managed hostname(s) already on 76.97.4.210
+                #   allow-list: declared=76.97.4.210 detected=76.97.4.210
+                #   allow-list: already trusts 76.97.4.210, nothing to propose
+                #   allow-list PR: None (new=False)
+                # Line 2 is the AWS credential working, line 3 is the GitHub
+                # token working. Both are required before arming; a run that
+                # prints only line 1 has proven nothing.
+                #
+                # To disarm in a hurry, set this back to "true" - it takes effect
+                # on the next scheduled tick and needs no code change. To stop it
+                # dead instead:
+                #   kubectl -n wan-ip-monitor patch cronjob wan-ip-monitor \
+                #     -p '{"spec":{"suspend":true}}'
                 - name: DRY_RUN
-                  value: "true"
+                  value: "false"
                 # The Route 53 A records this job owns. This list is the
                 # SELECTOR for the DNS half - a record is moved onto the newly
                 # detected address because its name is here, never because its
@@ -116,7 +155,7 @@ spec:
                   # cpu: 200m (there was previously no CPU limit at all) is
                   # sized for that same pip install: it is CPU-bound at
                   # container start and, throttled to 0.2 core, takes on the
-                  # order of a minute or two - comfortably inside the 5-minute
+                  # order of a minute or two - comfortably inside the 12-hour
                   # schedule, and concurrencyPolicy: Forbid means a slow start
                   # here delays the next run rather than overlapping it.
                   cpu: 200m

--- a/base-apps/wan-ip-monitor/docs.md
+++ b/base-apps/wan-ip-monitor/docs.md
@@ -23,7 +23,7 @@ sources:
 # wan-ip-monitor
 
 ## What it is
-A CronJob (`*/5 * * * *`) that keeps the home WAN address's two dependents in
+A CronJob (`0 */12 * * *`) that keeps the home WAN address's two dependents in
 sync with reality: the Route 53 A records that point at it, and the Istio
 `AuthorizationPolicy` allow-list that trusts it. This is the ISP-facing
 counterpart to `base-apps/istio-ingress/authorizationpolicy.yaml`'s access
@@ -73,7 +73,7 @@ re-raising, because those two failures need very different responses and a
 bare traceback does not distinguish them.
 
 Both halves are still reconcilers, not change-detectors — nothing is persisted
-between runs, and the steady state (288 runs a day) re-derives the same
+between runs, and the steady state (two runs a day) re-derives the same
 conclusion each time. Between rotation and merge, `open_allowlist_pr`'s
 existing-PR lookup finds the same PR rather than opening a new one.
 
@@ -233,7 +233,7 @@ path replaces `aws_json` first via `monkeypatch`.
 The CronJob's container `command` installs `boto3==1.35.99` and
 `pyyaml==6.0.2` at start (`pip install --quiet ... && python3
 /app/reconcile.py`, see `cronjob.yaml`) rather than baking a custom image —
-the few seconds of install time are immaterial on a 5-minute schedule, and
+the few seconds of install time are immaterial twice a day, and
 there is then no bespoke image to build, publish, or keep patched.
 
 ## Where config lives
@@ -272,8 +272,12 @@ there is then no bespoke image to build, publish, or keep patched.
 - **`"event": "wan-ip-reconciled"`** — a rotation was actually acted on:
   records moved, or a PR was newly created (`records_updated`, `new`,
   `pr_url`). It deliberately does *not* fire on the runs between the rotation
-  and the merge, when DNS is already fixed and the PR is already open — 288
-  of those a day would train the operator to ignore it.
+  and the merge, when DNS is already fixed and the PR is already open —
+  repeating that alert every run would train the operator to ignore it. The
+  guard was written when the schedule was `*/5` and 288 such alerts a day was
+  the concrete risk; it matters less at the current twice-daily cadence, but it
+  is what makes the cadence a free choice rather than one constrained by how
+  noisy the alerting gets.
 - **`"event": "wan-ip-monitor-failed"`** — `reconcile()` raised. Carries
   `error_type` and `error`. `main()` wraps the whole body for this reason:
   without it, the only failure signal is a non-zero pod exit in a namespace

--- a/base-apps/wan-ip-monitor/docs/index.md
+++ b/base-apps/wan-ip-monitor/docs/index.md
@@ -23,7 +23,7 @@ sources:
 # wan-ip-monitor
 
 ## What it is
-A CronJob (`*/5 * * * *`) that keeps the home WAN address's two dependents in
+A CronJob (`0 */12 * * *`) that keeps the home WAN address's two dependents in
 sync with reality: the Route 53 A records that point at it, and the Istio
 `AuthorizationPolicy` allow-list that trusts it. This is the ISP-facing
 counterpart to `base-apps/istio-ingress/authorizationpolicy.yaml`'s access
@@ -73,7 +73,7 @@ re-raising, because those two failures need very different responses and a
 bare traceback does not distinguish them.
 
 Both halves are still reconcilers, not change-detectors — nothing is persisted
-between runs, and the steady state (288 runs a day) re-derives the same
+between runs, and the steady state (two runs a day) re-derives the same
 conclusion each time. Between rotation and merge, `open_allowlist_pr`'s
 existing-PR lookup finds the same PR rather than opening a new one.
 
@@ -233,7 +233,7 @@ path replaces `aws_json` first via `monkeypatch`.
 The CronJob's container `command` installs `boto3==1.35.99` and
 `pyyaml==6.0.2` at start (`pip install --quiet ... && python3
 /app/reconcile.py`, see `cronjob.yaml`) rather than baking a custom image —
-the few seconds of install time are immaterial on a 5-minute schedule, and
+the few seconds of install time are immaterial twice a day, and
 there is then no bespoke image to build, publish, or keep patched.
 
 ## Where config lives
@@ -272,8 +272,12 @@ there is then no bespoke image to build, publish, or keep patched.
 - **`"event": "wan-ip-reconciled"`** — a rotation was actually acted on:
   records moved, or a PR was newly created (`records_updated`, `new`,
   `pr_url`). It deliberately does *not* fire on the runs between the rotation
-  and the merge, when DNS is already fixed and the PR is already open — 288
-  of those a day would train the operator to ignore it.
+  and the merge, when DNS is already fixed and the PR is already open —
+  repeating that alert every run would train the operator to ignore it. The
+  guard was written when the schedule was `*/5` and 288 such alerts a day was
+  the concrete risk; it matters less at the current twice-daily cadence, but it
+  is what makes the cadence a free choice rather than one constrained by how
+  noisy the alerting gets.
 - **`"event": "wan-ip-monitor-failed"`** — `reconcile()` raised. Carries
   `error_type` and `error`. `main()` wraps the whole body for this reason:
   without it, the only failure signal is a non-zero pod exit in a namespace

--- a/base-apps/wan-ip-monitor/docs/runbook.md
+++ b/base-apps/wan-ip-monitor/docs/runbook.md
@@ -68,7 +68,7 @@ docs.md, "DRY_RUN").
   ```
 - **Fix:** whichever half the `error_type` points at, above. The job is
   self-healing once the cause clears — it re-derives everything from scratch
-  on the next 5-minute run and needs no manual catch-up.
+  on the next scheduled run and needs no manual catch-up.
 - **If the failure is real but no notification arrived**, the notification path
   itself is broken. `notify()` is best-effort and swallows its own errors by
   design, so this is silent. Confirm the `wan-ip-rotated` workflow is active in
@@ -188,7 +188,7 @@ docs.md, "DRY_RUN").
 - **Likely cause:** branch deletion racing the job. `open_allowlist_pr` dedups
   by checking for an existing open PR on branch `automation/wan-ip-<new_ip>`
   (`branch_name`) before creating anything; if that branch was deleted (e.g.
-  during PR cleanup) while the CronJob still runs every 5 minutes, the next
+  during PR cleanup) while the CronJob still runs on schedule, the next
   run finds no matching branch/PR and opens a new one.
 - **Check:** confirm `branch_name(new_ip)` is still deterministic for a given
   IP (`tests/wan_ip/test_logic.py::test_branch_name_is_deterministic_per_address`)
@@ -228,7 +228,7 @@ docs.md, "DRY_RUN").
 Two options, in order of reversibility:
 - **Soft disable (keep observing, stop acting):** set `DRY_RUN` to `"true"` on
   the CronJob (`cronjob.yaml`) and let Argo CD sync it. The job keeps running
-  every 5 minutes and logging `detected=... declared=... dry_run=True`, but
+  on schedule and logging `detected=... declared=... dry_run=True`, but
   never touches Route 53 or opens a PR.
 - **Hard disable (stop running entirely):**
   ```bash

--- a/base-apps/wan-ip-monitor/runbook.md
+++ b/base-apps/wan-ip-monitor/runbook.md
@@ -68,7 +68,7 @@ docs.md, "DRY_RUN").
   ```
 - **Fix:** whichever half the `error_type` points at, above. The job is
   self-healing once the cause clears — it re-derives everything from scratch
-  on the next 5-minute run and needs no manual catch-up.
+  on the next scheduled run and needs no manual catch-up.
 - **If the failure is real but no notification arrived**, the notification path
   itself is broken. `notify()` is best-effort and swallows its own errors by
   design, so this is silent. Confirm the `wan-ip-rotated` workflow is active in
@@ -188,7 +188,7 @@ docs.md, "DRY_RUN").
 - **Likely cause:** branch deletion racing the job. `open_allowlist_pr` dedups
   by checking for an existing open PR on branch `automation/wan-ip-<new_ip>`
   (`branch_name`) before creating anything; if that branch was deleted (e.g.
-  during PR cleanup) while the CronJob still runs every 5 minutes, the next
+  during PR cleanup) while the CronJob still runs on schedule, the next
   run finds no matching branch/PR and opens a new one.
 - **Check:** confirm `branch_name(new_ip)` is still deterministic for a given
   IP (`tests/wan_ip/test_logic.py::test_branch_name_is_deterministic_per_address`)
@@ -228,7 +228,7 @@ docs.md, "DRY_RUN").
 Two options, in order of reversibility:
 - **Soft disable (keep observing, stop acting):** set `DRY_RUN` to `"true"` on
   the CronJob (`cronjob.yaml`) and let Argo CD sync it. The job keeps running
-  every 5 minutes and logging `detected=... declared=... dry_run=True`, but
+  on schedule and logging `detected=... declared=... dry_run=True`, but
   never touches Route 53 or opens a PR.
 - **Hard disable (stop running entirely):**
   ```bash

--- a/scripts/wan-ip-monitor-vault-setup.sh
+++ b/scripts/wan-ip-monitor-vault-setup.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# wan-ip-monitor Vault setup — run INSIDE the Vault pod.
+#
+#   kubectl -n vault cp wan-ip-monitor-vault-setup.sh vault-0:/tmp/setup.sh
+#   kubectl -n vault exec -it vault-0 -- sh /tmp/setup.sh
+#   kubectl -n vault exec vault-0 -- rm -f /tmp/setup.sh      # afterwards
+#
+# Creates the three things base-apps/wan-ip-monitor needs:
+#   1. ACL policy      wan-ip-monitor      (read one KV path, nothing else)
+#   2. K8s auth role   wan-ip-monitor      (default SA in the wan-ip-monitor ns)
+#   3. KV secret       k8s-secrets/wan-ip-monitor
+#
+# Idempotent: re-running overwrites the policy and role with identical values,
+# and re-prompts for the secret. Safe to run twice.
+#
+# Secrets are read with `read` and never appear in argv, so they stay out of
+# the process list. They DO land in Vault's audit log if one is enabled - that
+# is expected and is where they belong.
+
+set -eu
+
+POLICY_NAME="wan-ip-monitor"
+ROLE_NAME="wan-ip-monitor"
+K8S_NAMESPACE="wan-ip-monitor"
+K8S_SA="default"
+KV_MOUNT="k8s-secrets"
+KV_PATH="wan-ip-monitor"
+AUTH_MOUNT="kubernetes"
+TOKEN_TTL="24h"
+
+: "${VAULT_ADDR:=http://127.0.0.1:8200}"
+export VAULT_ADDR
+
+say()  { printf '\n=== %s ===\n' "$1"; }
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------- preflight --
+say "Preflight"
+command -v vault >/dev/null 2>&1 || fail "vault CLI not found - are you inside the Vault pod?"
+printf 'VAULT_ADDR = %s\n' "$VAULT_ADDR"
+
+vault status >/dev/null 2>&1 || fail "cannot reach Vault, or it is sealed. Run: vault status"
+
+if ! vault token lookup >/dev/null 2>&1; then
+  printf 'Not authenticated. Paste a token with permission to write policies\n'
+  printf 'and auth roles (root, or an admin token), then press Enter.\n'
+  printf 'Token (hidden): '
+  stty -echo 2>/dev/null || true
+  read -r VAULT_TOKEN
+  stty echo 2>/dev/null || true
+  printf '\n'
+  export VAULT_TOKEN
+  vault token lookup >/dev/null 2>&1 || fail "that token is not valid"
+fi
+printf 'Authenticated OK\n'
+
+# Confirm the mounts this script assumes actually exist, rather than creating
+# a policy that silently points at nothing.
+#
+# Listing mounts needs sys/mounts + sys/auth read, which a scoped identity may
+# not have even when it CAN write policies and roles. So a denial here is a
+# warning, not a failure - the real writes below will error clearly if a mount
+# is genuinely wrong, and refusing to run over a missing read permission would
+# be a false blocker.
+if SECRETS_JSON=$(vault secrets list -format=json 2>/dev/null); then
+  printf '%s' "$SECRETS_JSON" | grep -q "\"${KV_MOUNT}/\"" \
+    || fail "KV mount '${KV_MOUNT}/' does not exist. Check: vault secrets list"
+  printf "KV mount %s/ present\n" "$KV_MOUNT"
+else
+  printf "WARN: cannot list secrets mounts (no permission) - skipping that check\n"
+fi
+
+if AUTH_JSON=$(vault auth list -format=json 2>/dev/null); then
+  printf '%s' "$AUTH_JSON" | grep -q "\"${AUTH_MOUNT}/\"" \
+    || fail "auth mount '${AUTH_MOUNT}/' does not exist. Check: vault auth list"
+  printf "auth mount %s/ present\n" "$AUTH_MOUNT"
+else
+  printf "WARN: cannot list auth mounts (no permission) - skipping that check\n"
+fi
+
+# ------------------------------------------------------------------ policy ---
+# The /data/ segment is required: k8s-secrets is KV v2, where the API path for
+# a secret at <mount>/<path> is <mount>/data/<path>. Omitting it is the single
+# most common cause of a 403 that looks like a role problem.
+say "1/3  ACL policy '${POLICY_NAME}'"
+vault policy write "$POLICY_NAME" - <<EOF
+path "${KV_MOUNT}/data/${KV_PATH}" {
+  capabilities = ["read"]
+}
+EOF
+printf 'Written. Effective policy:\n'
+vault policy read "$POLICY_NAME"
+
+# -------------------------------------------------------------------- role ---
+say "2/3  Kubernetes auth role '${ROLE_NAME}'"
+printf "Binding: serviceaccount '%s' in namespace '%s'\n" "$K8S_SA" "$K8S_NAMESPACE"
+printf "(the namespace need not exist yet - Argo CD creates it on sync)\n"
+vault write "auth/${AUTH_MOUNT}/role/${ROLE_NAME}" \
+  bound_service_account_names="$K8S_SA" \
+  bound_service_account_namespaces="$K8S_NAMESPACE" \
+  policies="$POLICY_NAME" \
+  ttl="$TOKEN_TTL" >/dev/null
+printf 'Written. Effective role:\n'
+vault read "auth/${AUTH_MOUNT}/role/${ROLE_NAME}"
+
+# ------------------------------------------------------------------ secret ---
+say "3/3  Secret '${KV_MOUNT}/${KV_PATH}'"
+
+if vault kv get "${KV_MOUNT}/${KV_PATH}" >/dev/null 2>&1; then
+  printf 'A secret already exists at this path.\n'
+  printf 'Overwrite it? [y/N]: '
+  read -r REPLY
+  case "$REPLY" in
+    y|Y) : ;;
+    *) printf 'Left unchanged. Skipping to verification.\n'; SKIP_SECRET=1 ;;
+  esac
+fi
+
+if [ "${SKIP_SECRET:-0}" != "1" ]; then
+  printf '\nAWS access key id (Route 53 scoped): '
+  read -r AWS_ID
+  [ -n "$AWS_ID" ] || fail "AWS access key id cannot be empty"
+
+  printf 'AWS secret access key (hidden): '
+  stty -echo 2>/dev/null || true
+  read -r AWS_SECRET
+  stty echo 2>/dev/null || true
+  printf '\n'
+  [ -n "$AWS_SECRET" ] || fail "AWS secret access key cannot be empty"
+
+  printf 'GitHub token, Contents+PRs read/write on arigsela/kubernetes (hidden): '
+  stty -echo 2>/dev/null || true
+  read -r GH_TOKEN
+  stty echo 2>/dev/null || true
+  printf '\n'
+  [ -n "$GH_TOKEN" ] || fail "GitHub token cannot be empty"
+
+  # Key names must match base-apps/wan-ip-monitor/external-secret.yaml exactly.
+  vault kv put "${KV_MOUNT}/${KV_PATH}" \
+    aws-access-key-id="$AWS_ID" \
+    aws-secret-access-key="$AWS_SECRET" \
+    github-token="$GH_TOKEN" >/dev/null
+
+  unset AWS_ID AWS_SECRET GH_TOKEN
+  printf 'Written.\n'
+fi
+
+# ------------------------------------------------------------- verification --
+say "Verification"
+
+printf 'Keys present (values not shown):\n'
+vault kv get -format=json "${KV_MOUNT}/${KV_PATH}" \
+  | tr ',' '\n' | grep -oE '"(aws-access-key-id|aws-secret-access-key|github-token)"' \
+  | sort -u | sed 's/^/  /'
+
+MISSING=0
+for K in aws-access-key-id aws-secret-access-key github-token; do
+  vault kv get -format=json "${KV_MOUNT}/${KV_PATH}" | grep -q "\"$K\"" || {
+    printf 'MISSING KEY: %s\n' "$K"; MISSING=1; }
+done
+[ "$MISSING" -eq 0 ] || fail "one or more required keys are missing - re-run and overwrite"
+
+printf '\nAll three objects exist:\n'
+printf '  policy  %s\n' "$POLICY_NAME"
+printf '  role    auth/%s/role/%s\n' "$AUTH_MOUNT" "$ROLE_NAME"
+printf '  secret  %s/%s (3 keys)\n' "$KV_MOUNT" "$KV_PATH"
+
+cat <<'NEXT'
+
+Next, from your laptop (not this pod):
+
+  # after PR #549 merges and Argo CD syncs
+  kubectl -n wan-ip-monitor get externalsecret wan-ip-monitor
+  # want: SecretSynced / True
+
+  # dry run - DRY_RUN is still "true", so this writes nothing
+  kubectl -n wan-ip-monitor create job --from=cronjob/wan-ip-monitor manual-check
+  kubectl -n wan-ip-monitor logs job/manual-check
+
+Expect five lines. Line 2 (route53: ... already on <ip>) proves the AWS key
+works; line 3 (allow-list: declared=...) proves the GitHub token does. Only
+after seeing both should you flip DRY_RUN to "false" in its own commit.
+
+Then delete this script from the pod:
+  kubectl -n vault exec vault-0 -- rm -f /tmp/setup.sh
+NEXT


### PR DESCRIPTION
Follow-up to #549. Two changes that belong together — the second is only defensible once the first is verified.

## 1. Armed (`DRY_RUN` → `"false"`)

Justified by a dry run against the live cluster that exercised **both** credentials end to end:

```
detected=76.97.4.210 dry_run=True
route53: 21 managed hostname(s) already on 76.97.4.210
allow-list: declared=76.97.4.210 detected=76.97.4.210
allow-list: already trusts 76.97.4.210, nothing to propose
allow-list PR: None (new=False)
```

- **Line 2** — the Route 53 credential works, and independently confirms `MANAGED_HOSTNAMES` matches the live zone **21/21**, observed from inside the cluster rather than from a laptop
- **Line 3** — the GitHub token works

A run printing only line 1 would have proven nothing, so both were required before flipping the flag. Supporting state at the time: app `Synced/Healthy`, ExternalSecret `Ready=True reason=SecretSynced`.

## 2. Schedule `*/5` → `0 */12`

**This costs real detection latency, and the header comment now says so** instead of keeping the old "a rotation is caught before it is noticed" claim — which twelve hours plainly does not deliver. A rotation at 00:05 isn't noticed until noon, and every host in `authorizationpolicy.yaml` is unreachable for that window. That is the exact outage this app was built after.

What the tool still guarantees: such an outage now **ends automatically within 12 hours** rather than lasting until someone investigates. That's the honest framing.

What the trade buys is removing **288 `pip install boto3` runs a day**. API cost was never the concern — a steady-state run is two read-only calls — but a runtime PyPI dependency hit 288 times daily is a recurring failure mode, and twice daily makes it noise instead.

Recorded in the manifest for whoever revisits this: **bake an image first** so pip leaves the hot path, *then* raise frequency — not the other way round. Hourly (`0 * * * *`) is the obvious middle ground at 24 runs a day.

## Doc sweep

Cadence was referenced in six places beyond the schedule field — cronjob comments, `docs.md`, `runbook.md`, and the notify anti-spam rationale all said "every 5 minutes" or "288 a day". All updated. One mention of `*/5` is deliberately kept where it explains *why* the anti-spam guard exists.

## Verification

`78 tests pass`, `validate-agent-docs` 22 apps 0 warnings, `gen-techdocs --check` in sync, manifests parse. `MANAGED_HOSTNAMES` still 21 entries.

## After merge

First armed run is at the next 00:00 or 12:00 tick. Steady state stays silent — no notification, no PR — because nothing has rotated. The next real rotation is what exercises the write paths for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz8hTES8Wi8DnKf2CCdVUD