### PR TITLE
logging: run Alloy on every node, not just workload=application

### DIFF
--- a/base-apps/logging/alloy-daemonset.yaml
+++ b/base-apps/logging/alloy-daemonset.yaml
@@ -14,8 +14,12 @@ spec:
       labels:
         app: alloy
     spec:
-      nodeSelector:
-        node.kubernetes.io/workload: application
+      # No nodeSelector on purpose: pod discovery is scoped to the local node
+      # (alloy-config.yaml), so a node without an Alloy pod has no log collection at all.
+      # Restricting this to workload=application silently dropped every pod on
+      # k3s-control-01 - argo-cd, kyverno, kube-system, cert-manager, external-secrets,
+      # dex, falco and atlantis among them. The toleration below already covers the
+      # control-plane NoSchedule taint.
       serviceAccountName: alloy
       tolerations:
       - effect: NoSchedule

--- a/base-apps/logging/docs.md
+++ b/base-apps/logging/docs.md
@@ -35,7 +35,8 @@ under `base-apps/logging/`.
 
 ## Pipeline
 1. **Alloy** (`alloy-daemonset.yaml`, image `grafana/alloy:v1.4.3`) runs as a DaemonSet on
-   every `node.kubernetes.io/workload: application` node, using a cluster-wide RBAC
+   **every** node including `k3s-control-01` (no `nodeSelector`; the `NoSchedule` toleration
+   covers the control-plane taint), using a cluster-wide RBAC
    ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods. It collects **logs
    only** (`alloy-config.yaml`): `discovery.kubernetes` lists pods on its own node (field
    selector `spec.nodeName=` + `sys.env("HOSTNAME")`, where the DaemonSet injects `HOSTNAME`
@@ -48,6 +49,8 @@ under `base-apps/logging/`.
    Alloy pod scraped all three nodes plus every annotated pod and tailed every pod in the
    cluster. That duplicated collection was ~160MB of the ~240MB live heap per pod and
    OOM-killed them in a loop; see `runbook.md`.
+   Because discovery is node-scoped, a node with no Alloy pod gets no log collection at
+   all — which is why the DaemonSet must stay unrestricted by `nodeSelector`.
    Because tailing goes through the API, the `varlog`/`varlibdockercontainers` `hostPath`
    mounts and `privileged: true`/`runAsUser: 0` in `alloy-daemonset.yaml` are vestigial from
    an earlier file-tailing config and are not read by the current pipeline.

--- a/base-apps/logging/docs/index.md
+++ b/base-apps/logging/docs/index.md
@@ -35,7 +35,8 @@ under `base-apps/logging/`.
 
 ## Pipeline
 1. **Alloy** (`alloy-daemonset.yaml`, image `grafana/alloy:v1.4.3`) runs as a DaemonSet on
-   every `node.kubernetes.io/workload: application` node, using a cluster-wide RBAC
+   **every** node including `k3s-control-01` (no `nodeSelector`; the `NoSchedule` toleration
+   covers the control-plane taint), using a cluster-wide RBAC
    ClusterRole/ClusterRoleBinding (`alloy-rbac.yaml`) to discover pods. It collects **logs
    only** (`alloy-config.yaml`): `discovery.kubernetes` lists pods on its own node (field
    selector `spec.nodeName=` + `sys.env("HOSTNAME")`, where the DaemonSet injects `HOSTNAME`
@@ -48,6 +49,8 @@ under `base-apps/logging/`.
    Alloy pod scraped all three nodes plus every annotated pod and tailed every pod in the
    cluster. That duplicated collection was ~160MB of the ~240MB live heap per pod and
    OOM-killed them in a loop; see `runbook.md`.
+   Because discovery is node-scoped, a node with no Alloy pod gets no log collection at
+   all — which is why the DaemonSet must stay unrestricted by `nodeSelector`.
    Because tailing goes through the API, the `varlog`/`varlibdockercontainers` `hostPath`
    mounts and `privileged: true`/`runAsUser: 0` in `alloy-daemonset.yaml` are vestigial from
    an earlier file-tailing config and are not read by the current pipeline.

--- a/base-apps/logging/docs/runbook.md
+++ b/base-apps/logging/docs/runbook.md
@@ -56,6 +56,25 @@ sources:
 
   Since Alloy is a DaemonSet, an OOMKilled pod only breaks log collection on that one node.
 
+### Symptom: no logs in Loki from a whole node, or from a namespace that only runs there
+- **Check:** `kubectl -n logging get pods -l app=alloy -o wide` and confirm there is one
+  Alloy pod **per node** (`kubectl get nodes`). Then confirm the missing namespace's pods
+  actually run on a node that has one:
+  `kubectl get pods -A -o wide --field-selector status.phase=Running | grep <namespace>`.
+  To see what a given Alloy is tailing:
+  `kubectl -n logging port-forward <alloy-pod> 12345:12345` then
+  `curl -s localhost:12345/api/v0/web/components/discovery.relabel.pods` — every target
+  should carry the local node's `__meta_kubernetes_pod_node_name`.
+- **Fix:** log discovery is scoped to the local node (`spec.nodeName` field selector in
+  `alloy-config.yaml`), so **a node without an Alloy pod has no log collection at all** —
+  the two settings are coupled. Don't add a `nodeSelector` to `alloy-daemonset.yaml` while
+  that filter is in place. This bit us on 2026-08-18: the DaemonSet was pinned to
+  `node.kubernetes.io/workload: application`, and when discovery became node-scoped every
+  pod on `k3s-control-01` (argo-cd, kyverno, kube-system, cert-manager, external-secrets,
+  dex, falco, atlantis) silently stopped shipping logs. If a new node is tainted such that
+  the existing `NoSchedule`/`Exists` toleration doesn't cover it, widen the toleration
+  rather than narrowing where Alloy runs.
+
 ### Symptom: Loki can't write logs / storage errors ("AccessDenied", "NoSuchBucket")
 - **Check:** `kubectl -n logging get pods -l app=loki` and `kubectl -n logging logs
   deploy/loki` for S3 errors. Then confirm the credentials chain: `kubectl -n logging get

--- a/base-apps/logging/runbook.md
+++ b/base-apps/logging/runbook.md
@@ -56,6 +56,25 @@ sources:
 
   Since Alloy is a DaemonSet, an OOMKilled pod only breaks log collection on that one node.
 
+### Symptom: no logs in Loki from a whole node, or from a namespace that only runs there
+- **Check:** `kubectl -n logging get pods -l app=alloy -o wide` and confirm there is one
+  Alloy pod **per node** (`kubectl get nodes`). Then confirm the missing namespace's pods
+  actually run on a node that has one:
+  `kubectl get pods -A -o wide --field-selector status.phase=Running | grep <namespace>`.
+  To see what a given Alloy is tailing:
+  `kubectl -n logging port-forward <alloy-pod> 12345:12345` then
+  `curl -s localhost:12345/api/v0/web/components/discovery.relabel.pods` — every target
+  should carry the local node's `__meta_kubernetes_pod_node_name`.
+- **Fix:** log discovery is scoped to the local node (`spec.nodeName` field selector in
+  `alloy-config.yaml`), so **a node without an Alloy pod has no log collection at all** —
+  the two settings are coupled. Don't add a `nodeSelector` to `alloy-daemonset.yaml` while
+  that filter is in place. This bit us on 2026-08-18: the DaemonSet was pinned to
+  `node.kubernetes.io/workload: application`, and when discovery became node-scoped every
+  pod on `k3s-control-01` (argo-cd, kyverno, kube-system, cert-manager, external-secrets,
+  dex, falco, atlantis) silently stopped shipping logs. If a new node is tainted such that
+  the existing `NoSchedule`/`Exists` toleration doesn't cover it, widen the toleration
+  rather than narrowing where Alloy runs.
+
 ### Symptom: Loki can't write logs / storage errors ("AccessDenied", "NoSuchBucket")
 - **Check:** `kubectl -n logging get pods -l app=loki` and `kubectl -n logging logs
   deploy/loki` for S3 errors. Then confirm the credentials chain: `kubectl -n logging get


### PR DESCRIPTION
Follow-up to #567. That PR is working as intended on memory — but it introduced a log-coverage regression I caught while validating the rollout, and this fixes it.

## The regression

#567 scoped pod discovery to the local node so the two Alloy pods stopped tailing the whole cluster. That couples log coverage to DaemonSet placement — and the DaemonSet has `nodeSelector: node.kubernetes.io/workload: application`, so **nothing collects logs from `k3s-control-01` any more**.

Before #567 this worked by accident: discovery was cluster-wide, so the worker Alloys reached across the Kubernetes API and tailed control-plane pods (twice over).

Evidence from Loki — `argo-cd-argocd-application-controller-0` (runs on the control node):

```
19:08=157  19:09=139  19:10=136  19:11=57  19:14=40  19:15=131  19:16=193  19:17=50   lines/min
                                                                          ← rollout landed 19:17Z; nothing after
```

Namespaces still shipping in the 3 minutes after the rollout: `argo-workflows`, `backstage`, `coroot`, `falco`, `kagent`, `logging`, `vault`, `weather-kitchen` — all worker-node pods. Silently missing: **argo-cd, kyverno, kube-system, cert-manager, external-secrets, argo-rollouts, dex, atlantis, cnpg-system, system-upgrade**, plus the control-node half of `istio-system` and `falco`.

## The fix

Drop the `nodeSelector` so Alloy runs on all three nodes, one per node, each tailing its own. `k3s-control-01`'s only taint is `node-role.kubernetes.io/control-plane:NoSchedule`, which the DaemonSet's existing `NoSchedule`/`Exists` toleration already covers — no toleration change needed.

This keeps every win from #567: still no duplicate tailing (each node's Alloy sees a disjoint target set), still no metrics pipeline, still `GOMEMLIMIT`. It adds one Alloy pod on the control node, which will tail that node's ~36 pods.

The runbook gains this failure mode, because the coupling isn't obvious from either file alone: **with a node-scoped field selector, a node without an Alloy pod has no log collection at all** — so `nodeSelector` and the field selector must not be tightened independently.

## Verification of #567 itself (unchanged by this PR)

- Both pods rolled cleanly, `GOMEMLIMIT=440MiB` present, **0 restarts** (was 102 and 89).
- All 6 components healthy, `alloy_config_load_failures_total 0`; no `prometheus.scrape`/`remote_write` components remain.
- Target sets are disjoint and node-local: worker-01's Alloy has 35 pods all labelled `k3s-worker-01`, worker-02's has 31 all labelled `k3s-worker-02`, overlap 0.
- No metrics gap: Alloy's 15 healthy scrape targets were a strict **subset** of Prometheus's 18. The only failures (`weather-kitchen-backend`, which serves JSON not Prometheus text) fail for both and are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdWCnjLmoG2AMnpAD26xzW