### PR TITLE
docs: implementation plan for the CVE HTML report

### DIFF
--- a/docs/superpowers/plans/2026-08-18-cve-html-report.md
+++ b/docs/superpowers/plans/2026-08-18-cve-html-report.md
@@ -1,0 +1,1009 @@
+# CVE HTML Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the weekly scan's 24,320 findings into a self-contained HTML report at a stable S3 URL, so reviewing CVEs needs no new application, image, or ingress.
+
+**Architecture:** The aggregate step's logic moves out of inline workflow YAML into a ConfigMap-held `render.py` — the same one-home pattern `wan-ip-monitor` uses — which makes it unit-testable for the first time. That script gains HTML rendering and writes to **stable** S3 keys (`cve-reports/latest.{json,html}` plus dated copies) alongside the existing Argo artifact, decoupling consumers from Argo's generated per-run key layout.
+
+**Tech Stack:** Argo Workflows v4.1.1, Python 3.12 (stdlib + boto3), S3, pytest.
+
+**Spec:** [`docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md`](../specs/2026-08-17-image-vulnerability-scanning-design.md) — this plan is an increment on it. §3.2 of that spec promises the full inventory is "queryable on demand"; today that means an 8MB JSON at an unguessable key. This plan makes good on it.
+
+## Global Constraints
+
+- **No new application, image, repository, or ingress.** The whole point of this approach over a deployed dashboard is that it adds nothing to maintain and nothing to patch.
+- **No new credentials.** The aggregate step uses the existing `argo-workflows-s3-creds` Secret (keys `username` and `attribute.secret` — there is no `attribute.id`), which already has write access to `asela-argo-workflows-artifacts`.
+- **Bucket:** `asela-argo-workflows-artifacts`, region `us-east-1`.
+- **Stable key prefix:** `cve-reports/`. Exactly these four keys per run: `latest.json`, `latest.html`, `<YYYY-MM-DD>.json`, `<YYYY-MM-DD>.html`.
+- **"Actionable" is `severity in (CRITICAL, HIGH) AND fixed`** — identical to the Slack alert. Two definitions would mean two disagreeing numbers and neither trusted.
+- **The HTML must be entirely self-contained**: inline CSS and JS, no CDN, no external fonts. It is opened from a presigned S3 URL with no network guarantees.
+- **The script has exactly one home** — the ConfigMap. Do not keep a second copy under `scripts/`; that is the drift the `wan-ip-monitor` pattern exists to prevent.
+- **Never `kubectl apply`.** Everything lands through git; Argo CD syncs.
+- `python` is not on PATH on the dev machine. Use `python3`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `base-apps/argo-workflow-tasks/configmap-cve-report.yaml` | **New.** Sole home of `render.py`: aggregation, HTML rendering, S3 writes |
+| `base-apps/argo-workflow-tasks/image-scan.yaml` | *Modify.* Aggregate step mounts the ConfigMap, gains AWS env + a date param |
+| `tests/cve_report/conftest.py` | **New.** Loads `render.py` out of the ConfigMap as a module |
+| `tests/cve_report/test_aggregate.py` | **New.** Aggregation and the actionable filter |
+| `tests/cve_report/test_html.py` | **New.** HTML rendering |
+| `tests/cve_report/test_s3.py` | **New.** Stable-key writes, against a fake client |
+| `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md` | *Modify.* Add §5.2 describing the report surface and how to view it |
+
+---
+
+### Task 1: Move the aggregate logic into a testable ConfigMap script
+
+Pure refactor — identical behaviour, now unit-testable. A reviewer can accept this
+without any opinion on HTML or S3 keys.
+
+**Files:**
+- Create: `base-apps/argo-workflow-tasks/configmap-cve-report.yaml`
+- Create: `tests/cve_report/__init__.py`, `tests/cve_report/conftest.py`, `tests/cve_report/test_aggregate.py`
+- Modify: `base-apps/argo-workflow-tasks/image-scan.yaml` (aggregate step runs the mounted script)
+
+**Interfaces:**
+- Produces: module `render` with
+  - `load_reports(root: str) -> tuple[list[dict], list[str], list[str]]` returning `(findings, scanned, failed)`
+  - `actionable(findings: list[dict], owned_prefix: str) -> list[dict]`
+  - `summarise(findings, actionable) -> dict` with keys `total`, `actionable`, `by_severity`, `by_image`
+- Tasks 2 and 3 import these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/cve_report/__init__.py` (empty file), then `tests/cve_report/conftest.py`:
+
+```python
+"""Load render.py out of the ConfigMap that ships it.
+
+The script has exactly one home - the ConfigMap - so there is no second copy to
+drift. Tests extract it and import it as a module. Mirrors tests/wan_ip/conftest.py.
+"""
+import importlib.util
+import pathlib
+import tempfile
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+CONFIGMAP = REPO / "base-apps" / "argo-workflow-tasks" / "configmap-cve-report.yaml"
+
+
+@pytest.fixture(scope="session")
+def render():
+    source = yaml.safe_load(CONFIGMAP.read_text())["data"]["render.py"]
+    path = pathlib.Path(tempfile.mkdtemp()) / "render.py"
+    path.write_text(source)
+    spec = importlib.util.spec_from_file_location("render", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+```
+
+Then `tests/cve_report/test_aggregate.py`:
+
+```python
+import json
+
+OWNED = "852893458518.dkr.ecr."
+
+
+def _finding(image, severity="HIGH", fixed="1.2.3", vid="CVE-2026-1"):
+    return {
+        "image": image, "id": vid, "pkg": "libfoo",
+        "installed": "1.0.0", "fixed": fixed,
+        "severity": severity, "title": "example",
+    }
+
+
+def test_load_reports_reads_every_json(render, tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "report.json").write_text(json.dumps({
+        "ArtifactName": "img-a",
+        "Results": [{"Vulnerabilities": [
+            {"VulnerabilityID": "CVE-1", "PkgName": "p", "InstalledVersion": "1",
+             "FixedVersion": "2", "Severity": "HIGH", "Title": "t"}]}],
+    }))
+    (tmp_path / "b" / "report.json").write_text(json.dumps({
+        "ArtifactName": "img-b", "Results": [],
+    }))
+
+    findings, scanned, failed = render.load_reports(str(tmp_path))
+
+    assert sorted(scanned) == ["img-a", "img-b"]
+    assert failed == []
+    assert len(findings) == 1
+    assert findings[0]["image"] == "img-a"
+    assert findings[0]["id"] == "CVE-1"
+
+
+def test_load_reports_records_unparseable_as_failed_not_clean(render, tmp_path):
+    (tmp_path / "bad.json").write_text("{not json")
+    findings, scanned, failed = render.load_reports(str(tmp_path))
+    assert findings == []
+    assert scanned == []
+    assert len(failed) == 1, "an unreadable report must be failed, never silently clean"
+
+
+def test_actionable_requires_owned_severity_and_a_fix(render):
+    findings = [
+        _finding(OWNED + "mine:v1", "CRITICAL", "9.9"),          # counts
+        _finding(OWNED + "mine:v1", "HIGH", "9.9"),              # counts
+        _finding(OWNED + "mine:v1", "HIGH", ""),                 # no fix
+        _finding(OWNED + "mine:v1", "MEDIUM", "9.9"),            # too low
+        _finding("docker.io/upstream:v1", "CRITICAL", "9.9"),    # not ours
+    ]
+    got = render.actionable(findings, OWNED)
+    assert len(got) == 2
+    assert {f["severity"] for f in got} == {"CRITICAL", "HIGH"}
+
+
+def test_summarise_counts_by_severity_and_image(render):
+    findings = [
+        _finding(OWNED + "a:v1", "CRITICAL"),
+        _finding(OWNED + "a:v1", "HIGH"),
+        _finding(OWNED + "b:v1", "HIGH"),
+        _finding("docker.io/up:v1", "LOW", ""),
+    ]
+    s = render.summarise(findings, render.actionable(findings, OWNED))
+    assert s["total"] == 4
+    assert s["actionable"] == 3
+    assert s["by_severity"]["CRITICAL"] == 1
+    assert s["by_image"]["a:v1"] == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+python3 -m pytest tests/cve_report/ -q
+```
+
+Expected: collection error — `configmap-cve-report.yaml` does not exist yet.
+
+- [ ] **Step 3: Create the ConfigMap with the extracted logic**
+
+Create `base-apps/argo-workflow-tasks/configmap-cve-report.yaml`. This is the
+existing inline aggregate logic, reorganised into named functions and nothing more
+— HTML and S3 come in Tasks 2 and 3.
+
+```yaml
+# Sole home of the CVE report renderer.
+#
+# The aggregate step of image-scan.yaml mounts this and runs it. Keeping the
+# script here rather than inline in the workflow makes it unit-testable
+# (tests/cve_report/), which inline YAML never was. Same pattern and same reason
+# as base-apps/wan-ip-monitor/configmap-reconcile.yaml.
+#
+# There is exactly ONE copy of this script. Do not add a second under scripts/.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cve-report
+  namespace: argo-workflows
+data:
+  render.py: |
+    """Aggregate Trivy reports, render HTML, publish to stable S3 keys."""
+    import collections
+    import json
+    import os
+    import pathlib
+    import sys
+    import urllib.request
+
+    ALERT_SEVERITIES = {"CRITICAL", "HIGH"}
+    SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+
+
+    def load_reports(root):
+        """Read every *.json under root. Returns (findings, scanned, failed).
+
+        Matches *.json rather than exactly report.json because Argo lays
+        artifacts out under the repository keyFormat and the leaf filename is
+        not guaranteed. An unreadable report is recorded as failed, never
+        omitted -- silence about an unscanned image is the failure worth
+        avoiding.
+        """
+        findings, scanned, failed = [], [], []
+        for path in sorted(pathlib.Path(root).rglob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+            except Exception as exc:
+                failed.append(f"{path}: {exc}")
+                continue
+            artifact = data.get("ArtifactName") or str(path)
+            scanned.append(artifact)
+            for result in data.get("Results") or []:
+                for vuln in result.get("Vulnerabilities") or []:
+                    findings.append({
+                        "image": artifact,
+                        "id": vuln.get("VulnerabilityID"),
+                        "pkg": vuln.get("PkgName"),
+                        "installed": vuln.get("InstalledVersion"),
+                        "fixed": vuln.get("FixedVersion"),
+                        "severity": vuln.get("Severity"),
+                        "title": (vuln.get("Title") or "")[:200],
+                    })
+        return findings, scanned, failed
+
+
+    def actionable(findings, owned_prefix):
+        """CRITICAL/HIGH, in an image we build, with a published fix.
+
+        This definition is shared with the Slack alert on purpose. Two
+        definitions would produce two numbers and neither would be trusted.
+        """
+        return [
+            f for f in findings
+            if (f.get("image") or "").startswith(owned_prefix)
+            and f.get("severity") in ALERT_SEVERITIES
+            and f.get("fixed")
+        ]
+
+
+    def summarise(findings, act):
+        by_sev = collections.Counter(f.get("severity") for f in findings)
+        by_img = collections.Counter(
+            (f.get("image") or "").split("/")[-1] for f in act
+        )
+        return {
+            "total": len(findings),
+            "actionable": len(act),
+            "by_severity": dict(by_sev),
+            "by_image": dict(by_img),
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+python3 -m pytest tests/cve_report/ -q
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Point the workflow's aggregate step at the mounted script**
+
+In `base-apps/argo-workflow-tasks/image-scan.yaml`, replace the aggregate
+template's inline `script:` body with a call to the mounted file, and add the
+volume. Keep the existing `inputs.artifacts`, `outputs.artifacts`, and
+`resources` blocks exactly as they are.
+
+The `source:` becomes:
+
+```python
+          import runpy, sys
+          sys.argv = [
+              "render.py",
+              "--reports", "/reports",
+              "--out", "/tmp/out",
+              "--owned-prefix", "{{workflow.parameters.owned-image-prefix}}",
+              "--webhook", "{{workflow.parameters.n8n-webhook}}",
+              "--workflow-name", "{{workflow.name}}",
+          ]
+          runpy.run_path("/app/render.py", run_name="__main__")
+```
+
+and add to that template's `volumeMounts`:
+
+```yaml
+          - name: script
+            mountPath: /app
+            readOnly: true
+```
+
+and to its `volumes`:
+
+```yaml
+        - name: script
+          configMap:
+            name: cve-report
+```
+
+Then append a `main()` to `render.py` in the ConfigMap that reproduces the
+previous behaviour exactly — full report to `/tmp/out/full-report.json`, POST to
+n8n when there is anything actionable or any failure, exit 1 iff actionable:
+
+```python
+    def _slack_text(act, failed):
+        by_image = {}
+        for f in act:
+            by_image.setdefault(f["image"], []).append(f)
+        lines = []
+        for image, items in sorted(by_image.items()):
+            short = image.split("/")[-1]
+            crit = sum(1 for i in items if i["severity"] == "CRITICAL")
+            high = sum(1 for i in items if i["severity"] == "HIGH")
+            lines.append(f"*{short}* - {crit} critical, {high} high (all fixable)")
+            for i in sorted(items, key=lambda x: x["id"] or "")[:5]:
+                lines.append(f"  - {i['id']} {i['pkg']} {i['installed']} -> {i['fixed']}")
+            if len(items) > 5:
+                lines.append(f"  - ...and {len(items) - 5} more")
+        if failed:
+            lines.append(f"_{len(failed)} image(s) could not be scanned_")
+        return "\n".join(lines)
+
+
+    def main(argv=None):
+        import argparse
+        p = argparse.ArgumentParser()
+        p.add_argument("--reports", required=True)
+        p.add_argument("--out", required=True)
+        p.add_argument("--owned-prefix", required=True)
+        p.add_argument("--webhook", required=True)
+        p.add_argument("--workflow-name", default="unknown")
+        args = p.parse_args(argv)
+
+        findings, scanned, failed = load_reports(args.reports)
+        act = actionable(findings, args.owned_prefix)
+        summary = summarise(findings, act)
+
+        out = pathlib.Path(args.out)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "full-report.json").write_text(json.dumps(
+            {"scanned": scanned, "failed": failed, "findings": findings}, indent=2))
+
+        print(f"scanned {len(scanned)} images, {len(failed)} failed")
+        print(f"{summary['total']} total findings, {summary['actionable']} actionable")
+
+        if act or failed:
+            payload = {
+                "scanned": len(scanned), "actionable": len(act),
+                "failed": len(failed), "workflow": args.workflow_name,
+                "text": _slack_text(act, failed),
+            }
+            try:
+                req = urllib.request.Request(
+                    args.webhook, data=json.dumps(payload).encode(),
+                    headers={"Content-Type": "application/json"})
+                urllib.request.urlopen(req, timeout=30).read()
+                print("posted to n8n")
+            except Exception as exc:
+                # A webhook failure must not hide the finding.
+                print(f"WARNING: n8n post failed: {exc}", file=sys.stderr)
+
+        return 1 if act else 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+```
+
+- [ ] **Step 6: Verify manifests parse and the suite is green**
+
+```bash
+python3 -c "import yaml; list(yaml.safe_load_all(open('base-apps/argo-workflow-tasks/configmap-cve-report.yaml')))"
+python3 -c "import yaml; list(yaml.safe_load_all(open('base-apps/argo-workflow-tasks/image-scan.yaml')))"
+python3 -m pytest tests/ -q
+```
+
+Expected: both parse; suite green (was 316 passed before this task, expect 320).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add base-apps/argo-workflow-tasks/configmap-cve-report.yaml \
+        base-apps/argo-workflow-tasks/image-scan.yaml tests/cve_report/
+git commit -m "refactor(image-scan): move aggregate logic into a testable ConfigMap script
+
+The aggregate step's logic lived inline in workflow YAML, where it could not
+be tested at all. Moving it into a ConfigMap - the same one-home pattern
+wan-ip-monitor uses - makes it unit-testable without creating a second copy
+to drift. Behaviour is unchanged."
+```
+
+---
+
+### Task 2: Render the findings as a self-contained HTML report
+
+**Files:**
+- Modify: `base-apps/argo-workflow-tasks/configmap-cve-report.yaml`
+- Create: `tests/cve_report/test_html.py`
+
+**Interfaces:**
+- Consumes: `summarise()`, `actionable()` from Task 1.
+- Produces: `render_html(summary: dict, findings: list[dict], act: list[dict], generated: str) -> str` returning a complete HTML document. Task 3 uploads its return value.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/cve_report/test_html.py`:
+
+```python
+OWNED = "852893458518.dkr.ecr."
+
+
+def _f(image, severity="HIGH", fixed="1.2.3", vid="CVE-2026-1"):
+    return {"image": image, "id": vid, "pkg": "libfoo", "installed": "1.0.0",
+            "fixed": fixed, "severity": severity, "title": "example title"}
+
+
+def _doc(render):
+    findings = [
+        _f(OWNED + "mine:v1", "CRITICAL", "9.9", "CVE-A"),
+        _f(OWNED + "mine:v1", "HIGH", "", "CVE-B"),
+        _f("docker.io/up:v1", "LOW", "", "CVE-C"),
+    ]
+    act = render.actionable(findings, OWNED)
+    return render.render_html(
+        render.summarise(findings, act), findings, act, "2026-08-18")
+
+
+def test_html_is_a_complete_document(render):
+    html = _doc(render)
+    assert html.lstrip().startswith("<!doctype html>")
+    assert "</html>" in html
+
+
+def test_html_is_self_contained(render):
+    """No CDN, no external fonts - it is opened from a presigned S3 URL."""
+    html = _doc(render).lower()
+    for forbidden in ["http://", "https://cdn", "<script src=", "<link rel=\"stylesheet\" href="]:
+        assert forbidden not in html, f"external reference found: {forbidden}"
+
+
+def test_html_reports_the_actionable_count(render):
+    html = _doc(render)
+    assert "1" in html
+    assert "actionable" in html.lower()
+
+
+def test_html_includes_every_finding(render):
+    html = _doc(render)
+    for vid in ("CVE-A", "CVE-B", "CVE-C"):
+        assert vid in html
+
+
+def test_html_escapes_untrusted_text(render):
+    """Titles come from an external vulnerability feed, not from us."""
+    findings = [{"image": "i", "id": "CVE-X", "pkg": "p", "installed": "1",
+                 "fixed": "2", "severity": "HIGH",
+                 "title": "<script>alert(1)</script>"}]
+    act = render.actionable(findings, OWNED)
+    html = render.render_html(render.summarise(findings, act), findings, act, "2026-08-18")
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+python3 -m pytest tests/cve_report/test_html.py -q
+```
+
+Expected: FAIL — `AttributeError: module 'render' has no attribute 'render_html'`.
+
+- [ ] **Step 3: Implement `render_html`**
+
+Add to `render.py` in the ConfigMap, after `summarise()`. Note `html.escape` on
+every interpolated field: titles and package names come from an external
+vulnerability feed, and this document is opened in a browser.
+
+```python
+    def render_html(summary, findings, act, generated):
+        """A complete, self-contained HTML report.
+
+        Inline CSS and JS only. This is opened from a presigned S3 URL where no
+        external fetch is guaranteed to succeed, and a report that renders as
+        unstyled text because a CDN was unreachable is a report nobody reads.
+        """
+        import html as html_mod
+
+        e = html_mod.escape
+        act_ids = {(f.get("image"), f.get("id")) for f in act}
+
+        rows = []
+        # Actionable first, then by severity, so the top of the table is the
+        # part anyone can act on.
+        def sort_key(f):
+            is_act = 0 if (f.get("image"), f.get("id")) in act_ids else 1
+            try:
+                sev = SEVERITY_ORDER.index(f.get("severity"))
+            except ValueError:
+                sev = len(SEVERITY_ORDER)
+            return (is_act, sev, f.get("image") or "", f.get("id") or "")
+
+        for f in sorted(findings, key=sort_key):
+            is_act = (f.get("image"), f.get("id")) in act_ids
+            rows.append(
+                "<tr class='{cls}' data-act='{act}' data-sev='{sev}'>"
+                "<td>{flag}</td><td class='sev {sev}'>{sev}</td>"
+                "<td class='img'>{img}</td><td>{vid}</td>"
+                "<td>{pkg}</td><td>{inst}</td><td>{fix}</td><td>{title}</td></tr>".format(
+                    cls="act" if is_act else "",
+                    act="1" if is_act else "0",
+                    sev=e(f.get("severity") or "UNKNOWN"),
+                    flag="&#9679;" if is_act else "",
+                    img=e((f.get("image") or "").split("/")[-1]),
+                    vid=e(f.get("id") or ""),
+                    pkg=e(f.get("pkg") or ""),
+                    inst=e(f.get("installed") or ""),
+                    fix=e(f.get("fixed") or "-"),
+                    title=e(f.get("title") or ""),
+                )
+            )
+
+        by_image = "".join(
+            f"<li><span>{e(img)}</span><b>{n}</b></li>"
+            for img, n in sorted(summary["by_image"].items(), key=lambda kv: -kv[1])
+        ) or "<li>none</li>"
+
+        by_sev = "".join(
+            f"<li><span class='sev {e(s)}'>{e(s)}</span><b>{summary['by_severity'].get(s, 0)}</b></li>"
+            for s in SEVERITY_ORDER if summary["by_severity"].get(s)
+        )
+
+        return """<!doctype html>
+    <html lang="en"><head><meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>CVE report {generated}</title>
+    <style>
+    :root{{--bg:#fff;--fg:#111;--mut:#666;--line:#e3e3e3;--act:#b30000}}
+    @media(prefers-color-scheme:dark){{:root{{--bg:#141414;--fg:#eee;--mut:#999;--line:#333;--act:#ff6b6b}}}}
+    *{{box-sizing:border-box}}
+    body{{margin:0;padding:2rem;background:var(--bg);color:var(--fg);
+      font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}}
+    h1{{margin:0 0 .25rem;font-size:1.4rem}}
+    .sub{{color:var(--mut);margin-bottom:1.5rem}}
+    .cards{{display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:1.5rem}}
+    .card{{border:1px solid var(--line);border-radius:8px;padding:1rem 1.25rem;min-width:190px}}
+    .card h2{{margin:0 0 .5rem;font-size:.75rem;text-transform:uppercase;
+      letter-spacing:.06em;color:var(--mut)}}
+    .big{{font-size:2rem;font-weight:600}}
+    .big.act{{color:var(--act)}}
+    .card ul{{list-style:none;margin:0;padding:0}}
+    .card li{{display:flex;justify-content:space-between;gap:1.5rem;padding:.15rem 0}}
+    .controls{{margin-bottom:.75rem;display:flex;gap:1rem;align-items:center;flex-wrap:wrap}}
+    input[type=search]{{padding:.4rem .6rem;border:1px solid var(--line);border-radius:6px;
+      background:var(--bg);color:var(--fg);min-width:240px}}
+    .wrap{{overflow-x:auto;border:1px solid var(--line);border-radius:8px}}
+    table{{border-collapse:collapse;width:100%;font-size:13px}}
+    th,td{{text-align:left;padding:.45rem .7rem;border-bottom:1px solid var(--line);
+      white-space:nowrap}}
+    th{{position:sticky;top:0;background:var(--bg);cursor:pointer;user-select:none}}
+    td:last-child{{white-space:normal;min-width:22rem}}
+    tr.act td:first-child{{color:var(--act)}}
+    .sev.CRITICAL{{color:#b30000;font-weight:600}}
+    .sev.HIGH{{color:#c25e00;font-weight:600}}
+    .sev.MEDIUM{{color:#8a7500}}
+    .sev.LOW,.sev.UNKNOWN{{color:var(--mut)}}
+    .img{{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}}
+    </style></head><body>
+    <h1>Container CVE report</h1>
+    <div class="sub">Generated {generated} &middot; {scanned} images scanned{failed}</div>
+    <div class="cards">
+      <div class="card"><h2>Actionable</h2><div class="big act">{actionable}</div>
+        <div class="sub" style="margin:0">ours &middot; CRITICAL/HIGH &middot; fixable</div></div>
+      <div class="card"><h2>All findings</h2><div class="big">{total}</div>
+        <div class="sub" style="margin:0">including unfixable upstream</div></div>
+      <div class="card"><h2>By severity</h2><ul>{by_sev}</ul></div>
+      <div class="card"><h2>Actionable by image</h2><ul>{by_image}</ul></div>
+    </div>
+    <div class="controls">
+      <label><input type="checkbox" id="only" checked> actionable only</label>
+      <input type="search" id="q" placeholder="filter image, CVE, package&hellip;">
+      <span class="sub" id="count" style="margin:0"></span>
+    </div>
+    <div class="wrap"><table id="t"><thead><tr>
+    <th></th><th>Severity</th><th>Image</th><th>CVE</th>
+    <th>Package</th><th>Installed</th><th>Fixed</th><th>Title</th>
+    </tr></thead><tbody>{rows}</tbody></table></div>
+    <script>
+    var tb=document.getElementById('t').tBodies[0];
+    var only=document.getElementById('only'),q=document.getElementById('q');
+    var count=document.getElementById('count');
+    function apply(){{
+      var term=q.value.toLowerCase(),shown=0;
+      Array.prototype.forEach.call(tb.rows,function(r){{
+        var okAct=!only.checked||r.dataset.act==='1';
+        var okQ=!term||r.textContent.toLowerCase().indexOf(term)>-1;
+        var vis=okAct&&okQ; r.style.display=vis?'':'none'; if(vis)shown++;
+      }});
+      count.textContent=shown+' shown';
+    }}
+    only.addEventListener('change',apply); q.addEventListener('input',apply);
+    Array.prototype.forEach.call(document.querySelectorAll('#t th'),function(th,i){{
+      th.addEventListener('click',function(){{
+        var rows=Array.prototype.slice.call(tb.rows);
+        var asc=th.dataset.asc!=='1'; th.dataset.asc=asc?'1':'0';
+        rows.sort(function(a,b){{
+          var x=a.cells[i].textContent,y=b.cells[i].textContent;
+          return asc?x.localeCompare(y):y.localeCompare(x);
+        }});
+        rows.forEach(function(r){{tb.appendChild(r)}});
+      }});
+    }});
+    apply();
+    </script></body></html>
+    """.format(
+            generated=e(generated),
+            scanned=summary["scanned_count"],
+            failed="" if not summary.get("failed_count") else
+                   f" &middot; {summary['failed_count']} failed",
+            actionable=summary["actionable"],
+            total=summary["total"],
+            by_sev=by_sev,
+            by_image=by_image,
+            rows="".join(rows),
+        )
+```
+
+Also extend `summarise()` to carry the two counts the header needs — replace its
+`return` with:
+
+```python
+        return {
+            "total": len(findings),
+            "actionable": len(act),
+            "by_severity": dict(by_sev),
+            "by_image": dict(by_img),
+            "scanned_count": 0,
+            "failed_count": 0,
+        }
+```
+
+and in `main()`, after computing `summary`, set the real values:
+
+```python
+        summary["scanned_count"] = len(scanned)
+        summary["failed_count"] = len(failed)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+python3 -m pytest tests/cve_report/ -q
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 5: Eyeball the output once**
+
+Generating HTML you never look at is how unreadable reports ship.
+
+```bash
+python3 - <<'PY'
+import importlib.util, pathlib, tempfile, yaml, json, webbrowser
+cm = yaml.safe_load(open("base-apps/argo-workflow-tasks/configmap-cve-report.yaml"))
+p = pathlib.Path(tempfile.mkdtemp()) / "render.py"
+p.write_text(cm["data"]["render.py"])
+s = importlib.util.spec_from_file_location("render", p)
+m = importlib.util.module_from_spec(s); s.loader.exec_module(m)
+OWNED = "852893458518.dkr.ecr."
+findings = [
+    {"image": OWNED+"backstage-portal:v1.4.12", "id": "CVE-2026-1", "pkg": "openssl",
+     "installed": "3.0.1", "fixed": "3.0.2", "severity": "CRITICAL", "title": "buffer overflow"},
+    {"image": OWNED+"backstage-portal:v1.4.12", "id": "CVE-2026-2", "pkg": "zlib",
+     "installed": "1.2", "fixed": "", "severity": "HIGH", "title": "no fix available"},
+    {"image": "docker.io/grafana:11", "id": "CVE-2026-3", "pkg": "go",
+     "installed": "1.21", "fixed": "1.22", "severity": "MEDIUM", "title": "upstream issue"},
+]
+act = m.actionable(findings, OWNED)
+sm = m.summarise(findings, act); sm["scanned_count"]=3; sm["failed_count"]=0
+out = pathlib.Path("/tmp/cve-preview.html")
+out.write_text(m.render_html(sm, findings, act, "2026-08-18"))
+print("wrote", out)
+PY
+open /tmp/cve-preview.html
+```
+
+Confirm: the actionable count reads 1, the "actionable only" checkbox filters to
+one row, the search box works, and clicking a column header sorts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add base-apps/argo-workflow-tasks/configmap-cve-report.yaml tests/cve_report/test_html.py
+git commit -m "feat(cve-report): render findings as a self-contained HTML report
+
+Inline CSS and JS only -- the report is opened from a presigned S3 URL where
+no external fetch is guaranteed, and one that renders unstyled because a CDN
+was unreachable is one nobody reads. Actionable findings sort to the top and
+are the default filter; everything else stays one checkbox away.
+
+Titles come from an external vulnerability feed, so every interpolated field
+is escaped."
+```
+
+---
+
+### Task 3: Publish to stable S3 keys
+
+**Files:**
+- Modify: `base-apps/argo-workflow-tasks/configmap-cve-report.yaml`
+- Create: `tests/cve_report/test_s3.py`
+
+**Interfaces:**
+- Consumes: `render_html()` from Task 2.
+- Produces: `publish(client, bucket, prefix, date, report_json: str, report_html: str) -> list[str]` returning the keys written, in the order written.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/cve_report/test_s3.py`:
+
+```python
+class FakeS3:
+    """Minimal stand-in for a boto3 S3 client."""
+
+    def __init__(self):
+        self.puts = []
+
+    def put_object(self, Bucket, Key, Body, ContentType=None, **kw):
+        self.puts.append({"bucket": Bucket, "key": Key,
+                          "body": Body, "content_type": ContentType})
+
+
+def test_publish_writes_latest_and_dated_for_both_formats(render):
+    s3 = FakeS3()
+    keys = render.publish(s3, "b", "cve-reports/", "2026-08-18", '{"a":1}', "<html>")
+    assert keys == [
+        "cve-reports/2026-08-18.json",
+        "cve-reports/2026-08-18.html",
+        "cve-reports/latest.json",
+        "cve-reports/latest.html",
+    ], "dated copies must be written before latest, so latest is never newer than its history"
+    assert all(p["bucket"] == "b" for p in s3.puts)
+
+
+def test_publish_sets_content_types_so_browsers_render_the_html(render):
+    s3 = FakeS3()
+    render.publish(s3, "b", "cve-reports/", "2026-08-18", "{}", "<html>")
+    by_key = {p["key"]: p["content_type"] for p in s3.puts}
+    assert by_key["cve-reports/latest.html"] == "text/html; charset=utf-8"
+    assert by_key["cve-reports/latest.json"] == "application/json"
+
+
+def test_publish_bodies_are_bytes(render):
+    s3 = FakeS3()
+    render.publish(s3, "b", "cve-reports/", "2026-08-18", "{}", "<html>")
+    assert all(isinstance(p["body"], bytes) for p in s3.puts)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+python3 -m pytest tests/cve_report/test_s3.py -q
+```
+
+Expected: FAIL — `module 'render' has no attribute 'publish'`.
+
+- [ ] **Step 3: Implement `publish`**
+
+Add to `render.py`:
+
+```python
+    def publish(client, bucket, prefix, date, report_json, report_html):
+        """Write the report to STABLE keys. Returns keys written, in order.
+
+        Consumers (a browser via presigned URL, a Backstage plugin, a notebook)
+        need a key they can predict. Argo's own artifact key embeds the
+        generated workflow and pod names, so finding "the latest report" there
+        means listing and sorting -- coupling every consumer to Argo's layout.
+
+        Dated copies are written BEFORE latest, so a partial failure can leave
+        latest pointing at an older complete report, never at nothing.
+        """
+        writes = [
+            (f"{prefix}{date}.json", report_json, "application/json"),
+            (f"{prefix}{date}.html", report_html, "text/html; charset=utf-8"),
+            (f"{prefix}latest.json", report_json, "application/json"),
+            (f"{prefix}latest.html", report_html, "text/html; charset=utf-8"),
+        ]
+        written = []
+        for key, body, ctype in writes:
+            client.put_object(Bucket=bucket, Key=key,
+                              Body=body.encode("utf-8"), ContentType=ctype)
+            written.append(key)
+        return written
+```
+
+Then wire it into `main()`. Add these arguments:
+
+```python
+        p.add_argument("--bucket", default="")
+        p.add_argument("--prefix", default="cve-reports/")
+        p.add_argument("--date", default="")
+```
+
+and, after the full-report write and before the n8n POST:
+
+```python
+        if args.bucket and args.date:
+            html_doc = render_html(summary, findings, act, args.date)
+            (out / "report.html").write_text(html_doc)
+            try:
+                import boto3
+                keys = publish(boto3.client("s3"), args.bucket, args.prefix,
+                               args.date, json.dumps(
+                                   {"scanned": scanned, "failed": failed,
+                                    "findings": findings}, indent=2), html_doc)
+                for k in keys:
+                    print(f"published s3://{args.bucket}/{k}")
+            except Exception as exc:
+                # Publishing is a convenience; the Argo artifact is the record
+                # of truth and the Slack alert is the thing that pages someone.
+                # Do not lose either because S3 rejected a PUT.
+                print(f"WARNING: S3 publish failed: {exc}", file=sys.stderr)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+python3 -m pytest tests/cve_report/ -q
+```
+
+Expected: 12 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base-apps/argo-workflow-tasks/configmap-cve-report.yaml tests/cve_report/test_s3.py
+git commit -m "feat(cve-report): publish to stable S3 keys
+
+Argo's artifact key embeds generated workflow and pod names, so finding the
+latest report means listing and sorting -- coupling every consumer to Argo's
+layout. cve-reports/latest.{json,html} plus dated copies gives consumers a
+key they can predict.
+
+Dated copies are written before latest so a partial failure leaves latest on
+an older complete report rather than nothing. A failed publish warns but does
+not fail the run: the Argo artifact is the record and Slack is what pages."
+```
+
+---
+
+### Task 4: Wire the workflow, verify live, and document how to read it
+
+**Files:**
+- Modify: `base-apps/argo-workflow-tasks/image-scan.yaml`
+- Modify: `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+
+- [ ] **Step 1: Add the workflow parameters**
+
+In `image-scan.yaml`, add to `spec.arguments.parameters`:
+
+```yaml
+      - name: report-bucket
+        value: "asela-argo-workflows-artifacts"
+      - name: report-prefix
+        value: "cve-reports/"
+```
+
+- [ ] **Step 2: Pass bucket, prefix and date to the script**
+
+Extend the aggregate step's `sys.argv` from Task 1 with:
+
+```python
+              "--bucket", "{{workflow.parameters.report-bucket}}",
+              "--prefix", "{{workflow.parameters.report-prefix}}",
+              "--date", "{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}-{{workflow.creationTimestamp.d}}",
+```
+
+`workflow.creationTimestamp` is used rather than a clock read inside the script so
+a re-run of the same workflow overwrites its own dated key instead of creating a
+second one.
+
+- [ ] **Step 3: Give the aggregate step AWS credentials**
+
+Add to the aggregate template's container `env` — the same Secret the artifact
+repository already uses, so no new credential is created:
+
+```yaml
+          env:
+            # Already has write on asela-argo-workflows-artifacts: it is the
+            # artifact repository credential from base-apps/argo-workflows.yaml.
+            # Keys are username / attribute.secret -- there is no attribute.id.
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: argo-workflows-s3-creds
+                  key: username
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: argo-workflows-s3-creds
+                  key: attribute.secret
+            - name: AWS_DEFAULT_REGION
+              value: "us-east-1"
+```
+
+- [ ] **Step 4: Install boto3 in the aggregate step**
+
+`python:3.12-slim` has no boto3. Prepend to the aggregate `source:` before the
+`runpy` call:
+
+```python
+          import subprocess, sys
+          subprocess.check_call([sys.executable, "-m", "pip", "install",
+                                 "--quiet", "--disable-pip-version-check", "boto3"])
+```
+
+- [ ] **Step 5: Verify statically, then commit and push**
+
+```bash
+python3 -c "import yaml; list(yaml.safe_load_all(open('base-apps/argo-workflow-tasks/image-scan.yaml')))"
+python3 -m pytest tests/ -q
+git add base-apps/argo-workflow-tasks/image-scan.yaml
+git commit -m "feat(image-scan): publish the HTML report to stable S3 keys
+
+Passes bucket, prefix and creationTimestamp-derived date to the renderer, and
+gives the aggregate step the artifact repository's existing S3 credential --
+no new IAM user. creationTimestamp rather than a clock read so a re-run
+overwrites its own dated key instead of creating a second."
+git push
+```
+
+- [ ] **Step 6: Run it live**
+
+Do not wait a week. After Argo CD syncs:
+
+```bash
+kubectl create -f - <<'YAML'
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: image-scan-report-verify-
+  namespace: argo-workflows
+spec:
+  workflowTemplateRef:
+    name: image-scan
+YAML
+```
+
+Expect ~40 minutes (78 images at parallelism 4). The run finishing **red is
+correct** when actionable findings exist.
+
+- [ ] **Step 7: Verify the stable keys and open the report**
+
+```bash
+aws s3 ls s3://asela-argo-workflows-artifacts/cve-reports/
+aws s3 presign s3://asela-argo-workflows-artifacts/cve-reports/latest.html --expires-in 3600
+```
+
+Expected: four keys (`latest.json`, `latest.html`, `<date>.json`, `<date>.html`).
+Open the presigned URL — the summary counts must match the aggregate step's log
+line (`N total findings, M actionable`).
+
+- [ ] **Step 8: Record it in the spec**
+
+Add a §5.2 to `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md`
+covering: the four stable keys and why they exist (Argo's key embeds generated
+names); that the HTML is self-contained deliberately; how to view it
+(`aws s3 presign`, one hour); and that the dated copies make trend possible
+because the artifacts bucket has no lifecycle policy.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+git commit -m "docs: record the CVE report surface and how to view it"
+git push
+```
+
+---
+
+## Notes for whoever executes this
+
+**The report is not served anywhere, deliberately.** `aws s3 presign` produces a
+browser-openable link valid for an hour. Hosting it would mean a bucket policy or
+a CloudFront distribution — new public surface for a document listing your
+unpatched vulnerabilities. If it becomes a nuisance, the next cheapest step is a
+presign helper script, not a web server.
+
+**Trend is available but not built.** The dated keys accumulate (~8MB/week) and the
+artifacts bucket has no lifecycle policy, so "are we improving?" is answerable from
+a notebook whenever it is wanted. Building it now would be speculative.
+
+**Watch the `latest.html` size.** 24,320 rows of HTML will be several MB and
+browsers get sluggish past roughly 10k rows. If it becomes unusable, the fix is to
+cap the table at actionable-plus-CRITICAL and leave the rest to `latest.json` —
+not pagination, which nobody will click through.


### PR DESCRIPTION
Plan for approach **B** — turn the weekly scan's 24,320 findings into a self-contained HTML report at a stable S3 URL, adding no application, image, repository, or ingress.

**Plan:** `docs/superpowers/plans/2026-08-18-cve-html-report.md`
**Extends:** `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md`

## Four tasks, each independently testable

1. **Move the aggregate logic into a ConfigMap script** — pure refactor. It currently lives inline in workflow YAML where it cannot be tested at all; the `wan-ip-monitor` one-home pattern makes it unit-testable without creating a second copy to drift.
2. **HTML rendering** — self-contained, actionable-first, escaped.
3. **Stable S3 keys** — tested against a fake client.
4. **Wire the workflow, run it live, document how to read it.**

Tests come first in every task, so feedback is `pytest` in seconds rather than a 40-minute workflow run.

## The load-bearing decision: stable keys

Argo's artifact key is `argo-workflows/<workflow-name>/<pod-name>/full-report.json` — **both segments generated per run.** Any consumer wanting "the latest report" must list and sort, coupling itself to Argo's layout.

The plan adds:

```
cve-reports/latest.json
cve-reports/latest.html
cve-reports/<YYYY-MM-DD>.json
cve-reports/<YYYY-MM-DD>.html
```

Dated copies are written **before** `latest`, so a partial failure leaves `latest` on an older complete report rather than nothing.

This is also what makes **approach C (Backstage) tractable** — a plugin can fetch a known URL instead of reverse-engineering Argo's layout.

## No new credentials

The aggregate step uses `argo-workflows-s3-creds` — the artifact repository's existing credential, which already has write on that bucket.

## Deliberate non-goals, stated in the plan

- **Not served anywhere.** `aws s3 presign` gives a browser link for an hour. Hosting means a bucket policy or CloudFront — new public surface for a document listing your unpatched vulnerabilities.
- **Trend not built.** The dated keys accumulate and the bucket has no lifecycle policy, so it's answerable from a notebook whenever wanted. Building it now would be speculative.
- **A caution recorded:** 24,320 rows of HTML is several MB and browsers get sluggish past ~10k rows. If it becomes unusable the fix is capping the table, not pagination nobody clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF