### PR TITLE
fix(image-scan): store the aggregate report as raw JSON too

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -304,6 +304,12 @@ spec:
         artifacts:
           - name: full-report
             path: /tmp/out/full-report.json
+            # Raw JSON, not a tarball. This is the artifact a human or a
+            # notebook fetches from S3 to answer "what is the posture of
+            # everything" (design §3.2); shipping it gzipped would mean
+            # unpacking before every query for no benefit.
+            archive:
+              none: {}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -233,6 +233,42 @@ re-run, and the new webhook is never registered. The failure is silent — n8n
 returns 404 for the path and the scan's alert POST fails. Recompute with the
 command in that file's comment.
 
+## 5.1 First full run — measured 2026-08-17
+
+The design's central claim was that scanning everything and alerting on
+everything would bury the signal. Measured, end to end:
+
+```
+scanned 79 images, 0 failed
+24320 total findings, 386 actionable
+posted to n8n
+```
+
+**24,320 → 386.** That is the noise-reduction argument, quantified. The 386 are
+CRITICAL/HIGH, in our own images, **with a fix available**:
+
+| Image | Actionable |
+|---|---|
+| `backstage-portal:v1.4.12` | 196 |
+| `oncall-agent:v2.0.2` | 71 |
+| `weather-kitchen-backend:latest` | 57 |
+| `kagent-ui:0.9.11-node20` | 28 |
+| `weather-kitchen-frontend:latest` | 24 |
+| `homelab-agent:v0.3.0` | 10 |
+
+38 CRITICAL, 348 HIGH. The workflow exited non-zero and the Slack alert fired,
+both as designed.
+
+Note how much the fixable filter does on its own: a standalone scan of
+`homelab-agent` found 4 CRITICAL and 29 HIGH, but only **10** of those 33 have a
+published fix. The other 23 are real and still in the S3 report — they are just
+not something anyone can act on this week.
+
+**386 is a lot to action**, and that is a genuine finding rather than a flaw in
+the filter: these are patchable vulnerabilities in images we build. Reducing
+that number means rebuilding those images on newer bases, which is work this
+design surfaces rather than performs.
+
 ## 6. Verification
 
 **Static:** all manifests parse; `python -m pytest tests/ -q` stays green; the


### PR DESCRIPTION
`archive: none` was set on the per-image artifact but **not** on the aggregate's `full-report`, so the one artifact a human actually fetches landed as `full-report.tgz`. Design §3.2 promises that inventory is queryable on demand — including from the Jupyter workspace — and unpacking a tarball before every query taxes exactly the path the design calls out.

## First full run — the design validated end to end

```
scanned 79 images, 0 failed
24320 total findings, 386 actionable
posted to n8n
```

**24,320 → 386.** That's the noise-reduction argument, quantified. The workflow exited non-zero and the Slack alert fired, both as designed.

| Image | Actionable (CRITICAL/HIGH, fixable) |
|---|---|
| `backstage-portal:v1.4.12` | **196** |
| `oncall-agent:v2.0.2` | 71 |
| `weather-kitchen-backend:latest` | 57 |
| `kagent-ui:0.9.11-node20` | 28 |
| `weather-kitchen-frontend:latest` | 24 |
| `homelab-agent:v0.3.0` | 10 |

38 CRITICAL, 348 HIGH.

The fixable filter carries more weight than expected: a standalone scan of `homelab-agent` found 4 CRITICAL and 29 HIGH, but only **10 of those 33** have a published fix. The other 23 stay in the S3 report because they're real, and out of the alert because nobody can act on them this week.

**386 is a lot to action — that's a finding, not a filter failure.** These are patchable vulnerabilities in images we build; `backstage-portal` alone is 196. Reducing it means rebuilding on newer bases, which this design surfaces rather than performs.

## Verification

`python3 -m pytest tests/ -q` → 316 passed · manifest parses · full run completed with 0 scan failures, ≤4 concurrent, no evictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF