### PR TITLE
deploy(backstage): bump portal to v1.4.14

### DIFF
--- a/base-apps/backstage/deployments.yaml
+++ b/base-apps/backstage/deployments.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: backstage
-        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.13
+        image: 852893458518.dkr.ecr.us-east-2.amazonaws.com/backstage-portal:v1.4.14
         imagePullPolicy: Always
         ports:
         - containerPort: 7007


### PR DESCRIPTION
Three fixes found by running `v1.4.13` in production (arigsela/backstage#40).
No new feature surface — the CVE card and Security tab already work; these
address how they behave once live.

## What's fixed

**Poll hourly instead of every 10 seconds.** `useKubernetesObjects` was called
without an interval, so it used the 10s default — correct for a live pod-status
view, wrong for weekly scan data. Observed in production: three
`POST /api/cve/report` calls in a single page load. Measured after the fix: **1
request** for the same page load and idle window.

**Stop the card blanking on every refresh.** The effect reset to a loading
skeleton on each re-fire, so the Vulnerabilities card visibly emptied every 10
seconds. A user catching that mid-cycle sees an empty card on an entity that
*has* findings — which reads as "nothing here", the same reassuring emptiness
this feature exists to prevent, reached from a different direction. The skeleton
now shows on first load only; later refreshes keep the previous result on screen.

**Give the trend and the headline one shared cache TTL.** `getLatest` was
TTL-cached but `getHistory` re-listed S3 on every request, so a freshly written
dated report appeared in the sparkline while the headline still served the
previous run — the card displaying two scans' numbers side by side for up to an
hour. This becomes relevant the moment a new scan runs. `GET /api/cve/health`
deliberately still bypasses the cache, since its whole purpose is answering
"have the report keys landed yet?".

## Tag hygiene

`v1.4.13` was rebuilt in place earlier today, so that tag currently refers to two
different images. `v1.4.14` restores a one-tag-one-image mapping.

| Tag | Digest |
|---|---|
| v1.4.13 (rebuilt) | `sha256:09ff1cce…` |
| **v1.4.14** | `sha256:aa7038be…` |

## Verification

- `yarn tsc` clean; 104 backend tests, 54 app tests
- `yarn lint:all` — zero problems in any file the feature branch created
- Built with `yarn install --immutable`, so the lockfile is verified consistent

Each fix carries regression tests: the hourly interval is asserted, a poll tick
with unchanged images is asserted to leave a resolved state intact, and four
tests cover the shared TTL — a new report stays invisible to both halves inside
the window, appears in both together after it expires, `health()` sees it
immediately, and the listing is not re-fetched per call.

## After merge

`backstage-portal` findings stay at 195 until the next scan runs; these are
behavioural fixes, not content changes. The image's own CVE count is unchanged
from v1.4.13 (132 actionable, down from 204 at v1.4.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYAaoFnQ1dKp1yibWQZNCy