### PR TITLE
fix(image-scan): collect pods on completion, not only on success

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -23,8 +23,18 @@ spec:
   # Keep a quarter's worth of history for trend, then let them go.
   ttlStrategy:
     secondsAfterCompletion: 7776000
+  # OnWorkflowCompletion, NOT OnWorkflowSuccess. This workflow fails by design
+  # whenever there is anything actionable (§3.6), which — at 386 findings on the
+  # first run — means every week until those images are rebuilt. Collecting pods
+  # only on success would therefore never collect them: ~79 pods per run against
+  # a 90-day TTL is over a thousand pods before anything reaps them.
+  #
+  # Safe because the chart sets artifactRepository.archiveLogs: true, so each
+  # pod's logs are in S3 and stay readable from the Argo UI after the pod is
+  # gone. Do not "fix" this back to OnWorkflowSuccess to make failed runs
+  # debuggable — the logs outlive the pods already.
   podGC:
-    strategy: OnWorkflowSuccess
+    strategy: OnWorkflowCompletion
 
   arguments:
     parameters:


### PR DESCRIPTION
`podGC: OnWorkflowSuccess` collects pods **only when the workflow succeeds** — but this workflow **fails by design** whenever there's anything actionable (§3.6). At 386 findings on the first run, that means every week until those images are rebuilt.

So it would have collected nothing, ever.

## Measured

One verification run left **87 completed pods** in the namespace. Against the 90-day TTL that's ~13 runs and **1,000+ pods** before anything reaps them — etcd pressure and a namespace that gets unpleasant to work in.

## Why `OnWorkflowCompletion` is safe

The chart already sets `artifactRepository.archiveLogs: true`. Each pod's logs go to S3 and stay readable from the Argo UI after the pod is deleted — which is the usual reason to keep failed pods around. Confirmed: `main.log` objects landed in S3 alongside the reports during the verification run.

Comment added so nobody "fixes" it back to `OnWorkflowSuccess` for debuggability.

## Verification

Manifest parses; `tests/appset/` passes. Cleanup of the existing 87 pods is separate — deleting the verification workflow reclaims them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF