### PR TITLE
managed-apps: set applicationsSync create-update, and correct what the pilot disproved

### DIFF
--- a/base-apps/managed-apps.yaml
+++ b/base-apps/managed-apps.yaml
@@ -32,6 +32,19 @@ spec:
     # apps front real S3 buckets and IAM users via Crossplane CRs that have no
     # deletionPolicy: Orphan, so a cascade here would be unrecoverable.
     preserveResourcesOnDeletion: true
+    # This controller must never DELETE an Application, only create and update.
+    #
+    # Measured 2026-08-13: a config missing one key does not halt the render for
+    # the set, as originally assumed -- the broken entry is skipped and the rest
+    # generate ("generated 11 applications"). A reduced generated set is the same
+    # signal the controller gets when an app is legitimately removed from Git, so
+    # under the default policy a one-line typo can put an app on the deletion
+    # path while the other eleven look healthy.
+    #
+    # The cost is that removing a config leaves an orphan Application to delete
+    # by hand; see the "Removing an app" section of the runbook. For twelve
+    # rarely-changing infrastructure apps that is the better trade.
+    applicationsSync: create-update
   template:
     metadata:
       name: '{{ .name }}'

--- a/docs/managed-apps-appset.md
+++ b/docs/managed-apps-appset.md
@@ -138,10 +138,19 @@ Restoring the glob restores the Applications. This is why
 front real S3 buckets and IAM users via Crossplane CRs with the default
 `deletionPolicy: Delete`.
 
-**A malformed config**: `goTemplateOptions: ["missingkey=error"]` halts the
-render for *all* apps in the set. Existing Applications keep running but stop
-reconciling from the ApplicationSet, which is quiet — `tests/appset/` is the
-loud failure, and the Preview Apps tab is the pre-merge check.
+**A malformed config**: the broken entry drops out of the generated set — the
+render does **not** halt for the others. Measured on 2026-08-13 by deleting one
+config's `namespace` key: the controller logged a precise error naming the
+missing key, then `generated 11 applications`.
+
+That is the dangerous part. A reduced generated set is the same signal the
+controller gets when an app is legitimately removed from Git, so a one-line typo
+can put an app on the deletion path while the other eleven look perfectly
+healthy. `preserveResourcesOnDeletion: true` means its workloads survive
+regardless, but nothing would be reconciling them.
+
+`tests/appset/` is the loud failure and catches this at PR time — the break above
+reddens three tests. Treat Preview as the second line, not the first.
 
 **Never set `recurse: true` on `master-app`.** The config files live outside
 `base-apps/` precisely so that `master-app` cannot reach them; recursing would

--- a/docs/managed-apps-appset.md
+++ b/docs/managed-apps-appset.md
@@ -105,10 +105,21 @@ Delete its config file, its golden, and its entry in `EXPECTED_APPS`
 (`tests/appset/test_managed_apps.py`) — `test_expected_configs_present`
 asserts the config directory's stems equal that hardcoded set exactly, so it
 fails the moment the config is gone if the set isn't updated too.
-`applicationsSync` is at its default, so the Application is deleted on the
-next reconcile. Because `preserveResourcesOnDeletion: true` is set, **its
-Kubernetes resources are not deleted** — they keep running, unmanaged. Clean
-them up deliberately if that is what you want.
+Then delete the Application object by hand:
+
+```bash
+kubectl delete application <name> -n argo-cd
+```
+
+That manual step is required: `applicationsSync: create-update` stops this
+ApplicationSet from ever deleting an Application, so removing the config alone
+leaves an orphan that nothing reconciles and nothing cleans up. The policy is
+deliberate — see the comment in `base-apps/managed-apps.yaml` — because it also
+means a malformed config cannot evict a healthy app.
+
+`preserveResourcesOnDeletion: true` means deleting the Application still leaves
+**its Kubernetes resources running, unmanaged**. Clean those up deliberately if
+that is what you want.
 
 ## Rollback
 
@@ -143,11 +154,13 @@ render does **not** halt for the others. Measured on 2026-08-13 by deleting one
 config's `namespace` key: the controller logged a precise error naming the
 missing key, then `generated 11 applications`.
 
-That is the dangerous part. A reduced generated set is the same signal the
-controller gets when an app is legitimately removed from Git, so a one-line typo
-can put an app on the deletion path while the other eleven look perfectly
-healthy. `preserveResourcesOnDeletion: true` means its workloads survive
-regardless, but nothing would be reconciling them.
+That would be the dangerous part under the default policy: a reduced generated
+set is the same signal the controller gets when an app is legitimately removed
+from Git, so a one-line typo could put an app on the deletion path while the
+other eleven look perfectly healthy. **`applicationsSync: create-update` closes
+that path** — this ApplicationSet cannot delete an Application at all, so the
+broken app simply stops updating, which is visibly stale rather than silently
+gone.
 
 `tests/appset/` is the loud failure and catches this at PR time — the break above
 reddens three tests. Treat Preview as the second line, not the first.

--- a/docs/superpowers/specs/2026-08-13-managed-apps-appset-design.md
+++ b/docs/superpowers/specs/2026-08-13-managed-apps-appset-design.md
@@ -267,7 +267,7 @@ Phase 0 does not need reverting — no-finalizer is the intended end state eithe
 |---|---|---|
 | Generator matches nothing (path typo, branch rename, repo unreachable) | All 12 Applications deleted | `preserveResourcesOnDeletion: true` — workloads and Crossplane CRs keep running; restoring the glob restores the Applications. This is the failure behind [argo-cd#18780](https://github.com/argoproj/argo-cd/issues/18780) and [argo-cd#9227](https://github.com/argoproj/argo-cd/issues/9227) |
 | Duplicate names — someone adds both `base-apps/foo.yaml` and `appsets/managed-apps/foo.yaml` | Two controllers fight over one object | Test asserting the two name sets are disjoint (§6) |
-| Malformed config | `missingkey=error` stops the render for all 12; existing Applications keep running but stop reconciling from the ApplicationSet | Fail-safe but silent. The Preview Apps tab is the pre-flight check — see §8 |
+| Malformed config | The broken entry **drops out of the generated set**; the render does *not* halt for the others. Measured 2026-08-13 — see §11 | `preserveResourcesOnDeletion: true` keeps workloads alive whichever way the controller resolves a reduced set. `applicationsSync: create-update` would remove the deletion path entirely |
 
 ## 6. Testing
 
@@ -314,3 +314,67 @@ Two documents are still in scope:
 - `base-apps/crossplane-system/secret-store.yaml` sits at the umbrella chart's root rather than under `templates/`, so Argo is almost certainly not applying it. Pre-existing and unchanged by this work.
 - `CLAUDE.md` imports `@AGENTS.md`, which does not exist in the repository.
 - The Argo CD version pin in `terraform/modules/argocd/variables.tf:13` carries a TODO to move off the `3.5.0-rc2` binaries once argo-helm publishes a 3.5 chart. That is now unblocked: 3.5.1 GA shipped 2026-08-12 and argo-cd chart 10.3.3 shipped 2026-08-13.
+
+## 11. What the pilot measured (2026-08-13)
+
+The cutover is live and verified: all 12 Applications generated, Synced, Healthy,
+carrying no finalizer, with every live spec matching its golden exactly. The S3
+buckets and IAM users behind the three Crossplane-backed apps survived the prune.
+
+Acceptance criterion 5 — the deliberate break — was then run by pointing the
+Preview tab's sandboxed generator at a branch with the `namespace` key deleted
+from `appsets/managed-apps/ecr-auth.yaml`. It produced two findings.
+
+### 11.1 Preview works, and the error is precise
+
+```
+failed to execute go template {{ .namespace }}: template: base:1:3:
+executing "base" at <.namespace>: map has no entry for key "namespace"
+```
+
+It names the failing template expression and the missing key, and the logged
+`params` dump shows every config's resolved values, so the offending file is
+identifiable. As a pre-flight check this is genuinely useful.
+
+Note the workflow is not the one §8 assumed. The generator is pinned to
+`revision: main`, so a change on a branch is invisible to Preview. Exercising it
+means editing `revision` **inside the Preview tab's sandbox** — those edits are
+never saved — and re-previewing. Opening a PR does nothing on its own.
+
+### 11.2 The render does NOT halt for the whole set — §5.4 was wrong
+
+The controller logged:
+
+```
+level=error msg="error generating application from params" ... ecr-auth ...
+level=info  msg="generated 11 applications" applicationset=managed-apps
+```
+
+Eleven, not zero. The broken entry is skipped and the rest render normally. This
+matters more than the error message, because a reduced generated set is the same
+signal the controller receives when an app is legitimately removed from Git —
+i.e. the deletion path.
+
+What the controller then does with a partial result is **not settled by this
+evidence**, and upstream reports conflict: [argo-cd#16832](https://github.com/argoproj/argo-cd/issues/16832)
+describes the controller logging "generated x applications" while creating none,
+whereas [argo-cd#18780](https://github.com/argoproj/argo-cd/issues/18780) and
+[argo-cd#9227](https://github.com/argoproj/argo-cd/issues/9227) are about reduced
+sets causing deletions. Determining which applies here would require merging the
+broken config, which is not worth doing to a production cluster.
+
+Either way `preserveResourcesOnDeletion: true` holds the important line: the
+workloads survive. But the failure mode is *partial and silent* — eleven apps
+look perfectly healthy — rather than the clean whole-set freeze §5.4 predicted.
+
+### 11.3 Consequences for the design
+
+- §4.3's choice of `applicationsSync` default (`create-update-delete`) was made on
+  the belief that a malformed config produced a harmless freeze. That belief is
+  now falsified, and `create-update` deserves reconsideration: it makes the
+  deletion path impossible at the cost of leaving an orphan Application behind
+  when a config is legitimately removed.
+- `tests/appset/` catches this class of error at PR time — the break reddens three
+  tests — so Preview's marginal value here is smaller than §1.1 assumed. Preview's
+  real value is the class CI cannot see: a generator whose glob silently matches
+  nothing, or a template edit whose blast radius is not obvious from the diff.

--- a/docs/superpowers/specs/2026-08-13-managed-apps-appset-design.md
+++ b/docs/superpowers/specs/2026-08-13-managed-apps-appset-design.md
@@ -198,7 +198,7 @@ spec:
           {{- end }}
 ```
 
-`applicationsSync` is left at its default (`create-update-delete`), so the set stays fully declarative: removing a config file removes the Application.
+`applicationsSync` is set to `create-update`, so this ApplicationSet can never delete an Application. This reverses the original decision; §11.2 records the measurement that prompted it. The cost is that removing a config leaves an orphan Application to delete by hand — accepted, because it also means a malformed config cannot evict a healthy app.
 
 #### Why `syncOptions` needs `templatePatch`
 
@@ -369,11 +369,12 @@ look perfectly healthy — rather than the clean whole-set freeze §5.4 predicte
 
 ### 11.3 Consequences for the design
 
-- §4.3's choice of `applicationsSync` default (`create-update-delete`) was made on
-  the belief that a malformed config produced a harmless freeze. That belief is
-  now falsified, and `create-update` deserves reconsideration: it makes the
-  deletion path impossible at the cost of leaving an orphan Application behind
-  when a config is legitimately removed.
+- §4.3's original choice of the `applicationsSync` default was made on the belief
+  that a malformed config produced a harmless freeze. That belief is falsified,
+  so the decision was **reversed**: the ApplicationSet now sets
+  `applicationsSync: create-update`, making the deletion path impossible. The
+  cost is an orphan Application when a config is legitimately removed, which the
+  runbook's "Removing an app" section now covers with an explicit manual step.
 - `tests/appset/` catches this class of error at PR time — the break reddens three
   tests — so Preview's marginal value here is smaller than §1.1 assumed. Preview's
   real value is the class CI cannot see: a generator whose glob silently matches

--- a/tests/appset/test_disjoint.py
+++ b/tests/appset/test_disjoint.py
@@ -70,6 +70,10 @@ def test_applicationset_manifest_exists_and_is_wellformed(repo_root):
     assert doc["spec"]["goTemplate"] is True
     assert doc["spec"]["goTemplateOptions"] == ["missingkey=error"]
     assert doc["spec"]["syncPolicy"]["preserveResourcesOnDeletion"] is True
+    # create-update, not the default: a malformed config skips its entry rather
+    # than halting the render, so under the default policy a typo could put an
+    # app on the deletion path. Measured 2026-08-13.
+    assert doc["spec"]["syncPolicy"]["applicationsSync"] == "create-update"
     files = doc["spec"]["generators"][0]["git"]["files"]
     assert files == [{"path": "appsets/managed-apps/*.yaml"}]
 


### PR DESCRIPTION
Follow-up to [#553](https://github.com/arigsela/kubernetes/pull/553). The cutover is live and healthy — all 12 Applications Synced, no finalizers, every live spec matching its golden, and the S3 buckets and IAM users intact. This PR acts on what the pilot's final experiment measured.

## What the experiment found

Acceptance criterion 5 was run by pointing the Preview tab's sandboxed generator at a branch with the `namespace` key deleted from `appsets/managed-apps/ecr-auth.yaml`.

**Preview works, and the error is precise:**

```
failed to execute go template {{ .namespace }}: template: base:1:3:
executing "base" at <.namespace>: map has no entry for key "namespace"
```

**But the controller then logged `generated 11 applications`.**

The design and the runbook both claimed `missingkey=error` halts the render for all 12 — a clean, fail-safe freeze. It does not. The broken entry is skipped and the rest render normally.

## Why that needed a policy change

A reduced generated set is the *same signal* the controller receives when an app is legitimately removed from Git. Under the default `applicationsSync`, a one-line typo could therefore put an app on the deletion path while the other eleven look perfectly healthy — partial and silent, rather than the loud whole-set stall the design predicted.

Whether the controller applies the partial set or aborts is version-dependent and upstream reports conflict ([#16832](https://github.com/argoproj/argo-cd/issues/16832) vs [#18780](https://github.com/argoproj/argo-cd/issues/18780) / [#9227](https://github.com/argoproj/argo-cd/issues/9227)). Settling it would mean merging a broken config into this cluster, which isn't worth doing.

`applicationsSync: create-update` removes the question: this ApplicationSet can no longer delete an Application at all. A broken config leaves its app **visibly stale** instead of silently gone.

**The cost**, accepted deliberately: removing a config now leaves an orphan Application. The runbook's "Removing an app" procedure carries the explicit `kubectl delete application` step.

## Changes

| File | |
|---|---|
| `base-apps/managed-apps.yaml` | `applicationsSync: create-update`, with the measurement recorded in a comment |
| `tests/appset/test_disjoint.py` | Pins the policy so it can't be dropped silently |
| `docs/managed-apps-appset.md` | Corrected failure mode; removal procedure gains the manual delete |
| `…/2026-08-13-managed-apps-appset-design.md` | §4.3 reversed, plus a new §11 recording what the pilot measured |

## Also corrected: Preview cannot see a branch

The generator is pinned to `revision: main`, so a config change on a branch is invisible to Preview — opening a PR does nothing. It has to be exercised by editing `revision` **inside the Preview tab's sandbox**, where edits are never saved. The design's §8 assumed the PR workflow and was wrong; §11.1 records the actual one.

## Verdict on the pilot

Worth recording, since evaluating the 3.5 feature was the whole point:

- `tests/appset/` catches this class of error at PR time — the deliberate break reddens three tests — so **Preview's marginal value for malformed configs is smaller than assumed**.
- Preview's real value is the class CI cannot see: a generator whose glob silently matches nothing, or a template edit whose blast radius isn't obvious from the diff.
- The genuinely valuable outcome wasn't the tab. It was discovering that the documented failure mode was wrong.

## Testing

`python -m pytest tests/appset/ -q` → 12 passed. `kubeconform` with CI's exact flags → Valid. `yamllint` clean. `kubectl apply --dry-run=server` confirms the live CRD accepts `applicationsSync` (read-only; nothing applied).

Cleanup: delete `experiment/appset-preview-break` once you're satisfied — it must never merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M8N3K3CzPSymsM3bH6Mf2