### PR TITLE
chore(argo-workflows): upgrade to v4.1.1 (chart 2.0.1)

### DIFF
--- a/base-apps/argo-workflows.yaml
+++ b/base-apps/argo-workflows.yaml
@@ -10,10 +10,48 @@ spec:
   source:
     repoURL: https://argoproj.github.io/argo-helm
     chart: argo-workflows
-    targetRevision: 0.45.19
+    # Chart 2.0.1 -> app v4.1.1 (was 0.45.19 -> v3.6.10). Two chart majors, and
+    # the only structural change that affects us is CRD installation.
+    #
+    # With crds.full=true (the default, kept below) the chart no longer ships
+    # CRDs as plain templates. It installs them from a `crdinstaller` image via
+    # a Job annotated `helm.sh/hook: pre-install,pre-upgrade`, which Argo CD maps
+    # to its PreSync phase. Consequences worth knowing before debugging a sync:
+    #
+    #   - A crdinstaller Job pod is created on EVERY sync of this app, not only
+    #     on version changes (hook-delete-policy recreates it each time). A
+    #     short-lived Job appearing in argo-workflows on unrelated syncs is
+    #     expected, not a leak.
+    #   - The Job server-side-applies the CRDs itself, so Argo CD never applies
+    #     them. The full CRDs are large; this is what keeps them clear of
+    #     client-side apply's annotation size limit.
+    #   - If the Job cannot schedule or lacks RBAC, the sync stalls in PreSync
+    #     and the controller is never upgraded. Look at the Job, not the chart.
+    #
+    # The alternative is crds.full=false: minified CRDs applied as ordinary
+    # templates with x-kubernetes-preserve-unknown-fields, no Job. Rejected —
+    # it drops OpenAPI validation, so a typo in a Workflow spec is accepted by
+    # the API server and only fails at runtime.
+    #
+    # 4.0 removed the Python SDK, the singular mutex/semaphore/schedule fields,
+    # podPriority, and INFORMER_WRITE_BACK. None are used here; verified against
+    # base-apps/argo-workflow-tasks/ before upgrading.
+    targetRevision: 2.0.1
     helm:
       releaseName: argo-workflows
       values: |
+        crds:
+          # Bound the PreSync Job so it cannot schedule unconstrained. The chart
+          # defaults these to {}, and ClusterPolicy/require-resource-limits is
+          # Audit rather than Enforce, so nothing else would catch it.
+          upgradeJob:
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
         controller:
           workflowNamespaces:
             - argo-workflows


### PR DESCRIPTION
Upgrades Argo Workflows from **v3.6.10** (chart `0.45.19`) to **v4.1.1** (chart `2.0.1`) — two chart majors and one app major.

## Why this is low risk here

4.0 removed the Python SDK, the singular `mutex`/`semaphore`/`schedule` fields, `podPriority`, and `INFORMER_WRITE_BACK`. **None are used.** `base-apps/argo-workflow-tasks/` holds three WorkflowTemplates (`artifact-example`, `cluster-health-check`, `hello-world-dag`) and there are zero CronWorkflows — the install has run nothing but examples for 124 days.

Every values key we set (`controller.*`, `artifactRepository.*`, `server.authModes`, node selectors, tolerations) still exists in 2.0.1. Verified by extracting the chart tarball and checking, rather than trusting the release notes — which say only "install full CRDs with the crdinstaller image" and do not enumerate what changed.

## The one structural change: CRD installation

With `crds.full=true` (the default, kept) the chart no longer ships CRDs as plain templates. It installs them from a `crdinstaller` image via a Job annotated `helm.sh/hook: pre-install,pre-upgrade`, which **Argo CD maps to PreSync**. Consequences, documented inline:

- A crdinstaller Job pod is created on **every sync** of this app, not just version changes. Expected, not a leak.
- The Job server-side-applies the CRDs itself, so Argo CD never applies them — which is what keeps the large full CRDs clear of client-side apply's annotation size limit.
- **If the Job can't schedule or lacks RBAC, the sync stalls in PreSync and the controller is never upgraded.** The failure looks like a chart problem and is really a Job problem.

Kept full CRDs rather than `crds.full=false`: the minified alternative uses `x-kubernetes-preserve-unknown-fields`, dropping OpenAPI validation, so a typo in a Workflow spec would be accepted by the API server and fail only at runtime.

Also bounded the PreSync Job's resources — the chart leaves them `{}` and `ClusterPolicy/require-resource-limits` is Audit, so nothing else would flag it.

## Verification

Application manifest and embedded Helm values both parse; `tests/appset/` 12 passed.

**Watch on merge:** the PreSync Job should run and complete, then the controller and server roll to `v4.1.1`. If the sync sits in PreSync, look at the Job in `argo-workflows`.

Sources: [Argo Workflows releases](https://github.com/argoproj/argo-workflows/releases) · [Upgrading guide](https://argo-workflows.readthedocs.io/en/latest/upgrading/) · [CRD installer docs](https://argo-workflows.readthedocs.io/en/latest/crd-installer/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF