### PR TITLE
fix(image-scan): create the output dir, and store reports unarchived

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -122,10 +122,17 @@ spec:
         source: |
           set -eo pipefail
           IMAGE="{{inputs.parameters.image}}"
+          # Trivy does NOT create parent directories for --output and fails with
+          # "no such file or directory" if they are missing. The emptyDir mounts
+          # at /tmp, so /tmp/out has to be made here.
+          mkdir -p /tmp/out
           echo "scanning ${IMAGE}" >&2
           # Full severity set here; filtering to what we alert on happens at
           # aggregate time so the S3 report keeps everything.
+          # --quiet suppresses the DB-download progress bar, which otherwise
+          # buries real errors under megabytes of carriage returns in the logs.
           trivy image \
+            --quiet \
             --format json \
             --output /tmp/out/report.json \
             --scanners vuln \
@@ -169,6 +176,10 @@ spec:
             # Absent on scan failure; the aggregate step treats a missing
             # report as "unscanned" rather than "clean".
             optional: true
+            # Argo tar+gzips artifacts by default. The aggregate step reads
+            # these as plain JSON, so store them raw.
+            archive:
+              none: {}
 
     # --------------------------------------------------------------- aggregate
     - name: aggregate
@@ -192,7 +203,11 @@ spec:
           ALERT_SEVERITIES = {"CRITICAL", "HIGH"}
 
           findings, scanned, failed = [], [], []
-          for p in sorted(pathlib.Path("/reports").rglob("report.json")):
+          # rglob("*.json") rather than "report.json": Argo lays artifacts out
+          # under the repository keyFormat, and the leaf filename is not
+          # guaranteed to survive as report.json. Matching any .json under the
+          # prefix is robust to that without depending on the exact layout.
+          for p in sorted(pathlib.Path("/reports").rglob("*.json")):
               try:
                   data = json.loads(p.read_text())
               except Exception as e:

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -135,6 +135,32 @@ present for finishing early.
 > declined to make, so it is left broken and recorded rather than quietly
 > widened.
 
+### 3.4.2 Two artifact-handling details the first run exposed
+
+Amended 2026-08-17 after the second live run.
+
+**Trivy does not create `--output` parent directories.** The `emptyDir` mounts at
+`/tmp`, so `/tmp/out` does not exist and every scan died with
+`open /tmp/out/report.json: no such file or directory`. The scan step now
+`mkdir -p /tmp/out` first. Worth noting how this presented: the first two
+failures were both ECR images, which looked like an authentication problem and
+was not — they were simply the first to reach the write step, and the fault was
+universal.
+
+**Argo tar+gzips artifacts by default.** The aggregate step reads plain JSON, so
+the report artifact sets `archive: none`. The aggregate glob is also
+`rglob("*.json")` rather than the exact `report.json`, since the leaf filename
+under the repository `keyFormat` is not guaranteed.
+
+`--quiet` was added to the Trivy invocation as well: its DB-download progress bar
+wrote megabytes of carriage-returns into the pod log and buried the actual error
+message, which is what made the first diagnosis slower than it should have been.
+
+**Verified in-cluster** before merge, on `homelab-agent:v0.3.0` with the real
+`ecr-registry` credential: a 1.1MB report written, **4 CRITICAL and 29 HIGH, 65
+with a fix available**. ECR authentication works, and the alert path will have
+genuine findings to carry on its first scheduled run.
+
 ### 3.5 RBAC — a prerequisite that is already blocking something else
 
 Discovering running images needs `get`/`list` on pods cluster-wide. The


### PR DESCRIPTION
Second live run: **every scan failed.**

```
FATAL run error: report error: unable to write results:
open /tmp/out/report.json: no such file or directory
```

Trivy doesn't create parent directories for `--output`, and the `emptyDir` mounts at `/tmp`, so `/tmp/out` never existed.

## A diagnosis worth recording

The first two failures were both **ECR images**, which looked like an authentication problem. It wasn't — they were simply the first to reach the write step, and the fault was universal. **ECR auth works fine**, verified separately below.

What made that slower to see than it should have been: Trivy's DB-download progress bar wrote megabytes of carriage returns into the pod log and buried the actual error. `--quiet` added.

## Three fixes

1. **`mkdir -p /tmp/out`** before the scan.
2. **`archive: none`** on the report artifact — Argo tar+gzips artifacts by default, but the aggregate step reads plain JSON.
3. **`rglob("*.json")`** instead of the exact `report.json` — the leaf filename under the repository `keyFormat` isn't guaranteed to survive.

## Verified in-cluster before asking you to merge

Ran the real scan step with the real `ecr-registry` credential against `homelab-agent:v0.3.0`:

```
OK bytes=1164819
      4 "Severity": "CRITICAL"
     29 "Severity": "HIGH"
     90 "Severity": "MEDIUM"
     98 "Severity": "LOW"
FIXABLE: 65
```

So: ECR authentication works, reports write correctly, and **the alert path will have genuine findings on its first scheduled run** — `homelab-agent` alone has 4 criticals with fixes available.

Also confirmed earlier in the same run: discovery emitted all 78 images, fan-out held to exactly 4 concurrent, and no pod was evicted for exceeding the 8Gi `sizeLimit` while worker-01 sat at 59% with 79G free.

## Verification

`python3 -m pytest tests/ -q` → **316 passed** · manifest parses · scan step verified live.

**After merge:** `argo submit --from workflowtemplate/image-scan -n argo-workflows --watch`. Expect the run to go **red** — that's correct behaviour when an ECR image has fixable criticals, and a Slack message should land in `#oncall-alerts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF
