### PR TITLE
fix(image-scan): discover images via the K8s API, not a dead kubectl image

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -57,15 +57,47 @@ spec:
     - name: discover-images
       # Emits a JSON array of distinct images, which withParam fans out over.
       # Requires ClusterRole/argo-workflow-pod-reader (serviceaccount.yaml).
+      #
+      # Talks to the Kubernetes API directly rather than shelling out to kubectl,
+      # deliberately. The obvious `bitnami/kubectl` is gone — Bitnami withdrew its
+      # public Docker Hub catalog, and `bitnami/kubectl:1.30` now 404s on pull.
+      # (base-apps/argo-workflow-tasks/cluster-health-check.yaml still references
+      # it and is broken for the same reason.) The official replacement,
+      # registry.k8s.io/kubectl, is distroless — no shell — so a `script` block
+      # cannot run there either.
+      #
+      # Using the API from python:3.12-slim removes the third-party image
+      # dependency altogether, reuses the image the aggregate step already needs,
+      # and asks for exactly the access the ClusterRole grants.
       script:
-        image: bitnami/kubectl:1.30
-        command: [bash]
+        image: python:3.12-slim
+        command: [python3]
         source: |
-          set -eo pipefail
-          kubectl get pods -A \
-            -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
-            | grep -v '^$' | sort -u \
-            | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))'
+          import json, ssl, urllib.request
+
+          SA = "/var/run/secrets/kubernetes.io/serviceaccount"
+          token = open(f"{SA}/token").read().strip()
+          ctx = ssl.create_default_context(cafile=f"{SA}/ca.crt")
+
+          images, cont = set(), ""
+          while True:
+              url = "https://kubernetes.default.svc/api/v1/pods?limit=500"
+              if cont:
+                  url += f"&continue={cont}"
+              req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+              page = json.load(urllib.request.urlopen(req, context=ctx, timeout=60))
+              for pod in page.get("items", []):
+                  spec = pod.get("spec", {})
+                  # initContainers too: a vulnerable init image runs in the same
+                  # pod and is no less present for finishing early.
+                  for c in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+                      if c.get("image"):
+                          images.add(c["image"])
+              cont = page.get("metadata", {}).get("continue") or ""
+              if not cont:
+                  break
+
+          print(json.dumps(sorted(images)))
         resources:
           requests: {cpu: 50m, memory: 64Mi}
           limits: {cpu: 200m, memory: 256Mi}

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -7,7 +7,7 @@
 
 ## 1. Problem
 
-Nothing in the cluster scans container images. 75 distinct images run across all
+Nothing in the cluster scans container images. 78 distinct images run across all
 namespaces and no one knows whether any carries a known vulnerability.
 
 The naive version of this is worse than nothing. Scanning 75 images surfaces
@@ -16,10 +16,10 @@ ClickHouse — that cannot be fixed here at all. A report nobody acts on gets
 ignored within two weeks, and then it is actively harmful, because it is assumed
 to be watching.
 
-**The split that makes this tractable: 6 of the 75 images are ours** (ECR:
+**The split that makes this tractable: 6 of the 78 images are ours** (ECR:
 `backstage-portal`, `homelab-agent`, `kagent-ui`, `oncall-agent`,
 `weather-kitchen-backend`, `weather-kitchen-frontend`). Those have Dockerfiles we
-control and can rebuild. The other 69 we can only observe.
+control and can rebuild. The other 72 we can only observe.
 
 ## 2. Scope
 
@@ -144,11 +144,17 @@ cluster read access at all**.
 
 This is not new debt. `base-apps/argo-workflow-tasks/cluster-health-check.yaml`
 already carries the comment *"requires Phase 4 RBAC (ClusterRole with get/list on
-nodes & pods) to read cluster-wide"* — that template would fail today. This
-design adds the ClusterRole, which unblocks it as a side effect.
+nodes & pods) to read cluster-wide"* — that template would fail today.
 
 Scope is deliberately narrow: `get`/`list`/`watch` on `pods` only. Not nodes, not
-secrets, not workloads. Image discovery needs the pod list and nothing more.
+secrets, not workloads. Image discovery needs the pod list and nothing more, and
+this ServiceAccount is what *every* workflow in the namespace runs as — anything
+granted here is granted to arbitrary workflow code.
+
+That narrowness is why this does **not** fix `cluster-health-check`: it reads
+nodes as well as pods, and is independently broken by the dead `bitnami/kubectl`
+image (§3.4.1). Widening the role to make an unrelated template work would be
+exactly the reflex worth resisting. It stays broken and recorded.
 
 ### 3.6 Failure semantics
 

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -102,6 +102,39 @@ are ordinary Argo output artifacts; nothing new is wired.
 The scan never touches it; it POSTs to an n8n webhook and n8n owns the token.
 This keeps the Slack credential in exactly one place.
 
+### 3.4.1 Image discovery talks to the API, not kubectl
+
+Amended 2026-08-17 after the first live run failed.
+
+The discover step originally used `bitnami/kubectl:1.30`, copied from the
+sibling `cluster-health-check.yaml`. **That image no longer exists** — Bitnami
+withdrew its public Docker Hub catalog, and the pull now 404s:
+
+```
+failed to resolve reference "docker.io/bitnami/kubectl:1.30": not found
+```
+
+The official replacement, `registry.k8s.io/kubectl`, is **distroless** — no
+shell — so an Argo `script` block cannot run there either.
+
+Rather than pick another third-party kubectl image, the step now reads the
+Kubernetes API directly from `python:3.12-slim` using the pod's ServiceAccount
+token. This removes the third-party dependency entirely, reuses the image the
+aggregate step already needs, and asks for precisely the access §3.5 grants.
+It also paginates, which a `kubectl -o jsonpath` one-liner did not.
+
+Verified in-cluster as the `argo-workflow` ServiceAccount: **78 distinct images,
+6 of them ECR.** The count rose from 75 because the API walk includes
+`initContainers` — a vulnerable init image runs in the same pod and is no less
+present for finishing early.
+
+> **Finding, not fixed here:** `base-apps/argo-workflow-tasks/cluster-health-check.yaml`
+> still references the dead `bitnami/kubectl:1.30` and cannot run. It is broken
+> a second way too — it reads **nodes**, which the ClusterRole in §3.5
+> deliberately excludes. Repairing it needs an RBAC decision this design
+> declined to make, so it is left broken and recorded rather than quietly
+> widened.
+
 ### 3.5 RBAC — a prerequisite that is already blocking something else
 
 Discovering running images needs `get`/`list` on pods cluster-wide. The
@@ -135,7 +168,7 @@ the failure mode worth avoiding.
 CronWorkflow (Sun 04:00 UTC)
    └─ WorkflowTemplate: image-scan
         │
-        ├─ [1] discover ────── kubectl get pods -A → distinct images → JSON list
+        ├─ [1] discover ────── K8s API (SA token) → distinct images incl. initContainers
         │                       (needs ClusterRole: pods get/list)
         ├─ [2] scan ─────────── withParam fan-out, parallelism 4, retry 2
         │        each: trivy image --format json


### PR DESCRIPTION
The first live run of the scanner never got past discovery.

## What happened

`bitnami/kubectl:1.30` **404s on pull** — Bitnami withdrew its public Docker Hub catalog, so that reference is simply gone:

```
failed to resolve reference "docker.io/bitnami/kubectl:1.30": not found
```

I'd copied that image from the sibling `cluster-health-check.yaml`, which means **that template is broken too** and has been since Bitnami's change — consistent with the install having run nothing but examples for 124 days.

The official replacement, `registry.k8s.io/kubectl`, is **distroless** — no shell — so an Argo `script` block can't run there either.

## The fix

Read the Kubernetes API directly from `python:3.12-slim` using the pod's ServiceAccount token. This:

- **removes the third-party image dependency altogether** — no Bitnami, no Docker Hub rate limits, no distroless workaround
- reuses the image the aggregate step already needs
- asks for exactly the access `ClusterRole/argo-workflow-pod-reader` grants
- **paginates**, which the `kubectl -o jsonpath` one-liner did not

## Verified before asking you to merge

Ran the exact script in-cluster as the `argo-workflow` ServiceAccount:

```
78 distinct images
ECR: 6
```

The count rose from 75 because the API walk includes **`initContainers`** — a vulnerable init image runs in the same pod and is no less present for having finished early.

## Finding recorded, not fixed

`cluster-health-check.yaml` references the same dead image. It's broken **twice over**: the image is gone, *and* it reads **nodes**, which the ClusterRole deliberately excludes.

Repairing it needs an RBAC decision the design declined to make — that ServiceAccount is what every workflow in the namespace runs as, so anything granted goes to arbitrary workflow code. Widening the role to fix an unrelated template is exactly the reflex worth resisting, so it stays broken and documented (spec §3.4.1).

## Also in here

The spec claimed the ClusterRole would unblock `cluster-health-check` "as a side effect". §3.4.1 then established it doesn't. Contradiction corrected, counts updated 75 → 78.

## Verification

`python3 -m pytest tests/ -q` → **316 passed** · manifests parse · discover step verified live.

**After merge:** `argo submit --from workflowtemplate/image-scan -n argo-workflows --watch` — expect ~78 images discovered, ≤4 concurrent scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF
