### PR TITLE
logging: stop Alloy OOM-crashlooping by cutting duplicated collection

### DIFF
--- a/base-apps/logging/alloy-config.yaml
+++ b/base-apps/logging/alloy-config.yaml
@@ -9,9 +9,24 @@ data:
     /*     LOGS COLLECTION (Loki)              */
     /********************************************/
 
-    // Discover Kubernetes pods for logs
+    // Logs only, by design. Metrics collection lives in Prometheus: prometheus-config.yaml
+    // already scrapes the API server, nodes, cAdvisor and annotated pods directly. Alloy used
+    // to scrape those same targets and remote-write them, which duplicated every series and
+    // accounted for ~160MB of the ~240MB live heap per pod. See runbook.md, "Alloy DaemonSet
+    // pods CrashLooping / OOMKilled".
+
+    // Discover Kubernetes pods for logs.
+    // The field selector pins each DaemonSet pod to its own node. Without it every Alloy pod
+    // tails every pod in the cluster, so each log line is shipped once per node and Loki
+    // rejects the copies. HOSTNAME is the node name (alloy-daemonset.yaml sets it from
+    // spec.nodeName).
     discovery.kubernetes "pods" {
       role = "pod"
+
+      selectors {
+        role  = "pod"
+        field = "spec.nodeName=" + sys.env("HOSTNAME")
+      }
     }
 
     // Relabel to extract useful Kubernetes metadata
@@ -115,190 +130,6 @@ data:
     loki.write "loki" {
       endpoint {
         url = "http://loki.logging.svc.cluster.local:3100/loki/api/v1/push"
-      }
-
-      external_labels = {
-        cluster = "homelab",
-        source  = "alloy",
-      }
-    }
-
-    /********************************************/
-    /*   METRICS COLLECTION (Prometheus)       */
-    /********************************************/
-
-    // Discover Kubernetes pods for metrics
-    discovery.kubernetes "metrics_pods" {
-      role = "pod"
-    }
-
-    // Relabel for Prometheus metrics scraping
-    discovery.relabel "metrics_pods" {
-      targets = discovery.kubernetes.metrics_pods.targets
-
-      // Keep only pods with prometheus.io/scrape annotation
-      rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
-        action        = "keep"
-        regex         = "true"
-      }
-
-      // Use custom metrics path if specified
-      rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
-        action        = "replace"
-        target_label  = "__metrics_path__"
-        regex         = "(.+)"
-        replacement   = "$1"
-      }
-
-      // Use custom port if specified
-      rule {
-        source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
-        action        = "replace"
-        regex         = "([^:]+)(?::\\d+)?;(\\d+)"
-        replacement   = "$1:$2"
-        target_label  = "__address__"
-      }
-
-      // Add namespace label (SAME AS LOGS)
-      rule {
-        source_labels = ["__meta_kubernetes_namespace"]
-        target_label  = "namespace"
-      }
-
-      // Add pod label (SAME AS LOGS)
-      rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        target_label  = "pod"
-      }
-
-      // Add container label (SAME AS LOGS)
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_name"]
-        target_label  = "container"
-      }
-
-      // Add app label (SAME AS LOGS)
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app"]
-        target_label  = "app"
-      }
-
-      // Add cluster label
-      rule {
-        target_label = "cluster"
-        replacement  = "homelab"
-      }
-    }
-
-    // Scrape metrics from discovered pods
-    prometheus.scrape "pods" {
-      targets    = discovery.relabel.metrics_pods.output
-      forward_to = [prometheus.remote_write.prometheus.receiver]
-
-      scrape_interval = "15s"
-      scrape_timeout  = "10s"
-    }
-
-    // Discover Kubernetes nodes for metrics
-    discovery.kubernetes "nodes" {
-      role = "node"
-    }
-
-    // Relabel nodes
-    discovery.relabel "nodes" {
-      targets = discovery.kubernetes.nodes.targets
-
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        target_label  = "node"
-      }
-
-      rule {
-        source_labels = ["__address__"]
-        target_label  = "__address__"
-        regex         = "([^:]+)(?::\\d+)?"
-        replacement   = "$1:10250"
-      }
-
-      rule {
-        target_label = "cluster"
-        replacement  = "homelab"
-      }
-    }
-
-    // Scrape node metrics
-    prometheus.scrape "nodes" {
-      targets    = discovery.relabel.nodes.output
-      forward_to = [prometheus.remote_write.prometheus.receiver]
-
-      scrape_interval = "15s"
-      scrape_timeout  = "10s"
-      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-
-      tls_config {
-        ca_file             = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        insecure_skip_verify = false
-      }
-    }
-
-    // Relabel nodes for cAdvisor scraping
-    discovery.relabel "cadvisor" {
-      targets = discovery.kubernetes.nodes.targets
-
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        target_label  = "node"
-      }
-
-      rule {
-        source_labels = ["__address__"]
-        target_label  = "__address__"
-        regex         = "([^:]+)(?::\\d+)?"
-        replacement   = "$1:10250"
-      }
-
-      rule {
-        target_label = "__metrics_path__"
-        replacement  = "/metrics/cadvisor"
-      }
-
-      rule {
-        target_label = "cluster"
-        replacement  = "homelab"
-      }
-    }
-
-    // Scrape cAdvisor metrics (container CPU/memory)
-    prometheus.scrape "cadvisor" {
-      targets    = discovery.relabel.cadvisor.output
-      forward_to = [prometheus.remote_write.prometheus.receiver]
-
-      scrape_interval = "15s"
-      scrape_timeout  = "10s"
-      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-
-      tls_config {
-        ca_file             = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        insecure_skip_verify = false
-      }
-    }
-
-    // Send metrics to Prometheus
-    prometheus.remote_write "prometheus" {
-      endpoint {
-        url = "http://prometheus.logging.svc.cluster.local:9090/api/v1/write"
-
-        queue_config {
-          capacity          = 10000
-          max_shards        = 10
-          min_shards        = 1
-          max_samples_per_send = 1000
-          batch_send_deadline  = "5s"
-          min_backoff          = "30ms"
-          max_backoff          = "5s"
-        }
       }
 
       external_labels = {

--- a/base-apps/logging/alloy-daemonset.yaml
+++ b/base-apps/logging/alloy-daemonset.yaml
@@ -33,10 +33,17 @@ spec:
           name: http
           protocol: TCP
         env:
+        # Node name, used by alloy-config.yaml to scope pod discovery to this node.
         - name: HOSTNAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        # Without this, Go sizes its heap target from the host's memory, not the cgroup:
+        # next_gc sat at 527MB against this 512Mi limit, so the kernel OOM-killed Alloy
+        # before the GC ever ran (86-97 restarts). Keep at ~85% of limits.memory below,
+        # leaving room for non-heap RSS.
+        - name: GOMEMLIMIT
+          value: 440MiB
         volumeMounts:
         - name: config
           mountPath: /etc/alloy

--- a/base-apps/logging/docs.md
+++ b/base-apps/logging/docs.md
@@ -6,7 +6,7 @@ app: logging
 catalog_entity: logging
 kind: docs
 namespace: logging
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-18
 status: current
 tags: [loki, grafana, prometheus, alloy]
 sources:
@@ -36,15 +36,21 @@ under `base-apps/logging/`.
 ## Pipeline
 1. **Alloy** (`alloy-daemonset.yaml`, image `grafana/alloy:v1.4.3`) runs as a DaemonSet on
    every `node.kubernetes.io/workload: application` node, using a cluster-wide RBAC
-   ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods/nodes. Its pipeline
-   config (`alloy-config.yaml`) does two things in parallel:
-   - **Logs**: discovers running pods, tails `/var/log/pods/...` (mounted `hostPath`
-     `varlog`/`varlibdockercontainers`), parses JSON fields, drops nginx health-check and
-     non-`development` `[DEBUG]` lines, and pushes to
-     `http://loki.logging.svc.cluster.local:3100/loki/api/v1/push`.
-   - **Metrics**: scrapes pods annotated `prometheus.io/scrape: "true"`, plus node and
-     cAdvisor metrics (via the node's kubelet on port 10250), and remote-writes to
-     `http://prometheus.logging.svc.cluster.local:9090/api/v1/write`.
+   ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods. It collects **logs
+   only** (`alloy-config.yaml`): `discovery.kubernetes` lists pods on its own node (field
+   selector `spec.nodeName=` + `sys.env("HOSTNAME")`, where the DaemonSet injects `HOSTNAME`
+   from `spec.nodeName`), `loki.source.kubernetes` tails those containers **through the
+   Kubernetes API**, and the pipeline parses JSON fields, drops nginx health-check and
+   non-`development` `[DEBUG]` lines, then pushes to
+   `http://loki.logging.svc.cluster.local:3100/loki/api/v1/push`.
+   Alloy deliberately collects **no metrics** — Prometheus scrapes those itself (step 3).
+   Until 2026-08-18 it did both, and neither half was scoped to the local node, so every
+   Alloy pod scraped all three nodes plus every annotated pod and tailed every pod in the
+   cluster. That duplicated collection was ~160MB of the ~240MB live heap per pod and
+   OOM-killed them in a loop; see `runbook.md`.
+   Because tailing goes through the API, the `varlog`/`varlibdockercontainers` `hostPath`
+   mounts and `privileged: true`/`runAsUser: 0` in `alloy-daemonset.yaml` are vestigial from
+   an earlier file-tailing config and are not read by the current pipeline.
 2. **Loki** (`loki-deployment.yaml`, single-replica Deployment, image `grafana/loki:3.2.1`,
    `-target=all` monolithic mode) receives log pushes and stores chunks/index in **S3**
    (`loki-config.yaml`: `common.storage.s3` and `storage_config.aws.s3` both point at bucket
@@ -59,10 +65,11 @@ under `base-apps/logging/`.
    because `local-path` is a hostPath directory with no quota enforcement — without it the
    TSDB grew to 59 GB, past its own 50Gi request, consuming worker-01's root filesystem.
    Whichever limit trips first wins, so sustained ingest growth shortens the retention
-   window rather than filling the node. It has `--web.enable-remote-write-receiver` on so it
-   can accept Alloy's remote-write pushes. `prometheus-config.yaml` also has it self-scrape
-   the Kubernetes API server, nodes, cAdvisor, and any pod/service annotated for scraping —
-   so it collects both from its own service discovery and from Alloy's forwarded metrics.
+   window rather than filling the node. `prometheus-config.yaml` has it scrape the Kubernetes
+   API server, nodes, cAdvisor, and any pod/service annotated `prometheus.io/scrape: "true"`.
+   Since Alloy stopped forwarding metrics (2026-08-18) this service discovery is the only
+   path into the TSDB; `--web.enable-remote-write-receiver` is still enabled but nothing
+   writes to it.
 4. **Grafana** (`grafana-deployment.yaml`, single-replica Deployment, image
    `grafana/grafana:11.3.1`, 10Gi `local-path` PVC) is provisioned with two datasources
    (`grafana-datasources` ConfigMap): `Loki` at `http://loki.logging.svc.cluster.local:3100`

--- a/base-apps/logging/docs/index.md
+++ b/base-apps/logging/docs/index.md
@@ -6,7 +6,7 @@ app: logging
 catalog_entity: logging
 kind: docs
 namespace: logging
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-18
 status: current
 tags: [loki, grafana, prometheus, alloy]
 sources:
@@ -36,15 +36,21 @@ under `base-apps/logging/`.
 ## Pipeline
 1. **Alloy** (`alloy-daemonset.yaml`, image `grafana/alloy:v1.4.3`) runs as a DaemonSet on
    every `node.kubernetes.io/workload: application` node, using a cluster-wide RBAC
-   ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods/nodes. Its pipeline
-   config (`alloy-config.yaml`) does two things in parallel:
-   - **Logs**: discovers running pods, tails `/var/log/pods/...` (mounted `hostPath`
-     `varlog`/`varlibdockercontainers`), parses JSON fields, drops nginx health-check and
-     non-`development` `[DEBUG]` lines, and pushes to
-     `http://loki.logging.svc.cluster.local:3100/loki/api/v1/push`.
-   - **Metrics**: scrapes pods annotated `prometheus.io/scrape: "true"`, plus node and
-     cAdvisor metrics (via the node's kubelet on port 10250), and remote-writes to
-     `http://prometheus.logging.svc.cluster.local:9090/api/v1/write`.
+   ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods. It collects **logs
+   only** (`alloy-config.yaml`): `discovery.kubernetes` lists pods on its own node (field
+   selector `spec.nodeName=` + `sys.env("HOSTNAME")`, where the DaemonSet injects `HOSTNAME`
+   from `spec.nodeName`), `loki.source.kubernetes` tails those containers **through the
+   Kubernetes API**, and the pipeline parses JSON fields, drops nginx health-check and
+   non-`development` `[DEBUG]` lines, then pushes to
+   `http://loki.logging.svc.cluster.local:3100/loki/api/v1/push`.
+   Alloy deliberately collects **no metrics** — Prometheus scrapes those itself (step 3).
+   Until 2026-08-18 it did both, and neither half was scoped to the local node, so every
+   Alloy pod scraped all three nodes plus every annotated pod and tailed every pod in the
+   cluster. That duplicated collection was ~160MB of the ~240MB live heap per pod and
+   OOM-killed them in a loop; see `runbook.md`.
+   Because tailing goes through the API, the `varlog`/`varlibdockercontainers` `hostPath`
+   mounts and `privileged: true`/`runAsUser: 0` in `alloy-daemonset.yaml` are vestigial from
+   an earlier file-tailing config and are not read by the current pipeline.
 2. **Loki** (`loki-deployment.yaml`, single-replica Deployment, image `grafana/loki:3.2.1`,
    `-target=all` monolithic mode) receives log pushes and stores chunks/index in **S3**
    (`loki-config.yaml`: `common.storage.s3` and `storage_config.aws.s3` both point at bucket
@@ -59,10 +65,11 @@ under `base-apps/logging/`.
    because `local-path` is a hostPath directory with no quota enforcement — without it the
    TSDB grew to 59 GB, past its own 50Gi request, consuming worker-01's root filesystem.
    Whichever limit trips first wins, so sustained ingest growth shortens the retention
-   window rather than filling the node. It has `--web.enable-remote-write-receiver` on so it
-   can accept Alloy's remote-write pushes. `prometheus-config.yaml` also has it self-scrape
-   the Kubernetes API server, nodes, cAdvisor, and any pod/service annotated for scraping —
-   so it collects both from its own service discovery and from Alloy's forwarded metrics.
+   window rather than filling the node. `prometheus-config.yaml` has it scrape the Kubernetes
+   API server, nodes, cAdvisor, and any pod/service annotated `prometheus.io/scrape: "true"`.
+   Since Alloy stopped forwarding metrics (2026-08-18) this service discovery is the only
+   path into the TSDB; `--web.enable-remote-write-receiver` is still enabled but nothing
+   writes to it.
 4. **Grafana** (`grafana-deployment.yaml`, single-replica Deployment, image
    `grafana/grafana:11.3.1`, 10Gi `local-path` PVC) is provisioned with two datasources
    (`grafana-datasources` ConfigMap): `Loki` at `http://loki.logging.svc.cluster.local:3100`

--- a/base-apps/logging/docs/runbook.md
+++ b/base-apps/logging/docs/runbook.md
@@ -6,7 +6,7 @@ app: logging
 catalog_entity: logging
 kind: runbook
 namespace: logging
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-18
 status: current
 tags: [loki, grafana, prometheus, alloy]
 sources:
@@ -25,16 +25,36 @@ sources:
 
 ### Symptom: Alloy DaemonSet pods CrashLooping / OOMKilled
 - **Check:** `kubectl -n logging get pods -l app=alloy` — look for `OOMKilled` (exit code
-  137) in `kubectl -n logging describe pod <alloy-pod>`, and restart counts. Compare against
-  current limits in `alloy-daemonset.yaml` (`requests.memory: 256Mi`, `limits.memory: 512Mi`
-  — these were raised from 128Mi/256Mi after pods sitting at ~253Mi steady-state caused a
-  real OOMKilled crashloop and log-shipping gaps).
-- **Fix:** if pods are again running close to the current 512Mi limit,
-  PR a further increase to `alloy-daemonset.yaml`'s `resources.requests/limits.memory`. Since
-  Alloy is a DaemonSet, an OOMKilled pod only breaks log/metric collection on that one node,
-  but if it's cluster-wide, check whether a recent change to `alloy-config.yaml` (e.g. a new
-  scrape target or log volume spike) is driving memory up rather than assuming the limit
-  alone is at fault.
+  137) in `kubectl -n logging describe pod <alloy-pod>`, and restart counts. Then find out
+  *where* the memory is before touching limits. Port-forward the pod
+  (`kubectl -n logging port-forward <alloy-pod> 12345:12345`) and read its own metrics:
+
+  ```bash
+  curl -s localhost:12345/metrics | grep -E \
+    'process_resident_memory_bytes|go_memstats_(heap_inuse|next_gc)_bytes|scrape_targets_gauge'
+  curl -s localhost:12345/debug/pprof/heap > heap.pb.gz   # go tool pprof -top -inuse_space
+  ```
+
+  `next_gc_bytes` at or above `limits.memory` means Go is being killed before it collects,
+  not that it needs more memory. `scrape_targets_gauge` above the local node's share means
+  discovery has lost its node filter.
+- **Fix:** raising `resources.limits.memory` is usually the wrong first move — it was raised
+  twice already (128Mi/256Mi → 256Mi/512Mi) and the crashloop came back both times. Work
+  through these in order:
+  1. **Is `GOMEMLIMIT` still ~85% of `limits.memory`?** (Both in `alloy-daemonset.yaml`.) If
+     they drift apart, Go sizes its heap target from host memory rather than the cgroup and
+     the kernel kills the process before a GC runs. That was the 2026-08-18 crashloop:
+     `next_gc` 527MB against a 512Mi limit, 86-97 restarts per pod.
+  2. **Has Alloy's workload widened?** It should tail only pods on its own node (the
+     `spec.nodeName` field selector in `alloy-config.yaml`) and collect no metrics at all.
+     Removing the node filter, or re-adding `prometheus.scrape`/`remote_write` components,
+     multiplies memory by the node count and makes every pod ship duplicate data — visible
+     as Loki `entry too old` drops (`loki_write_dropped_entries_total`) and Prometheus
+     `out of order sample` rejections (`prometheus_remote_storage_samples_failed_total`).
+  3. **Only if neither holds** and live heap (`inuse_space`) is genuinely growing, raise
+     `requests`/`limits` and `GOMEMLIMIT` together, keeping the ~85% ratio.
+
+  Since Alloy is a DaemonSet, an OOMKilled pod only breaks log collection on that one node.
 
 ### Symptom: Loki can't write logs / storage errors ("AccessDenied", "NoSuchBucket")
 - **Check:** `kubectl -n logging get pods -l app=loki` and `kubectl -n logging logs

--- a/base-apps/logging/runbook.md
+++ b/base-apps/logging/runbook.md
@@ -6,7 +6,7 @@ app: logging
 catalog_entity: logging
 kind: runbook
 namespace: logging
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-18
 status: current
 tags: [loki, grafana, prometheus, alloy]
 sources:
@@ -25,16 +25,36 @@ sources:
 
 ### Symptom: Alloy DaemonSet pods CrashLooping / OOMKilled
 - **Check:** `kubectl -n logging get pods -l app=alloy` — look for `OOMKilled` (exit code
-  137) in `kubectl -n logging describe pod <alloy-pod>`, and restart counts. Compare against
-  current limits in `alloy-daemonset.yaml` (`requests.memory: 256Mi`, `limits.memory: 512Mi`
-  — these were raised from 128Mi/256Mi after pods sitting at ~253Mi steady-state caused a
-  real OOMKilled crashloop and log-shipping gaps).
-- **Fix:** if pods are again running close to the current 512Mi limit,
-  PR a further increase to `alloy-daemonset.yaml`'s `resources.requests/limits.memory`. Since
-  Alloy is a DaemonSet, an OOMKilled pod only breaks log/metric collection on that one node,
-  but if it's cluster-wide, check whether a recent change to `alloy-config.yaml` (e.g. a new
-  scrape target or log volume spike) is driving memory up rather than assuming the limit
-  alone is at fault.
+  137) in `kubectl -n logging describe pod <alloy-pod>`, and restart counts. Then find out
+  *where* the memory is before touching limits. Port-forward the pod
+  (`kubectl -n logging port-forward <alloy-pod> 12345:12345`) and read its own metrics:
+
+  ```bash
+  curl -s localhost:12345/metrics | grep -E \
+    'process_resident_memory_bytes|go_memstats_(heap_inuse|next_gc)_bytes|scrape_targets_gauge'
+  curl -s localhost:12345/debug/pprof/heap > heap.pb.gz   # go tool pprof -top -inuse_space
+  ```
+
+  `next_gc_bytes` at or above `limits.memory` means Go is being killed before it collects,
+  not that it needs more memory. `scrape_targets_gauge` above the local node's share means
+  discovery has lost its node filter.
+- **Fix:** raising `resources.limits.memory` is usually the wrong first move — it was raised
+  twice already (128Mi/256Mi → 256Mi/512Mi) and the crashloop came back both times. Work
+  through these in order:
+  1. **Is `GOMEMLIMIT` still ~85% of `limits.memory`?** (Both in `alloy-daemonset.yaml`.) If
+     they drift apart, Go sizes its heap target from host memory rather than the cgroup and
+     the kernel kills the process before a GC runs. That was the 2026-08-18 crashloop:
+     `next_gc` 527MB against a 512Mi limit, 86-97 restarts per pod.
+  2. **Has Alloy's workload widened?** It should tail only pods on its own node (the
+     `spec.nodeName` field selector in `alloy-config.yaml`) and collect no metrics at all.
+     Removing the node filter, or re-adding `prometheus.scrape`/`remote_write` components,
+     multiplies memory by the node count and makes every pod ship duplicate data — visible
+     as Loki `entry too old` drops (`loki_write_dropped_entries_total`) and Prometheus
+     `out of order sample` rejections (`prometheus_remote_storage_samples_failed_total`).
+  3. **Only if neither holds** and live heap (`inuse_space`) is genuinely growing, raise
+     `requests`/`limits` and `GOMEMLIMIT` together, keeping the ~85% ratio.
+
+  Since Alloy is a DaemonSet, an OOMKilled pod only breaks log collection on that one node.
 
 ### Symptom: Loki can't write logs / storage errors ("AccessDenied", "NoSuchBucket")
 - **Check:** `kubectl -n logging get pods -l app=loki` and `kubectl -n logging logs


### PR DESCRIPTION
Both Alloy pods have been OOMKilled in a loop — 86 and 97 restarts, RSS **534.7MB against the 536.9MB (512Mi) limit**. The limit was already raised once (b849597, 128Mi/256Mi → 256Mi/512Mi) and the crashloop came back, so this PR fixes what's actually driving it rather than raising it again.

## Where the memory was going

Heap profile from a live pod (`/debug/pprof/heap`, 241.5MB `inuse_space`):

| | |
|---|---|
| 107.7 MB | prometheus scrape (cadvisor/nodes/pods) |
| 52.6 MB | remote_write + WAL |
| 13.9 MB | loki log tailing |
| 5.8 MB | k8s discovery |

## What changed

**1. Removed Alloy's metrics pipeline.** Prometheus already scrapes all of it directly and healthily — `kubernetes-nodes` 3/3 up, `kubernetes-cadvisor` 3/3 up, `kubernetes-pods` 20 up — and nothing in the repo selects `source="alloy"` (the two dashboard queries touching `container_memory_working_set_bytes` use `max()`, so they don't depend on the duplicate copy). This also stops feeding a second copy of every series into the TSDB that 9a2a80b had to bound at 40GB.

**2. Scoped pod discovery to the local node.** Neither pipeline had a node filter, so each DaemonSet pod scraped all three nodes and tailed all 100 running pods. Both pods emitted byte-identical series to the same Prometheus: **243,677 rejected samples** (`out of order sample`) out of 1,845,634, a saturated 10,240-sample queue, and 4,115 dropped Loki entries. The DaemonSet already injected `HOSTNAME` from `spec.nodeName` — `alloy-config.yaml` just never referenced it.

**3. Set `GOMEMLIMIT=440MiB`.** `go_memstats_next_gc_bytes` was **527MB against a 536.9MB cgroup limit** — Go was targeting its next collection at the point the kernel kills the process. That's what turned "uses a lot of memory" into a guaranteed crashloop. 440MiB is ~85% of `limits.memory`; keep the two in step if either moves.

Coroot's "memory leak, 18%/hour" alert was the post-restart ramp, not a leak.

Resource requests/limits are unchanged — with the metrics half gone, live heap should land near 80MB, so 512Mi is now generous.

## Validation

- `alloy fmt` clean and `alloy run` evaluates the full component graph against `grafana/alloy:v1.4.3` in Docker; the only errors are the expected out-of-cluster `unable to load in-cluster configuration`. Uses `sys.env()` rather than `env()`, which v1.4.3 logs as deprecated.
- `kubectl apply --dry-run=client` OK on both manifests.
- `gen-okf.py --check`, `gen-techdocs.py --check`, `validate-agent-docs.py`, `validate-catalog-refs.py` all pass.
- Docs updated: `docs.md` pipeline section (it described file-based tailing, but `loki.source.kubernetes` reads through the API) and the runbook's OOM failure mode, whose advice was "PR a further increase" — now replaced with the profile-first procedure and the `GOMEMLIMIT`/node-filter checks.

## What to watch after sync

Restart counts should stop climbing, RSS should settle well under the limit, and `loki_write_dropped_entries_total` / `prometheus_remote_storage_samples_failed_total` should go quiet. Log coverage should stay complete — each pod now tails its own node instead of both tailing everything.

## Follow-ups not in this PR

- `alloy-rbac.yaml` still grants `nodes`/`nodes/proxy` list/watch, only needed by the removed metrics pipeline.
- `privileged: true`, `runAsUser: 0` and the `varlog`/`varlibdockercontainers` hostPath mounts are vestigial — API-based tailing doesn't read them. Dropping them is a real privilege reduction but wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdWCnjLmoG2AMnpAD26xzW