### PR TITLE
perf(image-scan): share one Trivy DB and double the fan-out

### DIFF
--- a/base-apps/argo-workflow-tasks/image-scan.yaml
+++ b/base-apps/argo-workflow-tasks/image-scan.yaml
@@ -28,9 +28,11 @@ spec:
   # at parallelism 4; 5400s (90m) leaves better than 2x headroom over that.
   activeDeadlineSeconds: 5400
 
-  # Bounds concurrent scan pods. Peak temp disk is roughly four scans' worth
-  # rather than seventy-five. See sizeLimit on the emptyDir below.
-  parallelism: 4
+  # Bounds concurrent scan pods. Raised from 4 to 8 on 2026-08-18 after
+  # measuring a real run: 115 pod-minutes through a 4-wide pipe was ~34 minutes
+  # of wall clock. Worst-case concurrent disk is unchanged, because the scan
+  # emptyDir halved to 4Gi once the vulnerability DB moved to the daemon.
+  parallelism: 8
 
   # Keep a quarter's worth of history for trend, then let them go.
   ttlStrategy:
@@ -64,20 +66,81 @@ spec:
     - name: main
       dag:
         tasks:
+          # The DB server and image discovery are independent; run them at the
+          # same time so the server's one-off ~16s DB download overlaps with
+          # listing pods rather than adding to the critical path.
+          - name: trivy-server
+            template: trivy-server
           - name: discover
             template: discover-images
           - name: scan
             template: scan-image
-            dependencies: [discover]
+            dependencies: [discover, trivy-server]
             # Fan out: one scan pod per distinct image.
             withParam: "{{tasks.discover.outputs.result}}"
             arguments:
               parameters:
                 - name: image
                   value: "{{item}}"
+                # Argo exposes a daemon pod's address as .ip. Scans reach the
+                # shared DB here instead of each downloading their own.
+                - name: server
+                  value: "{{tasks.trivy-server.ip}}"
           - name: report
             template: aggregate
             dependencies: [scan]
+
+    # ------------------------------------------------------------ trivy server
+    # Holds the vulnerability database for the whole run.
+    #
+    # Measured 2026-08-18 on this cluster: a cold scan of alpine:3.19 takes 16s,
+    # of which 15s is the DB download and 1s is the actual scan; the unpacked DB
+    # is 1.2GB on disk. Every one of ~79 scan pods paid that, which is ~20 of the
+    # run's 115 pod-minutes spent fetching the same file 79 times.
+    #
+    # Against a server, a client scan takes 1-2s and creates NO local cache
+    # directory at all - only vulnerability MATCHING moves server-side, so the
+    # client still pulls and analyses the image itself (hence it still needs the
+    # ECR credential below).
+    #
+    # daemon: true means Argo keeps this alive alongside the DAG and tears it
+    # down when the workflow finishes. The readiness probe gates the scans, so
+    # none of them start against a server that is still downloading.
+    #
+    # THE TRADE-OFF: this is a single point of failure for every scan. If it
+    # dies, all of them fail. That is tolerable only because the aggregate step
+    # treats a missing report as *unscanned* rather than clean, names the
+    # unscanned images, and still fires the Slack alert - so the failure is
+    # loud. Do not "simplify" that behaviour away.
+    - name: trivy-server
+      daemon: true
+      container:
+        image: aquasec/trivy:0.74.0
+        command: [trivy]
+        args:
+          - server
+          - --listen
+          - "0.0.0.0:4954"
+          - --cache-dir
+          - /tmp/cache
+        volumeMounts:
+          - name: db
+            mountPath: /tmp
+        readinessProbe:
+          tcpSocket:
+            port: 4954
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 30
+        resources:
+          requests: {cpu: 200m, memory: 512Mi}
+          limits: {cpu: "1", memory: 2Gi}
+      volumes:
+        # Sized for the unpacked DB (1.2GB measured) with headroom. Enforced by
+        # kubelet, unlike a local-path PVC's size request.
+        - name: db
+          emptyDir:
+            sizeLimit: 4Gi
 
     # ---------------------------------------------------------------- discover
     - name: discover-images
@@ -133,6 +196,7 @@ spec:
       inputs:
         parameters:
           - name: image
+          - name: server
       # A flaky registry pull must not lose the whole run. Individual failures
       # are tolerated by the aggregate step, which reports them as unscanned —
       # silence about an unscanned image is the failure mode worth avoiding.
@@ -157,8 +221,11 @@ spec:
           # aggregate time so the S3 report keeps everything.
           # --quiet suppresses the DB-download progress bar, which otherwise
           # buries real errors under megabytes of carriage returns in the logs.
+          # --server: vulnerability matching happens on the shared daemon,
+          # so this pod downloads no database. Measured 16s -> 1-2s per scan.
           trivy image \
             --quiet \
+            --server "http://{{inputs.parameters.server}}:4954" \
             --format json \
             --output /tmp/out/report.json \
             --scanners vuln \
@@ -170,8 +237,6 @@ spec:
           # base-apps/ecr-auth/cronjobs.yaml, so no new credential is minted.
           - name: DOCKER_CONFIG
             value: /docker
-          - name: TRIVY_CACHE_DIR
-            value: /tmp/cache
         volumeMounts:
           - name: scratch
             mountPath: /tmp
@@ -188,7 +253,11 @@ spec:
         # it is why no node pinning is needed here.
         - name: scratch
           emptyDir:
-            sizeLimit: 8Gi
+            # 4Gi, down from 8Gi: the 1.2GB vulnerability DB now lives on the
+            # trivy-server daemon, so this holds only image layers. Worst-case
+            # concurrent disk is unchanged (8 x 4Gi = the old 4 x 8Gi) while
+            # throughput doubles.
+            sizeLimit: 4Gi
         - name: ecr
           secret:
             secretName: ecr-registry


### PR DESCRIPTION
Takes the weekly CVE scan from **~34 minutes to an expected ~12**, using measurements rather than estimates.

## What the numbers said

Same pod, alpine scanned twice:

| | |
|---|---|
| Cold (DB download + pull + scan) | **16s** |
| Warm (DB cached) | **1s** |
| Unpacked DB on disk | **1.2 GB** |

**~15 of every 16 seconds on a small scan was the DB download.** Across 79 scans that's ~20 of the run's 115 pod-minutes spent fetching the same file 79 times.

## What changed

**1. A `trivy server` daemon holds the DB for the whole run.** Verified in-cluster before writing any of this:

```
server_ready=16s
client1=2s   findings=10
client2=1s
client-side cache: none created
```

Only vulnerability *matching* moves server-side — clients still pull and analyse images themselves, so the **ECR credential mount stays**.

`daemon: true` means Argo runs it alongside the DAG and tears it down at the end. A `tcpSocket` readiness probe gates the scans so none start against a server still downloading. It runs in parallel with `discover`, so its 16s overlaps rather than adding to the critical path.

**2. `parallelism: 4 → 8`.** The 4 was chosen for disk safety before any numbers existed. **Worst-case concurrent disk is unchanged** — the scan `emptyDir` halves to 4Gi now the DB lives on the daemon, so 8 × 4Gi equals the old 4 × 8Gi — while throughput doubles.

## An idea this killed

The original suggestion was to share the DB as an **Argo artifact**. At **1.2 GB unpacked**, shipping that to 78 pods would be far worse than each pulling 108 MB compressed. That only became obvious by measuring, and it's why the daemon approach won.

## The cost, stated plainly

**The daemon is a single point of failure for all 78 scans.** Today one bad scan is isolated; with this, a dead server fails everything.

It's tolerable only because the aggregate step already treats a missing report as **unscanned rather than clean**, names the unscanned images, and still fires the Slack alert. A dead server produces "78 images could not be scanned" in Slack — loud, not silent. That behaviour is load-bearing and is flagged inline as such.

## Verification

YAML parses; `tests/` **331 passed** (332 once #568 lands — it adds a test and is not in this branch); DAG structure asserted (`scan` depends on both `discover` and `trivy-server`, receives `.ip`, no `TRIVY_CACHE_DIR`, ECR mount retained).

**After merge** I'll run it live and confirm both the ~12 min figure and that findings still match the last run (~24,358 / 394 actionable) — a drop would mean the server isn't matching properly, which is the failure mode worth checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MadyPGpsD2PihB58sQtnEF