### PR TITLE
feat(argo-workflows): weekly image vulnerability scanning

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -1,0 +1,280 @@
+# Weekly container image vulnerability scan.
+#
+# Design: docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+#
+# Scans EVERY running image (~75) and reports all of it to S3, but alerts only on
+# the handful we build ourselves (ECR). Scanning everything and alerting on
+# everything would surface hundreds of CVEs in upstream images we cannot patch,
+# and a report nobody acts on gets ignored — at which point it is worse than
+# nothing, because it is assumed to be watching.
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: image-scan
+  namespace: argo-workflows
+spec:
+  entrypoint: main
+  serviceAccountName: argo-workflow
+
+  # Bounds concurrent scan pods. Peak temp disk is roughly four scans' worth
+  # rather than seventy-five. See sizeLimit on the emptyDir below.
+  parallelism: 4
+
+  # Keep a quarter's worth of history for trend, then let them go.
+  ttlStrategy:
+    secondsAfterCompletion: 7776000
+  podGC:
+    strategy: OnWorkflowSuccess
+
+  arguments:
+    parameters:
+      # Images matching this prefix are "ours" and are the only ones that alert.
+      - name: owned-image-prefix
+        value: "852893458518.dkr.ecr."
+      - name: n8n-webhook
+        value: "http://n8n.n8n.svc.cluster.local:5678/webhook/image-scan-report"
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: discover
+            template: discover-images
+          - name: scan
+            template: scan-image
+            dependencies: [discover]
+            # Fan out: one scan pod per distinct image.
+            withParam: "{{tasks.discover.outputs.result}}"
+            arguments:
+              parameters:
+                - name: image
+                  value: "{{item}}"
+          - name: report
+            template: aggregate
+            dependencies: [scan]
+
+    # ---------------------------------------------------------------- discover
+    - name: discover-images
+      # Emits a JSON array of distinct images, which withParam fans out over.
+      # Requires ClusterRole/argo-workflow-pod-reader (serviceaccount.yaml).
+      script:
+        image: bitnami/kubectl:1.30
+        command: [bash]
+        source: |
+          set -eo pipefail
+          kubectl get pods -A \
+            -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
+            | grep -v '^$' | sort -u \
+            | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))'
+        resources:
+          requests: {cpu: 50m, memory: 64Mi}
+          limits: {cpu: 200m, memory: 256Mi}
+
+    # -------------------------------------------------------------------- scan
+    - name: scan-image
+      inputs:
+        parameters:
+          - name: image
+      # A flaky registry pull must not lose the whole run. Individual failures
+      # are tolerated by the aggregate step, which reports them as unscanned —
+      # silence about an unscanned image is the failure mode worth avoiding.
+      retryStrategy:
+        limit: "2"
+        retryPolicy: OnError
+        backoff:
+          duration: "30s"
+          factor: "2"
+      script:
+        image: aquasec/trivy:0.74.0
+        command: [sh]
+        source: |
+          set -eo pipefail
+          IMAGE="{{inputs.parameters.image}}"
+          echo "scanning ${IMAGE}" >&2
+          # Full severity set here; filtering to what we alert on happens at
+          # aggregate time so the S3 report keeps everything.
+          trivy image \
+            --format json \
+            --output /tmp/out/report.json \
+            --scanners vuln \
+            --timeout 15m \
+            "${IMAGE}" >&2
+        env:
+          # Trivy reads registry credentials from a docker config. ecr-registry
+          # is a dockerconfigjson refreshed hourly into EVERY namespace by
+          # base-apps/ecr-auth/cronjobs.yaml, so no new credential is minted.
+          - name: DOCKER_CONFIG
+            value: /docker
+          - name: TRIVY_CACHE_DIR
+            value: /tmp/cache
+        volumeMounts:
+          - name: scratch
+            mountPath: /tmp
+          - name: ecr
+            mountPath: /docker
+            readOnly: true
+        resources:
+          requests: {cpu: 200m, memory: 512Mi}
+          limits: {cpu: "1", memory: 2Gi}
+      volumes:
+        # emptyDir sizeLimit IS enforced by kubelet — a pod exceeding it is
+        # evicted rather than filling the node. This is the control the
+        # local-path PVC in base-apps/jupyter deliberately cannot provide, and
+        # it is why no node pinning is needed here.
+        - name: scratch
+          emptyDir:
+            sizeLimit: 8Gi
+        - name: ecr
+          secret:
+            secretName: ecr-registry
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+      outputs:
+        artifacts:
+          - name: report
+            path: /tmp/out/report.json
+            # Absent on scan failure; the aggregate step treats a missing
+            # report as "unscanned" rather than "clean".
+            optional: true
+
+    # --------------------------------------------------------------- aggregate
+    - name: aggregate
+      inputs:
+        artifacts:
+          - name: reports
+            path: /reports
+            # All per-image reports from this workflow's artifact repository
+            # prefix. keyFormat is set chart-side in base-apps/argo-workflows.yaml.
+            s3:
+              key: "{{workflow.namespace}}/{{workflow.name}}"
+            optional: true
+      script:
+        image: python:3.12-slim
+        command: [python3]
+        source: |
+          import json, os, pathlib, sys, urllib.request
+
+          OWNED = "{{workflow.parameters.owned-image-prefix}}"
+          WEBHOOK = "{{workflow.parameters.n8n-webhook}}"
+          ALERT_SEVERITIES = {"CRITICAL", "HIGH"}
+
+          findings, scanned, failed = [], [], []
+          for p in sorted(pathlib.Path("/reports").rglob("report.json")):
+              try:
+                  data = json.loads(p.read_text())
+              except Exception as e:
+                  failed.append(f"{p}: {e}")
+                  continue
+              artifact = data.get("ArtifactName", str(p))
+              scanned.append(artifact)
+              for result in data.get("Results") or []:
+                  for v in result.get("Vulnerabilities") or []:
+                      findings.append({
+                          "image": artifact,
+                          "id": v.get("VulnerabilityID"),
+                          "pkg": v.get("PkgName"),
+                          "installed": v.get("InstalledVersion"),
+                          "fixed": v.get("FixedVersion"),
+                          "severity": v.get("Severity"),
+                          "title": (v.get("Title") or "")[:200],
+                      })
+
+          # The full picture goes to S3 — every image, every severity, fixable
+          # or not. This is the queryable inventory, not the alert.
+          pathlib.Path("/tmp/out").mkdir(parents=True, exist_ok=True)
+          pathlib.Path("/tmp/out/full-report.json").write_text(json.dumps({
+              "scanned": scanned, "failed": failed, "findings": findings,
+          }, indent=2))
+
+          # The alert is deliberately much narrower: our own images only,
+          # CRITICAL/HIGH only, and only where a fix actually exists. A CVE with
+          # no available patch is something to know, not something to do — it
+          # stays in the S3 report above.
+          actionable = [
+              f for f in findings
+              if f["image"].startswith(OWNED)
+              and f["severity"] in ALERT_SEVERITIES
+              and f["fixed"]
+          ]
+
+          print(f"scanned {len(scanned)} images, {len(failed)} failed")
+          print(f"{len(findings)} total findings, {len(actionable)} actionable")
+
+          if actionable or failed:
+              by_image = {}
+              for f in actionable:
+                  by_image.setdefault(f["image"], []).append(f)
+              lines = []
+              for image, items in sorted(by_image.items()):
+                  short = image.split("/")[-1]
+                  crit = sum(1 for i in items if i["severity"] == "CRITICAL")
+                  high = sum(1 for i in items if i["severity"] == "HIGH")
+                  lines.append(f"*{short}* — {crit} critical, {high} high (all fixable)")
+                  for i in sorted(items, key=lambda x: x["id"])[:5]:
+                      lines.append(
+                          f"  • {i['id']} {i['pkg']} {i['installed']} → {i['fixed']}"
+                      )
+                  if len(items) > 5:
+                      lines.append(f"  • …and {len(items) - 5} more")
+              if failed:
+                  lines.append(f"_{len(failed)} image(s) could not be scanned_")
+
+              payload = {
+                  "scanned": len(scanned),
+                  "actionable": len(actionable),
+                  "failed": len(failed),
+                  "workflow": "{{workflow.name}}",
+                  "text": "\n".join(lines),
+              }
+              try:
+                  req = urllib.request.Request(
+                      WEBHOOK,
+                      data=json.dumps(payload).encode(),
+                      headers={"Content-Type": "application/json"},
+                  )
+                  urllib.request.urlopen(req, timeout=30).read()
+                  print("posted to n8n")
+              except Exception as e:
+                  # A webhook failure must not hide the finding. Surface it and
+                  # still fail below, so the Argo run is red either way.
+                  print(f"WARNING: n8n post failed: {e}", file=sys.stderr)
+
+          # Red run iff something is actionable. Unscanned images alone do not
+          # fail the run, but they are named in the alert above.
+          sys.exit(1 if actionable else 0)
+        volumeMounts:
+          - name: out
+            mountPath: /tmp/out
+        resources:
+          requests: {cpu: 100m, memory: 256Mi}
+          limits: {cpu: 500m, memory: 1Gi}
+      volumes:
+        - name: out
+          emptyDir:
+            sizeLimit: 1Gi
+      outputs:
+        artifacts:
+          - name: full-report
+            path: /tmp/out/full-report.json
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: image-scan
+  namespace: argo-workflows
+spec:
+  # Sunday 04:00 UTC. Clear of every other schedule in the repo: ecr-auth
+  # (hourly), agent-audit (01:30, 07:00), CNPG backup (02:00), wan-ip-monitor
+  # (every 12h).
+  schedules:
+    - "0 4 * * 0"
+  timezone: UTC
+  concurrencyPolicy: Forbid
+  # A scan that did not run is not an emergency; skip rather than pile up.
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 4
+  workflowSpec:
+    workflowTemplateRef:
+      name: image-scan

--- a/base-apps/argo-workflow-tasks/serviceaccount.yaml
+++ b/base-apps/argo-workflow-tasks/serviceaccount.yaml
@@ -6,3 +6,38 @@ metadata:
 # Referenced by the Helm chart's argo-workflows-workflow RoleBinding
 # (which grants create on workflowtaskresults). The chart binds the SA
 # but does not create it, so we define it here.
+---
+# Cluster-wide pod READ, and nothing else.
+#
+# Added for image-scan.yaml, whose discover step needs the running image list.
+# It also unblocks cluster-health-check.yaml, which has carried the comment
+# "requires Phase 4 RBAC (ClusterRole with get/list on nodes & pods)" since it
+# was written and would fail today — the SA previously had no cluster read at
+# all, only the chart's RoleBinding for workflowtaskresults.
+#
+# Deliberately narrower than that comment asked for: pods only, not nodes.
+# Image discovery needs the pod list and nothing more, and this SA is what every
+# workflow in this namespace runs as — so anything granted here is granted to
+# arbitrary workflow code. Widen it only for a workflow that demonstrably needs
+# it, and prefer a separate ServiceAccount over widening this one.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-workflow-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflow-pod-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflow-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow
+    namespace: argo-workflows

--- a/base-apps/n8n/deployments.yaml
+++ b/base-apps/n8n/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         # or add a workflow, recompute this — else the pod won't roll and the
         # change won't take effect. (Or just
         # `kubectl rollout restart deploy/n8n -n n8n`.)
-        checksum/workflows: "bd209e38e3b5a0cb"
+        checksum/workflows: "eb14574689f870ee"
     spec:
       nodeSelector:
         node.kubernetes.io/workload: application
@@ -51,6 +51,8 @@ spec:
           n8n update:workflow --id=grafana-alerts-slack --active=true
           n8n import:workflow --input=/workflows/wan-ip-rotated.json
           n8n update:workflow --id=wan-ip-rotated --active=true
+          n8n import:workflow --input=/workflows/image-scan-report.json
+          n8n update:workflow --id=image-scan-report --active=true
         env:
         - name: DB_TYPE
           value: "postgresdb"

--- a/base-apps/n8n/workflows-configmap.yaml
+++ b/base-apps/n8n/workflows-configmap.yaml
@@ -133,3 +133,65 @@ data:
       "connections": {},
       "settings": { "executionOrder": "v1" }
     }
+  image-scan-report.json: |
+    {
+      "id": "image-scan-report",
+      "name": "Image Vulnerability Scan Report",
+      "active": true,
+      "nodes": [
+        {
+          "parameters": {
+            "httpMethod": "POST",
+            "path": "image-scan-report",
+            "options": {}
+          },
+          "id": "d3b8e3f2-6c8f-4c23-a222-000000000001",
+          "name": "Scan Webhook",
+          "type": "n8n-nodes-base.webhook",
+          "typeVersion": 2,
+          "position": [0, 0],
+          "webhookId": "d3b8e3f2-6c8f-4c23-a222-00000000000a"
+        },
+        {
+          "parameters": {
+            "jsCode": "const p = $json.body ?? $json;\nconst n = p.actionable || 0;\nconst head = n > 0\n  ? ':shield: *Image scan: ' + n + ' fixable finding(s) in our images*'\n  : ':shield: *Image scan: no fixable findings in our images*';\nconst foot = '_' + (p.scanned || 0) + ' images scanned'\n  + (p.failed ? ', ' + p.failed + ' failed' : '')\n  + ' — full report in S3 (workflow ' + (p.workflow || 'unknown') + ')_';\nconst text = [head, p.text || '', foot].filter(Boolean).join('\\n');\nreturn [{ json: { slack: { channel: '#oncall-alerts', text: text, unfurl_links: false } } }];"
+          },
+          "id": "d3b8e3f2-6c8f-4c23-a222-000000000002",
+          "name": "Format Scan Report",
+          "type": "n8n-nodes-base.code",
+          "typeVersion": 2,
+          "position": [220, 0]
+        },
+        {
+          "parameters": {
+            "method": "POST",
+            "url": "https://slack.com/api/chat.postMessage",
+            "sendHeaders": true,
+            "headerParameters": {
+              "parameters": [
+                { "name": "Authorization", "value": "=Bearer {{ $env.SLACK_BOT_TOKEN }}" },
+                { "name": "Content-Type", "value": "application/json" }
+              ]
+            },
+            "sendBody": true,
+            "specifyBody": "json",
+            "jsonBody": "={{ JSON.stringify($json.slack) }}",
+            "options": {}
+          },
+          "id": "d3b8e3f2-6c8f-4c23-a222-000000000003",
+          "name": "Post Scan to Slack",
+          "type": "n8n-nodes-base.httpRequest",
+          "typeVersion": 4.2,
+          "position": [440, 0]
+        }
+      ],
+      "connections": {
+        "Scan Webhook": {
+          "main": [[{ "node": "Format Scan Report", "type": "main", "index": 0 }]]
+        },
+        "Format Scan Report": {
+          "main": [[{ "node": "Post Scan to Slack", "type": "main", "index": 0 }]]
+        }
+      },
+      "settings": { "executionOrder": "v1" }
+    }

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -1,0 +1,209 @@
+# Image Vulnerability Scanning — Design
+
+- **Date:** 2026-08-17
+- **Status:** Draft for review
+- **Goal:** Know, weekly, whether any image we build has a fixable CRITICAL or HIGH vulnerability — without drowning that signal in CVEs we cannot act on.
+- **Related:** [ADP Remaining Pillars](2026-07-14-adp-remaining-pillars-roadmap.md) (L03 Security). Terraform drift detection was scoped out — see §7.
+
+## 1. Problem
+
+Nothing in the cluster scans container images. 75 distinct images run across all
+namespaces and no one knows whether any carries a known vulnerability.
+
+The naive version of this is worse than nothing. Scanning 75 images surfaces
+hundreds of CVEs, overwhelmingly in upstream images — Grafana, Vault, Postgres,
+ClickHouse — that cannot be fixed here at all. A report nobody acts on gets
+ignored within two weeks, and then it is actively harmful, because it is assumed
+to be watching.
+
+**The split that makes this tractable: 6 of the 75 images are ours** (ECR:
+`backstage-portal`, `homelab-agent`, `kagent-ui`, `oncall-agent`,
+`weather-kitchen-backend`, `weather-kitchen-frontend`). Those have Dockerfiles we
+control and can rebuild. The other 69 we can only observe.
+
+## 2. Scope
+
+**In scope.** Weekly scan of every running image; full JSON reports to S3;
+a Slack alert via n8n for **fixable CRITICAL/HIGH findings in our own images
+only**; the ServiceAccount RBAC that scanning requires.
+
+**Out of scope.** Terraform drift detection (§7). Admission-time blocking of
+vulnerable images. SBOM generation. Scanning images not currently running.
+Continuous scanning — see §3.1 approach 3.
+
+## 3. Key decisions
+
+### 3.1 Argo CronWorkflow with fan-out, not a CronJob and not Trivy Operator
+
+| | Approach | Verdict |
+|---|---|---|
+| 1 | Argo CronWorkflow, fan-out per image | **Chosen** |
+| 2 | Single container looping over images | Rejected — right shape at 6 images, wrong at 75 |
+| 3 | Trivy Operator | Rejected — disproportionate standing machinery |
+
+Approach 2 fails on scale: 75 sequential scans is one long run where a single
+flaky registry pull kills everything downstream, with no per-image retry. Argo's
+fan-out gives each image its own retry and its own failure.
+
+Approach 3 is the *proper* tool if the goal were continuous posture management —
+the operator watches workloads and emits `VulnerabilityReport` CRs as they
+change. It is rejected because the requirement is a **weekly** question, and
+answering it with a permanently-resident operator plus its own CRDs inverts the
+cost. It is also a new app to maintain indefinitely, against a CronWorkflow that
+can be deleted in one commit.
+
+There is a secondary reason to prefer Argo here: **the cluster has run Argo
+Workflows for 124 days and executed nothing but examples.** This is a real
+workload for infrastructure already paid for.
+
+### 3.2 Scan everything, alert on ours
+
+Two different questions, two different outputs:
+
+| Question | Answer | Delivery |
+|---|---|---|
+| "Is something I can fix broken?" | Fixable CRITICAL/HIGH in the 6 ECR images | **Slack, via n8n** |
+| "What is the posture of everything?" | Full JSON for all 75 | **S3, queried on demand** |
+
+The inventory stays queryable — from a notebook, since the Jupyter workspace can
+already read S3 — without any of it competing for attention.
+
+**`--ignore-unfixed` is applied to the alerting path.** A CVE with no available
+patch is not actionable this week; it is a thing to know, not a thing to do. It
+still lands in the S3 report.
+
+### 3.3 Bounded disk, and why this one is genuinely bounded
+
+Trivy downloads layers to scan them; 75 images is potentially tens of GB of
+temporary data, plus a ~700MB vulnerability database per run.
+
+The scan pods use an **`emptyDir` with `sizeLimit: 8Gi`** for Trivy's cache and
+temp space. Unlike the `local-path` PVC problem documented in the JupyterLab
+design (§3.3.1 there — `local-path` bind-mounts into the node filesystem and
+enforces nothing), **`emptyDir` `sizeLimit` is enforced by kubelet**: a pod
+exceeding it is evicted rather than filling the node. So no node pinning is
+needed here; the control is real.
+
+`parallelism: 4` at the workflow level bounds concurrent scans, so peak disk is
+roughly four scans' worth, not seventy-five.
+
+### 3.4 Credentials: reuse, don't mint
+
+**ECR** — `ecr-credentials-sync` (`base-apps/ecr-auth/cronjobs.yaml`) already
+refreshes an `ecr-registry` dockerconfigjson into **every** namespace hourly; one
+has existed in `argo-workflows` for 125 days. The scan step mounts it at
+`DOCKER_CONFIG`. No new credential, no new IAM user.
+
+**S3** — the artifact repository is already configured in the chart values
+against `argo-workflows-s3-creds` and `asela-argo-workflows-artifacts`. Reports
+are ordinary Argo output artifacts; nothing new is wired.
+
+**Slack** — n8n already holds `SLACK_BOT_TOKEN` and posts to `#oncall-alerts`.
+The scan never touches it; it POSTs to an n8n webhook and n8n owns the token.
+This keeps the Slack credential in exactly one place.
+
+### 3.5 RBAC — a prerequisite that is already blocking something else
+
+Discovering running images needs `get`/`list` on pods cluster-wide. The
+`argo-workflow` ServiceAccount currently has only the chart's
+`argo-workflows-workflow` RoleBinding (for `workflowtaskresults`) and **no
+cluster read access at all**.
+
+This is not new debt. `base-apps/argo-workflow-tasks/cluster-health-check.yaml`
+already carries the comment *"requires Phase 4 RBAC (ClusterRole with get/list on
+nodes & pods) to read cluster-wide"* — that template would fail today. This
+design adds the ClusterRole, which unblocks it as a side effect.
+
+Scope is deliberately narrow: `get`/`list`/`watch` on `pods` only. Not nodes, not
+secrets, not workloads. Image discovery needs the pod list and nothing more.
+
+### 3.6 Failure semantics
+
+The aggregate step exits non-zero when any ECR image has a fixable CRITICAL or
+HIGH. That makes the Argo run red *and* fires the Slack alert — the UI history
+becomes the record of which weeks were clean, without anyone needing to read it
+for the alert to work.
+
+Individual scan failures do **not** fail the run. A registry timeout on one of 75
+images should not suppress the other 74 results; failed images are listed in the
+report and named in the alert as unscanned. Silence about an unscanned image is
+the failure mode worth avoiding.
+
+## 4. Architecture
+
+```
+CronWorkflow (Sun 04:00 UTC)
+   └─ WorkflowTemplate: image-scan
+        │
+        ├─ [1] discover ────── kubectl get pods -A → distinct images → JSON list
+        │                       (needs ClusterRole: pods get/list)
+        ├─ [2] scan ─────────── withParam fan-out, parallelism 4, retry 2
+        │        each: trivy image --format json
+        │        emptyDir sizeLimit 8Gi · DOCKER_CONFIG=ecr-registry
+        │        → per-image JSON artifact
+        └─ [3] aggregate ────── merge → full report to S3
+                                filter: ECR images ∧ (CRITICAL|HIGH) ∧ fixable
+                                → POST n8n webhook `image-scan-report`
+                                → exit 1 if any finding
+                                        │
+                                        └─ n8n → Slack #oncall-alerts
+```
+
+## 5. Files
+
+| File | Change |
+|---|---|
+| `base-apps/argo-workflow-tasks/image-scan.yaml` | **New** — `WorkflowTemplate` + `CronWorkflow` |
+| `base-apps/argo-workflow-tasks/serviceaccount.yaml` | Add `ClusterRole` + `ClusterRoleBinding` for pod read |
+| `base-apps/n8n/workflows-configmap.yaml` | Add `image-scan-report.json` (webhook → format → Slack) |
+| `base-apps/n8n/deployments.yaml` | Recompute `checksum/workflows` |
+
+`base-apps/argo-workflow-tasks/` carries no `catalog-info.yaml`, so it is outside
+the agent-docs contract and no `docs.md`/`runbook.md` is required.
+
+**The n8n checksum is load-bearest here.** `deployments.yaml` documents it: the
+annotation is the sha256 of every workflow concatenated in sorted-key order, and
+if it is not recomputed the pod does not roll, the import initContainer does not
+re-run, and the new webhook is never registered. The failure is silent — n8n
+returns 404 for the path and the scan's alert POST fails. Recompute with the
+command in that file's comment.
+
+## 6. Verification
+
+**Static:** all manifests parse; `python -m pytest tests/ -q` stays green; the
+recomputed checksum matches the documented command's output.
+
+**After merge:**
+1. `kubectl -n argo-workflows get cronworkflow image-scan` exists and is not suspended.
+2. Submit manually rather than waiting a week:
+   `argo submit --from workflowtemplate/image-scan -n argo-workflows --watch`
+3. The discover step returns ~75 images.
+4. Scans run at most 4 concurrently; no pod is evicted for exceeding `sizeLimit`.
+5. A full JSON report lands in `asela-argo-workflows-artifacts`.
+6. `curl` the n8n webhook path directly to confirm it is registered (a 404 means
+   the checksum was not recomputed — see §5).
+7. Confirm the run is red iff an ECR image has a fixable CRITICAL/HIGH.
+
+## 7. Terraform drift detection — scoped out, with reasoning
+
+Originally paired with this. Removed after finding the repo has **one** Terraform
+root (`terraform/roots/asela-cluster`), not several. Drift detection is therefore
+a single `terraform init && plan -detailed-exitcode` — one container on a
+schedule, which is a CronJob. Argo's fan-out, artifacts, and per-step retry all
+buy nothing.
+
+It also has a genuine design question this design does not address: a scheduled
+plan contends with **Atlantis for the S3 state lock**, and the repo already
+documents that a wedged workdir needs `atlantis unlock`. That deserves its own
+spec rather than being smuggled in beside an unrelated scanner.
+
+## 8. Open questions
+
+None blocking. One judgement call worth review:
+
+**Alerting on ECR images only.** If an upstream image ever ships something
+severe and directly exposed — an Istio or Vault CVE, say — it lands in S3 and
+nobody is told. The counter-argument is that alerting on unfixable upstream CVEs
+is what makes scanners get ignored. If this proves wrong, the narrowest fix is a
+second, much tighter alert rule for a hand-picked list of internet-facing
+images, not widening this one.


### PR DESCRIPTION
Scans every running image weekly and reports all of it to S3 — but alerts only on the images we build ourselves.

**Design:** `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md`

## The problem this is shaped around

75 distinct images run in the cluster; **6 are ours** (ECR). Scanning all 75 and alerting on all 75 surfaces hundreds of CVEs in Grafana, Vault, Postgres and ClickHouse that we cannot patch here. A report nobody acts on gets ignored within two weeks — and is then worse than nothing, because it's assumed to be watching.

So the alert is narrowed three ways: **our ECR images only, CRITICAL/HIGH only, fixable only.** A CVE with no available patch is a thing to know, not a thing to do; it stays in the S3 report.

| Question | Answer | Delivery |
|---|---|---|
| "Is something I can fix broken?" | Fixable CRITICAL/HIGH in the 6 ECR images | Slack `#oncall-alerts` via n8n |
| "What's the posture of everything?" | Full JSON, all 75, all severities | S3 — queryable from the Jupyter workspace |

## Why Argo, and not the alternatives

**Not a CronJob:** 75 sequential scans is one long run where a single flaky registry pull kills everything downstream. Fan-out gives each image its own retry.

**Not Trivy Operator:** genuinely the right tool for *continuous* posture management, but the requirement is weekly. A permanently-resident operator plus its own CRDs to answer a weekly question inverts the cost — and it's a new app to maintain forever, against a CronWorkflow deletable in one commit.

Secondary: Argo Workflows has run for 124 days and executed nothing but examples. This is real work for infrastructure already paid for.

## No new credentials

- **ECR** — `ecr-credentials-sync` already refreshes an `ecr-registry` dockerconfigjson into *every* namespace hourly; one has existed in `argo-workflows` for 125 days. Mounted at `DOCKER_CONFIG`.
- **S3** — the artifact repository is already configured against `asela-argo-workflows-artifacts`. Reports are ordinary Argo artifacts.
- **Slack** — n8n already holds `SLACK_BOT_TOKEN`. The scan POSTs to a webhook; n8n owns the token, so it stays in one place.

## Disk, and a contrast worth noting

Trivy downloads layers; 75 images could be tens of GB. Scan pods use an **`emptyDir` with `sizeLimit: 8Gi`**, and unlike the `local-path` PVC problem documented in the JupyterLab design, **kubelet actually enforces this** — an over-running pod is evicted rather than filling the node. That's why this needs no node pinning. `parallelism: 4` keeps peak disk to about four scans' worth.

## RBAC — pre-existing debt, now paid

Adds `ClusterRole/argo-workflow-pod-reader` (pods `get`/`list`/`watch`, nothing else). The `argo-workflow` SA previously had **no cluster read at all**.

This isn't new: `cluster-health-check.yaml` has carried the comment *"requires Phase 4 RBAC (ClusterRole with get/list on nodes & pods)"* since it was written and **would fail today**. Scoped to pods rather than the nodes+pods that comment asked for — every workflow in the namespace runs as this SA, so anything granted here is granted to arbitrary workflow code.

## Failure semantics

The run goes red **iff** an ECR image has a fixable CRITICAL/HIGH. Individual scan failures do *not* fail the run — a timeout on 1 of 75 shouldn't suppress the other 74 — but unscanned images are named in both the report and the alert. Silence about an unscanned image is the failure mode worth avoiding.

## n8n wiring — three coupled edits

Adding an n8n workflow needs all three or it silently no-ops:
1. `image-scan-report.json` in the ConfigMap
2. **`import:workflow` + `update:workflow --active` lines in the initContainer** — the ConfigMap alone is never imported
3. **`checksum/workflows` recomputed** (`bd209e38e3b5a0cb` → `eb14574689f870ee`) — otherwise the pod doesn't roll, the import doesn't re-run, and the webhook returns 404

Verified all three: every workflow in the ConfigMap has matching import+activate lines, and the checksum matches the documented command's output.

## Version compatibility

Uses `schedules:` (plural, introduced in 3.6). Works on both the current **v3.6.10** and the **v4.1.1** in #559 — **merge order doesn't matter.**

## Verification

`python3 -m pytest tests/ -q` → **316 passed** · all manifests parse · doc gates in sync · checksum consistency asserted.

**After merge** — don't wait a week:
```
argo submit --from workflowtemplate/image-scan -n argo-workflows --watch
```
Then confirm ~75 images discovered, ≤4 concurrent scans, no evictions, a report in S3, and the n8n webhook registered (a 404 means the checksum didn't take).

## Scoped out: Terraform drift detection

You asked for this alongside. Removed after finding the repo has **one** Terraform root — so drift detection is a single `terraform plan`, i.e. a CronJob, and Argo's fan-out/artifacts/retries buy nothing. It also has an unanswered question this design shouldn't smuggle in: a scheduled plan **contends with Atlantis for the S3 state lock**, and the runbook already documents that a wedged workdir needs `atlantis unlock`. Recorded in the spec as §7; it deserves its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF
