### PR TITLE
feat(cve-report): HTML report at stable S3 keys

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -155,6 +155,19 @@ jobs:
       - name: Run wan-ip-monitor tests
         run: python -m pytest tests/wan_ip/ -q
 
+  cve-report-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: pip install pytest==8.3.3 pyyaml==6.0.2
+      - name: Run cve-report tests
+        run: python -m pytest tests/cve_report/ -q
+
   new-app-template-validate:
     runs-on: ubuntu-latest
     steps:

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -16,7 +16,6 @@ data:
     """Aggregate Trivy reports, render HTML, publish to stable S3 keys."""
     import collections
     import json
-    import os
     import pathlib
     import sys
     import urllib.request
@@ -111,14 +110,24 @@ data:
 
         for f in sorted(findings, key=sort_key):
             is_act = (f.get("image"), f.get("id")) in act_ids
+            sev_val = f.get("severity") or "UNKNOWN"
+            try:
+                sev_rank = SEVERITY_ORDER.index(sev_val)
+            except ValueError:
+                sev_rank = len(SEVERITY_ORDER)
             rows.append(
+                # data-rank carries SEVERITY_ORDER's position so the Severity
+                # column can sort by rank in the browser instead of falling
+                # back to localeCompare on the cell text, which would sort
+                # alphabetically (CRITICAL, HIGH, LOW, MEDIUM, UNKNOWN).
                 "<tr class='{cls}' data-act='{act}' data-sev='{sev}'>"
-                "<td>{flag}</td><td class='sev {sev}'>{sev}</td>"
+                "<td>{flag}</td><td class='sev {sev}' data-rank='{rank}'>{sev}</td>"
                 "<td class='img'>{img}</td><td>{vid}</td>"
                 "<td>{pkg}</td><td>{inst}</td><td>{fix}</td><td>{title}</td></tr>".format(
                     cls="act" if is_act else "",
                     act="1" if is_act else "0",
-                    sev=e(f.get("severity") or "UNKNOWN"),
+                    sev=e(sev_val),
+                    rank=sev_rank,
                     flag="&#9679;" if is_act else "",
                     img=e((f.get("image") or "").split("/")[-1]),
                     vid=e(f.get("id") or ""),
@@ -213,6 +222,10 @@ data:
         var rows=Array.prototype.slice.call(tb.rows);
         var asc=th.dataset.asc!=='1'; th.dataset.asc=asc?'1':'0';
         rows.sort(function(a,b){{
+          if(i===1){{
+            var rx=+a.cells[i].dataset.rank,ry=+b.cells[i].dataset.rank;
+            return asc?rx-ry:ry-rx;
+          }}
           var x=a.cells[i].textContent,y=b.cells[i].textContent;
           return asc?x.localeCompare(y):y.localeCompare(x);
         }});
@@ -308,19 +321,27 @@ data:
         if args.bucket and args.date:
             try:
                 html_doc = render_html(summary, findings, act, args.date)
-                (out / "report.html").write_text(html_doc)
                 import boto3
+                # Built explicitly rather than reusing the full-report.json
+                # string above: the published copy carries "generated" and
+                # "summary" so a consumer of latest.json can tell how fresh
+                # the pointer is and read the actionable count without
+                # re-deriving it from 24k+ raw findings. full-report.json
+                # (the Argo artifact) is unchanged.
+                published_json = json.dumps({
+                    "scanned": scanned, "failed": failed, "findings": findings,
+                    "generated": args.date, "summary": summary,
+                }, indent=2)
                 keys = publish(boto3.client("s3"), args.bucket, args.prefix,
-                               args.date, json.dumps(
-                                   {"scanned": scanned, "failed": failed,
-                                    "findings": findings}, indent=2), html_doc)
+                               args.date, published_json, html_doc)
                 for k in keys:
                     print(f"published s3://{args.bucket}/{k}")
             except Exception as exc:
                 # Publishing is a convenience; the Argo artifact is the record
                 # of truth and the Slack alert is the thing that pages someone.
-                # Nothing in this block -- rendering, writing report.html, or the
-                # S3 PUTs -- may prevent the Slack POST below or change the exit code.
+                # Nothing in this block -- rendering, building the published
+                # copy, or the S3 PUTs -- may prevent the Slack POST below or
+                # change the exit code.
                 print(f"WARNING: S3 publish failed: {exc}", file=sys.stderr)
 
         if act or failed:

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -41,7 +41,7 @@ data:
             except Exception as exc:
                 failed.append(f"{path}: {exc}")
                 continue
-            artifact = data.get("ArtifactName") or str(path)
+            artifact = data.get("ArtifactName", str(path))
             scanned.append(artifact)
             for result in data.get("Results") or []:
                 for vuln in result.get("Vulnerabilities") or []:
@@ -93,11 +93,11 @@ data:
             short = image.split("/")[-1]
             crit = sum(1 for i in items if i["severity"] == "CRITICAL")
             high = sum(1 for i in items if i["severity"] == "HIGH")
-            lines.append(f"*{short}* - {crit} critical, {high} high (all fixable)")
+            lines.append(f"*{short}* — {crit} critical, {high} high (all fixable)")
             for i in sorted(items, key=lambda x: x["id"] or "")[:5]:
-                lines.append(f"  - {i['id']} {i['pkg']} {i['installed']} -> {i['fixed']}")
+                lines.append(f"  • {i['id']} {i['pkg']} {i['installed']} → {i['fixed']}")
             if len(items) > 5:
-                lines.append(f"  - ...and {len(items) - 5} more")
+                lines.append(f"  • …and {len(items) - 5} more")
         if failed:
             lines.append(f"_{len(failed)} image(s) could not be scanned_")
         return "\n".join(lines)

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -1,0 +1,148 @@
+# Sole home of the CVE report renderer.
+#
+# The aggregate step of image-scan.yaml mounts this and runs it. Keeping the
+# script here rather than inline in the workflow makes it unit-testable
+# (tests/cve_report/), which inline YAML never was. Same pattern and same reason
+# as base-apps/wan-ip-monitor/configmap-reconcile.yaml.
+#
+# There is exactly ONE copy of this script. Do not add a second under scripts/.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cve-report
+  namespace: argo-workflows
+data:
+  render.py: |
+    """Aggregate Trivy reports, render HTML, publish to stable S3 keys."""
+    import collections
+    import json
+    import os
+    import pathlib
+    import sys
+    import urllib.request
+
+    ALERT_SEVERITIES = {"CRITICAL", "HIGH"}
+    SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+
+
+    def load_reports(root):
+        """Read every *.json under root. Returns (findings, scanned, failed).
+
+        Matches *.json rather than exactly report.json because Argo lays
+        artifacts out under the repository keyFormat and the leaf filename is
+        not guaranteed. An unreadable report is recorded as failed, never
+        omitted -- silence about an unscanned image is the failure worth
+        avoiding.
+        """
+        findings, scanned, failed = [], [], []
+        for path in sorted(pathlib.Path(root).rglob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+            except Exception as exc:
+                failed.append(f"{path}: {exc}")
+                continue
+            artifact = data.get("ArtifactName") or str(path)
+            scanned.append(artifact)
+            for result in data.get("Results") or []:
+                for vuln in result.get("Vulnerabilities") or []:
+                    findings.append({
+                        "image": artifact,
+                        "id": vuln.get("VulnerabilityID"),
+                        "pkg": vuln.get("PkgName"),
+                        "installed": vuln.get("InstalledVersion"),
+                        "fixed": vuln.get("FixedVersion"),
+                        "severity": vuln.get("Severity"),
+                        "title": (vuln.get("Title") or "")[:200],
+                    })
+        return findings, scanned, failed
+
+
+    def actionable(findings, owned_prefix):
+        """CRITICAL/HIGH, in an image we build, with a published fix.
+
+        This definition is shared with the Slack alert on purpose. Two
+        definitions would produce two numbers and neither would be trusted.
+        """
+        return [
+            f for f in findings
+            if (f.get("image") or "").startswith(owned_prefix)
+            and f.get("severity") in ALERT_SEVERITIES
+            and f.get("fixed")
+        ]
+
+
+    def summarise(findings, act):
+        by_sev = collections.Counter(f.get("severity") for f in findings)
+        by_img = collections.Counter(
+            (f.get("image") or "").split("/")[-1] for f in act
+        )
+        return {
+            "total": len(findings),
+            "actionable": len(act),
+            "by_severity": dict(by_sev),
+            "by_image": dict(by_img),
+        }
+
+
+    def _slack_text(act, failed):
+        by_image = {}
+        for f in act:
+            by_image.setdefault(f["image"], []).append(f)
+        lines = []
+        for image, items in sorted(by_image.items()):
+            short = image.split("/")[-1]
+            crit = sum(1 for i in items if i["severity"] == "CRITICAL")
+            high = sum(1 for i in items if i["severity"] == "HIGH")
+            lines.append(f"*{short}* - {crit} critical, {high} high (all fixable)")
+            for i in sorted(items, key=lambda x: x["id"] or "")[:5]:
+                lines.append(f"  - {i['id']} {i['pkg']} {i['installed']} -> {i['fixed']}")
+            if len(items) > 5:
+                lines.append(f"  - ...and {len(items) - 5} more")
+        if failed:
+            lines.append(f"_{len(failed)} image(s) could not be scanned_")
+        return "\n".join(lines)
+
+
+    def main(argv=None):
+        import argparse
+        p = argparse.ArgumentParser()
+        p.add_argument("--reports", required=True)
+        p.add_argument("--out", required=True)
+        p.add_argument("--owned-prefix", required=True)
+        p.add_argument("--webhook", required=True)
+        p.add_argument("--workflow-name", default="unknown")
+        args = p.parse_args(argv)
+
+        findings, scanned, failed = load_reports(args.reports)
+        act = actionable(findings, args.owned_prefix)
+        summary = summarise(findings, act)
+
+        out = pathlib.Path(args.out)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "full-report.json").write_text(json.dumps(
+            {"scanned": scanned, "failed": failed, "findings": findings}, indent=2))
+
+        print(f"scanned {len(scanned)} images, {len(failed)} failed")
+        print(f"{summary['total']} total findings, {summary['actionable']} actionable")
+
+        if act or failed:
+            payload = {
+                "scanned": len(scanned), "actionable": len(act),
+                "failed": len(failed), "workflow": args.workflow_name,
+                "text": _slack_text(act, failed),
+            }
+            try:
+                req = urllib.request.Request(
+                    args.webhook, data=json.dumps(payload).encode(),
+                    headers={"Content-Type": "application/json"})
+                urllib.request.urlopen(req, timeout=30).read()
+                print("posted to n8n")
+            except Exception as exc:
+                # A webhook failure must not hide the finding.
+                print(f"WARNING: n8n post failed: {exc}", file=sys.stderr)
+
+        return 1 if act else 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -234,6 +234,31 @@ data:
         )
 
 
+    def publish(client, bucket, prefix, date, report_json, report_html):
+        """Write the report to STABLE keys. Returns keys written, in order.
+
+        Consumers (a browser via presigned URL, a Backstage plugin, a notebook)
+        need a key they can predict. Argo's own artifact key embeds the
+        generated workflow and pod names, so finding "the latest report" there
+        means listing and sorting -- coupling every consumer to Argo's layout.
+
+        Dated copies are written BEFORE latest, so a partial failure can leave
+        latest pointing at an older complete report, never at nothing.
+        """
+        writes = [
+            (f"{prefix}{date}.json", report_json, "application/json"),
+            (f"{prefix}{date}.html", report_html, "text/html; charset=utf-8"),
+            (f"{prefix}latest.json", report_json, "application/json"),
+            (f"{prefix}latest.html", report_html, "text/html; charset=utf-8"),
+        ]
+        written = []
+        for key, body, ctype in writes:
+            client.put_object(Bucket=bucket, Key=key,
+                              Body=body.encode("utf-8"), ContentType=ctype)
+            written.append(key)
+        return written
+
+
     def _slack_text(act, failed):
         by_image = {}
         for f in act:
@@ -261,6 +286,9 @@ data:
         p.add_argument("--owned-prefix", required=True)
         p.add_argument("--webhook", required=True)
         p.add_argument("--workflow-name", default="unknown")
+        p.add_argument("--bucket", default="")
+        p.add_argument("--prefix", default="cve-reports/")
+        p.add_argument("--date", default="")
         args = p.parse_args(argv)
 
         findings, scanned, failed = load_reports(args.reports)
@@ -276,6 +304,23 @@ data:
 
         print(f"scanned {len(scanned)} images, {len(failed)} failed")
         print(f"{summary['total']} total findings, {summary['actionable']} actionable")
+
+        if args.bucket and args.date:
+            html_doc = render_html(summary, findings, act, args.date)
+            (out / "report.html").write_text(html_doc)
+            try:
+                import boto3
+                keys = publish(boto3.client("s3"), args.bucket, args.prefix,
+                               args.date, json.dumps(
+                                   {"scanned": scanned, "failed": failed,
+                                    "findings": findings}, indent=2), html_doc)
+                for k in keys:
+                    print(f"published s3://{args.bucket}/{k}")
+            except Exception as exc:
+                # Publishing is a convenience; the Argo artifact is the record
+                # of truth and the Slack alert is the thing that pages someone.
+                # Do not lose either because S3 rejected a PUT.
+                print(f"WARNING: S3 publish failed: {exc}", file=sys.stderr)
 
         if act or failed:
             payload = {

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -306,9 +306,9 @@ data:
         print(f"{summary['total']} total findings, {summary['actionable']} actionable")
 
         if args.bucket and args.date:
-            html_doc = render_html(summary, findings, act, args.date)
-            (out / "report.html").write_text(html_doc)
             try:
+                html_doc = render_html(summary, findings, act, args.date)
+                (out / "report.html").write_text(html_doc)
                 import boto3
                 keys = publish(boto3.client("s3"), args.bucket, args.prefix,
                                args.date, json.dumps(
@@ -319,7 +319,8 @@ data:
             except Exception as exc:
                 # Publishing is a convenience; the Argo artifact is the record
                 # of truth and the Slack alert is the thing that pages someone.
-                # Do not lose either because S3 rejected a PUT.
+                # Nothing in this block -- rendering, writing report.html, or the
+                # S3 PUTs -- may prevent the Slack POST below or change the exit code.
                 print(f"WARNING: S3 publish failed: {exc}", file=sys.stderr)
 
         if act or failed:

--- a/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
+++ b/base-apps/argo-workflow-tasks/configmap-cve-report.yaml
@@ -81,7 +81,157 @@ data:
             "actionable": len(act),
             "by_severity": dict(by_sev),
             "by_image": dict(by_img),
+            "scanned_count": 0,
+            "failed_count": 0,
         }
+
+
+    def render_html(summary, findings, act, generated):
+        """A complete, self-contained HTML report.
+
+        Inline CSS and JS only. This is opened from a presigned S3 URL where no
+        external fetch is guaranteed to succeed, and a report that renders as
+        unstyled text because a CDN was unreachable is a report nobody reads.
+        """
+        import html as html_mod
+
+        e = html_mod.escape
+        act_ids = {(f.get("image"), f.get("id")) for f in act}
+
+        rows = []
+        # Actionable first, then by severity, so the top of the table is the
+        # part anyone can act on.
+        def sort_key(f):
+            is_act = 0 if (f.get("image"), f.get("id")) in act_ids else 1
+            try:
+                sev = SEVERITY_ORDER.index(f.get("severity"))
+            except ValueError:
+                sev = len(SEVERITY_ORDER)
+            return (is_act, sev, f.get("image") or "", f.get("id") or "")
+
+        for f in sorted(findings, key=sort_key):
+            is_act = (f.get("image"), f.get("id")) in act_ids
+            rows.append(
+                "<tr class='{cls}' data-act='{act}' data-sev='{sev}'>"
+                "<td>{flag}</td><td class='sev {sev}'>{sev}</td>"
+                "<td class='img'>{img}</td><td>{vid}</td>"
+                "<td>{pkg}</td><td>{inst}</td><td>{fix}</td><td>{title}</td></tr>".format(
+                    cls="act" if is_act else "",
+                    act="1" if is_act else "0",
+                    sev=e(f.get("severity") or "UNKNOWN"),
+                    flag="&#9679;" if is_act else "",
+                    img=e((f.get("image") or "").split("/")[-1]),
+                    vid=e(f.get("id") or ""),
+                    pkg=e(f.get("pkg") or ""),
+                    inst=e(f.get("installed") or ""),
+                    fix=e(f.get("fixed") or "-"),
+                    title=e(f.get("title") or ""),
+                )
+            )
+
+        by_image = "".join(
+            f"<li><span>{e(img)}</span><b>{n}</b></li>"
+            for img, n in sorted(summary["by_image"].items(), key=lambda kv: -kv[1])
+        ) or "<li>none</li>"
+
+        by_sev = "".join(
+            f"<li><span class='sev {e(s)}'>{e(s)}</span><b>{summary['by_severity'].get(s, 0)}</b></li>"
+            for s in SEVERITY_ORDER if summary["by_severity"].get(s)
+        )
+
+        return """<!doctype html>
+    <html lang="en"><head><meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>CVE report {generated}</title>
+    <style>
+    :root{{--bg:#fff;--fg:#111;--mut:#666;--line:#e3e3e3;--act:#b30000}}
+    @media(prefers-color-scheme:dark){{:root{{--bg:#141414;--fg:#eee;--mut:#999;--line:#333;--act:#ff6b6b}}}}
+    *{{box-sizing:border-box}}
+    body{{margin:0;padding:2rem;background:var(--bg);color:var(--fg);
+      font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}}
+    h1{{margin:0 0 .25rem;font-size:1.4rem}}
+    .sub{{color:var(--mut);margin-bottom:1.5rem}}
+    .cards{{display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:1.5rem}}
+    .card{{border:1px solid var(--line);border-radius:8px;padding:1rem 1.25rem;min-width:190px}}
+    .card h2{{margin:0 0 .5rem;font-size:.75rem;text-transform:uppercase;
+      letter-spacing:.06em;color:var(--mut)}}
+    .big{{font-size:2rem;font-weight:600}}
+    .big.act{{color:var(--act)}}
+    .card ul{{list-style:none;margin:0;padding:0}}
+    .card li{{display:flex;justify-content:space-between;gap:1.5rem;padding:.15rem 0}}
+    .controls{{margin-bottom:.75rem;display:flex;gap:1rem;align-items:center;flex-wrap:wrap}}
+    input[type=search]{{padding:.4rem .6rem;border:1px solid var(--line);border-radius:6px;
+      background:var(--bg);color:var(--fg);min-width:240px}}
+    .wrap{{overflow-x:auto;border:1px solid var(--line);border-radius:8px}}
+    table{{border-collapse:collapse;width:100%;font-size:13px}}
+    th,td{{text-align:left;padding:.45rem .7rem;border-bottom:1px solid var(--line);
+      white-space:nowrap}}
+    th{{position:sticky;top:0;background:var(--bg);cursor:pointer;user-select:none}}
+    td:last-child{{white-space:normal;min-width:22rem}}
+    tr.act td:first-child{{color:var(--act)}}
+    .sev.CRITICAL{{color:#b30000;font-weight:600}}
+    .sev.HIGH{{color:#c25e00;font-weight:600}}
+    .sev.MEDIUM{{color:#8a7500}}
+    .sev.LOW,.sev.UNKNOWN{{color:var(--mut)}}
+    .img{{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}}
+    </style></head><body>
+    <h1>Container CVE report</h1>
+    <div class="sub">Generated {generated} &middot; {scanned} images scanned{failed}</div>
+    <div class="cards">
+      <div class="card"><h2>Actionable</h2><div class="big act">{actionable}</div>
+        <div class="sub" style="margin:0">ours &middot; CRITICAL/HIGH &middot; fixable</div></div>
+      <div class="card"><h2>All findings</h2><div class="big">{total}</div>
+        <div class="sub" style="margin:0">including unfixable upstream</div></div>
+      <div class="card"><h2>By severity</h2><ul>{by_sev}</ul></div>
+      <div class="card"><h2>Actionable by image</h2><ul>{by_image}</ul></div>
+    </div>
+    <div class="controls">
+      <label><input type="checkbox" id="only" checked> actionable only</label>
+      <input type="search" id="q" placeholder="filter image, CVE, package&hellip;">
+      <span class="sub" id="count" style="margin:0"></span>
+    </div>
+    <div class="wrap"><table id="t"><thead><tr>
+    <th></th><th>Severity</th><th>Image</th><th>CVE</th>
+    <th>Package</th><th>Installed</th><th>Fixed</th><th>Title</th>
+    </tr></thead><tbody>{rows}</tbody></table></div>
+    <script>
+    var tb=document.getElementById('t').tBodies[0];
+    var only=document.getElementById('only'),q=document.getElementById('q');
+    var count=document.getElementById('count');
+    function apply(){{
+      var term=q.value.toLowerCase(),shown=0;
+      Array.prototype.forEach.call(tb.rows,function(r){{
+        var okAct=!only.checked||r.dataset.act==='1';
+        var okQ=!term||r.textContent.toLowerCase().indexOf(term)>-1;
+        var vis=okAct&&okQ; r.style.display=vis?'':'none'; if(vis)shown++;
+      }});
+      count.textContent=shown+' shown';
+    }}
+    only.addEventListener('change',apply); q.addEventListener('input',apply);
+    Array.prototype.forEach.call(document.querySelectorAll('#t th'),function(th,i){{
+      th.addEventListener('click',function(){{
+        var rows=Array.prototype.slice.call(tb.rows);
+        var asc=th.dataset.asc!=='1'; th.dataset.asc=asc?'1':'0';
+        rows.sort(function(a,b){{
+          var x=a.cells[i].textContent,y=b.cells[i].textContent;
+          return asc?x.localeCompare(y):y.localeCompare(x);
+        }});
+        rows.forEach(function(r){{tb.appendChild(r)}});
+      }});
+    }});
+    apply();
+    </script></body></html>
+    """.format(
+            generated=e(generated),
+            scanned=summary["scanned_count"],
+            failed="" if not summary.get("failed_count") else
+                   f" &middot; {summary['failed_count']} failed",
+            actionable=summary["actionable"],
+            total=summary["total"],
+            by_sev=by_sev,
+            by_image=by_image,
+            rows="".join(rows),
+        )
 
 
     def _slack_text(act, failed):
@@ -116,6 +266,8 @@ data:
         findings, scanned, failed = load_reports(args.reports)
         act = actionable(findings, args.owned_prefix)
         summary = summarise(findings, act)
+        summary["scanned_count"] = len(scanned)
+        summary["failed_count"] = len(failed)
 
         out = pathlib.Path(args.out)
         out.mkdir(parents=True, exist_ok=True)

--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -16,6 +16,18 @@ spec:
   entrypoint: main
   serviceAccountName: argo-workflow
 
+  # Without this, a wedged step (missing ConfigMap, a hung pip install, a
+  # registry pull that never times out) never fails, never alerts, and never
+  # turns the run red -- it just sits. Because the CronWorkflow below sets
+  # concurrencyPolicy: Forbid, that also blocks every subsequent weekly run
+  # from starting, silently, which is exactly the failure mode design §3.6
+  # calls out as the one worth avoiding -- worse here because this workflow
+  # is red by design most weeks (§3.6), so "red" alone carries no signal.
+  # This converts a hang into a failed run instead of an indefinite block.
+  # The first full measured run (design §5.1) took ~40 minutes for 78 images
+  # at parallelism 4; 5400s (90m) leaves better than 2x headroom over that.
+  activeDeadlineSeconds: 5400
+
   # Bounds concurrent scan pods. Peak temp disk is roughly four scans' worth
   # rather than seventy-five. See sizeLimit on the emptyDir below.
   parallelism: 4
@@ -220,7 +232,9 @@ spec:
           # is designed to survive (see the comment above that block).
           try:
               subprocess.check_call([sys.executable, "-m", "pip", "install",
-                                     "--quiet", "--disable-pip-version-check", "boto3"])
+                                     "--quiet", "--disable-pip-version-check",
+                                     "--timeout", "30", "--retries", "2",
+                                     "boto3==1.35.99"])
           except Exception as exc:
               print(f"WARNING: boto3 install failed, S3 publish will be skipped: {exc}",
                     file=sys.stderr)

--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -43,6 +43,10 @@ spec:
         value: "852893458518.dkr.ecr."
       - name: n8n-webhook
         value: "http://n8n.n8n.svc.cluster.local:5678/webhook/image-scan-report"
+      - name: report-bucket
+        value: "asela-argo-workflows-artifacts"
+      - name: report-prefix
+        value: "cve-reports/"
 
   templates:
     - name: main
@@ -206,7 +210,22 @@ spec:
         image: python:3.12-slim
         command: [python3]
         source: |
-          import runpy, sys
+          import subprocess, sys
+          # python:3.12-slim has no boto3. Guarded: an install failure here must
+          # not fail this step, because render.py's own S3 block only degrades
+          # to a warning if `import boto3` fails -- but check_call raises, and
+          # this runs before that try/except, outside its protection. Unguarded,
+          # a PyPI outage would kill the whole aggregate step and take the Slack
+          # alert POST down with it, which is exactly the failure mode publish()
+          # is designed to survive (see the comment above that block).
+          try:
+              subprocess.check_call([sys.executable, "-m", "pip", "install",
+                                     "--quiet", "--disable-pip-version-check", "boto3"])
+          except Exception as exc:
+              print(f"WARNING: boto3 install failed, S3 publish will be skipped: {exc}",
+                    file=sys.stderr)
+
+          import runpy
           sys.argv = [
               "render.py",
               "--reports", "/reports",
@@ -214,8 +233,27 @@ spec:
               "--owned-prefix", "{{workflow.parameters.owned-image-prefix}}",
               "--webhook", "{{workflow.parameters.n8n-webhook}}",
               "--workflow-name", "{{workflow.name}}",
+              "--bucket", "{{workflow.parameters.report-bucket}}",
+              "--prefix", "{{workflow.parameters.report-prefix}}",
+              "--date", "{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}-{{workflow.creationTimestamp.d}}",
           ]
           runpy.run_path("/app/render.py", run_name="__main__")
+        env:
+          # Already has write on asela-argo-workflows-artifacts: it is the
+          # artifact repository credential from base-apps/argo-workflows.yaml.
+          # Keys are username / attribute.secret -- there is no attribute.id.
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: argo-workflows-s3-creds
+                key: username
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: argo-workflows-s3-creds
+                key: attribute.secret
+          - name: AWS_DEFAULT_REGION
+            value: "us-east-1"
         volumeMounts:
           - name: out
             mountPath: /tmp/out

--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -206,103 +206,22 @@ spec:
         image: python:3.12-slim
         command: [python3]
         source: |
-          import json, os, pathlib, sys, urllib.request
-
-          OWNED = "{{workflow.parameters.owned-image-prefix}}"
-          WEBHOOK = "{{workflow.parameters.n8n-webhook}}"
-          ALERT_SEVERITIES = {"CRITICAL", "HIGH"}
-
-          findings, scanned, failed = [], [], []
-          # rglob("*.json") rather than "report.json": Argo lays artifacts out
-          # under the repository keyFormat, and the leaf filename is not
-          # guaranteed to survive as report.json. Matching any .json under the
-          # prefix is robust to that without depending on the exact layout.
-          for p in sorted(pathlib.Path("/reports").rglob("*.json")):
-              try:
-                  data = json.loads(p.read_text())
-              except Exception as e:
-                  failed.append(f"{p}: {e}")
-                  continue
-              artifact = data.get("ArtifactName", str(p))
-              scanned.append(artifact)
-              for result in data.get("Results") or []:
-                  for v in result.get("Vulnerabilities") or []:
-                      findings.append({
-                          "image": artifact,
-                          "id": v.get("VulnerabilityID"),
-                          "pkg": v.get("PkgName"),
-                          "installed": v.get("InstalledVersion"),
-                          "fixed": v.get("FixedVersion"),
-                          "severity": v.get("Severity"),
-                          "title": (v.get("Title") or "")[:200],
-                      })
-
-          # The full picture goes to S3 — every image, every severity, fixable
-          # or not. This is the queryable inventory, not the alert.
-          pathlib.Path("/tmp/out").mkdir(parents=True, exist_ok=True)
-          pathlib.Path("/tmp/out/full-report.json").write_text(json.dumps({
-              "scanned": scanned, "failed": failed, "findings": findings,
-          }, indent=2))
-
-          # The alert is deliberately much narrower: our own images only,
-          # CRITICAL/HIGH only, and only where a fix actually exists. A CVE with
-          # no available patch is something to know, not something to do — it
-          # stays in the S3 report above.
-          actionable = [
-              f for f in findings
-              if f["image"].startswith(OWNED)
-              and f["severity"] in ALERT_SEVERITIES
-              and f["fixed"]
+          import runpy, sys
+          sys.argv = [
+              "render.py",
+              "--reports", "/reports",
+              "--out", "/tmp/out",
+              "--owned-prefix", "{{workflow.parameters.owned-image-prefix}}",
+              "--webhook", "{{workflow.parameters.n8n-webhook}}",
+              "--workflow-name", "{{workflow.name}}",
           ]
-
-          print(f"scanned {len(scanned)} images, {len(failed)} failed")
-          print(f"{len(findings)} total findings, {len(actionable)} actionable")
-
-          if actionable or failed:
-              by_image = {}
-              for f in actionable:
-                  by_image.setdefault(f["image"], []).append(f)
-              lines = []
-              for image, items in sorted(by_image.items()):
-                  short = image.split("/")[-1]
-                  crit = sum(1 for i in items if i["severity"] == "CRITICAL")
-                  high = sum(1 for i in items if i["severity"] == "HIGH")
-                  lines.append(f"*{short}* — {crit} critical, {high} high (all fixable)")
-                  for i in sorted(items, key=lambda x: x["id"])[:5]:
-                      lines.append(
-                          f"  • {i['id']} {i['pkg']} {i['installed']} → {i['fixed']}"
-                      )
-                  if len(items) > 5:
-                      lines.append(f"  • …and {len(items) - 5} more")
-              if failed:
-                  lines.append(f"_{len(failed)} image(s) could not be scanned_")
-
-              payload = {
-                  "scanned": len(scanned),
-                  "actionable": len(actionable),
-                  "failed": len(failed),
-                  "workflow": "{{workflow.name}}",
-                  "text": "\n".join(lines),
-              }
-              try:
-                  req = urllib.request.Request(
-                      WEBHOOK,
-                      data=json.dumps(payload).encode(),
-                      headers={"Content-Type": "application/json"},
-                  )
-                  urllib.request.urlopen(req, timeout=30).read()
-                  print("posted to n8n")
-              except Exception as e:
-                  # A webhook failure must not hide the finding. Surface it and
-                  # still fail below, so the Argo run is red either way.
-                  print(f"WARNING: n8n post failed: {e}", file=sys.stderr)
-
-          # Red run iff something is actionable. Unscanned images alone do not
-          # fail the run, but they are named in the alert above.
-          sys.exit(1 if actionable else 0)
+          runpy.run_path("/app/render.py", run_name="__main__")
         volumeMounts:
           - name: out
             mountPath: /tmp/out
+          - name: script
+            mountPath: /app
+            readOnly: true
         resources:
           requests: {cpu: 100m, memory: 256Mi}
           limits: {cpu: 500m, memory: 1Gi}
@@ -310,6 +229,9 @@ spec:
         - name: out
           emptyDir:
             sizeLimit: 1Gi
+        - name: script
+          configMap:
+            name: cve-report
       outputs:
         artifacts:
           - name: full-report

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -269,6 +269,56 @@ the filter: these are patchable vulnerabilities in images we build. Reducing
 that number means rebuilding those images on newer bases, which is work this
 design surfaces rather than performs.
 
+## 5.2 CVE report surface — stable S3 keys
+
+Each aggregate run writes four keys under `cve-reports/` in
+`asela-argo-workflows-artifacts`, separate from the per-image scan artifacts
+Argo already stores there under its own `keyFormat`:
+
+```
+cve-reports/<YYYY-MM-DD>.json
+cve-reports/<YYYY-MM-DD>.html
+cve-reports/latest.json
+cve-reports/latest.html
+```
+
+**Why four keys, not Argo's own artifact key.** The artifact repository's key
+embeds the generated workflow and pod names
+(`{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}`, set chart-side in
+`base-apps/argo-workflows.yaml`) — finding "the latest report" there means
+listing the bucket and sorting. A stable `latest.*` key lets any consumer (a
+browser via a presigned link, a future Backstage plugin, a notebook) fetch the
+current report without knowing anything about how Argo named this particular
+run. `date` comes from
+`{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}-{{workflow.creationTimestamp.d}}`,
+not a clock read inside the script, so a manual re-run on the same day
+overwrites that day's dated key rather than creating a second one.
+
+**The HTML is self-contained on purpose.** `render_html()` inlines all CSS and
+JS rather than pulling from a CDN. The document is opened from a one-hour
+presigned URL, with no origin of its own to serve assets from — a CDN request
+failing silently would mean the report renders as unstyled text, which is
+worse than the extra kilobytes of inline CSS/JS.
+
+**How to view it.** The bucket stays private — no bucket policy, no
+CloudFront distribution, no new public surface for a document that lists
+unpatched CVEs (see "Notes for whoever executes this" below). Generate a
+short-lived link instead:
+
+```bash
+aws s3 presign s3://asela-argo-workflows-artifacts/cve-reports/latest.html --expires-in 3600
+```
+
+One hour is enough for a human to open the report after a Slack alert; there
+is nothing long-lived to protect by shortening it further.
+
+**Trend is possible because nothing expires the dated copies.** They
+accumulate (~8MB/week for both formats) and `asela-argo-workflows-artifacts`
+carries no lifecycle policy, so the full history stays queryable with
+`aws s3 ls` or a notebook loading successive `<date>.json` keys whenever "are
+we improving?" is worth asking. No trend dashboard is built here — that would
+be speculative ahead of having more than one week of data.
+
 ## 6. Verification
 
 **Static:** all manifests parse; `python -m pytest tests/ -q` stays green; the

--- a/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
+++ b/docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md
@@ -95,8 +95,15 @@ has existed in `argo-workflows` for 125 days. The scan step mounts it at
 `DOCKER_CONFIG`. No new credential, no new IAM user.
 
 **S3** — the artifact repository is already configured in the chart values
-against `argo-workflows-s3-creds` and `asela-argo-workflows-artifacts`. Reports
-are ordinary Argo output artifacts; nothing new is wired.
+against `argo-workflows-s3-creds` and `asela-argo-workflows-artifacts`. The
+`full-report.json` artifact is an ordinary Argo output artifact, uploaded by
+the wait sidecar the way every other step's artifacts are. The stable-key
+publish (§5.2) additionally injects that same `argo-workflows-s3-creds`
+secret into the aggregate pod's own environment (`AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY`) so `boto3` inside the script can call `put_object`
+directly. Still the same credential — nothing new is minted — but a
+different posture from "Argo's sidecar handles it": the pod process itself
+now holds S3 write access for the run's duration.
 
 **Slack** — n8n already holds `SLACK_BOT_TOKEN` and posts to `#oncall-alerts`.
 The scan never touches it; it POSTs to an n8n webhook and n8n owns the token.
@@ -219,9 +226,11 @@ CronWorkflow (Sun 04:00 UTC)
 | File | Change |
 |---|---|
 | `base-apps/argo-workflow-tasks/image-scan.yaml` | **New** — `WorkflowTemplate` + `CronWorkflow` |
+| `base-apps/argo-workflow-tasks/configmap-cve-report.yaml` | **New** — sole home of `render.py`: aggregate, render HTML, publish to stable S3 keys |
 | `base-apps/argo-workflow-tasks/serviceaccount.yaml` | Add `ClusterRole` + `ClusterRoleBinding` for pod read |
 | `base-apps/n8n/workflows-configmap.yaml` | Add `image-scan-report.json` (webhook → format → Slack) |
 | `base-apps/n8n/deployments.yaml` | Recompute `checksum/workflows` |
+| `tests/cve_report/` | **New** — unit tests for `render.py`, extracted from the ConfigMap |
 
 `base-apps/argo-workflow-tasks/` carries no `catalog-info.yaml`, so it is outside
 the agent-docs contract and no `docs.md`/`runbook.md` is required.
@@ -293,6 +302,21 @@ run. `date` comes from
 `{{workflow.creationTimestamp.Y}}-{{workflow.creationTimestamp.m}}-{{workflow.creationTimestamp.d}}`,
 not a clock read inside the script, so a manual re-run on the same day
 overwrites that day's dated key rather than creating a second one.
+
+**Why `boto3` and not Argo output artifacts with explicit `s3.key`s.** Argo
+output artifacts are all plausible here in principle — each key above could
+be declared as its own `outputs.artifacts` entry with a literal `s3.key`.
+The reason it isn't: Argo's wait sidecar uploads a step's output artifacts
+*after* the main container exits, and does not guarantee the order it
+uploads them in. `publish()`'s invariant — dated copies written before
+`latest`, so a partial failure leaves `latest` pointing at an older
+*complete* report rather than nothing — cannot be expressed through output
+artifacts at all, because nothing controls their upload order. Calling
+`boto3.put_object()` directly, in the sequence the script chooses, is what
+makes that ordering guarantee possible. (An earlier version of this
+reasoning cited per-key Content-Type control as the driver; that does not
+hold up, since Argo's S3 driver infers Content-Type from the file
+extension. The ordering guarantee is the real reason `boto3` is kept.)
 
 **The HTML is self-contained on purpose.** `render_html()` inlines all CSS and
 JS rather than pulling from a CDN. The document is opened from a one-hour

--- a/tests/cve_report/conftest.py
+++ b/tests/cve_report/conftest.py
@@ -1,0 +1,25 @@
+"""Load render.py out of the ConfigMap that ships it.
+
+The script has exactly one home - the ConfigMap - so there is no second copy to
+drift. Tests extract it and import it as a module. Mirrors tests/wan_ip/conftest.py.
+"""
+import importlib.util
+import pathlib
+import tempfile
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+CONFIGMAP = REPO / "base-apps" / "argo-workflow-tasks" / "configmap-cve-report.yaml"
+
+
+@pytest.fixture(scope="session")
+def render():
+    source = yaml.safe_load(CONFIGMAP.read_text())["data"]["render.py"]
+    path = pathlib.Path(tempfile.mkdtemp()) / "render.py"
+    path.write_text(source)
+    spec = importlib.util.spec_from_file_location("render", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/cve_report/test_aggregate.py
+++ b/tests/cve_report/test_aggregate.py
@@ -1,0 +1,74 @@
+import json
+
+OWNED = "852893458518.dkr.ecr."
+
+
+def _finding(image, severity="HIGH", fixed="1.2.3", vid="CVE-2026-1"):
+    return {
+        "image": image, "id": vid, "pkg": "libfoo",
+        "installed": "1.0.0", "fixed": fixed,
+        "severity": severity, "title": "example",
+    }
+
+
+def test_load_reports_reads_every_json(render, tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "report.json").write_text(json.dumps({
+        "ArtifactName": "img-a",
+        "Results": [{"Vulnerabilities": [
+            {"VulnerabilityID": "CVE-1", "PkgName": "p", "InstalledVersion": "1",
+             "FixedVersion": "2", "Severity": "HIGH", "Title": "t"}]}],
+    }))
+    (tmp_path / "b" / "report.json").write_text(json.dumps({
+        "ArtifactName": "img-b", "Results": [],
+    }))
+
+    findings, scanned, failed = render.load_reports(str(tmp_path))
+
+    assert sorted(scanned) == ["img-a", "img-b"]
+    assert failed == []
+    assert len(findings) == 1
+    assert findings[0]["image"] == "img-a"
+    assert findings[0]["id"] == "CVE-1"
+
+
+def test_load_reports_records_unparseable_as_failed_not_clean(render, tmp_path):
+    (tmp_path / "bad.json").write_text("{not json")
+    findings, scanned, failed = render.load_reports(str(tmp_path))
+    assert findings == []
+    assert scanned == []
+    assert len(failed) == 1, "an unreadable report must be failed, never silently clean"
+
+
+def test_actionable_requires_owned_severity_and_a_fix(render):
+    findings = [
+        _finding(OWNED + "mine:v1", "CRITICAL", "9.9"),          # counts
+        _finding(OWNED + "mine:v1", "HIGH", "9.9"),              # counts
+        _finding(OWNED + "mine:v1", "HIGH", ""),                 # no fix
+        _finding(OWNED + "mine:v1", "MEDIUM", "9.9"),            # too low
+        _finding("docker.io/upstream:v1", "CRITICAL", "9.9"),    # not ours
+    ]
+    got = render.actionable(findings, OWNED)
+    assert len(got) == 2
+    assert {f["severity"] for f in got} == {"CRITICAL", "HIGH"}
+
+
+def test_summarise_counts_by_severity_and_image(render):
+    # A real ECR reference always has a "/" between the registry host and the
+    # repo (e.g. "...amazonaws.com/repo:tag"), which is what by_image's
+    # split("/")[-1] extracts down to the short name. Written explicitly here
+    # (rather than OWNED + "a:v1", which has no "/" at all) so this fixture
+    # matches that shape instead of silently asserting against the whole
+    # prefixed string.
+    findings = [
+        _finding(OWNED + "/a:v1", "CRITICAL"),
+        _finding(OWNED + "/a:v1", "HIGH"),
+        _finding(OWNED + "/b:v1", "HIGH"),
+        _finding("docker.io/up:v1", "LOW", ""),
+    ]
+    s = render.summarise(findings, render.actionable(findings, OWNED))
+    assert s["total"] == 4
+    assert s["actionable"] == 3
+    assert s["by_severity"]["CRITICAL"] == 1
+    assert s["by_image"]["a:v1"] == 2

--- a/tests/cve_report/test_html.py
+++ b/tests/cve_report/test_html.py
@@ -1,3 +1,5 @@
+import re
+
 OWNED = "852893458518.dkr.ecr."
 
 
@@ -24,16 +26,20 @@ def test_html_is_a_complete_document(render):
 
 
 def test_html_is_self_contained(render):
-    """No CDN, no external fonts - it is opened from a presigned S3 URL."""
-    html = _doc(render).lower()
-    for forbidden in ["http://", "https://cdn", "<script src=", "<link rel=\"stylesheet\" href="]:
-        assert forbidden not in html, f"external reference found: {forbidden}"
+    """No CDN, no external fonts, no @import - it is opened from a presigned
+    S3 URL where no external fetch is guaranteed to succeed."""
+    html = _doc(render)
+    assert not re.search(r"\bhttps?://", html), \
+        "external URL reference in a self-contained report"
+    assert "@import" not in html.lower(), \
+        "@import can pull an external stylesheet"
 
 
 def test_html_reports_the_actionable_count(render):
     html = _doc(render)
-    assert "1" in html
-    assert "actionable" in html.lower()
+    m = re.search(r'class="big act">(\d+)<', html)
+    assert m and m.group(1) == "1", \
+        f"actionable count not rendered as 1: {m and m.group(1)}"
 
 
 def test_html_includes_every_finding(render):

--- a/tests/cve_report/test_html.py
+++ b/tests/cve_report/test_html.py
@@ -1,0 +1,53 @@
+OWNED = "852893458518.dkr.ecr."
+
+
+def _f(image, severity="HIGH", fixed="1.2.3", vid="CVE-2026-1"):
+    return {"image": image, "id": vid, "pkg": "libfoo", "installed": "1.0.0",
+            "fixed": fixed, "severity": severity, "title": "example title"}
+
+
+def _doc(render):
+    findings = [
+        _f(OWNED + "mine:v1", "CRITICAL", "9.9", "CVE-A"),
+        _f(OWNED + "mine:v1", "HIGH", "", "CVE-B"),
+        _f("docker.io/up:v1", "LOW", "", "CVE-C"),
+    ]
+    act = render.actionable(findings, OWNED)
+    return render.render_html(
+        render.summarise(findings, act), findings, act, "2026-08-18")
+
+
+def test_html_is_a_complete_document(render):
+    html = _doc(render)
+    assert html.lstrip().startswith("<!doctype html>")
+    assert "</html>" in html
+
+
+def test_html_is_self_contained(render):
+    """No CDN, no external fonts - it is opened from a presigned S3 URL."""
+    html = _doc(render).lower()
+    for forbidden in ["http://", "https://cdn", "<script src=", "<link rel=\"stylesheet\" href="]:
+        assert forbidden not in html, f"external reference found: {forbidden}"
+
+
+def test_html_reports_the_actionable_count(render):
+    html = _doc(render)
+    assert "1" in html
+    assert "actionable" in html.lower()
+
+
+def test_html_includes_every_finding(render):
+    html = _doc(render)
+    for vid in ("CVE-A", "CVE-B", "CVE-C"):
+        assert vid in html
+
+
+def test_html_escapes_untrusted_text(render):
+    """Titles come from an external vulnerability feed, not from us."""
+    findings = [{"image": "i", "id": "CVE-X", "pkg": "p", "installed": "1",
+                 "fixed": "2", "severity": "HIGH",
+                 "title": "<script>alert(1)</script>"}]
+    act = render.actionable(findings, OWNED)
+    html = render.render_html(render.summarise(findings, act), findings, act, "2026-08-18")
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html

--- a/tests/cve_report/test_s3.py
+++ b/tests/cve_report/test_s3.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import urllib.request
 
 
@@ -42,25 +43,20 @@ def test_publish_bodies_are_bytes(render):
 OWNED = "852893458518.dkr.ecr."
 
 
-def test_main_posts_to_slack_and_keeps_exit_code_when_publish_raises(render, tmp_path, monkeypatch):
-    """publish() is a convenience. Even if report generation/S3-write blows up,
-    the Slack/n8n POST -- what actually pages someone -- and the exit-code
-    contract (1 iff there are actionable findings) must survive untouched."""
-    reports = tmp_path / "reports"
-    reports.mkdir()
-    (reports / "report.json").write_text(json.dumps({
+def _write_actionable_report(reports_dir):
+    reports_dir.mkdir()
+    (reports_dir / "report.json").write_text(json.dumps({
         "ArtifactName": OWNED + "mine:v1",
         "Results": [{"Vulnerabilities": [
             {"VulnerabilityID": "CVE-2026-9", "PkgName": "libfoo",
              "InstalledVersion": "1.0.0", "FixedVersion": "1.2.3",
              "Severity": "CRITICAL", "Title": "bad"}]}],
     }))
-    out = tmp_path / "out"
 
-    def raise_publish(*a, **kw):
-        raise RuntimeError("S3 is on fire")
-    monkeypatch.setattr(render, "publish", raise_publish)
 
+def _patch_urlopen(monkeypatch):
+    """Record webhook posts instead of hitting the network. Returns the list
+    that gets one entry per POST main() attempts."""
     posted = []
 
     class FakeResponse:
@@ -70,7 +66,65 @@ def test_main_posts_to_slack_and_keeps_exit_code_when_publish_raises(render, tmp
     def fake_urlopen(req, timeout=30):
         posted.append(req)
         return FakeResponse()
+
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return posted
+
+
+def test_main_posts_to_slack_and_keeps_exit_code_when_render_html_raises(
+        render, tmp_path, monkeypatch):
+    """The block the publish-is-a-convenience constraint protects spans
+    render_html(), the report.html write, the boto3 import, and publish()
+    itself. render_html() is reached first -- before boto3 is even imported --
+    so this is the failure window Finding 1 was about: a plain RuntimeError
+    here, with no boto3 involved at all, must still let the Slack/n8n POST
+    happen and the exit-code contract hold.
+    """
+    reports = tmp_path / "reports"
+    _write_actionable_report(reports)
+    out = tmp_path / "out"
+
+    def raise_render_html(*a, **kw):
+        raise RuntimeError("rendering blew up")
+    monkeypatch.setattr(render, "render_html", raise_render_html)
+
+    posted = _patch_urlopen(monkeypatch)
+
+    rc = render.main([
+        "--reports", str(reports),
+        "--out", str(out),
+        "--owned-prefix", OWNED,
+        "--webhook", "http://n8n.example.invalid/hook",
+        "--bucket", "some-bucket",
+        "--date", "2026-08-18",
+    ])
+
+    assert posted, "render_html() raising must not suppress the Slack/n8n POST"
+    assert rc == 1, "exit-code contract (1 iff actionable findings) must survive a render_html failure"
+
+
+def test_main_posts_to_slack_and_keeps_exit_code_when_publish_raises(
+        render, tmp_path, monkeypatch):
+    """Same property, for a failure inside publish() itself. Reaching that
+    call requires `import boto3` to succeed first, and boto3 is not installed
+    in this environment, so it is stubbed in sys.modules for the duration of
+    the test -- a plain object with a .client() method is all main() touches
+    before calling publish(), which is what actually raises here.
+    """
+    reports = tmp_path / "reports"
+    _write_actionable_report(reports)
+    out = tmp_path / "out"
+
+    class FakeBoto3Module:
+        def client(self, *a, **kw):
+            return object()
+    monkeypatch.setitem(sys.modules, "boto3", FakeBoto3Module())
+
+    def raise_publish(*a, **kw):
+        raise RuntimeError("S3 is on fire")
+    monkeypatch.setattr(render, "publish", raise_publish)
+
+    posted = _patch_urlopen(monkeypatch)
 
     rc = render.main([
         "--reports", str(reports),

--- a/tests/cve_report/test_s3.py
+++ b/tests/cve_report/test_s3.py
@@ -137,3 +137,49 @@ def test_main_posts_to_slack_and_keeps_exit_code_when_publish_raises(
 
     assert posted, "publish() raising must not suppress the Slack/n8n POST"
     assert rc == 1, "exit-code contract (1 iff actionable findings) must survive a publish failure"
+
+
+def test_main_publishes_generated_and_summary_but_leaves_full_report_untouched(
+        render, tmp_path, monkeypatch):
+    """The published S3 copy (dated + latest) must carry 'generated' and
+    'summary' so a consumer of latest.json can tell how fresh the pointer is
+    and read the actionable count without re-deriving it from thousands of
+    raw findings. full-report.json -- the Argo artifact -- is a separate
+    dict built earlier in main() and must not gain these keys.
+    """
+    reports = tmp_path / "reports"
+    _write_actionable_report(reports)
+    out = tmp_path / "out"
+
+    s3 = FakeS3()
+
+    class FakeBoto3Module:
+        def client(self, *a, **kw):
+            return s3
+    monkeypatch.setitem(sys.modules, "boto3", FakeBoto3Module())
+
+    posted = _patch_urlopen(monkeypatch)
+
+    rc = render.main([
+        "--reports", str(reports),
+        "--out", str(out),
+        "--owned-prefix", OWNED,
+        "--webhook", "http://n8n.example.invalid/hook",
+        "--bucket", "some-bucket",
+        "--date", "2026-08-18",
+    ])
+
+    assert rc == 1
+    assert posted
+
+    by_key = {p["key"]: p["body"] for p in s3.puts}
+    for key in ("cve-reports/2026-08-18.json", "cve-reports/latest.json"):
+        body = json.loads(by_key[key])
+        assert body["generated"] == "2026-08-18"
+        assert body["summary"]["actionable"] == 1
+        assert "scanned" in body and "findings" in body
+
+    full_report = json.loads((out / "full-report.json").read_text())
+    assert "generated" not in full_report, \
+        "full-report.json is the Argo artifact; only the published copy gains fields"
+    assert "summary" not in full_report

--- a/tests/cve_report/test_s3.py
+++ b/tests/cve_report/test_s3.py
@@ -1,0 +1,35 @@
+class FakeS3:
+    """Minimal stand-in for a boto3 S3 client."""
+
+    def __init__(self):
+        self.puts = []
+
+    def put_object(self, Bucket, Key, Body, ContentType=None, **kw):
+        self.puts.append({"bucket": Bucket, "key": Key,
+                          "body": Body, "content_type": ContentType})
+
+
+def test_publish_writes_latest_and_dated_for_both_formats(render):
+    s3 = FakeS3()
+    keys = render.publish(s3, "b", "cve-reports/", "2026-08-18", '{"a":1}', "<html>")
+    assert keys == [
+        "cve-reports/2026-08-18.json",
+        "cve-reports/2026-08-18.html",
+        "cve-reports/latest.json",
+        "cve-reports/latest.html",
+    ], "dated copies must be written before latest, so latest is never newer than its history"
+    assert all(p["bucket"] == "b" for p in s3.puts)
+
+
+def test_publish_sets_content_types_so_browsers_render_the_html(render):
+    s3 = FakeS3()
+    render.publish(s3, "b", "cve-reports/", "2026-08-18", "{}", "<html>")
+    by_key = {p["key"]: p["content_type"] for p in s3.puts}
+    assert by_key["cve-reports/latest.html"] == "text/html; charset=utf-8"
+    assert by_key["cve-reports/latest.json"] == "application/json"
+
+
+def test_publish_bodies_are_bytes(render):
+    s3 = FakeS3()
+    render.publish(s3, "b", "cve-reports/", "2026-08-18", "{}", "<html>")
+    assert all(isinstance(p["body"], bytes) for p in s3.puts)

--- a/tests/cve_report/test_s3.py
+++ b/tests/cve_report/test_s3.py
@@ -1,3 +1,7 @@
+import json
+import urllib.request
+
+
 class FakeS3:
     """Minimal stand-in for a boto3 S3 client."""
 
@@ -33,3 +37,49 @@ def test_publish_bodies_are_bytes(render):
     s3 = FakeS3()
     render.publish(s3, "b", "cve-reports/", "2026-08-18", "{}", "<html>")
     assert all(isinstance(p["body"], bytes) for p in s3.puts)
+
+
+OWNED = "852893458518.dkr.ecr."
+
+
+def test_main_posts_to_slack_and_keeps_exit_code_when_publish_raises(render, tmp_path, monkeypatch):
+    """publish() is a convenience. Even if report generation/S3-write blows up,
+    the Slack/n8n POST -- what actually pages someone -- and the exit-code
+    contract (1 iff there are actionable findings) must survive untouched."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "report.json").write_text(json.dumps({
+        "ArtifactName": OWNED + "mine:v1",
+        "Results": [{"Vulnerabilities": [
+            {"VulnerabilityID": "CVE-2026-9", "PkgName": "libfoo",
+             "InstalledVersion": "1.0.0", "FixedVersion": "1.2.3",
+             "Severity": "CRITICAL", "Title": "bad"}]}],
+    }))
+    out = tmp_path / "out"
+
+    def raise_publish(*a, **kw):
+        raise RuntimeError("S3 is on fire")
+    monkeypatch.setattr(render, "publish", raise_publish)
+
+    posted = []
+
+    class FakeResponse:
+        def read(self):
+            return b"{}"
+
+    def fake_urlopen(req, timeout=30):
+        posted.append(req)
+        return FakeResponse()
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    rc = render.main([
+        "--reports", str(reports),
+        "--out", str(out),
+        "--owned-prefix", OWNED,
+        "--webhook", "http://n8n.example.invalid/hook",
+        "--bucket", "some-bucket",
+        "--date", "2026-08-18",
+    ])
+
+    assert posted, "publish() raising must not suppress the Slack/n8n POST"
+    assert rc == 1, "exit-code contract (1 iff actionable findings) must survive a publish failure"


### PR DESCRIPTION
Implements the plan merged in #565: turn the weekly scan's ~24,000 findings into a self-contained HTML report at a **predictable** S3 URL — adding no application, image, repository, or ingress.

**Plan:** `docs/superpowers/plans/2026-08-18-cve-html-report.md`
**Spec:** `docs/superpowers/specs/2026-08-17-image-vulnerability-scanning-design.md` (§5.2 added)

## What lands

| | |
|---|---|
| `cve-reports/latest.json` · `latest.html` | Always the most recent run |
| `cve-reports/<YYYY-MM-DD>.json` · `.html` | Per-run history, for trend |

Dated copies are written **before** `latest`, so a partial failure leaves `latest` on an older *complete* report rather than nothing.

**Why stable keys:** Argo's own artifact key is `argo-workflows/<workflow-name>/<pod-name>/full-report.json` — both segments generated per run, so any consumer wanting "the latest report" must list-and-sort against Argo's internal layout. This is also what makes the Backstage plugin (approach C) tractable.

## The refactor underneath

The aggregate logic lived **inline in workflow YAML**, where it could not be tested. It now lives in a ConfigMap-held `render.py` — the repo's `wan-ip-monitor` one-home pattern — with **15 unit tests**, and `tests/cve_report/` is wired into CI.

## Measured, not assumed

A reviewer rendered all 24,320 findings and drove the result in headless Chromium:

- **8.6 MB**, 0.05s to render, **95 MB peak RSS** against a 1 Gi limit
- DOMContentLoaded **2.29s**; default view shows only the ~387 actionable, filtering in **23 ms**
- Revealing all 24,320 rows costs ~0.9s — real, but only if you ask for it

## What review caught

Worth listing, because several were defects in the plan rather than the implementation:

- A test that **passed with the actionable count forced to zero**
- A regression test that passed **identically against the code it was meant to guard** (an unimportable `boto3` raised first, so the injected error never fired)
- `render_html()` and a local write sitting **outside** the try/except — a failure there would have killed the Slack alert
- **`tests/cve_report/` never ran in CI at all** — the entire justification for the refactor, unrealised
- No `activeDeadlineSeconds` with `concurrencyPolicy: Forbid`: a wedged run would never alert *and* would silently block every future week — made worse because this workflow is **red by design** every week, so "red" carries no signal
- A dead 8.6 MB write ordered ahead of the useful work inside the same try

## The central constraint

**Publishing is a convenience and must never suppress the alert.** The Argo artifact is the record; Slack is what pages someone. Every publishing statement is inside one try/except; the Slack POST and the exit code are unreachable from any publish failure. Two tests exercise both halves of that window, and one was rewritten after it was proven not to discriminate.

## Verification

`python3 -m pytest tests/ -q` → **331 passed** (was 330) · all YAML parses · agent-docs and OKF gates green.

**Not yet verified:** the workflow has never run with these changes, since Argo CD syncs `main`. After merge I'll run it live and check the four keys and the report at real size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF
