### PR TITLE
deploy(backstage): bump portal to v1.4.13

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.12
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.13
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Ships the container CVE surfacing feature (arigsela/backstage#40) and a 35%
reduction in the portal image's own actionable findings.

## Image CVE delta

Measured with `trivy --severity CRITICAL,HIGH --ignore-unfixed` against both
tags in ECR:

| Class | v1.4.12 | v1.4.13 | Δ |
|---|---:|---:|---:|
| Debian OS packages | 74 | **0** | −74 |
| Node.js production deps | 129 | 129 | 0 |
| Python | 1 | 3 | +2 |
| **Total actionable** | **204** | **132** | **−72 (−35%)** |

The OS slice went to zero. `build-and-push.sh` now passes `--pull` so buildx
cannot reuse a stale `node:24-trixie-slim` layer, and the Dockerfile runs
`apt-get upgrade -y`, so the base is both current and patched. That removed all
74 Debian findings including the 61 `linux-libc-dev` ones — more than expected,
and it makes the previously-recommended multi-stage Dockerfile split much less
urgent, since the findings that justified it are already gone.

The remaining 132 are almost entirely Node production transitives (vm2 27,
brace-expansion 15, tar 14, axios 10, undici 9). These are **not**
devDependency leakage — the Dockerfile already runs
`yarn workspaces focus --all --production` — so clearing them needs yarn
`resolutions` or upstream Backstage bumps, which is a separate judgement call.

## ⚠️ The CVE card will not work until an IAM policy is widened

The feature reads `s3://asela-argo-workflows-artifacts/cve-reports/`, but the
`backstage-scaffolder` IAM user's only policy is `BackstageScaffolderECR`,
which grants ECR actions and nothing else:

```
ECRAuthToken · ECRRepoManagement · ECRImagePushPull
```

The backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the
default credential chain — the same two variables the `aws:ecr:*` scaffolder
actions already use (`base-apps/backstage/external-secrets.yaml`) — so a second,
separate credential cannot simply be added alongside it without a code change
to pass explicit credentials to the S3 client.

Until this is resolved, `GET /api/cve/health` returns `BUCKET_UNREACHABLE` and
the card renders an error state (deliberately an error, never a reassuring
zero). Deploying this tag is still safe and worthwhile for the CVE reduction
above; the card simply reports that it cannot reach the bucket.

The minimal fix is to add an S3 read statement to `BackstageScaffolderECR`:

```json
{
  "Sid": "CveReportsRead",
  "Effect": "Allow",
  "Action": ["s3:GetObject"],
  "Resource": "arn:aws:s3:::asela-argo-workflows-artifacts/cve-reports/*"
},
{
  "Sid": "CveReportsList",
  "Effect": "Allow",
  "Action": ["s3:ListBucket"],
  "Resource": "arn:aws:s3:::asela-argo-workflows-artifacts",
  "Condition": {"StringLike": {"s3:prefix": ["cve-reports/*"]}}
}
```

That policy is not managed in this repo (it is a hand-created IAM policy, not
Crossplane-provisioned), so it cannot be changed by this PR.

## Verification already done

The stable report keys landed and were validated directly:

- `cve-reports/latest.json` and `cve-reports/2026-08-18.json` exist
- The Layer 3 contract script passes sections 1–4 against the real report
- The shipped aggregation modules were run against the real bucket:
  `backstage-portal` resolves to **195 actionable (23 CRITICAL / 172 HIGH)**,
  exactly matching the scanner's own `summary.by_image` figure
- The repo-path join survives tag drift (a never-scanned `v9.9.9` still matches
  and reports 195), and a genuinely unscanned image correctly reports
  `not-scanned` rather than `clean`

Only one dated report exists so far, so the card will show
"Trend available after the next scan" until the next Sunday run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYAaoFnQ1dKp1yibWQZNCy